### PR TITLE
Always set text/html header to prevent download

### DIFF
--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -69,7 +69,7 @@ class CloudflareCommHandler extends InngestCommHandler {
             status: 200,
             headers: {
               ...headers,
-              "content-type": "text/html;charset=UTF-8",
+              "content-type": "text/html; charset=utf-8",
             },
           });
         }

--- a/src/express.ts
+++ b/src/express.ts
@@ -235,7 +235,7 @@ export class InngestCommHandler {
           }
 
           // Grab landing page and serve
-          res.header("content-type", "text/html; charset=utf-8")
+          res.header("content-type", "text/html; charset=utf-8");
           return void res.status(200).send(landing);
         }
 

--- a/src/express.ts
+++ b/src/express.ts
@@ -235,6 +235,7 @@ export class InngestCommHandler {
           }
 
           // Grab landing page and serve
+          res.header("content-type", "text/html; charset=utf-8")
           return void res.status(200).send(landing);
         }
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -60,6 +60,7 @@ class NextCommHandler extends InngestCommHandler {
           }
 
           // Grab landing page and serve
+          res.setHeader("content-type", "text/html; charset=utf-8");
           return void res.status(200).send(landing);
         }
 

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -74,7 +74,7 @@ class RemixCommHandler extends InngestCommHandler {
             status: 200,
             headers: {
               ...headers,
-              "content-type": "text/html;charset=UTF-8",
+              "content-type": "text/html; charset=utf-8",
             },
           });
         }


### PR DESCRIPTION
## Description

This should fix an issue where some users browsers are downloading the landing page instead of rendering it.

* Next.js will not set this header automatically, so some browsers may download the landing page instead of rendering it.
* Express.js should automatically set the text/html header, but we should not rely on this and ensure it's always set.