### PR TITLE
Upgrade volta-cli action for volta@1.1.0

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -3,7 +3,7 @@ description: "Sets up Node, installs dependencies, and builds the project."
 runs:
   using: composite
   steps:
-    - uses: volta-cli/action@v3
+    - uses: volta-cli/action@v4
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path


### PR DESCRIPTION
## Description

Follows #22 to support tests across all node LTS.

### Notes

`volta-cli/action@v3` is broken for `volta@1.1.0`.  See: https://github.com/volta-cli/action/issues/117