### PR TITLE
Use op hash as ID

### DIFF
--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -5,7 +5,7 @@ import {
   FunctionConfig,
   FunctionOptions,
   FunctionTrigger,
-  Op,
+  HashedOp,
   OpStack,
   SingleStepFnArgs,
 } from "../types";
@@ -134,7 +134,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
      * state and to allow for multi-step functions.
      */
     opStack: OpStack
-  ): Promise<[isOp: true, op: Op] | [isOp: false, data: unknown]> {
+  ): Promise<[isOp: true, op: HashedOp] | [isOp: false, data: unknown]> {
     /**
      * Create some values to be mutated and passed to the step tools. Once the
      * user's function has run, we can check the mutated state of these to see

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -20,7 +20,7 @@ describe("waitForEvent", () => {
   test("returns `event` as ID", async () => {
     expect(() => waitForEvent("event")).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      id: "event",
+      name: "event",
     });
   });
 
@@ -34,7 +34,9 @@ describe("waitForEvent", () => {
   test("return a hash of the op", async () => {
     expect(() => waitForEvent("event")).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      hash: "17ffb6f7b5118797c77057e5176fdc2412e275fe",
+      name: "event",
+      op: "WaitForEvent",
+      opts: {},
     });
   });
 
@@ -72,7 +74,6 @@ describe("waitForEvent", () => {
       opts: {
         match: "event.name == async.name",
       },
-      hash: "b3702cc0450f2e014e1ea9b9d2438e8f3127c95a",
     });
   });
 
@@ -84,7 +85,6 @@ describe("waitForEvent", () => {
       opts: {
         match: "name == 123",
       },
-      hash: "9d3fe213c82f60f52e91b036388fa7851b7ef6b3",
     });
   });
 
@@ -96,7 +96,6 @@ describe("waitForEvent", () => {
       opts: {
         match: "event.name == async.name",
       },
-      hash: "b3702cc0450f2e014e1ea9b9d2438e8f3127c95a",
     });
   });
 });
@@ -116,10 +115,10 @@ describe("step", () => {
     });
   });
 
-  test("return step name as ID", async () => {
+  test("return step name as name", async () => {
     expect(() => run("step", () => undefined)).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      id: "step",
+      name: "step",
     });
   });
 
@@ -158,10 +157,10 @@ describe("sleep", () => {
     });
   });
 
-  test("return time string as ID", async () => {
+  test("return time string as name", async () => {
     expect(() => sleep("1m")).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      id: "1m",
+      name: "1m",
     });
   });
 });
@@ -191,7 +190,7 @@ describe("sleepUntil", () => {
 
     expect(() => sleepUntil(upcoming)).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      id: expect.stringContaining("6d"),
+      name: expect.stringContaining("6d"),
     });
   });
 });

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -77,8 +77,11 @@ export const createStepTools = <
   const getNextPastOpData = (
     op: HashedOp
   ): [found: false, data: undefined] | [found: true, data: any] => {
-    const next = opStack[op.hash];
-    return [Boolean(next), next?.data];
+    const next: unknown = opStack[op.id];
+    // if the data is undefined, it hasn't ran.  Any other data, such
+    // as false, null, etc. indicates that the step has already ran as
+    // state was persisted.
+    return [next !== undefined, next as any];
   };
 
   /**
@@ -154,7 +157,7 @@ export const createStepTools = <
        */
       const opId: HashedOp = {
         ...unhashedOpId,
-        hash: hashOp(unhashedOpId, pos++),
+        id: hashOp(unhashedOpId, pos++),
       };
 
       const [found, data] = getNextPastOpData(opId);
@@ -277,7 +280,7 @@ export const createStepTools = <
 
         return {
           op: StepOpCode.WaitForEvent,
-          id: event as string,
+          name: event as string,
           opts: matchOpts,
         };
       }
@@ -322,7 +325,7 @@ export const createStepTools = <
       (name) => {
         return {
           op: StepOpCode.RunStep,
-          id: name,
+          name,
         };
       },
       ({ submitOp }, _name, fn) => {
@@ -350,7 +353,7 @@ export const createStepTools = <
        */
       return {
         op: StepOpCode.Sleep,
-        id: time,
+        name: time,
       };
     }),
 
@@ -373,7 +376,7 @@ export const createStepTools = <
        */
       return {
         op: StepOpCode.Sleep,
-        id: dateToTimeStr(time),
+        name: dateToTimeStr(time),
       };
     }),
   };
@@ -467,7 +470,7 @@ const hashOp = (
   return (
     sha1()
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      .update(sigmund({ pos, op: op.op, id: op.id, opts: op.opts }))
+      .update(sigmund({ pos, op: op.op, name: op.name, opts: op.opts }))
       .digest("hex")
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,10 +62,9 @@ export type Op = {
   op: StepOpCode;
 
   /**
-   * An identifier for this operation, used to confirm that the operation was
-   * completed when it is received from Inngest.
+   * The unhashed step name for this operation.
    */
-  id: string;
+  name: string;
 
   /**
    * Any additional data required for this operation to send to Inngest. This
@@ -87,16 +86,18 @@ export type Op = {
  */
 export type HashedOp = Op & {
   /**
-   * The hash of the operation, using all fields present in the op
+   * The hashed identifier for this operation, used to confirm that the operation
+   * was completed when it is received from Inngest.
    */
-  hash: string;
+  id: string;
 };
 
 /**
  * A helper type to represent a stack of operations that will accumulate
- * throughout a step function's run.
+ * throughout a step function's run.  This stack contains an object of
+ * op hashes to data.
  */
-export type OpStack = Record<string, Op>;
+export type OpStack = Record<string, any>;
 
 /**
  * A function that can be used to submit an operation to Inngest internally.


### PR DESCRIPTION
Tools use the op hash to load function state, so we must use the op hash as the op ID so that the executor can use this identifier when storing state.