### PR TITLE
Ensure `name`, `ts`, and `v` aren't always required when sending events

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -61,9 +61,11 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     readonly inngestBaseUrl: URL;
     readonly name: string;
     // Warning: (ae-forgotten-export) The symbol "SingleOrArray" needs to be exported by the entry point index.d.ts
-    send<Event extends keyof Events>(name: Event, payload: SingleOrArray<Omit<Events[Event], "name">>): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "ValueOf" needs to be exported by the entry point index.d.ts
-    send<Payload extends SingleOrArray<ValueOf<Events>>>(payload: Payload): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "PartialK" needs to be exported by the entry point index.d.ts
+    send<Event extends keyof Events>(name: Event, payload: SingleOrArray<PartialK<Omit<Events[Event], "name" | "v">, "ts">>): Promise<void>;
+    send<Payload extends SingleOrArray<{
+        [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
+    }[keyof Events]>>(payload: Payload): Promise<void>;
 }
 
 // @public

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { SingleOrArray, ValueOf } from "../helpers/types";
+import { PartialK, SingleOrArray, ValueOf } from "../helpers/types";
 import { ClientOptions, EventPayload, FunctionOptions, StepFn } from "../types";
 import { version } from "../version";
 import { InngestFunction } from "./InngestFunction";
@@ -174,7 +174,7 @@ export class Inngest<Events extends Record<string, EventPayload>> {
    */
   public async send<Event extends keyof Events>(
     name: Event,
-    payload: SingleOrArray<Omit<Events[Event], "name">>
+    payload: SingleOrArray<PartialK<Omit<Events[Event], "name" | "v">, "ts">>
   ): Promise<void>;
   /**
    * Send one or many events to Inngest. Takes an entire payload (including
@@ -200,12 +200,24 @@ export class Inngest<Events extends Record<string, EventPayload>> {
    * }>("My App", "API_KEY");
    * ```
    */
-  public async send<Payload extends SingleOrArray<ValueOf<Events>>>(
-    payload: Payload
-  ): Promise<void>;
+  public async send<
+    Payload extends SingleOrArray<
+      {
+        [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
+      }[keyof Events]
+    >
+  >(payload: Payload): Promise<void>;
   public async send<Event extends keyof Events>(
-    nameOrPayload: Event | SingleOrArray<ValueOf<Events>>,
-    maybePayload?: SingleOrArray<Omit<Events[Event], "name">>
+    nameOrPayload:
+      | Event
+      | SingleOrArray<
+          ValueOf<{
+            [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
+          }>
+        >,
+    maybePayload?: SingleOrArray<
+      PartialK<Omit<Events[Event], "name" | "v">, "ts">
+    >
   ): Promise<void> {
     let payloads: ValueOf<Events>[];
 

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -11,3 +11,13 @@ export type ValueOf<T> = T extends Record<string, any>
  * Returns the given generic as either itself or an array of itself.
  */
 export type SingleOrArray<T> = T | T[];
+
+/**
+ * Acts like `Partial<T>` but only for the keys in `K`, leaving the rest alone.
+ */
+export type PartialK<T, K extends PropertyKey = PropertyKey> = Partial<
+  Pick<T, Extract<keyof T, K>>
+> &
+  Omit<T, K> extends infer O
+  ? { [P in keyof O]: O[P] }
+  : never;


### PR DESCRIPTION
Depending on the typed event, `name`, `ts`, and `v` was always required when using `inngest.send`.

The following example would break, as the generated type shows that `ts` is always present in the event, so sending required the same.

![image](https://user-images.githubusercontent.com/1736957/191955466-a9c9133e-25c4-430d-a38d-4a9546ecb242.png)

This now works fine with this PR, still allowing the user to specify `ts` if they wish to.

![image](https://user-images.githubusercontent.com/1736957/191955651-8dfb049f-a69f-4aac-bfaf-856329f82c2b.png)

It's worth doing this here rather than in type generation to ensure we handle custom event typing elegantly too.