### PR TITLE
Automatically use dev server if available when sending events

### DIFF
--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -91,7 +91,7 @@ export class Inngest<Events extends Record<string, EventPayload>> {
    */
   constructor({
     name,
-    eventKey = process.env[envKeys.EventKey],
+    eventKey,
     inngestBaseUrl = "https://inn.gs/",
   }: ClientOptions) {
     if (!name) {
@@ -105,7 +105,13 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     }
 
     this.name = name;
-    this.eventKey = eventKey;
+
+    this.eventKey =
+      eventKey ||
+      (typeof process === "undefined"
+        ? ""
+        : process.env[envKeys.EventKey] || "");
+
     this.inngestBaseUrl = new URL(inngestBaseUrl);
     this.inngestApiUrl = new URL(`e/${this.eventKey}`, this.inngestBaseUrl);
 

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -268,7 +268,10 @@ export class Inngest<Events extends Record<string, EventPayload>> {
 
     if (!isProd()) {
       const host = devServerHost();
-      if (await devServerAvailable(host, fetch)) {
+      // If the dev server host env var has been set we always want to use
+      // the dev server - even if it's down.  Otherwise, optimistically use
+      // it for non-prod services.
+      if (host !== undefined || await devServerAvailable(host, fetch)) {
         url = devServerUrl(host, `e/${this.eventKey}`).href;
       }
     }

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,4 +1,6 @@
 import { envKeys } from "../helpers/consts";
+import { devServerHost, isProd } from "../helpers/env";
+import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import type {
   PartialK,
   SendEventPayload,
@@ -254,7 +256,18 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       );
     }
 
-    const response = await fetch(this.inngestApiUrl.href, {
+    // When sending events, check if the dev server is available.  If so, use the
+    // dev server.
+    let url = this.inngestApiUrl.href;
+
+    if (!isProd()) {
+      const host = devServerHost()
+      if (await devServerAvailable(host, fetch)) {
+        url = devServerUrl(host, `e/${this.eventKey}`).href;
+      }
+    }
+
+    const response = await fetch(url, {
       method: "POST",
       body: JSON.stringify(payloads),
       headers: { ...this.headers },

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,6 +1,6 @@
 import { envKeys } from "../helpers/consts";
-import { devServerHost, isProd } from "../helpers/env";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
+import { devServerHost, isProd } from "../helpers/env";
 import type {
   PartialK,
   SendEventPayload,
@@ -261,7 +261,7 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     let url = this.inngestApiUrl.href;
 
     if (!isProd()) {
-      const host = devServerHost()
+      const host = devServerHost();
       if (await devServerAvailable(host, fetch)) {
         url = devServerUrl(host, `e/${this.eventKey}`).href;
       }

--- a/src/express.ts
+++ b/src/express.ts
@@ -351,7 +351,6 @@ export class InngestCommHandler {
 
     if (!this.isProd) {
       const hasDevServer = await devServerAvailable(devServerHost, this.fetch);
-
       if (hasDevServer) {
         registerURL = devServerUrl(devServerHost, "/fn/register");
       }

--- a/src/express.ts
+++ b/src/express.ts
@@ -194,7 +194,7 @@ export class InngestCommHandler {
     return async (req: Request, res: Response) => {
       res.setHeader("x-inngest-sdk", this.sdkHeader.join(""));
 
-      const hostname = req.get('host') || req.headers["host"];
+      const hostname = req.get("host") || req.headers["host"];
       const protocol = hostname?.includes("://") ? "" : `${req.protocol}://`;
 
       let reqUrl;

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -11,13 +11,15 @@ type FetchT = typeof fetch;
 /**
  * Attempts to contact the dev server, returning a boolean indicating whether or
  * not it was successful.
+ *
+ * @example devServerUrl(process.env[envKeys.DevServerUrl], "/your-path")
  */
 export const devServerAvailable = async (
   /**
    * The host of the dev server. You should pass in an environment variable as
    * this parameter.
    */
-  host = defaultDevServerHost,
+  host: string = defaultDevServerHost,
 
   /**
    * The fetch implementation to use to communicate with the dev server.
@@ -28,15 +30,23 @@ export const devServerAvailable = async (
     const url = devServerUrl(host, "/dev");
     const result = await fetch(url.toString());
     await result.json();
-
     return true;
   } catch (e) {
     return false;
   }
 };
 
+/**
+ * devServerUrl returns a full URL for the given path name.
+ *
+ * Because Cloudflare/V8 platforms don't allow process.env, you are expected
+ * to pass in the host from the dev server env key:
+ *
+ * @example devServerUrl(process.env[envKeys.DevServerUrl], "/your-path")
+ * @example devServerUrl("http://localhost:8288/", "/your-path")
+ */
 export const devServerUrl = (
-  host = defaultDevServerHost,
+  host: string = defaultDevServerHost,
   pathname = ""
 ): URL => {
   return new URL(pathname, host.includes("://") ? host : `http://${host}`);

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -16,26 +16,29 @@ import { defaultDevServerHost } from "./consts";
 export const devServerHost = (): string => {
   // devServerKeys are the env keys we search for to discover the dev server
   // URL.  This includes the standard key first, then includes prefixed keys
-  // for use within common frameworks (eg. CRA, next). 
-  // 
+  // for use within common frameworks (eg. CRA, next).
+  //
   // We have to fully write these using process.env as they're typically
   // processed using webpack's DefinePlugin, which is dumb and does a straight
   // text replacement instead of actually understanding the AST, despite webpack
   // being fully capable of understanding the AST.
-  const values = [
-    process.env.INNGEST_DEVSERVER_URL,
-    process.env.REACT_APP_INNGEST_DEVSERVER_URL,
-    process.env.NEXT_PUBLIC_INNGEST_DEVSERVER_URL,
-  ];
+  const values =
+    typeof process === "undefined"
+      ? []
+      : [
+          process.env.INNGEST_DEVSERVER_URL,
+          process.env.REACT_APP_INNGEST_DEVSERVER_URL,
+          process.env.NEXT_PUBLIC_INNGEST_DEVSERVER_URL,
+        ];
 
-  return values.find(a => !!a) || defaultDevServerHost;
-}
+  return values.find((a) => !!a) || defaultDevServerHost;
+};
 
 export const isProd = (): boolean => {
-  const values = [
-    process.env.NODE_ENV,
-    process.env.VERCEL_ENV,
-    process.env.CONTEXT,
-  ]
-  return !!values.find(v => v === "production");
-}
+  const values =
+    typeof process === "undefined"
+      ? []
+      : [process.env.NODE_ENV, process.env.VERCEL_ENV, process.env.CONTEXT];
+
+  return values.includes("production");
+};

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,0 +1,38 @@
+import { defaultDevServerHost, devServerKeys } from "./consts";
+
+// This file exists to help
+
+/**
+ * devServerHost returns the dev server host by searching for the INNGEST_DEVSERVER_URL
+ * environment variable (plus project prefixces for eg. react, such as REACT_APP_INNGEST_DEVSERVER_URL).
+ *
+ * If not found, this returns the default URL of "http://127.0.0.1:8288/"
+ *
+ * @example devServerHost(process.env)
+ */
+export const devServerHost = (): string => {
+  // devServerKeys are the env keys we search for to discover the dev server
+  // URL.  This includes the standard key first, then includes prefixed keys
+  // for use within common frameworks (eg. CRA, next). 
+  // 
+  // We have to fully write these using process.env as they're typically
+  // processed using webpack's DefinePlugin, which is dumb and does a straight
+  // text replacement instead of actually understanding the AST, despite webpack
+  // being fully capable of understanding the AST.
+  const values = [
+    process.env.INNGEST_DEVSERVER_URL,
+    process.env.REACT_APP_INNGEST_DEVSERVER_URL,
+    process.env.NEXT_PUBLIC_INNGEST_DEVSERVER_URL,
+  ];
+
+  return values.find(a => !!a) || defaultDevServerHost;
+}
+
+export const isProd = (): boolean => {
+  const values = [
+    process.env.NODE_ENV,
+    process.env.VERCEL_ENV,
+    process.env.CONTEXT,
+  ]
+  return !!values.find(v => v === "PRODUCTION");
+}

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,4 +1,4 @@
-import { defaultDevServerHost, devServerKeys } from "./consts";
+import { defaultDevServerHost } from "./consts";
 
 // This file exists to help
 
@@ -8,7 +8,7 @@ import { defaultDevServerHost, devServerKeys } from "./consts";
  *
  * If not found, this returns the default URL of "http://127.0.0.1:8288/"
  *
- * @example devServerHost(process.env)
+ * @example devServerHost()
  */
 export const devServerHost = (): string => {
   // devServerKeys are the env keys we search for to discover the dev server
@@ -34,5 +34,5 @@ export const isProd = (): boolean => {
     process.env.VERCEL_ENV,
     process.env.CONTEXT,
   ]
-  return !!values.find(v => v === "PRODUCTION");
+  return !!values.find(v => v === "production");
 }

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,6 +1,9 @@
 import { defaultDevServerHost } from "./consts";
 
-// This file exists to help
+// This file exists to help normalize process.env amongst the backend
+// and frontend.  Many frontends (eg. Next, CRA) utilize webpack's DefinePlugin
+// along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
+// string in order to read variables.
 
 /**
  * devServerHost returns the dev server host by searching for the INNGEST_DEVSERVER_URL

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,5 +1,3 @@
-import { defaultDevServerHost } from "./consts";
-
 // This file exists to help normalize process.env amongst the backend
 // and frontend.  Many frontends (eg. Next, CRA) utilize webpack's DefinePlugin
 // along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
@@ -9,11 +7,11 @@ import { defaultDevServerHost } from "./consts";
  * devServerHost returns the dev server host by searching for the INNGEST_DEVSERVER_URL
  * environment variable (plus project prefixces for eg. react, such as REACT_APP_INNGEST_DEVSERVER_URL).
  *
- * If not found, this returns the default URL of "http://127.0.0.1:8288/"
+ * If not found this returns undefined, indicating that the env var has not been set.
  *
  * @example devServerHost()
  */
-export const devServerHost = (): string => {
+export const devServerHost = (): string | undefined => {
   // devServerKeys are the env keys we search for to discover the dev server
   // URL.  This includes the standard key first, then includes prefixed keys
   // for use within common frameworks (eg. CRA, next).
@@ -31,7 +29,7 @@ export const devServerHost = (): string => {
           process.env.NEXT_PUBLIC_INNGEST_DEVSERVER_URL,
         ];
 
-  return values.find((a) => !!a) || defaultDevServerHost;
+  return values.find((a) => !!a);
 };
 
 export const isProd = (): boolean => {

--- a/src/next.ts
+++ b/src/next.ts
@@ -52,8 +52,7 @@ class NextCommHandler extends InngestCommHandler {
           if (Object.hasOwnProperty.call(req.query, queryKeys.Introspect)) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(devServerHost())
-                .href,
+              devServerURL: devServerUrl(devServerHost()).href,
               hasSigningKey: Boolean(this.signingKey),
             };
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -7,6 +7,7 @@ import {
 } from "./express";
 import { envKeys, queryKeys } from "./helpers/consts";
 import { devServerUrl } from "./helpers/devserver";
+import { devServerHost } from "./helpers/env";
 import { landing } from "./landing";
 import { IntrospectRequest } from "./types";
 
@@ -51,7 +52,7 @@ class NextCommHandler extends InngestCommHandler {
           if (Object.hasOwnProperty.call(req.query, queryKeys.Introspect)) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl])
+              devServerURL: devServerUrl(devServerHost())
                 .href,
               hasSigningKey: Boolean(this.signingKey),
             };

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -7,6 +7,7 @@ import {
 } from "./express";
 import { envKeys, queryKeys } from "./helpers/consts";
 import { devServerUrl } from "./helpers/devserver";
+import { devServerHost } from "./helpers/env";
 import { landing } from "./landing";
 import type { IntrospectRequest } from "./types";
 
@@ -59,7 +60,7 @@ class RemixCommHandler extends InngestCommHandler {
           if (isIntrospection) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(process.env[envKeys.DevServerUrl])
+              devServerURL: devServerUrl(devServerHost())
                 .href,
               hasSigningKey: Boolean(this.signingKey),
             };

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -60,8 +60,7 @@ class RemixCommHandler extends InngestCommHandler {
           if (isIntrospection) {
             const introspection: IntrospectRequest = {
               ...this.registerBody(reqUrl),
-              devServerURL: devServerUrl(devServerHost())
-                .href,
+              devServerURL: devServerUrl(devServerHost()).href,
               hasSigningKey: Boolean(this.signingKey),
             };
 


### PR DESCRIPTION
This PR changes the event URL to use the dev server, if the dev server is locally available.

Because events may be sent from the front and backend, we introduce a new `env` file _specifically_ for manaing process.env, which searches known variables including frontend prefixes transformed via webpack's basic DefinePlugin