### PR TITLE
Ensure external PRs (from users) can run integration tests

### DIFF
--- a/.github/sdk-example-repo-access.gpg
+++ b/.github/sdk-example-repo-access.gpg
@@ -1,0 +1,1 @@
+Œ	DŽ7'1ö0>ÿÒª\!Y/˜¤p9éae"hOÐîA÷}ûŸQÂ&@	e\!Ôi«ˆvøZ¯P˜s0+’L=£+ú+˜ðeðVÕ²V÷"zg¬ÌDƒ?>3cîìG3õ92c]ŸkgE¾2=à¢àŸ¯dv×ZMƒëÈ5vÌ¾h±[D­Š¤bT„ÁqèÆ‹KÌ¬¼œA™é›50ÔY“HF{0»ìù_@Š˜¡Á¨

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,11 +65,20 @@ jobs:
         with:
           working-directory: sdk
 
+      # Decrypt and return a fine-grained access token to pull example repo
+      # contents
+      - name: Decrypt access token
+        id: sdk-example-repo-access
+        working-directory: sdk
+        run: |
+          gpg --quiet --batch --yes --decrypt --passphrase="sdk-example-repo-access" --output ./.github/token ./.github/sdk-example-repo-access.gpg
+          echo "token=$(cat ./.github/token)" >> $GITHUB_OUTPUT
+
       # Checkout the example repo
       - name: Checkout example
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.EXAMPLES_GITHUB_TOKEN }}
+          token: ${{ steps.sdk-example-repo-access.outputs.token }}
           repository: ${{ matrix.repo }}
           path: examples/${{ matrix.repo }}
           ref: main


### PR DESCRIPTION
## Summary

GitHub Actions doesn't allow access to secrets from external workflow triggers (non-collaborators, bots, etc.). This causes issues when non-collaborators (#56) or bots (#62) wish to submit PRs; the workflows fail as they need access to clone the examples.

Integration tests here use a secret to clone `inngest/sdk-example-*` repos. This PR changes them to use an encrypted personal access token that provides read-only, contents-only access to specifically those repositories required, which are all already public repos.

We can't hard-code it, as GitHub revokes it on sight, so we have to "encrypt" it loosely (read: hard-code the passphrase instead) to ensure external users have access.

## Related

- #56 
- #62 
- #63 