### PR TITLE
Read event key from env before throwing an error

### DIFF
--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -98,19 +98,17 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       throw new Error("A name must be passed to create an Inngest instance.");
     }
 
+    this.name = name;
+    this.eventKey =
+      eventKey || (hasProcessEnv() ? process.env[envKeys.EventKey] || "" : "");
+    this.inngestBaseUrl = new URL(inngestBaseUrl);
+    this.inngestApiUrl = new URL(`e/${this.eventKey}`, this.inngestBaseUrl);
+
     if (!eventKey) {
       throw new Error(
         "An event key must be passed to create an Inngest instance."
       );
     }
-
-    this.name = name;
-
-    this.eventKey =
-      eventKey || (hasProcessEnv() ? process.env[envKeys.EventKey] || "" : "");
-
-    this.inngestBaseUrl = new URL(inngestBaseUrl);
-    this.inngestApiUrl = new URL(`e/${this.eventKey}`, this.inngestBaseUrl);
 
     this.headers = {
       "Content-Type": "application/json",


### PR DESCRIPTION
Even though we had code to read from env, we were throwing an error if the event key used in the Inngest constructor was falsey prior to reading from env.  This commit changes the logic to read from env first, always.