### PR TITLE
Test example functions and repos together on every PR

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       shell: bash
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       working-directory: ${{ inputs.working-directory }}
 
     - uses: actions/cache@v3

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -1,5 +1,10 @@
 name: "Setup and build"
 description: "Sets up Node, installs dependencies, and builds the project."
+inputs:
+  working-directory:  # id of input
+    description: 'The directory to run the action in.'
+    required: false
+    default: '.'
 runs:
   using: composite
   steps:
@@ -9,6 +14,7 @@ runs:
       id: yarn-cache-dir-path
       shell: bash
       run: echo "::set-output name=dir::$(yarn cache dir)"
+      working-directory: ${{ inputs.working-directory }}
 
     - uses: actions/cache@v3
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -20,10 +26,12 @@ runs:
 
     - shell: bash
       run: yarn install --frozen-lockfile
+      working-directory: ${{ inputs.working-directory }}
 
     - shell: bash
       run: yarn install --frozen-lockfile
-      working-directory: landing
+      working-directory: ${{ inputs.working-directory }}/landing
 
     - shell: bash
       run: yarn build
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Get the SDK ready and link it locally
       - run: yarn prelink
-      - run: test -f ../examples/integration/${{ matrix.repo }}/yarn.lock && yarn link || npm link
+      - run: yarn link
         working-directory: dist
 
       # Install dependencies in the example repo
@@ -72,11 +72,11 @@ jobs:
         working-directory: examples/integration/${{ matrix.repo }}
 
       # Link the SDK
-      - run: test -f yarn.lock && yarn link inngest || npm link inngest --force
+      - run: yarn link inngest
         working-directory: examples/integration/${{ matrix.repo }}
 
       # Try to build the example
-      - run: test -f yarn.lock && yarn build || npm run build
+      - run: yarn build
         working-directory: examples/integration/${{ matrix.repo }}
 
       # TODO Run the example and confirm SDK UI shows correctly

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,20 +53,25 @@ jobs:
     steps:
       # Checkout the repo
       - uses: actions/checkout@v3
+        with:
+          path: sdk
       - uses: ./.github/actions/setup-and-build
+        with:
+          working-directory: sdk
 
       # Checkout the example repo
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.EXAMPLES_GITHUB_TOKEN }}
           repository: ${{ matrix.repo }}
-          path: examples/integration/${{ matrix.repo }}
+          path: examples/${{ matrix.repo }}
           ref: main
 
       # Get the SDK ready and link it locally
       - run: yarn prelink
+        working-directory: sdk
       - run: yarn link
-        working-directory: dist
+        working-directory: sdk/dist
 
       # Install dependencies in the example repo
       - run: test -f yarn.lock && yarn install --frozen-lockfile || npm ci
@@ -78,7 +83,7 @@ jobs:
       # Because repos are always owner/repo with a slash, the directory will be
       # the same, therefore we must venture an extra level deep when searching
       # for package.json.
-      - run: volta run --yarn $(cat ../../../../package.json | jq -r .volta.yarn) yarn link inngest
+      - run: volta run --yarn $(cat ../../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
         working-directory: examples/integration/${{ matrix.repo }}
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,8 +72,9 @@ jobs:
       - run: test -f yarn.lock && yarn install --frozen-lockfile || npm ci
         working-directory: examples/integration/${{ matrix.repo }}
 
-      # Link the SDK
-      - run: yarn link inngest
+      # Link the SDK, making sure to use the same Yarn version that we used to
+      # create the link
+      - run: volta run --yarn $(cat ../../../package.json | jq -r .volta.yarn) yarn link inngest
         working-directory: examples/integration/${{ matrix.repo }}
 
       # Try to build the example

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,11 +67,6 @@ jobs:
           path: examples/${{ matrix.repo }}
           ref: main
 
-      - run: |
-          ls -la
-          ls -la sdk
-          ls -la examples
-
       # Get the SDK ready and link it locally
       - run: yarn prelink
         working-directory: sdk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,7 @@ jobs:
       matrix:
         repo:
           - inngest/sdk-example-cloudflare-workers
+          - inngest/sdk-example-nextjs-vercel
     steps:
       # Checkout the repo
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,8 +74,12 @@ jobs:
 
       # Link the SDK, making sure to use the same Yarn version that we used to
       # create the link
-      - run: volta run --yarn $(cat ../../../package.json | jq -r .volta.yarn) yarn link inngest
-        working-directory: examples/integration/${{ matrix.repo }}
+      - working-directory: examples/integration/${{ matrix.repo }}
+        run: |
+          pwd
+          ls -la
+          cat ../../../package.json
+          volta run --yarn $(cat ../../../package.json | jq -r .volta.yarn) yarn link inngest
 
       # Try to build the example
       - run: yarn build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,9 +100,25 @@ jobs:
       - run: test -f yarn.lock && yarn build || npm run build
         working-directory: examples/${{ matrix.repo }}
 
-      # TODO Run the example and confirm SDK UI shows correctly
-      # - run: npm run dev &
-      # - run: sleep 5
-      # - run: curl http://localhost:3000/api/inngest
+      # Run the example
+      - run: test -f yarn.lock && (yarn dev &) || (npm run dev &)
+        working-directory: examples/${{ matrix.repo }}
+        # Provide the example any env vars it might need
+        env:
+          PORT: 3000
+      - uses: ifaxity/wait-on-action@v1
+        with:
+          resource: http-get://localhost:3000
+          timeout: 20000
 
+      # Confirm the example vaguely returns all the expected functions
+      - id: assert-function-count
+        run: |
+          echo "expected-count=$(ls src/examples | grep -v index.* | grep -v README | wc -l)" >> $GITHUB_OUTPUT
 
+          echo "actual-count=$(curl -s http://localhost:3000/api/inngest?introspect | jq -r '.functions | length')" >> $GITHUB_OUTPUT
+        working-directory: sdk
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: ${{ steps.assert-function-count.outputs.expected-count }}
+          actual: ${{ steps.assert-function-count.outputs.actual-count }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: examples/integration/${{ matrix.repo }}
 
       # Link the SDK
-      - run: test -f yarn.lock && yarn link inngest || npm link inngest
+      - run: test -f yarn.lock && yarn link inngest || npm link inngest --force
         working-directory: examples/integration/${{ matrix.repo }}
 
       # Try to build the example

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Get the SDK ready and link it locally
       - run: yarn prelink
-      - run: yarn link
+      - run: test -f ../examples/integration/${{ matrix.repo }}/yarn.lock && yarn link || npm link
         working-directory: dist
 
       # Install dependencies in the example repo

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,7 +83,7 @@ jobs:
 
 
       # Try to build the example
-      - run: yarn build
+      - run: test -f yarn.lock && yarn build || npm run build
         working-directory: examples/integration/${{ matrix.repo }}
 
       # TODO Run the example and confirm SDK UI shows correctly

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,7 @@ jobs:
       # Checkout the example repo
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.EXAMPLES_GITHUB_TOKEN }}
           repository: ${{ matrix.repo }}
           path: examples/integration/${{ matrix.repo }}
           ref: main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,6 +86,15 @@ jobs:
       - run: volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
         working-directory: examples/${{ matrix.repo }}
 
+      # Copy any SDK function examples to the example repo so that we're always
+      # testing many functions against many handlers.
+      - id: inngest-functions-path
+        run: echo "dir=$(dirname $(echo \"$(git ls-files | grep inngest/index.ts)))\"" >> $GITHUB_OUTPUT
+        working-directory: examples/${{ matrix.repo }}
+      - run: rm -rf ${{ steps.inngest-functions-path.outputs.dir }}
+        working-directory: examples/${{ matrix.repo }}
+      - run: cp -r ../../../sdk/src/examples/ ${{ steps.inngest-functions-path.outputs.dir }}
+        working-directory: examples/${{ matrix.repo }}
 
       # Try to build the example
       - run: test -f yarn.lock && yarn build || npm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: sdk
-      - uses: ./.github/actions/setup-and-build
+      - uses: ./sdk/.github/actions/setup-and-build
         with:
           working-directory: sdk
 
@@ -67,6 +67,11 @@ jobs:
           path: examples/${{ matrix.repo }}
           ref: main
 
+      - run: |
+          ls -la
+          ls -la sdk
+          ls -la examples
+
       # Get the SDK ready and link it locally
       - run: yarn prelink
         working-directory: sdk
@@ -75,7 +80,7 @@ jobs:
 
       # Install dependencies in the example repo
       - run: test -f yarn.lock && yarn install --frozen-lockfile || npm ci
-        working-directory: examples/integration/${{ matrix.repo }}
+        working-directory: examples/${{ matrix.repo }}
 
       # Link the SDK, making sure to use the same Yarn version that we used to
       # create the link.
@@ -83,13 +88,13 @@ jobs:
       # Because repos are always owner/repo with a slash, the directory will be
       # the same, therefore we must venture an extra level deep when searching
       # for package.json.
-      - run: volta run --yarn $(cat ../../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
-        working-directory: examples/integration/${{ matrix.repo }}
+      - run: volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
+        working-directory: examples/${{ matrix.repo }}
 
 
       # Try to build the example
       - run: test -f yarn.lock && yarn build || npm run build
-        working-directory: examples/integration/${{ matrix.repo }}
+        working-directory: examples/${{ matrix.repo }}
 
       # TODO Run the example and confirm SDK UI shows correctly
       # - run: npm run dev &

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,13 +73,14 @@ jobs:
         working-directory: examples/integration/${{ matrix.repo }}
 
       # Link the SDK, making sure to use the same Yarn version that we used to
-      # create the link
-      - working-directory: examples/integration/${{ matrix.repo }}
-        run: |
-          pwd
-          ls -la
-          cat ../../../package.json
-          volta run --yarn $(cat ../../../package.json | jq -r .volta.yarn) yarn link inngest
+      # create the link.
+      #
+      # Because repos are always owner/repo with a slash, the directory will be
+      # the same, therefore we must venture an extra level deep when searching
+      # for package.json.
+      - run: volta run --yarn $(cat ../../../../package.json | jq -r .volta.yarn) yarn link inngest
+        working-directory: examples/integration/${{ matrix.repo }}
+
 
       # Try to build the example
       - run: yarn build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,3 +40,47 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build
       - run: yarn lint
+
+  examples:
+    name: Test examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - inngest/sdk-example-cloudflare-workers
+    steps:
+      # Checkout the repo
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-and-build
+
+      # Checkout the example repo
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ matrix.repo }}
+          path: examples/integration/${{ matrix.repo }}
+          ref: main
+
+      # Get the SDK ready and link it locally
+      - run: yarn prelink
+      - run: yarn link
+        working-directory: dist
+
+      # Install dependencies in the example repo
+      - run: test -f yarn.lock && yarn install --frozen-lockfile || npm ci
+        working-directory: examples/integration/${{ matrix.repo }}
+
+      # Link the SDK
+      - run: test -f yarn.lock && yarn link inngest || npm link inngest
+        working-directory: examples/integration/${{ matrix.repo }}
+
+      # Try to build the example
+      - run: test -f yarn.lock && yarn build || npm run build
+        working-directory: examples/integration/${{ matrix.repo }}
+
+      # TODO Run the example and confirm SDK UI shows correctly
+      # - run: npm run dev &
+      # - run: sleep 5
+      # - run: curl http://localhost:3000/api/inngest
+
+

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
-    "sha.js": "^2.4.11",
+    "hash.js": "^1.1.7",
     "zod": "^3.19.1"
   },
   "devDependencies": {

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -1,0 +1,5 @@
+# Inngest SDK Examples
+
+This directory contains examples of how to use the Inngest SDK.
+
+They are copied to various example repos to test against when building releases.

--- a/src/examples/helloWorld.ts
+++ b/src/examples/helloWorld.ts
@@ -1,0 +1,7 @@
+import { createFunction } from "inngest";
+
+export default createFunction(
+  "Hello World",
+  "demo/event.sent",
+  () => "Hello, Inngest!"
+);

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -1,0 +1,3 @@
+import helloWorld from "./helloWorld";
+
+export default [helloWorld];

--- a/src/express.ts
+++ b/src/express.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import shajs from "sha.js";
+import { sha256 } from "hash.js";
 import { z } from "zod";
 import { Inngest } from "./components/Inngest";
 import { InngestFunction } from "./components/InngestFunction";
@@ -200,7 +200,7 @@ export class InngestCommHandler {
     const key = this.signingKey.replace(/^signkey-(test|prod)-/, "");
 
     // Decode the key from its hex representation into a bytestream
-    return `${prefix}${shajs("sha256").update(key, "hex").digest("hex")}`;
+    return `${prefix}${sha256().update(key, "hex").digest("hex")}`;
   }
 
   public createHandler(): any {
@@ -375,7 +375,7 @@ export class InngestCommHandler {
     };
 
     // Calculate the checksum of the body... without the checksum itself being included.
-    body.hash = shajs("sha256").update(JSON.stringify(body)).digest("hex");
+    body.hash = sha256().update(JSON.stringify(body)).digest("hex");
     return body;
   }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/test/**/*"]
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/test/**/*",
+    "src/examples/**/*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,10 @@
     "noImplicitOverride": true,
     "resolveJsonModule": true,
     "noUncheckedIndexedAccess": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "paths": {
+      "inngest": ["./src"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,6 +2712,14 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -2859,7 +2867,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1:
+inherits@2, inherits@2.0.4, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4017,6 +4025,11 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -4933,7 +4946,7 @@ rxjs@^7.0.0:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1:
+safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5022,14 +5035,6 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
-
-sha.js@^2.4.11:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Introduces a new directory, `src/examples`, containing a collection of example Inngest functions and step functions, e.g. `helloWorld.ts`, `dripCampaign.ts`, etc.

With this, we then introduce a new PR check which will take in a list of example repositories (e.g. [inngest/sdk-example-cloudflare-workers](https://github.com/inngest/sdk-example-cloudflare-workers)) and for each:

- Clone both the SDK and the example repo
- Link the SDK locally to the example repo
- Copy the example functions from the SDK into the example repo's `inngest` folder
- Assert that the example builds correctly with the SDK and the example functions
- Boot the dev server for the example repo
- Assert basic functionality by curling the introspection endpoint

With this, we can add further assertions or tests now that we have a place where the example repo is booted with example functions from the SDK.

We could also venture to add test files for each example function, which can attempt to access `http://localhost:3000/api/inngest` and assert that that function is behaving correctly. I want to round off tests today, though, and we may want to think about how the dev server fits into this picture before going ham on integration tests.