### PR TITLE
Add proxy script `npx inngest` to go to `npx inngest-cli@latest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "contents": "dist"
   },
   "bin": {
-    "inngest-init": "./init.js"
+    "inngest-init": "./init.js",
+    "inngest": "./cli.js"
   },
   "scripts": {
     "prebuild": "yarn run pb:version && yarn run pb:landing",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { spawn } from "child_process";
+
+const [, , ...args] = process.argv;
+
+spawn("npx", ["--quiet", "inngest-cli@latest", ...args], {
+  stdio: "inherit",
+});


### PR DESCRIPTION
## Summary

Using this, we can retain the separate packages but show for users that they should run:

```sh
npx inngest dev
# instead of
npx inngest-cli@latest dev
```

Incidentally, this also means that users running the script will keep pulling the very latest version whenever they run it.