### PR TITLE
Ensure scheme exists and handle undefined signing keys

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -89,7 +89,7 @@ export class InngestCommHandler {
     // (undocumented)
     protected runStep(functionId: string, stepId: string, data: any): Promise<StepRunResponse>;
     // (undocumented)
-    protected readonly signingKey: string;
+    protected readonly signingKey: string | undefined;
     // (undocumented)
     protected signResponse(): string;
     // (undocumented)

--- a/src/handlers/default.ts
+++ b/src/handlers/default.ts
@@ -176,22 +176,17 @@ export class InngestCommHandler {
   public createHandler(): any {
     return async (req: Request, res: Response) => {
       const hostname = req.hostname || req.headers["host"];
-      if (!hostname) {
-        console.error("Unable to determine your site URL to host Inngest.");
-        return res.status(500).json("Unable to determine your site URL to host Inngest.");
-      }
-
-      let scheme = "";
-      if (hostname.indexOf("://") === -1) {
-        scheme = (process.env.NODE_ENV === "development" || !req.connection.encrypted) ? "http://" : "https://";
-      }
+      const protocol = hostname?.includes("://") ? "" : `${req.protocol}://`;
 
       let reqUrl;
       try {
-        reqUrl = new URL(req.originalUrl, scheme + hostname);
-      } catch(e) {
-        console.error("Unable to determine your site URL to host Inngest.");
-        return res.status(500).json("Unable to determine your site URL to host Inngest.");
+        reqUrl = new URL(req.originalUrl, `${protocol}${hostname || ""}`);
+      } catch (e) {
+        const message =
+          "Unable to determine your site URL to serve the Inngest handler.";
+        console.error(message);
+
+        return res.status(500).json({ message });
       }
 
       switch (req.method) {


### PR DESCRIPTION
This PR ensures that undefined signing keys are handled correctly, and ensures that we always have a scheme (required for node's URL parsing).