### PR TITLE
Add Node LTS, 14, 16, 18 tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nodeVersion: [14, 16, 18]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build
-      - run: yarn test
+      - run: volta run --node ${{ matrix.nodeVersion }} yarn test
 
   api_diff:
     name: Local API diff

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodeVersion: [14, 16, 18]
+        nodeVersion: [14, 16, 18, lts]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         nodeVersion: [14, 16, 18, lts]
     steps:


### PR DESCRIPTION
Following #21, add a matrix for testing against Node 14, 16, 18, and LTS. The LTS addition will run a duplicate of 16 right now, but should ensure we're always covering the latest.