### PR TITLE
Add dev server integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,8 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Create a function with '...'
 2. Send this event '...'
 3. ...
@@ -23,10 +23,11 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **System info (please complete the following information):**
- - OS: [e.g. Mac, Windows]
- - npm package Version [e.g. 0.7.0]
- - Framework [e.g. Next.js, Express] 
- - Platform [e.g. Vercel, AWS Lambda]
+
+- OS: [e.g. Mac, Windows]
+- npm package Version [e.g. 0.7.0]
+- Framework [e.g. Next.js, Express]
+- Platform [e.g. Vercel, AWS Lambda]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: feature
-assignees: ''
-
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ npm install inngest  # or yarn install inngest
 **Writing functions**: Write serverless functions and background jobs right in your own code:
 
 ```ts
-
 import { createFunction } from "inngest";
 
 export default createFunction(
@@ -62,12 +61,11 @@ export default createFunction(
 );
 ```
 
-Functions listen to events which can be triggered by API calls, webhooks, integrations, or external services.  When a matching event is received, the serverless function runs automatically, with built in retries.
+Functions listen to events which can be triggered by API calls, webhooks, integrations, or external services. When a matching event is received, the serverless function runs automatically, with built in retries.
 
 <br />
 
 **Triggering functions by events:**
-
 
 ```ts
 // Send events
@@ -78,20 +76,19 @@ const inngest = new Inngest({ name: "My App" });
 inngest.send("app/user.created", { data: { id: 123 } });
 ```
 
-Events trigger any number of functions automatically, in parallel, in the background.  Inngest also stores a history of all events for observability, testing, and replay.
-
+Events trigger any number of functions automatically, in parallel, in the background. Inngest also stores a history of all events for observability, testing, and replay.
 
 <br />
 
 ## Features
 
-- **Fully serverless:**  Run background jobs, scheduled functions, and build event-driven systems without any servers, state, or setup
-- **Deploy anywhere**:  works with NextJS, Netlify, Vercel, Redwood, Express, Cloudflare, and Lambda
-- **Use your existing code:**  write functions within your current project, zero learning required
-- **A complete platform**:  complex functionality built in, such as **event replay**, **canary deploys**, **version management** and **git integration**
-- **Fully typed**:  Event schemas, versioning, and governance out of the box
-- **Observable**:  A full UI for managing and inspecting your functions
-- **Any language:**  Use our CLI to write functions using any language
+- **Fully serverless:** Run background jobs, scheduled functions, and build event-driven systems without any servers, state, or setup
+- **Deploy anywhere**: works with NextJS, Netlify, Vercel, Redwood, Express, Cloudflare, and Lambda
+- **Use your existing code:** write functions within your current project, zero learning required
+- **A complete platform**: complex functionality built in, such as **event replay**, **canary deploys**, **version management** and **git integration**
+- **Fully typed**: Event schemas, versioning, and governance out of the box
+- **Observable**: A full UI for managing and inspecting your functions
+- **Any language:** Use our CLI to write functions using any language
 
 <br />
 

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -69,47 +69,12 @@ export class Inngest<Events extends Record<string, EventPayload>> {
 }
 
 // @public
-export class InngestCommHandler {
-    constructor(nameOrInngest: string | Inngest<any>, signingKey: string, functions: InngestFunction<any>[], { inngestRegisterUrl }?: RegisterOptions);
-    // Warning: (ae-forgotten-export) The symbol "FunctionConfig" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    protected configs(url: URL): FunctionConfig[];
-    // (undocumented)
-    createHandler(): any;
-    // (undocumented)
-    protected readonly frameworkName: string;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    protected register(url: URL): Promise<{
-        status: number;
-        message: string;
-    }>;
-    // Warning: (ae-forgotten-export) The symbol "StepRunResponse" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    protected runStep(functionId: string, stepId: string, data: any): Promise<StepRunResponse>;
-    // (undocumented)
-    protected readonly signingKey: string | undefined;
-    // (undocumented)
-    protected signResponse(): string;
-    // (undocumented)
-    protected validateSignature(): boolean;
-}
-
-// @public
-export type RegisterHandler = (
-nameOrInngest: string | Inngest<any>,
-signingKey: string, functions: InngestFunction<any>[], opts?: RegisterOptions) => any;
-
-// @public
 export interface RegisterOptions {
+    fetch?: typeof fetch;
     inngestRegisterUrl?: string;
+    landingPage?: boolean;
+    signingKey?: string;
 }
-
-// @public
-export const serve: <Events extends Record<string, EventPayload>>(...args: [nameOrInngest: string | Inngest<Events>, signingKey: string, functions: InngestFunction<Events>[], opts?: RegisterOptions | undefined] | [commHandler: InngestCommHandler]) => any;
 
 // @public
 export type StepFn<Event, FnId, StepId> = (arg: {

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -69,12 +69,47 @@ export class Inngest<Events extends Record<string, EventPayload>> {
 }
 
 // @public
-export interface RegisterOptions {
-    fetch?: typeof fetch;
-    inngestRegisterUrl?: string;
-    landingPage?: boolean;
-    signingKey?: string;
+export class InngestCommHandler {
+    constructor(nameOrInngest: string | Inngest<any>, signingKey: string, functions: InngestFunction<any>[], { inngestRegisterUrl }?: RegisterOptions);
+    // Warning: (ae-forgotten-export) The symbol "FunctionConfig" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected configs(url: URL): FunctionConfig[];
+    // (undocumented)
+    createHandler(): any;
+    // (undocumented)
+    protected readonly frameworkName: string;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    protected register(url: URL): Promise<{
+        status: number;
+        message: string;
+    }>;
+    // Warning: (ae-forgotten-export) The symbol "StepRunResponse" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    protected runStep(functionId: string, stepId: string, data: any): Promise<StepRunResponse>;
+    // (undocumented)
+    protected readonly signingKey: string | undefined;
+    // (undocumented)
+    protected signResponse(): string;
+    // (undocumented)
+    protected validateSignature(): boolean;
 }
+
+// @public
+export type RegisterHandler = (
+nameOrInngest: string | Inngest<any>,
+signingKey: string, functions: InngestFunction<any>[], opts?: RegisterOptions) => any;
+
+// @public
+export interface RegisterOptions {
+    inngestRegisterUrl?: string;
+}
+
+// @public
+export const serve: <Events extends Record<string, EventPayload>>(...args: [nameOrInngest: string | Inngest<Events>, signingKey: string, functions: InngestFunction<Events>[], opts?: RegisterOptions | undefined] | [commHandler: InngestCommHandler]) => any;
 
 // @public
 export type StepFn<Event, FnId, StepId> = (arg: {

--- a/landing/src/index.css
+++ b/landing/src/index.css
@@ -2,7 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body, #app {
+html,
+body,
+#app {
   height: 100%;
   width: 100%;
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postversion": "yarn run build && yarn run build:copy",
     "release": "yarn run np",
     "api-extractor": "api-extractor",
-    "dev": "concurrently --names Build,Lint,Landing --prefix-colors \"green.inverse,magenta.inverse,blue.inverse\" --handle-input \"yarn run dev:build\" \"yarn run dev:lint\" \"yarn run dev:landing\"",
+    "dev": "yarn && sh -c 'cd ./landing && yarn' && concurrently --names Build,Lint,Landing --prefix-colors \"green.inverse,magenta.inverse,blue.inverse\" --handle-input \"yarn run dev:build\" \"yarn run dev:lint\" \"yarn run dev:landing\"",
     "dev:build": "nodemon -w src -e ts -i version.ts -i landing.ts --delay 300ms -x 'yarn run build && yarn run build:check --local'",
     "dev:lint": "nodemon -w src -e ts -i version.ts -i landing.ts --delay 300ms -x 'yarn lint'",
     "dev:landing": "nodemon -w landing/src -e ts,tsx,css --delay 300ms -x 'yarn run build:landing'",

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -37,6 +37,10 @@ class CloudflareCommHandler extends InngestCommHandler {
         this.signingKey = env[envKeys.SigningKey];
       }
 
+      this._isProd =
+        process.env.CF_PAGES === "1" ||
+        process.env.ENVIRONMENT === "production";
+
       switch (req.method) {
         case "GET": {
           const showLandingPage = this.shouldShowLandingPage(

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -19,6 +19,8 @@ class CloudflareCommHandler extends InngestCommHandler {
       request: Request;
       env: Record<string, string | undefined>;
     }): Promise<Response> => {
+      const headers = { "x-inngest-sdk": this.sdkHeader.join("") };
+
       let reqUrl: URL;
       let isIntrospection: boolean;
 
@@ -30,6 +32,7 @@ class CloudflareCommHandler extends InngestCommHandler {
       } catch (err) {
         return new Response(JSON.stringify(err), {
           status: 500,
+          headers,
         });
       }
 
@@ -57,6 +60,7 @@ class CloudflareCommHandler extends InngestCommHandler {
 
             return new Response(JSON.stringify(introspection), {
               status: 200,
+              headers,
             });
           }
 
@@ -64,6 +68,7 @@ class CloudflareCommHandler extends InngestCommHandler {
           return new Response(landing, {
             status: 200,
             headers: {
+              ...headers,
               "content-type": "text/html;charset=UTF-8",
             },
           });
@@ -72,7 +77,7 @@ class CloudflareCommHandler extends InngestCommHandler {
         case "PUT": {
           // Push config to Inngest.
           const { status, message } = await this.register(reqUrl);
-          return new Response(JSON.stringify({ message }), { status });
+          return new Response(JSON.stringify({ message }), { status, headers });
         }
 
         case "POST": {
@@ -92,16 +97,18 @@ class CloudflareCommHandler extends InngestCommHandler {
           if (stepRes.status === 500) {
             return new Response(JSON.stringify(stepRes.error), {
               status: stepRes.status,
+              headers,
             });
           }
 
           return new Response(JSON.stringify(stepRes.body), {
             status: stepRes.status,
+            headers,
           });
         }
       }
 
-      return new Response(null, { status: 405 });
+      return new Response(null, { status: 405, headers });
     };
   }
 }

--- a/src/express.ts
+++ b/src/express.ts
@@ -168,7 +168,7 @@ export class InngestCommHandler {
 
     this.headers = {
       "Content-Type": "application/json",
-      "User-Agent": `InngestJS v${version} (${this.frameworkName})`,
+      "User-Agent": `inngest-js:v${version} (${this.frameworkName})`,
     };
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/express.ts
+++ b/src/express.ts
@@ -197,7 +197,7 @@ export class InngestCommHandler {
           "Unable to determine your site URL to serve the Inngest handler.";
         console.error(message);
 
-        return res.status(500).json({ message });
+        return res.status(500).set("x-inngest-sdk", `js/${this.frameworkName}`).json({ message });
       }
 
       switch (req.method) {
@@ -214,7 +214,7 @@ export class InngestCommHandler {
               hasSigningKey: Boolean(this.signingKey),
             };
 
-            return void res.status(200).json(introspection);
+            return void res.status(200).set("x-inngest-sdk", `js/${this.frameworkName}`).json(introspection);
           }
 
           // Grab landing page and serve
@@ -224,7 +224,7 @@ export class InngestCommHandler {
         case "PUT": {
           // Push config to Inngest.
           const { status, message } = await this.register(reqUrl);
-          return void res.status(status).json({ message });
+          return void res.status(status).set("x-inngest-sdk", `js/${this.frameworkName}`).json({ message });
         }
 
         case "POST": {
@@ -242,10 +242,10 @@ export class InngestCommHandler {
           const stepRes = await this.runStep(fnId, stepId, req.body);
 
           if (stepRes.status === 500) {
-            return void res.status(stepRes.status).json(stepRes.error);
+            return void res.status(stepRes.status).set("x-inngest-sdk", `js/${this.frameworkName}`).json(stepRes.error);
           }
 
-          return void res.status(stepRes.status).json(stepRes.body);
+          return void res.status(stepRes.status).set("x-inngest-sdk", `js/${this.frameworkName}`).json(stepRes.body);
         }
       }
 

--- a/src/express.ts
+++ b/src/express.ts
@@ -197,7 +197,10 @@ export class InngestCommHandler {
           "Unable to determine your site URL to serve the Inngest handler.";
         console.error(message);
 
-        return res.status(500).set("x-inngest-sdk", `js/${this.frameworkName}`).json({ message });
+        return res
+          .status(500)
+          .set("x-inngest-sdk", `js/${this.frameworkName}`)
+          .json({ message });
       }
 
       switch (req.method) {
@@ -214,7 +217,10 @@ export class InngestCommHandler {
               hasSigningKey: Boolean(this.signingKey),
             };
 
-            return void res.status(200).set("x-inngest-sdk", `js/${this.frameworkName}`).json(introspection);
+            return void res
+              .status(200)
+              .set("x-inngest-sdk", `js/${this.frameworkName}`)
+              .json(introspection);
           }
 
           // Grab landing page and serve
@@ -224,7 +230,10 @@ export class InngestCommHandler {
         case "PUT": {
           // Push config to Inngest.
           const { status, message } = await this.register(reqUrl);
-          return void res.status(status).set("x-inngest-sdk", `js/${this.frameworkName}`).json({ message });
+          return void res
+            .status(status)
+            .set("x-inngest-sdk", `js/${this.frameworkName}`)
+            .json({ message });
         }
 
         case "POST": {
@@ -242,10 +251,16 @@ export class InngestCommHandler {
           const stepRes = await this.runStep(fnId, stepId, req.body);
 
           if (stepRes.status === 500) {
-            return void res.status(stepRes.status).set("x-inngest-sdk", `js/${this.frameworkName}`).json(stepRes.error);
+            return void res
+              .status(stepRes.status)
+              .set("x-inngest-sdk", `js/${this.frameworkName}`)
+              .json(stepRes.error);
           }
 
-          return void res.status(stepRes.status).set("x-inngest-sdk", `js/${this.frameworkName}`).json(stepRes.body);
+          return void res
+            .status(stepRes.status)
+            .set("x-inngest-sdk", `js/${this.frameworkName}`)
+            .json(stepRes.body);
         }
       }
 
@@ -346,7 +361,12 @@ export class InngestCommHandler {
       console.warn("Couldn't unpack register response:", err);
     }
     const { status, error } = registerResSchema.parse(data);
-    console.log("Registered Inngest functions:", res.status, res.statusText, data);
+    console.log(
+      "Registered Inngest functions:",
+      res.status,
+      res.statusText,
+      data
+    );
 
     return { status, message: error };
   }

--- a/src/express.ts
+++ b/src/express.ts
@@ -8,7 +8,6 @@ import { strBoolean } from "./helpers/scalar";
 import { landing } from "./landing";
 import { available, devserverURL } from "./helpers/devserver";
 import type {
-  EventPayload,
   FunctionConfig,
   IntrospectRequest,
   RegisterOptions,

--- a/src/express.ts
+++ b/src/express.ts
@@ -150,6 +150,8 @@ export class InngestCommHandler {
       {}
     );
 
+    // TODO: This should change if the dev server is available.
+
     this.inngestRegisterUrl = new URL(
       inngestRegisterUrl || "https://api.inngest.com/fn/register"
     );

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -8,7 +8,7 @@ export enum envKeys {
   SigningKey = "INNGEST_SIGNING_KEY",
   EventKey = "INNGEST_EVENT_KEY",
   LandingPage = "INNGEST_LANDING_PAGE",
-  DevServerURL = "INNGEST_DEVSERVER_URL",
+  DevServerUrl = "INNGEST_DEVSERVER_URL",
 }
 
 export enum prodEnvKeys {
@@ -16,3 +16,5 @@ export enum prodEnvKeys {
   VercelEnvKey = "VERCEL_ENV",
   NetlifyEnvKey = "CONTEXT",
 }
+
+export const defaultDevServerHost = "http://127.0.0.1:8288/";

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -8,4 +8,11 @@ export enum envKeys {
   SigningKey = "INNGEST_SIGNING_KEY",
   EventKey = "INNGEST_EVENT_KEY",
   LandingPage = "INNGEST_LANDING_PAGE",
+  DevServerURL = "INNGEST_DEVSERVER_URL",
+}
+
+export enum prodEnvKeys {
+  NodeEnvKey = "NODE_ENV",
+  VercelEnvKey = "VERCEL_ENV",
+  NetlifyEnvKey = "CONTEXT",
 }

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -16,9 +16,9 @@ export const available = async (): Promise<boolean> => {
     const result = await fetch(url.toString());
     await result.json();
     return true;
-  } catch (e) {}
-
-  return false;
+  } catch (e) {
+    return false;
+  }
 };
 
 // isProd compares any supported standard env variable for "production",

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -1,0 +1,91 @@
+import fetch from 'cross-fetch';
+
+type InfoResponse = {
+  version: string; // Version of the dev server
+  startOpts: {
+    sdkURLs: string[]; // URLs the dev server was started with
+  };
+  // Account helpers
+  authed: boolean; // Are we logged in?
+  workspaces: {
+    prod: WorkspaceResponse; // To validate keys in test & prod.
+    test: WorkspaceResponse;
+  };
+  // SDK registration helpers
+  functions: Function[];
+  handlers: SDKHandler[];
+}
+
+type WorkspaceResponse = {
+  signingKey: string;
+  eventKeys: Array<{
+    name: string;
+    key: string;
+  }>
+};
+
+type SDKHandler = {
+  functionIDs: Array<string>;
+  createdAt: string;
+  updatedAt: string;
+  errors: Array<string>; // A list of errors from eg. function validation, or key validation.
+  sdk: {
+    url: string;
+    language: string; 
+    version: string;
+    framework?: string;
+    app: string; // app name
+  }
+}
+
+type Function = {
+  id: string;
+};
+
+const envVars = [
+  "NODE_ENV",   // express slash standard.
+  "VERCEL_ENV", // vercel
+  "CONTEXT",    // netlify
+];
+
+export const available = async (): Promise<boolean> => {
+  if (isProd()) {
+    return false;
+  }
+
+  try {
+    const result = await fetch(url());
+    await result.json();
+    return true;
+  } catch(e) {}
+
+  return false;
+}
+
+// isProd compares any supported standard env variable for "production",
+// returning true on first match. 
+export const isProd = (): boolean => {
+  return !!envVars.find(e => process.env[e] === "production");
+}
+
+// url returns the dev server URL, overriding to use the INNGEST_DEVSERVER_URL
+// env var if provided.
+export const url = (): string => {
+  let host = process.env.INNGEST_DEVSERVER_URL
+  if (!host) {
+    // Use the default.
+    return `http://127.0.0.1:8223/x/devserver`;
+  }
+
+  // Normalize the URL to be friendly here.  If the user hasn't added a scheme,
+  // default to http.
+  if (host.indexOf("://") === -1) {
+    host = `http://${host}`;
+  }
+
+  // Ensure the pathname is set correctly.  This lets people set the env var
+  // to eg. INNGEST_DEVSERVER_URL=127.0.0.1:9123
+  const parsed = new URL(host);
+  parsed.pathname = "/x/devserver";
+  return parsed.toString();
+}

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -1,5 +1,55 @@
-import fetch from 'cross-fetch';
+import fetch from "cross-fetch";
 
+const envVars = [
+  "NODE_ENV", // express slash standard.
+  "VERCEL_ENV", // vercel
+  "CONTEXT", // netlify
+];
+
+export const available = async (): Promise<boolean> => {
+  if (isProd()) {
+    return false;
+  }
+
+  try {
+    const url = devserverURL("/dev");
+    const result = await fetch(url.toString());
+    await result.json();
+    return true;
+  } catch (e) {}
+
+  return false;
+};
+
+// isProd compares any supported standard env variable for "production",
+// returning true on first match.
+export const isProd = (): boolean => {
+  return !!envVars.find((e) => process.env[e] === "production");
+};
+
+// url returns the dev server URL, overriding to use the INNGEST_DEVSERVER_URL
+// env var if provided.
+export const devserverURL = (pathname?: string): URL => {
+  let host = process.env.INNGEST_DEVSERVER_URL;
+  if (!host) {
+    // Use the default.
+    const url = new URL(`http://127.0.0.1:8288/`);
+    url.pathname = pathname || "";
+    return url;
+  }
+
+  // Normalize the URL to be friendly here.  If the user hasn't added a scheme,
+  // default to http.
+  if (host.indexOf("://") === -1) {
+    host = `http://${host}`;
+  }
+
+  const url = new URL(host);
+  url.pathname = pathname || "";
+  return url;
+};
+
+// InfoResponse is the API response for the dev server's /dev endpoint.
 type InfoResponse = {
   version: string; // Version of the dev server
   startOpts: {
@@ -14,14 +64,14 @@ type InfoResponse = {
   // SDK registration helpers
   functions: Function[];
   handlers: SDKHandler[];
-}
+};
 
 type WorkspaceResponse = {
   signingKey: string;
   eventKeys: Array<{
     name: string;
     key: string;
-  }>
+  }>;
 };
 
 type SDKHandler = {
@@ -31,61 +81,13 @@ type SDKHandler = {
   errors: Array<string>; // A list of errors from eg. function validation, or key validation.
   sdk: {
     url: string;
-    language: string; 
+    language: string;
     version: string;
     framework?: string;
     app: string; // app name
-  }
-}
+  };
+};
 
 type Function = {
   id: string;
 };
-
-const envVars = [
-  "NODE_ENV",   // express slash standard.
-  "VERCEL_ENV", // vercel
-  "CONTEXT",    // netlify
-];
-
-export const available = async (): Promise<boolean> => {
-  if (isProd()) {
-    return false;
-  }
-
-  try {
-    const result = await fetch(url());
-    await result.json();
-    return true;
-  } catch(e) {}
-
-  return false;
-}
-
-// isProd compares any supported standard env variable for "production",
-// returning true on first match. 
-export const isProd = (): boolean => {
-  return !!envVars.find(e => process.env[e] === "production");
-}
-
-// url returns the dev server URL, overriding to use the INNGEST_DEVSERVER_URL
-// env var if provided.
-export const url = (): string => {
-  let host = process.env.INNGEST_DEVSERVER_URL
-  if (!host) {
-    // Use the default.
-    return `http://127.0.0.1:8223/x/devserver`;
-  }
-
-  // Normalize the URL to be friendly here.  If the user hasn't added a scheme,
-  // default to http.
-  if (host.indexOf("://") === -1) {
-    host = `http://${host}`;
-  }
-
-  // Ensure the pathname is set correctly.  This lets people set the env var
-  // to eg. INNGEST_DEVSERVER_URL=127.0.0.1:9123
-  const parsed = new URL(host);
-  parsed.pathname = "/x/devserver";
-  return parsed.toString();
-}

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -1,10 +1,5 @@
 import fetch from "cross-fetch";
-
-const envVars = [
-  "NODE_ENV", // express slash standard.
-  "VERCEL_ENV", // vercel
-  "CONTEXT", // netlify
-];
+import { envKeys, prodEnvKeys } from "./consts";
 
 export const available = async (): Promise<boolean> => {
   if (isProd()) {
@@ -24,13 +19,13 @@ export const available = async (): Promise<boolean> => {
 // isProd compares any supported standard env variable for "production",
 // returning true on first match.
 export const isProd = (): boolean => {
-  return !!envVars.find((e) => process.env[e] === "production");
+  return !!Object.values(prodEnvKeys).find((e) => process.env[e] === "production");
 };
 
 // url returns the dev server URL, overriding to use the INNGEST_DEVSERVER_URL
 // env var if provided.
 export const devserverURL = (pathname?: string): URL => {
-  let host = process.env.INNGEST_DEVSERVER_URL;
+  let host = process.env[envKeys.DevServerURL];
   if (!host) {
     // Use the default.
     const url = new URL(`http://127.0.0.1:8288/`);

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -1,5 +1,6 @@
 import fetch from "cross-fetch";
 import { envKeys, prodEnvKeys } from "./consts";
+import type { FunctionConfig } from "../types";
 
 export const available = async (): Promise<boolean> => {
   if (isProd()) {
@@ -19,7 +20,9 @@ export const available = async (): Promise<boolean> => {
 // isProd compares any supported standard env variable for "production",
 // returning true on first match.
 export const isProd = (): boolean => {
-  return !!Object.values(prodEnvKeys).find((e) => process.env[e] === "production");
+  return !!Object.values(prodEnvKeys).find(
+    (e) => process.env[e] === "production"
+  );
 };
 
 // url returns the dev server URL, overriding to use the INNGEST_DEVSERVER_URL
@@ -45,7 +48,7 @@ export const devserverURL = (pathname?: string): URL => {
 };
 
 // InfoResponse is the API response for the dev server's /dev endpoint.
-type InfoResponse = {
+export type InfoResponse = {
   version: string; // Version of the dev server
   startOpts: {
     sdkURLs: string[]; // URLs the dev server was started with
@@ -57,7 +60,7 @@ type InfoResponse = {
     test: WorkspaceResponse;
   };
   // SDK registration helpers
-  functions: Function[];
+  functions: FunctionConfig[];
   handlers: SDKHandler[];
 };
 
@@ -81,8 +84,4 @@ type SDKHandler = {
     framework?: string;
     app: string; // app name
   };
-};
-
-type Function = {
-  id: string;
 };

--- a/src/next.ts
+++ b/src/next.ts
@@ -30,6 +30,11 @@ class NextCommHandler extends InngestCommHandler {
 
       res.setHeader("x-inngest-sdk", `js/${this.frameworkName}`);
 
+      this._isProd =
+        process.env.VERCEL_ENV === "production" ||
+        process.env.CONTEXT === "production" ||
+        process.env.ENVIRONMENT === "production";
+
       switch (req.method) {
         case "GET": {
           const showLandingPage = this.shouldShowLandingPage(

--- a/src/next.ts
+++ b/src/next.ts
@@ -28,7 +28,7 @@ class NextCommHandler extends InngestCommHandler {
         return void res.status(500).json(err);
       }
 
-      res.setHeader("x-inngest-sdk", `js/${this.frameworkName}`);
+      res.setHeader("x-inngest-sdk", this.sdkHeader.join(""));
 
       this._isProd =
         process.env.VERCEL_ENV === "production" ||

--- a/src/next.ts
+++ b/src/next.ts
@@ -28,7 +28,7 @@ class NextCommHandler extends InngestCommHandler {
         return void res.status(500).json(err);
       }
 
-      res.setHeader("x-inngest-sdk", "inngest-js/next");
+      res.setHeader("x-inngest-sdk", `js/${this.frameworkName}`);
 
       switch (req.method) {
         case "GET": {

--- a/src/next.ts
+++ b/src/next.ts
@@ -28,6 +28,8 @@ class NextCommHandler extends InngestCommHandler {
         return void res.status(500).json(err);
       }
 
+      res.setHeader("x-inngest-sdk", "inngest-js/next");
+
       switch (req.method) {
         case "GET": {
           const showLandingPage = this.shouldShowLandingPage(

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -96,20 +96,21 @@ class RemixCommHandler extends InngestCommHandler {
 
           const stepRes = await this.runStep(fnId, stepId, await req.json());
 
-          return new Response(JSON.stringify(stepRes), {
-            status: stepRes.status || 200,
+          if (stepRes.status === 500) {
+            return new Response(JSON.stringify(stepRes.error), {
+              status: stepRes.status,
+              headers,
+            });
+          }
+
+          return new Response(JSON.stringify(stepRes.body), {
+            status: stepRes.status,
             headers,
           });
         }
-
-        default:
-          return new Response(null, {
-            status: 405,
-            headers,
-          });
       }
 
-      return new Response(null, { status: 405 });
+      return new Response(null, { status: 405, headers });
     };
   }
 }

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -22,6 +22,8 @@ class RemixCommHandler extends InngestCommHandler {
     }: {
       request: Request;
     }): Promise<Response> => {
+      const headers = { "x-inngest-sdk": this.sdkHeader.join("") };
+
       let reqUrl: URL;
       let isIntrospection: boolean;
 
@@ -33,9 +35,7 @@ class RemixCommHandler extends InngestCommHandler {
       } catch (err) {
         return new Response(JSON.stringify(err), {
           status: 500,
-          headers: {
-            "x-inngest-sdk": `js/${this.frameworkName}`,
-          },
+          headers,
         });
       }
 
@@ -67,7 +67,7 @@ class RemixCommHandler extends InngestCommHandler {
           return new Response(landing, {
             status: 200,
             headers: {
-              "x-inngest-sdk": `js/${this.frameworkName}`,
+              ...headers,
               "content-type": "text/html;charset=UTF-8",
             },
           });
@@ -78,9 +78,7 @@ class RemixCommHandler extends InngestCommHandler {
           const { status, message } = await this.register(reqUrl);
           return new Response(JSON.stringify({ message }), {
             status,
-            headers: {
-              "x-inngest-sdk": `js/${this.frameworkName}`,
-            },
+            headers,
           });
         }
 
@@ -100,18 +98,14 @@ class RemixCommHandler extends InngestCommHandler {
 
           return new Response(JSON.stringify(stepRes), {
             status: stepRes.status || 200,
-            headers: {
-              "x-inngest-sdk": `js/${this.frameworkName}`,
-            },
+            headers,
           });
         }
 
         default:
           return new Response(null, {
             status: 405,
-            headers: {
-              "x-inngest-sdk": `js/${this.frameworkName}`,
-            },
+            headers,
           });
       }
 

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -33,6 +33,9 @@ class RemixCommHandler extends InngestCommHandler {
       } catch (err) {
         return new Response(JSON.stringify(err), {
           status: 500,
+          headers: {
+            "x-inngest-sdk": `js/${this.frameworkName}`,
+          },
         });
       }
 
@@ -59,6 +62,7 @@ class RemixCommHandler extends InngestCommHandler {
           return new Response(landing, {
             status: 200,
             headers: {
+              "x-inngest-sdk": `js/${this.frameworkName}`,
               "content-type": "text/html;charset=UTF-8",
             },
           });
@@ -67,7 +71,12 @@ class RemixCommHandler extends InngestCommHandler {
         case "PUT": {
           // Push config to Inngest.
           const { status, message } = await this.register(reqUrl);
-          return new Response(JSON.stringify({ message }), { status });
+          return new Response(JSON.stringify({ message }), {
+            status,
+            headers: {
+              "x-inngest-sdk": `js/${this.frameworkName}`,
+            },
+          });
         }
 
         case "POST": {
@@ -84,16 +93,21 @@ class RemixCommHandler extends InngestCommHandler {
 
           const stepRes = await this.runStep(fnId, stepId, await req.json());
 
-          if (stepRes.status === 500) {
-            return new Response(JSON.stringify(stepRes.error), {
-              status: stepRes.status,
-            });
-          }
-
-          return new Response(JSON.stringify(stepRes.body), {
-            status: stepRes.status,
+          return new Response(JSON.stringify(stepRes), {
+            status: stepRes.status || 200,
+            headers: {
+              "x-inngest-sdk": `js/${this.frameworkName}`,
+            },
           });
         }
+
+        default:
+          return new Response(null, {
+            status: 405,
+            headers: {
+              "x-inngest-sdk": `js/${this.frameworkName}`,
+            },
+          });
       }
 
       return new Response(null, { status: 405 });

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -39,6 +39,11 @@ class RemixCommHandler extends InngestCommHandler {
         });
       }
 
+      this._isProd =
+        process.env.VERCEL_ENV === "production" ||
+        process.env.CONTEXT === "production" ||
+        process.env.ENVIRONMENT === "production";
+
       switch (req.method) {
         case "GET": {
           const showLandingPage = this.shouldShowLandingPage(


### PR DESCRIPTION
This PR introduces integrations with the `inngest-cli` dev server.  It attempts to check if the dev server is running, and will ultimately swap out:

- The registration API for the dev server's registration URL
- The event API for the dev server's API

Based on whether the dev server is available.

Note: the dev server is never available in production.