### PR TITLE
Use replace for Node 14.x support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,14 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nodeVersion: [14, 16, 18, lts]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build
-      - run: yarn test
+      - run: volta run --node ${{ matrix.nodeVersion }} yarn test
 
   api_diff:
     name: Local API diff

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inngest",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Official SDK for Inngest.com",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -1,4 +1,5 @@
 import { queryKeys } from "../helpers/consts";
+import { slugify } from "../helpers/strings";
 import {
   EventPayload,
   FunctionConfig,
@@ -117,15 +118,6 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
    * Generate an ID based on the function's name.
    */
   #generateId(prefix?: string) {
-    const join = "-";
-
-    return [prefix || "", this.#opts.name]
-      .join("-")
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9-]+/g, join)
-      .replaceAll(/-+/g, join)
-      .split(join)
-      .filter(Boolean)
-      .join(join);
+    return slugify([prefix || "", this.#opts.name].join("-"));
   }
 }

--- a/src/helpers/strings.test.ts
+++ b/src/helpers/strings.test.ts
@@ -1,0 +1,30 @@
+import { slugify } from "./strings";
+
+describe("slugify", () => {
+  it("Generates a slug using hyphens", () => {
+    const specs = [
+      { input: "Yes Ok THIS looks*good!!", expected: "yes-ok-this-looks-good" },
+      { input: "LOWER CASE", expected: "lower-case" },
+      { input: "Remove 🌝 emojis", expected: "remove-emojis" },
+      { input: "multi--dashes---", expected: "multi-dashes" },
+      {
+        input: "-leading and trailing dash-",
+        expected: "leading-and-trailing-dash",
+      },
+      { input: "extra   spac es", expected: "extra-spac-es" },
+      { input: "Num6er5", expected: "num6er5" },
+      {
+        input: `special !@#$%^&*()+ chars ={}[]|\\<>,._ removed '";:`,
+        expected: "special-chars-removed",
+      },
+      {
+        input: `öther Δ bītš añd ✓ bops`,
+        expected: "ther-b-t-a-d-bops",
+      },
+    ];
+
+    for (const spec of specs) {
+      expect(slugify(spec.input)).toEqual(spec.expected);
+    }
+  });
+});

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns a slugified string used ot generate consistent IDs.
+ */
+export const slugify = (str: string): string => {
+  const join = "-";
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, join)
+    .replace(/-+/g, join)
+    .split(join)
+    .filter(Boolean)
+    .join(join);
+};


### PR DESCRIPTION
## Description

`replaceAll` broke Node 14.x environments. `replaceAll` was added in Node 15 and Node 14 has LTS maintenance support until 2023-04-30. 

Reported by user in community discord ([link](https://discord.com/channels/842170679536517141/845000011040555018/1031281493072433212)).