### PR TITLE
When manually triggering a cron, send expected body and headers

### DIFF
--- a/landing/src/components/FunctionBlock.tsx
+++ b/landing/src/components/FunctionBlock.tsx
@@ -62,6 +62,10 @@ export const FunctionBlock = ({ config, altBg }: Props) => {
 
     const res = await fetch(url, {
       method: "POST",
+      body: JSON.stringify({ event: {} }),
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
     const json = await res.json();
     const status =

--- a/src/express.ts
+++ b/src/express.ts
@@ -306,7 +306,6 @@ export class InngestCommHandler {
         })
         .parse(data);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       const ret = await fn["runFn"]({ event }, steps || {});
       const isOp = ret[0];
 


### PR DESCRIPTION
The manual cron trigger in the SDK UI needs to partially match the expected input as it would be from Inngest.

There's the option to handle blank requests within the lib, though it's probably healthier to keep ensuring incoming requests are good.