### PR TITLE
Clean up types to be less verbose inline

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -11,10 +11,11 @@ export interface ClientOptions {
     name: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "EventName" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "InngestFunction" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const createFunction: <Event_1 extends EventPayload>(nameOrOpts: string | FunctionOptions, event: Event_1 extends EventPayload ? (Event_1 extends infer T ? { [K in keyof T]: K extends "name" ? Event_1[K] : never; } : never)[keyof Event_1] : never, fn: StepFn<Event_1, string, "step">) => InngestFunction<any>;
+export const createFunction: <Event_1 extends EventPayload>(nameOrOpts: string | FunctionOptions, event: EventName<Event_1>, fn: StepFn<Event_1, string, "step">) => InngestFunction<any>;
 
 // @public
 export const createScheduledFunction: (nameOrOpts: string | FunctionOptions, cron: string, fn: StepFn<null, string, "step">) => InngestFunction<any>;
@@ -63,9 +64,8 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     // Warning: (ae-forgotten-export) The symbol "SingleOrArray" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "PartialK" needs to be exported by the entry point index.d.ts
     send<Event extends keyof Events>(name: Event, payload: SingleOrArray<PartialK<Omit<Events[Event], "name" | "v">, "ts">>): Promise<void>;
-    send<Payload extends SingleOrArray<{
-        [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
-    }[keyof Events]>>(payload: Payload): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "SendEventPayload" needs to be exported by the entry point index.d.ts
+    send<Payload extends SendEventPayload<Events>>(payload: Payload): Promise<void>;
 }
 
 // @public

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { PartialK, SingleOrArray, ValueOf } from "../helpers/types";
+import {
+  PartialK,
+  SendEventPayload,
+  SingleOrArray,
+  ValueOf,
+} from "../helpers/types";
 import { ClientOptions, EventPayload, FunctionOptions, StepFn } from "../types";
 import { version } from "../version";
 import { InngestFunction } from "./InngestFunction";
@@ -200,13 +205,9 @@ export class Inngest<Events extends Record<string, EventPayload>> {
    * }>("My App", "API_KEY");
    * ```
    */
-  public async send<
-    Payload extends SingleOrArray<
-      {
-        [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
-      }[keyof Events]
-    >
-  >(payload: Payload): Promise<void>;
+  public async send<Payload extends SendEventPayload<Events>>(
+    payload: Payload
+  ): Promise<void>;
   public async send<Event extends keyof Events>(
     nameOrPayload:
       | Event

--- a/src/helpers/func.ts
+++ b/src/helpers/func.ts
@@ -1,6 +1,7 @@
 import { InngestFunction } from "../components/InngestFunction";
 import { InngestStep } from "../components/InngestStep";
 import { EventPayload, FunctionOptions, StepFn } from "../types";
+import { EventName } from "./types";
 
 /**
  * Given an event to listen to, run the given function when that event is
@@ -18,11 +19,7 @@ export const createFunction = <Event extends EventPayload>(
   /**
    * The event to listen for.
    */
-  event: Event extends EventPayload
-    ? {
-        [K in keyof Event]: K extends "name" ? Event[K] : never;
-      }[keyof Event]
-    : never,
+  event: EventName<Event>,
 
   /**
    * The function to run when the event is received.

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,3 +1,5 @@
+import { EventPayload } from "../types";
+
 /**
  * Returns a union of all of the values in a given object, regardless of key.
  */
@@ -21,3 +23,20 @@ export type PartialK<T, K extends PropertyKey = PropertyKey> = Partial<
   Omit<T, K> extends infer O
   ? { [P in keyof O]: O[P] }
   : never;
+
+/**
+ * A payload that could be sent to Inngest, based on the given `Events`.
+ */
+export type SendEventPayload<Events extends Record<string, EventPayload>> =
+  SingleOrArray<
+    {
+      [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
+    }[keyof Events]
+  >;
+
+/**
+ * Retrieve an event's name based on the given payload. Defaults to `string`.
+ */
+export type EventName<Event extends EventPayload> = Event extends EventPayload
+  ? Event["name"]
+  : string;


### PR DESCRIPTION
Cleaned up `createFunction` and `Inngest#send` types to be less verbose inline.