### PR TITLE
Allow customising the `fetch` implementation in an `Inngest` client

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -7,6 +7,7 @@
 // @public
 export interface ClientOptions {
     eventKey?: string;
+    fetch?: typeof fetch;
     inngestBaseUrl?: string;
     name: string;
 }
@@ -51,7 +52,7 @@ export interface FunctionOptions {
 
 // @public
 export class Inngest<Events extends Record<string, EventPayload>> {
-    constructor({ name, eventKey, inngestBaseUrl, }: ClientOptions);
+    constructor({ name, eventKey, inngestBaseUrl, fetch, }: ClientOptions);
     createFunction<Event extends keyof Events, Name extends string, Fn extends SingleStepFn<Events[Event], Name, "step">>(
     name: Name,
     event: Event,

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -18,6 +18,11 @@ import { version } from "../version";
 import { InngestFunction } from "./InngestFunction";
 
 /**
+ * Capturing the global type of fetch so that we can reliably access it below.
+ */
+type FetchT = typeof fetch;
+
+/**
  * A client used to interact with the Inngest API by sending or reacting to
  * events.
  *
@@ -66,6 +71,8 @@ export class Inngest<Events extends Record<string, EventPayload>> {
 
   private readonly headers: Record<string, string>;
 
+  private readonly fetch: FetchT;
+
   /**
    * A client used to interact with the Inngest API by sending or reacting to
    * events.
@@ -93,6 +100,7 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     name,
     eventKey,
     inngestBaseUrl = "https://inn.gs/",
+    fetch,
   }: ClientOptions) {
     if (!name) {
       throw new Error("A name must be passed to create an Inngest instance.");
@@ -114,6 +122,9 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       "Content-Type": "application/json",
       "User-Agent": `InngestJS v${version}`,
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    this.fetch = fetch || (require("cross-fetch") as FetchT);
   }
 
   /**
@@ -266,12 +277,12 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       // If the dev server host env var has been set we always want to use
       // the dev server - even if it's down.  Otherwise, optimistically use
       // it for non-prod services.
-      if (host !== undefined || (await devServerAvailable(host, fetch))) {
+      if (host !== undefined || (await devServerAvailable(host, this.fetch))) {
         url = devServerUrl(host, `e/${this.eventKey}`).href;
       }
     }
 
-    const response = await fetch(url, {
+    const response = await this.fetch(url, {
       method: "POST",
       body: JSON.stringify(payloads),
       headers: { ...this.headers },

--- a/src/express.ts
+++ b/src/express.ts
@@ -184,8 +184,13 @@ export class InngestCommHandler {
       "User-Agent": `inngest-js:v${version} (${this.frameworkName})`,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    this.fetch = fetch || (require("cross-fetch") as FetchT);
+    this.fetch =
+      fetch ||
+      (typeof nameOrInngest === "string"
+        ? undefined
+        : nameOrInngest["fetch"]) ||
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      (require("cross-fetch") as FetchT);
   }
 
   // hashedSigningKey creates a sha256 checksum of the signing key with the
@@ -226,7 +231,9 @@ export class InngestCommHandler {
         this.signingKey = process.env[envKeys.SigningKey];
       }
 
-      this._isProd = process.env.ENVIRONMENT === "production" || process.env.NODE_ENV === "production";
+      this._isProd =
+        process.env.ENVIRONMENT === "production" ||
+        process.env.NODE_ENV === "production";
 
       switch (req.method) {
         case "GET": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,16 @@ export interface ClientOptions {
    * Defaults to https://inn.gs/
    */
   inngestBaseUrl?: string;
+
+  /**
+   * If provided, will override the used `fetch` implementation. Useful for
+   * giving the library a particular implementation if accessing it is not done
+   * via globals.
+   *
+   * By default the library will try to use the native Web API fetch, falling
+   * back to a Node implementation if no global fetch can be found.
+   */
+  fetch?: typeof fetch;
 }
 
 /**


### PR DESCRIPTION
Also ensures that the default serve handler (Express) that most handlers are based on will infer the `fetch` implementation from a passed `Inngest` client, saving users having to specify it twice.