### PR TITLE
Ensure we use app as fn prefix with SDK-based functions

### DIFF
--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,0 +1,14 @@
+import { InngestFunction } from "./InngestFunction";
+import { InngestStep } from "./InngestStep";
+
+describe("#generateID", () => {
+  it("Returns a correct name", () => {
+    const fn = () => new InngestFunction(
+      { name: "HELLO 👋 there mr Wolf 🥳!", },
+      { event: "test/event.name" },
+      { step: new InngestStep(() => {}) },
+    )
+    expect(fn().id("MY MAGIC APP 🥳!")).toEqual("my-magic-app-hello-there-mr-wolf")
+    expect(fn().id()).toEqual("hello-there-mr-wolf")
+  })
+})

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -118,7 +118,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
   #generateId(prefix?: string) {
     const join = "-";
 
-    return `${prefix || ""}-${this.#opts.name}`
+    return [prefix || "", this.#opts.name].join("-");
       .toLowerCase()
       .replaceAll(/[^a-z0-9-]+/g, join)
       .replaceAll(/-+/g, join)

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -44,9 +44,9 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
   /**
    * The generated or given ID for this function.
    */
-  public get id() {
+  public id(prefix?: string) {
     if (!this.#opts.id) {
-      this.#opts.id = this.#generateId();
+      this.#opts.id = this.#generateId(prefix);
     }
 
     return this.#opts.id;
@@ -68,16 +68,17 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
      * This function can't be expected to know how it will be accessed, so
      * relies on an outside method providing context.
      */
-    baseUrl: URL
+    baseUrl: URL,
+    appPrefix?: string
   ): FunctionConfig {
     return {
-      id: this.id,
+      id: this.id(appPrefix),
       name: this.name,
       triggers: [this.#trigger as FunctionTrigger],
       steps: Object.keys(this.#steps).reduce<FunctionConfig["steps"]>(
         (acc, stepId) => {
           const url = new URL(baseUrl.href);
-          url.searchParams.set(fnIdParam, this.id);
+          url.searchParams.set(fnIdParam, this.id(appPrefix));
           url.searchParams.set(stepIdParam, stepId);
 
           return {
@@ -114,10 +115,10 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
   /**
    * Generate an ID based on the function's name.
    */
-  #generateId() {
+  #generateId(prefix?: string) {
     const join = "-";
 
-    return this.#opts.name
+    return `${prefix || ""}-${this.#opts.name}`
       .toLowerCase()
       .replaceAll(/[^a-z0-9-]+/g, join)
       .replaceAll(/-+/g, join)

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -71,14 +71,15 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
     baseUrl: URL,
     appPrefix?: string
   ): FunctionConfig {
+    const id = this.id(appPrefix);
     return {
-      id: this.id(appPrefix),
+      id,
       name: this.name,
       triggers: [this.#trigger as FunctionTrigger],
       steps: Object.keys(this.#steps).reduce<FunctionConfig["steps"]>(
         (acc, stepId) => {
           const url = new URL(baseUrl.href);
-          url.searchParams.set(fnIdParam, this.id(appPrefix));
+          url.searchParams.set(fnIdParam, id);
           url.searchParams.set(stepIdParam, stepId);
 
           return {
@@ -118,7 +119,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
   #generateId(prefix?: string) {
     const join = "-";
 
-    return [prefix || "", this.#opts.name].join("-");
+    return [prefix || "", this.#opts.name].join("-")
       .toLowerCase()
       .replaceAll(/[^a-z0-9-]+/g, join)
       .replaceAll(/-+/g, join)

--- a/src/handlers/default.ts
+++ b/src/handlers/default.ts
@@ -124,15 +124,15 @@ export class InngestCommHandler {
 
     this.fns = functions.reduce<Record<string, InngestFunction<any>>>(
       (acc, fn) => {
-        if (acc[fn.id]) {
+        if (acc[fn.id(this.name)]) {
           throw new Error(
-            `Duplicate function ID "${fn.id}"; please change a function's name or provide an explicit ID to avoid conflicts.`
+            `Duplicate function ID "${fn.id(this.name)}"; please change a function's name or provide an explicit ID to avoid conflicts.`
           );
         }
 
         return {
           ...acc,
-          [fn.id]: fn,
+          [fn.id(this.name)]: fn,
         };
       },
       {}
@@ -256,7 +256,7 @@ export class InngestCommHandler {
   }
 
   protected configs(url: URL): FunctionConfig[] {
-    return Object.values(this.fns).map((fn) => fn["getConfig"](url));
+    return Object.values(this.fns).map((fn) => fn["getConfig"](url, this.name));
   }
 
   protected async register(

--- a/src/handlers/default.ts
+++ b/src/handlers/default.ts
@@ -124,15 +124,17 @@ export class InngestCommHandler {
 
     this.fns = functions.reduce<Record<string, InngestFunction<any>>>(
       (acc, fn) => {
-        if (acc[fn.id(this.name)]) {
+        const id = fn.id(this.name);
+
+        if (acc[id]) {
           throw new Error(
-            `Duplicate function ID "${fn.id(this.name)}"; please change a function's name or provide an explicit ID to avoid conflicts.`
+            `Duplicate function ID "${id}"; please change a function's name or provide an explicit ID to avoid conflicts.`
           );
         }
 
         return {
           ...acc,
-          [fn.id(this.name)]: fn,
+          [id]: fn,
         };
       },
       {}


### PR DESCRIPTION
This reduces the chance of collisions when creating function IDs via the SDK.