### PR TITLE
Pull `user` field in `EventPayload` to be generic and not specify fields

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -29,12 +29,7 @@ export interface EventPayload {
     data: any;
     name: string;
     ts?: number;
-    user?: {
-        external_id?: string;
-        email?: string;
-        phone?: string;
-        [key: string]: any;
-    };
+    user?: Record<string, any>;
     v?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,28 +164,7 @@ export interface EventPayload {
    * Any user data associated with the event
    * All fields ending in "_id" will be used to attribute the event to a particular user
    */
-  user?: {
-    /**
-     * Your user's unique id in your system
-     */
-    external_id?: string;
-
-    /**
-     * Your user's email address
-     */
-    email?: string;
-
-    /**
-     * Your user's phone number
-     */
-    phone?: string;
-
-    /**
-     * The user block can contain arbitrary data that you can use within your
-     * own handlers too.
-     */
-    [key: string]: any;
-  };
+  user?: Record<string, any>;
 
   /**
    * A specific event schema version


### PR DESCRIPTION
Being overly-specific here results in generated types colliding with the expected types here, for example if a single event has a bad email address or phone number.

Strictly speaking, it's similar to data, so types shouldn't enforce too much here.