### PR TITLE
Add deploy ID to Inngest registration

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -103,7 +103,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     protected _isProd: boolean;
     readonly name: string;
     // (undocumented)
-    protected register(url: URL, devServerHost: string | undefined): Promise<{
+    protected register(url: URL, devServerHost: string | undefined, deployId?: string | undefined | null): Promise<{
         status: number;
         message: string;
     }>;

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -52,6 +52,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
               env,
               url,
               isProduction,
+              deployId: url.searchParams.get(queryKeys.DeployId),
             };
           }
         },

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -657,8 +657,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
       }
     }
 
-    // eslint-disable-next-line no-extra-boolean-cast
-    if (!!deployId) {
+    if (deployId) {
       registerURL.searchParams.set("deployId", deployId);
     }
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -504,7 +504,8 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
 
         const { status, message } = await this.register(
           this.reqUrl(registerRes.url),
-          registerRes.env[envKeys.DevServerUrl]
+          registerRes.env[envKeys.DevServerUrl],
+          registerRes.deployId,
         );
 
         return {
@@ -638,7 +639,8 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
 
   protected async register(
     url: URL,
-    devServerHost: string | undefined
+    devServerHost: string | undefined,
+    deployId?: string | undefined | null,
   ): Promise<{ status: number; message: string }> {
     const body = this.registerBody(url);
 
@@ -653,6 +655,10 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
       if (hasDevServer) {
         registerURL = devServerUrl(devServerHost, "/fn/register");
       }
+    }
+
+    if (!!deployId) {
+      registerURL.searchParams.set("deployId", deployId);
     }
 
     try {
@@ -785,6 +791,7 @@ type HandlerAction =
       env: Record<string, string | undefined>;
       url: URL;
       isProduction: boolean;
+      deployId?: null | string;
     }
   | {
       action: "run";

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -505,7 +505,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         const { status, message } = await this.register(
           this.reqUrl(registerRes.url),
           registerRes.env[envKeys.DevServerUrl],
-          registerRes.deployId,
+          registerRes.deployId
         );
 
         return {
@@ -640,7 +640,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
   protected async register(
     url: URL,
     devServerHost: string | undefined,
-    deployId?: string | undefined | null,
+    deployId?: string | undefined | null
   ): Promise<{ status: number; message: string }> {
     const body = this.registerBody(url);
 
@@ -657,6 +657,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
       }
     }
 
+    // eslint-disable-next-line no-extra-boolean-cast
     if (!!deployId) {
       registerURL.searchParams.set("deployId", deployId);
     }

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -27,6 +27,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
               env,
               isProduction,
               url,
+              deployId: url.searchParams.get(queryKeys.DeployId),
             };
           }
         },

--- a/src/express.ts
+++ b/src/express.ts
@@ -44,6 +44,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
               env,
               url,
               isProduction,
+              deployId: req.query[queryKeys.DeployId]?.toString(),
             };
           }
         },

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -2,6 +2,7 @@ export enum queryKeys {
   FnId = "fnId",
   StepId = "stepId",
   Introspect = "introspect",
+  DeployId = "deployId",
 }
 
 export enum envKeys {

--- a/src/next.ts
+++ b/src/next.ts
@@ -37,6 +37,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
               env,
               url,
               isProduction,
+              deployId: req.query[queryKeys.DeployId]?.toString(),
             };
           }
         },

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -46,6 +46,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
               env,
               isProduction,
               url,
+              deployId: event.queryStringParameters?.[queryKeys.DeployId],
             };
           }
         },

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -48,6 +48,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
               env,
               isProduction,
               url,
+              deployId: url.searchParams.get(queryKeys.DeployId),
             };
           }
         },


### PR DESCRIPTION
If the deploy ID is passed during an incoming PUT ping, use the deploy ID when creating our outgoing registration request to Inngest.

This ties together deploys from all platforms in a nice manner over two/three legged HTTP requests.