### PR TITLE
Allow `sleepUntil` to parse strings

### DIFF
--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import ms from "ms";
 import { StepOpCode } from "../types";
 import { createStepTools, StepFlowInterrupt } from "./InngestStepTools";
 
@@ -173,10 +174,18 @@ describe("sleepUntil", () => {
   test("return Sleep step op code", async () => {
     const future = new Date();
     future.setDate(future.getDate() + 1);
-
     expect(() => sleepUntil(future)).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
       op: StepOpCode.Sleep,
+    });
+  });
+
+  test("parses ISO strings", async () => {
+    const next = new Date().valueOf() + ms("6d");
+
+    expect(() => sleepUntil(new Date(next))).toThrow(StepFlowInterrupt);
+    await expect(state.nextOp).resolves.toMatchObject({
+      name: expect.stringContaining("6d"),
     });
   });
 

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -180,23 +180,37 @@ describe("sleepUntil", () => {
     });
   });
 
-  test("parses ISO strings", async () => {
-    const next = new Date().valueOf() + ms("6d");
+  test("parses dates", async () => {
+    const next = new Date();
 
-    expect(() => sleepUntil(new Date(next))).toThrow(StepFlowInterrupt);
+    expect(() => sleepUntil(next)).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      name: expect.stringContaining("6d"),
+      name: next.toISOString(),
     });
   });
 
-  test("return time string as ID given a date", async () => {
-    const upcoming = new Date();
-    upcoming.setDate(upcoming.getDate() + 6);
-    upcoming.setHours(upcoming.getHours() + 1);
+  test("parses ISO strings", async () => {
+    const next = new Date(new Date().valueOf() + ms("6d")).toISOString();
 
-    expect(() => sleepUntil(upcoming)).toThrow(StepFlowInterrupt);
+    expect(() => sleepUntil(next)).toThrow(StepFlowInterrupt);
     await expect(state.nextOp).resolves.toMatchObject({
-      name: expect.stringContaining("6d"),
+      name: next,
     });
+  });
+
+  test("throws if invalid date given", async () => {
+    const next = new Date("bad");
+
+    expect(() => sleepUntil(next)).toThrow(
+      "Invalid date or date string passed"
+    );
+  });
+
+  test("throws if invalid time string given", async () => {
+    const next = "bad";
+
+    expect(() => sleepUntil(next)).toThrow(
+      "Invalid date or date string passed"
+    );
   });
 });

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -362,7 +362,8 @@ export const createStepTools = <
     /**
      * Wait until a particular date before continuing by passing a `Date`.
      *
-     * To wait for a particular amount of time, use `sleep` instead.
+     * To wait for a particular amount of time from now, always use `sleep`
+     * instead.
      */
     sleepUntil: createTool<
       (
@@ -372,16 +373,28 @@ export const createStepTools = <
         time: Date | string
       ) => void
     >((time) => {
-      const date: Date = typeof time === "string" ? new Date(time) : time;
+      const date = typeof time === "string" ? new Date(time) : time;
 
       /**
        * The presence of this operation in the returned stack indicates that the
        * sleep is over and we should continue execution.
        */
-      return {
-        op: StepOpCode.Sleep,
-        name: timeStr(date),
-      };
+      try {
+        return {
+          op: StepOpCode.Sleep,
+          name: date.toISOString(),
+        };
+      } catch (err) {
+        /**
+         * If we're here, it's because the date is invalid. We'll throw a custom
+         * error here to standardise this response.
+         */
+        console.warn("Invalid date or date string passed to sleepUntil;", err);
+
+        throw new Error(
+          `Invalid date or date string passed to sleepUntil: ${time.toString()}`
+        );
+      }
     }),
   };
 

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -369,16 +369,18 @@ export const createStepTools = <
         /**
          * The date to wait until before continuing.
          */
-        time: Date
+        time: Date | string
       ) => void
     >((time) => {
+      const date: Date = typeof time === "string" ? new Date(time) : time;
+
       /**
        * The presence of this operation in the returned stack indicates that the
        * sleep is over and we should continue execution.
        */
       return {
         op: StepOpCode.Sleep,
-        name: timeStr(time),
+        name: timeStr(date),
       };
     }),
   };


### PR DESCRIPTION
`tools.run` always JSON-serializes output, which means that if a user returns a Date() then passes this into `tools.sleepUntil`, parsing previously fails.

This brings up another issue:  `tools.run` typing auto-genned is incorrect;  the resulting type is always serialized instead of being an instance of whatever object you return.

For example, a `Set` is always an array, a `Date` is always a string, a `Map` or `WeakMap`, is an object, classes are... tricky :)