### PR TITLE
Fix event key checking wrong var when picking up from environment

### DIFF
--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -104,7 +104,7 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     this.inngestBaseUrl = new URL(inngestBaseUrl);
     this.inngestApiUrl = new URL(`e/${this.eventKey}`, this.inngestBaseUrl);
 
-    if (!eventKey) {
+    if (!this.eventKey) {
       throw new Error(
         "An event key must be passed to create an Inngest instance."
       );


### PR DESCRIPTION
The event key here is erroneously checking the event key given to the instantiation instead of the end result of using either this event key or one found in the environment.