### PR TITLE
Deno integration testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "@inngest"],
   root: true,
-  ignorePatterns: ["dist/", "*.d.ts", "*.js"],
+  ignorePatterns: ["dist/", "*.d.ts", "*.js", "deno_compat/"],
   rules: {
     "prettier/prettier": "warn",
     "@typescript-eslint/no-explicit-any": "off",

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -208,7 +208,6 @@ jobs:
         working-directory: examples/${{ matrix.repo }}
         env:
           DO_NOT_TRACK: 1
-<<<<<<< HEAD
       - name: Wait for the Inngest dev server to start
         uses: mydea/action-wait-for-api@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,7 @@ jobs:
           - inngest/sdk-example-nextjs-cloudflare
           - inngest/sdk-example-nextjs-netlify
           - inngest/sdk-example-remix-vercel
+          - inngest/sdk-example-fresh-deno-deploy
     steps:
       # Checkout the repo
       - uses: actions/checkout@v3
@@ -94,16 +95,25 @@ jobs:
       # Because of this, we must instead link the SDK using a relative path, and
       # have the library's `dist/` directory appear as a separate package by
       # specifying an empty `yarn.lock` file within.
+      #
+      # Locally linking the lib to a Deno repo is harder, as Deno doesn't
+      # support local linking between ESM and CJS. Instead, we run a manual
+      # shim script to bend paths and adjust the target repo's import path.
       - run: |
-          yarnv=$(volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn -v)
-
-          if [[ $yarnv == 3* ]]; then
-            touch ../../../sdk/dist/yarn.lock
-            yarn link ../../../sdk/dist
+          if test -f deno.json; then
+            deno run --allow-read --allow-write ../../../sdk/deno_compat/link.ts
           else
-            volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
+            yarnv=$(volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn -v)
+
+            if [[ $yarnv == 3* ]]; then
+              touch ../../../sdk/dist/yarn.lock
+              yarn link ../../../sdk/dist
+            else
+              volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
+            fi
           fi
         working-directory: examples/${{ matrix.repo }}
+
 
       # Copy any SDK function examples to the example repo so that we're always
       # testing many functions against many handlers.
@@ -114,17 +124,25 @@ jobs:
         working-directory: examples/${{ matrix.repo }}
       - run: cp -r ../../../sdk/src/examples/ ${{ steps.inngest-functions-path.outputs.dir }}
         working-directory: examples/${{ matrix.repo }}
+      # IF we're using Deno, also replace any "inngest..." imports with
+      # "npm:inngest..."
+      - run: |
+          test -f deno.json && \
+            find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i 's/from "inngest/from "npm:inngest/g' {} \; || \
+            echo "No deno.json found; skipping Deno transforms"
+        working-directory: examples/${{ matrix.repo }}
 
       # Try to build the example
-      - run: test -f yarn.lock && yarn build || npm run build
+      - run: test -f yarn.lock && yarn build || test -f package-lock.json && npm run build || echo "No build script found"
         working-directory: examples/${{ matrix.repo }}
 
       # Run the example
-      - run: test -f yarn.lock && (yarn dev &) || (npm run dev &)
+      - run: test -f yarn.lock && (yarn dev &) || test -f package-lock.json && (npm run dev &) || (deno task start &)
         working-directory: examples/${{ matrix.repo }}
         # Provide the example any env vars it might need
         env:
           PORT: 3000
+          DO_NOT_TRACK: 1
       - uses: ifaxity/wait-on-action@v1
         with:
           resource: http-get://localhost:3000/api/inngest
@@ -134,6 +152,8 @@ jobs:
       - run: sleep 5
 
       # Run the dev server
+      # TODO Examples should run their own dev server, which means we can remove
+      # this.
       - run: npx inngest-cli@latest dev &
         working-directory: examples/${{ matrix.repo }}
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,8 @@ jobs:
           - inngest/sdk-example-fresh-deno-deploy
     steps:
       # Checkout the repo
-      - uses: actions/checkout@v3
+      - name: Checkout SDK
+        uses: actions/checkout@v3
         with:
           path: sdk
       - uses: ./sdk/.github/actions/setup-and-build
@@ -65,7 +66,8 @@ jobs:
           working-directory: sdk
 
       # Checkout the example repo
-      - uses: actions/checkout@v3
+      - name: Checkout example
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.EXAMPLES_GITHUB_TOKEN }}
           repository: ${{ matrix.repo }}
@@ -73,29 +75,33 @@ jobs:
           ref: main
 
       # Get the SDK ready and link it locally
-      - run: yarn prelink
+      - name: Prepare SDK for linking
+        run: yarn prelink
         working-directory: sdk
-      - run: yarn link
+      - name: Create link to SDK
+        run: yarn link
         working-directory: sdk/dist
 
       # If we find a deno.json file in the example repo, we need to pull Deno on
       # to the toolchain.
-      - id: deno-check
+      - name: Check if Deno is used
+        id: deno-check
         run: echo "isDeno=$(test -f deno.json && echo true || echo false)" >> $GITHUB_OUTPUT
         working-directory: examples/${{ matrix.repo }}
-      - uses: denoland/setup-deno@v1
+      - name: If Deno is used, install it
+        uses: denoland/setup-deno@v1
         if: ${{ steps.deno-check.outputs.isDeno == 'true' }}
         with:
           deno-version: vx.x.x
 
       # Install dependencies in the example repo
-      - run: |
+      - name: Install example dependencies
+        if: ${{ steps.deno-check.outputs.isDeno != 'true' }}
+        run: |
           if test -f yarn.lock; then
             yarn install --frozen-lockfile
           elif test -f package-lock.json; then
             npm ci
-          else
-            echo "No lockfile found; probably Deno, so skipping install"
           fi
         working-directory: examples/${{ matrix.repo }}
 
@@ -116,7 +122,8 @@ jobs:
       # Locally linking the lib to a Deno repo is harder, as Deno doesn't
       # support local linking between ESM and CJS. Instead, we run a manual
       # shim script to bend paths and adjust the target repo's import path.
-      - run: |
+      - name: Link local SDK to example
+        run: |
           if test -f deno.json; then
             deno run --allow-read --allow-write ../../../sdk/deno_compat/link.ts
           else
@@ -134,40 +141,40 @@ jobs:
 
       # Copy any SDK function examples to the example repo so that we're always
       # testing many functions against many handlers.
-      - id: inngest-functions-path
+      - name: Find inngest functions path in example
+        id: inngest-functions-path
         run: echo "dir=$(dirname $(echo \"$(git ls-files | grep inngest/index.ts)))\"" >> $GITHUB_OUTPUT
         working-directory: examples/${{ matrix.repo }}
-      - run: rm -rf ${{ steps.inngest-functions-path.outputs.dir }}
+      - name: Remove any existing inngest functions
+        run: rm -rf ${{ steps.inngest-functions-path.outputs.dir }}
         working-directory: examples/${{ matrix.repo }}
-      - run: cp -r ../../../sdk/src/examples/ ${{ steps.inngest-functions-path.outputs.dir }}
+      - name: Copy functions to test to example
+        run: cp -r ../../../sdk/src/examples/ ${{ steps.inngest-functions-path.outputs.dir }}
         working-directory: examples/${{ matrix.repo }}
       # IF we're using Deno, also replace any "inngest..." imports with
       # "npm:inngest..." and any direct file imports in `inngest/index.ts` with
       # `.ts` suffixes.
-      - run: |
-          if test -f deno.json; then
-            find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i 's/from "inngest/from "npm:inngest/g' {} \;
-            find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i -E 's/from "\.(.+)"/from "\.\1\.ts"/g' {} \;
-          else
-            echo "No deno.json found; skipping Deno transforms"
-          fi
+      - name: If Deno, transform imports
+        if: ${{ steps.deno-check.outputs.isDeno == 'true' }}
+        run: |
+          find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i 's/from "inngest/from "npm:inngest/g' {} \;
+          find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i -E 's/from "\.(.+)"/from "\.\1\.ts"/g' {} \;
         working-directory: examples/${{ matrix.repo }}
 
       # Try to build the example
-      - run: |
-          test -f yarn.lock && yarn build || test -f package-lock.json && npm run build || echo "No build script found"
-
+      - name: If not Deno, build the example
+        if: ${{ steps.deno-check.outputs.isDeno != 'true' }}
+        run: |
           if test -f yarn.lock; then
             yarn build
           elif test -f package-lock.json; then
             npm run build
-          else
-            echo "No build script found; probably a Deno project"
           fi
         working-directory: examples/${{ matrix.repo }}
 
       # Run the example
-      - run: |
+      - name: Run the example's dev server
+        run: |
           if test -f yarn.lock; then
             (yarn dev &)
           elif test -f package-lock.json; then
@@ -180,26 +187,31 @@ jobs:
         env:
           PORT: 3000
           DO_NOT_TRACK: 1
-      - uses: ifaxity/wait-on-action@v1
+      - name: Wait for the example to start
+        uses: ifaxity/wait-on-action@v1
         with:
           resource: http-get://localhost:3000/api/inngest
           timeout: 60000
 
       # Give the dev server 5 seconds to register with the example
-      - run: sleep 5
+      # TODO Check logs instead of sleeping
+      - name: Wait 5 seconds for dev server registration
+        run: sleep 5
 
-      # Run the dev server
       # TODO Examples should run their own dev server, which means we can remove
       # this.
-      - run: npx inngest-cli@latest dev &
+      - name: Run the Inngest dev server
+        run: npx inngest-cli@latest dev &
         working-directory: examples/${{ matrix.repo }}
         env:
           DO_NOT_TRACK: 1
-      - uses: ifaxity/wait-on-action@v1
+      - name: Wait for the Inngest dev server to start
+        uses: ifaxity/wait-on-action@v1
         with:
           resource: http-get://localhost:8288
           timeout: 20000
 
       # Run the examples test suite against the dev server
-      - run: yarn test:examples
+      - name: Run integration test suite
+        run: yarn test:examples
         working-directory: sdk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,10 +142,12 @@ jobs:
       - run: cp -r ../../../sdk/src/examples/ ${{ steps.inngest-functions-path.outputs.dir }}
         working-directory: examples/${{ matrix.repo }}
       # IF we're using Deno, also replace any "inngest..." imports with
-      # "npm:inngest..."
+      # "npm:inngest..." and any direct file imports in `inngest/index.ts` with
+      # `.ts` suffixes.
       - run: |
           if test -f deno.json; then
             find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i 's/from "inngest/from "npm:inngest/g' {} \;
+            find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i -E 's/from "\.(.+)"/from "\.\1\.ts"/g' {} \;
           else
             echo "No deno.json found; skipping Deno transforms"
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: sdk/dist
 
       # Install dependencies in the example repo
-      - run: test -f yarn.lock && yarn install --frozen-lockfile || npm ci
+      - run: test -f yarn.lock && yarn install --frozen-lockfile || test -f package-lock.json && npm ci || echo "No lockfile found; probably Deno, so skipping install"
         working-directory: examples/${{ matrix.repo }}
 
       # Link the SDK, making sure to use the same Yarn version that we used to

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,7 +89,14 @@ jobs:
           deno-version: vx.x.x
 
       # Install dependencies in the example repo
-      - run: test -f yarn.lock && yarn install --frozen-lockfile || test -f package-lock.json && npm ci || echo "No lockfile found; probably Deno, so skipping install"
+      - run: |
+          if test -f yarn.lock; then
+            yarn install --frozen-lockfile
+          elif test -f package-lock.json; then
+            npm ci
+          else
+            echo "No lockfile found; probably Deno, so skipping install"
+          fi
         working-directory: examples/${{ matrix.repo }}
 
       # Link the SDK, making sure to use the same Yarn version that we used to
@@ -137,17 +144,35 @@ jobs:
       # IF we're using Deno, also replace any "inngest..." imports with
       # "npm:inngest..."
       - run: |
-          test -f deno.json && \
-            find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i 's/from "inngest/from "npm:inngest/g' {} \; || \
+          if test -f deno.json; then
+            find ${{ steps.inngest-functions-path.outputs.dir }} -type f -name "*.ts" -exec sed -i 's/from "inngest/from "npm:inngest/g' {} \;
+          else
             echo "No deno.json found; skipping Deno transforms"
+          fi
         working-directory: examples/${{ matrix.repo }}
 
       # Try to build the example
-      - run: test -f yarn.lock && yarn build || test -f package-lock.json && npm run build || echo "No build script found"
+      - run: |
+          test -f yarn.lock && yarn build || test -f package-lock.json && npm run build || echo "No build script found"
+
+          if test -f yarn.lock; then
+            yarn build
+          elif test -f package-lock.json; then
+            npm run build
+          else
+            echo "No build script found; probably a Deno project"
+          fi
         working-directory: examples/${{ matrix.repo }}
 
       # Run the example
-      - run: test -f yarn.lock && (yarn dev &) || test -f package-lock.json && (npm run dev &) || (deno task start &)
+      - run: |
+          if test -f yarn.lock; then
+            (yarn dev &)
+          elif test -f package-lock.json; then
+            (npm run dev &)
+          else
+            (deno task start &)
+          fi
         working-directory: examples/${{ matrix.repo }}
         # Provide the example any env vars it might need
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,6 +78,16 @@ jobs:
       - run: yarn link
         working-directory: sdk/dist
 
+      # If we find a deno.json file in the example repo, we need to pull Deno on
+      # to the toolchain.
+      - id: deno-check
+        run: echo "isDeno=$(test -f deno.json && echo true || echo false)" >> $GITHUB_OUTPUT
+        working-directory: examples/${{ matrix.repo }}
+      - uses: denoland/setup-deno@v1
+        if: ${{ steps.deno-check.outputs.isDeno == 'true' }}
+        with:
+          deno-version: vx.x.x
+
       # Install dependencies in the example repo
       - run: test -f yarn.lock && yarn install --frozen-lockfile || test -f package-lock.json && npm ci || echo "No lockfile found; probably Deno, so skipping install"
         working-directory: examples/${{ matrix.repo }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enablePaths": ["./deno_compat"]
+}

--- a/deno_compat/README.md
+++ b/deno_compat/README.md
@@ -1,0 +1,8 @@
+A collection of compatibility files to allow locally linking the SDK when testing it with Deno.
+
+This ensures that in production we can use `npm:` specifiers, but when running integration testing we can locally link and avoid making per-commit deploys to npm.
+
+---
+
+TODO: GUIDE HOW THIS IS USED
+

--- a/deno_compat/README.md
+++ b/deno_compat/README.md
@@ -1,8 +1,18 @@
-A collection of compatibility files to allow locally linking the SDK when testing it with Deno.
+## Inngest `deno_compat/`
 
-This ensures that in production we can use `npm:` specifiers, but when running integration testing we can locally link and avoid making per-commit deploys to npm.
+A collection of compatibility files to allow locally linking the SDK during integration testing with Deno.
 
----
+This ensures that in production we can use `npm:` specifiers, but when running integration testing we can locally link and avoid making per-commit deploys to npm; it is not ever intended to be used in production and is not bundled with the library.
 
-TODO: GUIDE HOW THIS IS USED
+### Usage
+
+From the target Deno project (read: CWD should be your target), run `deno run -A ../path/to/sdk/deno_compat/link.ts`. This will adjust the target project's `import_map.json` file to override any `npm:inngest*` specifiers and instead link to the shim here.
+
+The shim itself then polyfills Node modules with Deno ones (as the `npm:` specifier would), imports the library as CommonJS, then re-exports it as shimmed ESM modules to the target project.
+
+See [The std/node Library - Loading CommonJS modules](https://deno.land/manual@v1.28.3/node/std_node#loading-commonjs-modules) in the Deno docs for more information.
+
+### Do I need this?
+
+No. This is purely internal tooling for integration tests for the Inngest SDK.
 

--- a/deno_compat/deno.fresh.ts
+++ b/deno_compat/deno.fresh.ts
@@ -1,0 +1,5 @@
+import { createRequire } from "https://deno.land/std@0.167.0/node/module.ts";
+
+const require = createRequire(import.meta.url);
+
+export const serve = require("../dist/deno/fresh").serve;

--- a/deno_compat/import_map.json
+++ b/deno_compat/import_map.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "npm:inngest": "./inngest.ts",
+    "npm:inngest/deno/fresh": "./deno.fresh.ts"
+  }
+}

--- a/deno_compat/inngest.ts
+++ b/deno_compat/inngest.ts
@@ -1,0 +1,10 @@
+import { createRequire } from "https://deno.land/std@0.167.0/node/module.ts";
+
+const require = createRequire(import.meta.url);
+
+const inngest = require("../dist");
+
+export const Inngest = inngest.Inngest;
+export const createFunction = inngest.createFunction;
+export const createScheduledFunction = inngest.createScheduledFunction;
+export const createStepFunction = inngest.createStepFunction;

--- a/deno_compat/link.ts
+++ b/deno_compat/link.ts
@@ -1,0 +1,70 @@
+/**
+ * Assuming the CWD is the root of the target repo, this script will:
+ *
+ * Search for a `deno.json` file in the CWD to confirm the target repo is a Deno
+ * project.
+ *
+ * From the `deno.json` file, retrieve the `importMap` property.
+ *
+ * If found, read the file, merge with our local import map, and write.
+ *
+ * If not found, maybe assume that this project does not want to use import
+ * maps, and will use npm instead? We need to investigate this further with
+ * Remix.
+ *  It might be the case that we only want to perform Deno compat if we find
+ *  both a `deno.json` file and an `importMap` property are found. If not, we
+ *  might be able to resort to usual npm linking and leave it at that.
+ */
+import { deepMerge } from "https://deno.land/std@0.167.0/collections/deep_merge.ts";
+import {
+  dirname,
+  join,
+  relative,
+  resolve,
+} from "https://deno.land/std@0.167.0/path/mod.ts";
+
+console.log('Finding "deno.json" file...');
+
+const denoJson = JSON.parse(
+  await Deno.readTextFile(join(Deno.cwd(), "deno.json"))
+);
+const importMapRelPath = denoJson.importMap;
+
+if (!importMapRelPath) {
+  console.error("No import map found in deno.json");
+  Deno.exit(0);
+}
+
+console.log('Building paths to "import_map.json" and compatibility map...');
+
+const importMapPath = join(Deno.cwd(), importMapRelPath);
+const compatImportMapPath = new URL(import.meta.resolve("./import_map.json"))
+  .pathname;
+
+console.log('Reading "import_map.json" and compatibility map...');
+
+const [importMap, compatImportMap] = await Promise.all([
+  Deno.readTextFile(importMapPath).then(JSON.parse),
+  Deno.readTextFile(compatImportMapPath).then(JSON.parse),
+]);
+
+console.log("Merging import maps...");
+
+// Adjust all paths in our compat map to point to the correct relative dir from
+// the target repo.
+compatImportMap.imports = Object.fromEntries(
+  Object.entries(compatImportMap.imports).map(([k, v]) => {
+    const absolutePath = resolve(dirname(compatImportMapPath), v as string);
+    const relativePath = relative(dirname(importMapPath), absolutePath);
+
+    return [k, relativePath];
+  })
+);
+
+const linkedImportMap = deepMerge(importMap, compatImportMap);
+
+console.log('Writing "import_map.json" to target repo...');
+
+Deno.writeTextFile(importMapPath, JSON.stringify(linkedImportMap, null, 2));
+
+console.log("Done.");

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import {
+  InngestCommHandler,
+  serve as defaultServe,
+  ServeHandler,
+} from "../express";
+import { envKeys, queryKeys } from "../helpers/consts";
+import { devServerUrl } from "../helpers/devserver";
+import { devServerHost } from "../helpers/env";
+import { landing } from "../landing";
+import type { IntrospectRequest } from "../types";
+
+class DenoFreshCommHandler extends InngestCommHandler {
+  protected override frameworkName = "deno/fresh";
+
+  public override createHandler() {
+    return async (
+      req: Request,
+      env: { [index: string]: string }
+    ): Promise<Response> => {
+      const headers = { "x-inngest-sdk": this.sdkHeader.join("") };
+
+      let reqUrl: URL;
+      let isIntrospection: boolean;
+
+      try {
+        reqUrl = this.reqUrl(
+          req.url,
+          `https://${req.headers.get("host") || ""}`
+        );
+        isIntrospection = reqUrl.searchParams.has(queryKeys.Introspect);
+        reqUrl.searchParams.delete(queryKeys.Introspect);
+      } catch (err) {
+        return new Response(JSON.stringify(err), {
+          status: 500,
+          headers,
+        });
+      }
+
+      if (!this.signingKey && env[envKeys.SigningKey]) {
+        this.signingKey = env[envKeys.SigningKey];
+      }
+
+      this._isProd =
+        env.VERCEL_ENV === "production" ||
+        env.CONTEXT === "production" ||
+        env.ENVIRONMENT === "production";
+
+      switch (req.method) {
+        case "GET": {
+          const showLandingPage = this.shouldShowLandingPage(
+            env[envKeys.LandingPage]
+          );
+
+          if (this._isProd || !showLandingPage) break;
+
+          if (isIntrospection) {
+            const introspection: IntrospectRequest = {
+              ...this.registerBody(reqUrl),
+              devServerURL: devServerUrl(devServerHost()).href,
+              hasSigningKey: Boolean(this.signingKey),
+            };
+
+            return new Response(JSON.stringify(introspection), {
+              status: 200,
+              headers,
+            });
+          }
+
+          // Grab landing page and serve
+          return new Response(landing, {
+            status: 200,
+            headers: {
+              ...headers,
+              "content-type": "text/html; charset=utf-8",
+            },
+          });
+        }
+
+        case "PUT": {
+          // Push config to Inngest.
+          const { status, message } = await this.register(
+            reqUrl,
+            env[envKeys.DevServerUrl]
+          );
+
+          return new Response(JSON.stringify({ message }), {
+            status,
+            headers,
+          });
+        }
+
+        case "POST": {
+          // Inngest is trying to run a step; confirm signed and run.
+          const { fnId, stepId } = z
+            .object({
+              fnId: z.string().min(1),
+              stepId: z.string().min(1),
+            })
+            .parse({
+              fnId: reqUrl.searchParams.get(queryKeys.FnId),
+              stepId: reqUrl.searchParams.get(queryKeys.StepId),
+            });
+
+          const stepRes = await this.runStep(fnId, stepId, await req.json());
+
+          if (stepRes.status === 500) {
+            return new Response(JSON.stringify(stepRes.error), {
+              status: stepRes.status,
+              headers,
+            });
+          }
+
+          return new Response(JSON.stringify(stepRes.body), {
+            status: stepRes.status,
+            headers,
+          });
+        }
+      }
+
+      return new Response(null, { status: 405, headers });
+    };
+  }
+}
+
+/**
+ * In Remix, serve and register any declared functions with Inngest, making them
+ * available to be triggered by events.
+ *
+ * Remix requires that you export both a "loader" for serving `GET` requests,
+ * and an "action" for serving other requests, therefore exporting both is
+ * required.
+ *
+ * See {@link https://remix.run/docs/en/v1/guides/resource-routes}
+ *
+ * @example
+ * ```ts
+ * import { serve } from "inngest/remix";
+ * import fns from "~/inngest";
+ *
+ * const handler = serve("My Remix App", fns);
+ *
+ * export { handler as loader, handler as action };
+ * ```
+ *
+ * @public
+ */
+export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const handler = defaultServe(
+    new DenoFreshCommHandler(nameOrInngest, fns, opts)
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+  return (req: Request) => handler(req, Deno.env.toObject());
+};
+
+declare const Deno: { env: { toObject: () => { [index: string]: string } } };


### PR DESCRIPTION
## Summary

Adds some tooling for Deno support, allowing folks to use `"npm:inngest"` imports.

Most of the changes here (all of the `deno_compat/` directory) are for integration testing purposes; we shouldn't have to update those files as we add features or fix bugs.

This also includes the addition of a new handler, `"inngest/deno/fresh"`, which can be used with the [Fresh](https://fresh.deno.dev/) framework to deploy to [Deno Deploy](https://deno.com/deploy). Integration tests have also been added here for the [inngest/sdk-example-fresh-deno-deploy](https://github.com/inngest/sdk-example-fresh-deno-deploy) example repo, with unit tests for the handler coming in #52, as this refactors handlers some.

At time of writing, [Deno Deploy doesn't support `npm:` specifiers](https://deno.com/blog/npm-and-deno-anywhere#:~:text=npm%20specifiers%20aren%27t%20currently%20supported%20in%20Deploy%2C%20but%20will%20be%20soon.), but it will soon™️.

## Related

- #52

