### PR TITLE
fix: `require` not defined on landing page

### DIFF
--- a/landing/src/components/ExpandableEventSender.tsx
+++ b/landing/src/components/ExpandableEventSender.tsx
@@ -49,7 +49,12 @@ const ExpandableEventSenderUI = ({
       return;
     }
 
-    const inngest = new Inngest({ name: value.appName, inngestBaseUrl: value.devServerURL, eventKey: "dev-server" });
+    const inngest = new Inngest({
+      name: value.appName,
+      inngestBaseUrl: value.devServerURL,,
+      eventKey: "dev-server",
+      fetch: fetch.bind(window),
+    });
     await inngest.send(JSON.parse(data));
     push({ type: "success", message: "Event sent.  Check your terminal for logs." });
   }

--- a/landing/src/components/ExpandableEventSender.tsx
+++ b/landing/src/components/ExpandableEventSender.tsx
@@ -51,7 +51,7 @@ const ExpandableEventSenderUI = ({
 
     const inngest = new Inngest({
       name: value.appName,
-      inngestBaseUrl: value.devServerURL,,
+      inngestBaseUrl: value.devServerURL,
       eventKey: "dev-server",
       fetch: fetch.bind(window),
     });

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,3 +1,4 @@
+import { fetch as crossFetch } from "cross-fetch";
 import { envKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import { devServerHost, hasProcessEnv, isProd } from "../helpers/env";
@@ -123,8 +124,7 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       "User-Agent": `InngestJS v${version}`,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    this.fetch = fetch || (require("cross-fetch") as FetchT);
+    this.fetch = fetch || crossFetch;
   }
 
   /**

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,4 +1,3 @@
-import { fetch as crossFetch } from "cross-fetch";
 import { envKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import { devServerHost, hasProcessEnv, isProd } from "../helpers/env";
@@ -124,7 +123,8 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       "User-Agent": `InngestJS v${version}`,
     };
 
-    this.fetch = fetch || crossFetch;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    this.fetch = fetch || (require("cross-fetch") as FetchT);
   }
 
   /**


### PR DESCRIPTION
**Problem**:
When trying to send event via landing page (For example: http://localhost:8911/inngest), it throws error that `require` is not defined.
![image](https://user-images.githubusercontent.com/2629902/207895642-ca2bd2e6-b794-4f07-bf05-05ca194a51e0.png)

**Fix:**
Avoid dynamic `require` import. We can use ES6 import but we are sharing Inngest.ts for the npm module (commonjs) and landing page, so thought this might be the safest way to go about it.

Let me know if you think of any changes. Also, feel free to discard this PR if not needed.

cc: @KrisCoulson
