### PR TITLE
Use `hash.js@^1.1.7` instead of `sha.js@^2.4.11` to remove `buffer` requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
-    "sha.js": "^2.4.11",
+    "hash.js": "^1.1.7",
     "zod": "^3.19.1"
   },
   "devDependencies": {

--- a/src/express.ts
+++ b/src/express.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import shajs from "sha.js";
+import { sha256 } from "hash.js";
 import { z } from "zod";
 import { Inngest } from "./components/Inngest";
 import { InngestFunction } from "./components/InngestFunction";
@@ -200,7 +200,7 @@ export class InngestCommHandler {
     const key = this.signingKey.replace(/^signkey-(test|prod)-/, "");
 
     // Decode the key from its hex representation into a bytestream
-    return `${prefix}${shajs("sha256").update(key, "hex").digest("hex")}`;
+    return `${prefix}${sha256().update(key, "hex").digest("hex")}`;
   }
 
   public createHandler(): any {
@@ -375,7 +375,7 @@ export class InngestCommHandler {
     };
 
     // Calculate the checksum of the body... without the checksum itself being included.
-    body.hash = shajs("sha256").update(JSON.stringify(body)).digest("hex");
+    body.hash = sha256().update(JSON.stringify(body)).digest("hex");
     return body;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,6 +2712,14 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -2859,7 +2867,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1:
+inherits@2, inherits@2.0.4, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4017,6 +4025,11 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -4933,7 +4946,7 @@ rxjs@^7.0.0:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1:
+safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5022,14 +5035,6 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
-
-sha.js@^2.4.11:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Uses [indutny/hash.js](https://github.com/indutny/hash.js) instead of [crypto-browserify/sha.js](https://github.com/crypto-browserify/sha.js) in order to remove a dependency on Node's `buffer` import.

In actuality, [crypto-browserify/sha.js](https://github.com/crypto-browserify/sha.js) does provide safety, but still appears to run a `require("buffer")` statement. Though this statement at run time will correctly fetch a browser-compatible `Buffer`, Cloudflare's Wrangler CLI sees this statement and immediately fails the build, ergo requiring us to circumvent this.

Tested against the currently-private [inngest/sdk-example-cloudflare-workers](https://github.com/inngest/sdk-example-cloudflare-workers).