### PR TITLE
Add devserver URL to introspection result

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Inngest SDK - Landing</title>
+    <title>Inngest SDK - Your functions</title>
   </head>
   <body>
     <div id="app"></div>

--- a/landing/src/components/Content.tsx
+++ b/landing/src/components/Content.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "preact/hooks";
+import { useInterval } from "react-use";
 import { useIntrospect } from "../hooks/useFnIntrospect";
 import { globalConfigErrors } from "./ConfigErrors";
 import { Wrapper } from "./Container";
@@ -10,6 +11,9 @@ import { Spinner } from "./Loading";
  */
 export const Content = () => {
   const { loading, value: fns, retry: refresh } = useIntrospect();
+
+  // Refresh our functions every 5 seconds.
+  useInterval(refresh, 5000);
 
   /**
    * Figure out if we have errors based on the latest fetched functions.
@@ -51,7 +55,7 @@ export const Content = () => {
     ];
   }, []);
 
-  if (loading) {
+  if (loading && !fns?.functions.length) {
     return (
       <div class="flex-1 w-full h-full flex items-center justify-center">
         <Spinner class="h-8 w-8" />

--- a/landing/src/components/DevServerBar.tsx
+++ b/landing/src/components/DevServerBar.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "preact/hooks";
 import { useAsyncRetry, useInterval } from "react-use";
+import { useIntrospect } from "../hooks/useFnIntrospect";
 import { classNames } from "../utils/classnames";
 import { Code } from "./Code";
+
+const defaultURL = "http://localhost:8288"
 
 /**
  * A nav bar intended to be at the top of the page.
@@ -30,15 +33,19 @@ interface DevServerInfo {
  * A large pill showing dev server connection status.
  */
 export const DevServerPill = () => {
+  const { value: data } = useIntrospect();
+
+  const url = new URL(data?.devServerURL || defaultURL);
+  url.pathname = "dev";
+
   const {
     loading,
     value: devServer,
     error,
     retry,
   } = useAsyncRetry(async () => {
-    const res = await fetch(new URL("http://localhost:8288/dev"));
+    const res = await fetch(url);
     const result: DevServerInfo = await res.json();
-
     return result;
   });
 
@@ -71,7 +78,7 @@ export const DevServerPill = () => {
         </div>
         {connected ? (
           <div>
-            Connected to <code>inngest dev</code> on <code>:8288</code>
+            Connected to <code>inngest dev</code> on <code>{url.hostname}:{url.port}</code>
           </div>
         ) : (
           <div>
@@ -80,7 +87,7 @@ export const DevServerPill = () => {
         )}
       </div>
       {!connected ? (
-        <Code copiable value={`npx inngest-cli -u ${window.location.href}`} />
+        <Code copiable value={`npx inngest-cli dev -u ${window.location.href}`} />
       ) : null}
     </>
   );

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -53,6 +53,7 @@ class CloudflareCommHandler extends InngestCommHandler {
           if (isIntrospection) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
+              devServerURL: new URL(env[envKeys.DevServerUrl] || "http://localhost:8288").href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -5,6 +5,7 @@ import {
   ServeHandler,
 } from "./express";
 import { envKeys, queryKeys } from "./helpers/consts";
+import { devServerUrl } from "./helpers/devserver";
 import { landing } from "./landing";
 import { IntrospectRequest } from "./types";
 
@@ -53,7 +54,7 @@ class CloudflareCommHandler extends InngestCommHandler {
           if (isIntrospection) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: new URL(env[envKeys.DevServerUrl] || "http://localhost:8288").href,
+              devServerURL: devServerUrl(env[envKeys.DevServerUrl]).href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/express.ts
+++ b/src/express.ts
@@ -226,6 +226,7 @@ export class InngestCommHandler {
           if (Object.hasOwnProperty.call(req.query, queryKeys.Introspect)) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
+              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl]).href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/express.ts
+++ b/src/express.ts
@@ -226,7 +226,8 @@ export class InngestCommHandler {
           if (Object.hasOwnProperty.call(req.query, queryKeys.Introspect)) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl]).href,
+              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl])
+                .href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -51,7 +51,8 @@ class NextCommHandler extends InngestCommHandler {
           if (Object.hasOwnProperty.call(req.query, queryKeys.Introspect)) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl]).href,
+              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl])
+                .href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -6,6 +6,7 @@ import {
   ServeHandler,
 } from "./express";
 import { envKeys, queryKeys } from "./helpers/consts";
+import { devServerUrl } from "./helpers/devserver";
 import { landing } from "./landing";
 import { IntrospectRequest } from "./types";
 
@@ -50,6 +51,7 @@ class NextCommHandler extends InngestCommHandler {
           if (Object.hasOwnProperty.call(req.query, queryKeys.Introspect)) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
+              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl]).href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -5,8 +5,8 @@ import {
   serve as defaultServe,
   ServeHandler,
 } from "./express";
-import { devServerUrl } from "./helpers/devserver";
 import { envKeys, queryKeys } from "./helpers/consts";
+import { devServerUrl } from "./helpers/devserver";
 import { landing } from "./landing";
 import type { IntrospectRequest } from "./types";
 
@@ -59,7 +59,8 @@ class RemixCommHandler extends InngestCommHandler {
           if (isIntrospection) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl]).href,
+              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl])
+                .href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -5,6 +5,7 @@ import {
   serve as defaultServe,
   ServeHandler,
 } from "./express";
+import { devServerUrl } from "./helpers/devserver";
 import { envKeys, queryKeys } from "./helpers/consts";
 import { landing } from "./landing";
 import type { IntrospectRequest } from "./types";
@@ -29,7 +30,6 @@ class RemixCommHandler extends InngestCommHandler {
 
       try {
         reqUrl = new URL(req.url, `https://${req.headers.get("host") || ""}`);
-
         isIntrospection = reqUrl.searchParams.has(queryKeys.Introspect);
         reqUrl.searchParams.delete(queryKeys.Introspect);
       } catch (err) {
@@ -59,6 +59,7 @@ class RemixCommHandler extends InngestCommHandler {
           if (isIntrospection) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
+              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl]).href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,11 @@ export interface IntrospectRequest extends RegisterRequest {
    * Represents whether a signing key could be found when running this handler.
    */
   hasSigningKey: boolean;
+
+  /**
+   * devserverURL must be included for the frontend to know where to ping.
+   */
+  devServerURL: string;
 }
 
 /**


### PR DESCRIPTION
This lets the frontend connect to a configurable dev server URL based off of the SDK's setup.

We can, in the future, auto-detect the devserver URL in our SDK's side by storing the host of registration handshakes.