### PR TITLE
Use `timeout` instead of `ttl` when pushing `waitForEvent` timeout

### DIFF
--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -160,9 +160,9 @@ describe("runFn", () => {
 
     // These represent hashes for each step in the above step function
     const hashes = {
-      firstWaitForEvent: "ad7a92c7c23670ab7fb94a6f2dda2ae7d8c34b39",
+      firstWaitForEvent: "a6fa9aa0df0cedf8365321eadd2574e4f6c42f19",
       step1: "375be344ee59a2b013ef35d909ac84b23136c732",
-      secondWaitForEvent: "c0fe3f23240c37a0a5b7287ba74be64b4a5d5f06",
+      secondWaitForEvent: "89948cabd5c9ded4f39c13349b3acc153621814e",
       step2: "3bff481d2c96dbbf8680d4f824c32882d109e8da",
       step3: "88a0e46b054ef061bc4ed598be3ae22be87fdd2d",
     };
@@ -183,7 +183,7 @@ describe("runFn", () => {
         expect(ret[1]).toEqual({
           op: StepOpCode.WaitForEvent,
           name: "bar",
-          opts: { ttl: "5m" },
+          opts: { timeout: "5m" },
           id: hashes.firstWaitForEvent,
         });
       });
@@ -289,7 +289,7 @@ describe("runFn", () => {
           op: StepOpCode.WaitForEvent,
           name: "baz",
           opts: {
-            ttl: "2d",
+            timeout: "2d",
           },
           id: hashes.secondWaitForEvent,
         });

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -54,7 +54,7 @@ describe("waitForEvent", () => {
     );
     await expect(state.nextOp).resolves.toMatchObject({
       opts: {
-        ttl: "1m",
+        timeout: "1m",
       },
     });
   });
@@ -69,7 +69,7 @@ describe("waitForEvent", () => {
     );
     await expect(state.nextOp).resolves.toMatchObject({
       opts: {
-        ttl: expect.stringContaining("6d"),
+        timeout: expect.stringContaining("6d"),
       },
     });
   });
@@ -80,7 +80,7 @@ describe("waitForEvent", () => {
     ).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
       opts: {
-        match: "event.name == async.name",
+        if: "event.name == async.name",
       },
     });
   });
@@ -91,7 +91,7 @@ describe("waitForEvent", () => {
     ).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
       opts: {
-        match: "name == 123",
+        if: "name == 123",
       },
     });
   });

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -266,14 +266,14 @@ export const createStepTools = <
          */
         opts: WaitForEventOpts<any, any>
       ) => {
-        const matchOpts: { timeout: string; match?: string } = {
+        const matchOpts: { timeout: string; if?: string } = {
           timeout: timeStr(opts.timeout),
         };
 
         if (opts?.match) {
-          matchOpts.match = `event.${opts.match} == async.${opts.match}`;
+          matchOpts.if = `event.${opts.match} == async.${opts.match}`;
         } else if (opts?.if) {
-          matchOpts.match = opts.if;
+          matchOpts.if = opts.if;
         }
 
         return {

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -266,8 +266,8 @@ export const createStepTools = <
          */
         opts: WaitForEventOpts<any, any>
       ) => {
-        const matchOpts: { ttl: string; match?: string } = {
-          ttl: timeStr(opts.timeout),
+        const matchOpts: { timeout: string; match?: string } = {
+          timeout: timeStr(opts.timeout),
         };
 
         if (opts?.match) {


### PR DESCRIPTION
## Summary

Executor expects `timeout` instead of `ttl` when declaring max wait for `waitForEvent` tool.

## Related

- inngest/inngest#308