### PR TITLE
Bundle `_init.ts` script to reduce TS scaffold complexity

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Official SDK for Inngest.com",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "inngest-init": "./dist/init.js"
+  },
   "scripts": {
     "build": "yarn run clean && tsc",
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,48 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import { URL } from "url";
 
-import axios, {
-  AxiosRequestConfig,
-  AxiosResponseHeaders,
-  AxiosResponse,
-} from "axios";
+/**
+ * An HTTP-like, standardised response format that allows Inngest to help
+ * orchestrate steps and retries.
+ */
+export interface InngestResponse {
+  /**
+   * A step response must contain an HTTP status code.
+   *
+   * A `2xx` response indicates success; this is not a failure and no retry is
+   * necessary.
+   *
+   * A `4xx` response indicates a bad request; this step will not be retried as
+   * it is deemed irrecoverable. Examples of this might be an event with
+   * insufficient data or concerning a user that no longer exists.
+   *
+   * A `5xx` status indicates a temporary internal error; this will be retried
+   * according to the step and function's retry policy (3 times, by default).
+   *
+   * @link https://www.inngest.com/docs/functions/function-input-and-output#response-format
+   * @link https://www.inngest.com/docs/functions/retries
+   */
+  status: number;
+
+  /**
+   * The output of the function - the `body` - can be any arbitrary
+   * JSON-compatible data. It is then usable by any future steps.
+   *
+   * @link https://www.inngest.com/docs/functions/function-input-and-output#response-format
+   */
+  body?: any;
+}
+
+/**
+ * A single step within a function.
+ */
+export type InngestStep<Context = any> = (
+  /**
+   * The context for this step, including the triggering event and any previous
+   * step output.
+   */
+  context: Context
+) => Promise<InngestResponse> | InngestResponse;
 
 /**
  * The event payload structure for sending data to Inngest

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import path from "path";
+import { InngestStep } from "./index";
+
+/**
+ * Init initializes the context for running the function.  This calls
+ * start() when
+ */
+async function init() {
+  const [, , fnPath, rawContext] = process.argv;
+
+  // We pass the event in as an argument to the node function.  Running
+  // npx ts-node "./foo.bar" means we have 2 arguments prior to the event.
+  // We'll also be adding stdin and lambda compatibility soon.
+  const context = JSON.parse(rawContext);
+
+  if (!context) {
+    throw new Error("unable to parse context");
+  }
+
+  // Import this asynchronously, such that any top-level
+  // errors in user code are caught.
+  const { run } = (await import(
+    path.join(process.cwd(), fnPath)
+  )) as unknown as {
+    run: InngestStep<any>;
+  };
+
+  const result = await run(context);
+
+  /**
+   * We could also validate the response format (status code required) here and
+   * throw an error if it's not there?
+   */
+  return result;
+}
+
+init()
+  .then((body) => {
+    if (typeof body === "string") {
+      console.log(JSON.stringify({ body }));
+      return;
+    }
+    console.log(JSON.stringify(body));
+  })
+  .catch((e: Error) => {
+    // TODO: Log error and stack trace.
+    console.log(
+      JSON.stringify({
+        error: e.stack || e.message,
+        status: 500,
+      })
+    );
+    process.exit(1);
+  });


### PR DESCRIPTION
Bundles the [`_init.js` file used in our TS scaffolds](https://github.com/inngest/scaffolds/blob/main/typescript/typescript-node-lts/data/src/_init.ts) as an `inngest-init` script that we can use in the scaffold `Dockerfile` instead of exposing another file to the user.

Also adds `InngestResponse` and `InngestStep` types so that we get some nicer types around input/output for our exported function and force the user to use the `status` and `body` response that we require for retries.

```ts
// New `index.ts` could be
import type { Args } from "./types";
import type { InngestStep } from "inngest";

export const run: InngestStep<Args> = ({ event }) => {
  // Your logic goes here.
  return event.name;
}
```

```Dockerfile
# Dockerfile entrypoint becomes
ENTRYPOINT ["./node_modules/.bin/inngest-init", "./build/index.js"]
```