### PR TITLE
Add DigitalOcean handler

### DIFF
--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -750,7 +750,7 @@ type Handler = (...args: any[]) => {
  * The response from the Inngest SDK before it is transformed in to a
  * framework-compatible response by an {@link InngestCommHandler} instance.
  */
-interface ActionResponse {
+export interface ActionResponse {
   /**
    * The HTTP status code to return.
    */

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -1,0 +1,146 @@
+import { InngestCommHandler } from "./components/InngestCommHandler";
+import { queryKeys } from "./helpers/consts";
+import { allProcessEnv } from "./helpers/env";
+import { RegisterOptions } from "./types";
+import type { Inngest } from "./components/Inngest";
+import type { InngestFunction } from "./components/InngestFunction";
+
+type HTTP = {
+  headers: {
+    host?: string;
+  };
+  method: string;
+  path: string;
+};
+
+type Main = {
+  http: HTTP;
+  // data can include any JSON-decoded post-data, and query args/saerch params.
+  [data: string]: any;
+};
+
+/**
+ * Opts extends RegisterOptions to make `servePath` and `serveHost` required.
+ */
+type Opts = RegisterOptions & {
+  /**
+   * The path to the Inngest serve endpoint. e.g.:
+   *
+   *     "/some/long/path/to/inngest/endpoint"
+   *
+   * By default, the library will try to infer this using request details such
+   * as the "Host" header and request path, but sometimes this isn't possible
+   * (e.g. when running in a more controlled environments such as AWS Lambda or
+   * when dealing with proxies/rediects).
+   *
+   * Provide the custom path (excluding the hostname) here to ensure that the
+   * path is reported correctly when registering functions with Inngest.
+   *
+   * To also provide a custom hostname, use `serveHost`.
+   */
+  servePath?: string;
+
+  /**
+   * The host used to access the Inngest serve endpoint, e.g.:
+   *
+   *     "https://myapp.com"
+   *
+   * By default, the library will try to infer this using request details such
+   * as the "Host" header and request path, but sometimes this isn't possible
+   * (e.g. when running in a more controlled environments such as AWS Lambda or
+   * when dealing with proxies/rediects).
+   *
+   * Provide the custom hostname here to ensure that the path is reported
+   * correctly when registering functions with Inngest.
+   *
+   * To also provide a custom path, use `servePath`.
+   */
+  serveHost: string;
+};
+
+type ServeHandler = (
+  /**
+   * The name of this app, used to scope and group Inngest functions, or
+   * the `Inngest` instance used to declare all functions.
+   */
+  nameOrInngest: string | Inngest<any>,
+
+  /**
+   * An array of the functions to serve and register with Inngest.
+   */
+  functions: InngestFunction<any>[],
+
+  /**
+   * A set of options to further configure the registration of Inngest
+   * functions.
+   */
+  opts: Opts
+) => any;
+
+export const serve: ServeHandler = (name, fns, opts: Opts) => {
+  const handler = new InngestCommHandler(
+    "digitalocean",
+    name,
+    fns,
+    opts,
+    (main: Main) => {
+      // Copy all params as data.
+      let { http, ...data } = main || {};
+
+      if (http === undefined) {
+        // This is an invocation from the DigitalOcean UI;  main is an empty object.
+        // In this case provide some defaults so that this doesn't run functions.
+        http = { method: "GET", headers: {}, path: "" };
+        data = {};
+      }
+
+      const env = allProcessEnv();
+      const isProduction = env.NODE_ENV !== "development";
+
+      // serveHost and servePath must be defined when running in DigitalOcean in order
+      // for the SDK to properly register and run functions.
+      //
+      // DigitalOcean provides no hostname or path in its arguments during execution.
+      const url = new URL(opts?.serveHost + (opts?.servePath || "/"));
+
+      return {
+        register: () => {
+          if (http.method === "PUT") {
+            return {
+              env,
+              url,
+              isProduction,
+              deployId: main[queryKeys.DeployId] as string,
+            };
+          }
+        },
+        run: () => {
+          if (http.method === "POST") {
+            return {
+              data: data as Record<string, any>,
+              fnId: (main[queryKeys.FnId] as string) || "",
+              env,
+              isProduction,
+              url,
+            };
+          }
+        },
+        view: () => {
+          if (http.method === "GET") {
+            return {
+              env,
+              isIntrospection: Object.hasOwnProperty.call(
+                main,
+                queryKeys.Introspect
+              ),
+              url,
+              isProduction,
+            };
+          }
+        },
+      };
+    },
+    (res) => res
+  );
+  return handler.createHandler();
+};

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -1,9 +1,7 @@
+import type { ServeHandler } from "./components/InngestCommHandler";
 import { InngestCommHandler } from "./components/InngestCommHandler";
 import { queryKeys } from "./helpers/consts";
 import { allProcessEnv } from "./helpers/env";
-import { RegisterOptions } from "./types";
-import type { Inngest } from "./components/Inngest";
-import type { InngestFunction } from "./components/InngestFunction";
 
 type HTTP = {
   headers: {
@@ -19,65 +17,12 @@ type Main = {
   [data: string]: any;
 };
 
-/**
- * Opts extends RegisterOptions to make `servePath` and `serveHost` required.
- */
-type Opts = RegisterOptions & {
-  /**
-   * The path to the Inngest serve endpoint. e.g.:
-   *
-   *     "/some/long/path/to/inngest/endpoint"
-   *
-   * By default, the library will try to infer this using request details such
-   * as the "Host" header and request path, but sometimes this isn't possible
-   * (e.g. when running in a more controlled environments such as AWS Lambda or
-   * when dealing with proxies/rediects).
-   *
-   * Provide the custom path (excluding the hostname) here to ensure that the
-   * path is reported correctly when registering functions with Inngest.
-   *
-   * To also provide a custom hostname, use `serveHost`.
-   */
-  servePath?: string;
-
-  /**
-   * The host used to access the Inngest serve endpoint, e.g.:
-   *
-   *     "https://myapp.com"
-   *
-   * By default, the library will try to infer this using request details such
-   * as the "Host" header and request path, but sometimes this isn't possible
-   * (e.g. when running in a more controlled environments such as AWS Lambda or
-   * when dealing with proxies/rediects).
-   *
-   * Provide the custom hostname here to ensure that the path is reported
-   * correctly when registering functions with Inngest.
-   *
-   * To also provide a custom path, use `servePath`.
-   */
-  serveHost: string;
-};
-
-type ServeHandler = (
-  /**
-   * The name of this app, used to scope and group Inngest functions, or
-   * the `Inngest` instance used to declare all functions.
-   */
-  nameOrInngest: string | Inngest<any>,
-
-  /**
-   * An array of the functions to serve and register with Inngest.
-   */
-  functions: InngestFunction<any>[],
-
-  /**
-   * A set of options to further configure the registration of Inngest
-   * functions.
-   */
-  opts: Opts
-) => any;
-
-export const serve: ServeHandler = (name, fns, opts: Opts) => {
+export const serve = (
+  name: Parameters<ServeHandler>[0],
+  fns: Parameters<ServeHandler>[1],
+  opts: Parameters<ServeHandler>[2] &
+    Required<Pick<NonNullable<Parameters<ServeHandler>[2]>, "serveHost">>
+) => {
   const handler = new InngestCommHandler(
     "digitalocean",
     name,
@@ -101,7 +46,7 @@ export const serve: ServeHandler = (name, fns, opts: Opts) => {
       // for the SDK to properly register and run functions.
       //
       // DigitalOcean provides no hostname or path in its arguments during execution.
-      const url = new URL(opts?.serveHost + (opts?.servePath || "/"));
+      const url = new URL(`${opts.serveHost}${opts?.servePath || "/"}`);
 
       return {
         register: () => {


### PR DESCRIPTION
This still needs tests, but allows users to deploy Inngest functions to DigitalOcean.

Example usage:

```typescript
const { serve } = require("inngest/digitalocean");

const fn = createStepFunction("User signup flow", "user/created", function({ event, tools }) {
  tools.run("Send a welcome email", () => {
    // Your email logic...
  });

  tools.sleep("24h");

  tools.run("Send reminder", () => {
   // Another email...
  });

  return {
    ok: true,
    event,
  };
});

// Call serve with your app name (for grouping functions), a list of
// functions which you want to execute, and the serveHost and Path.
// The URL to the function is needed for Inngest to register your
// functions and run them;  without this Inngest doesn't know where
// your functions are hosted.
const run = serve(
  "App name:  Signup flows",
  [fn],
  {
    // This is your digitalocean host
    serveHost: "https://faas-sfo3-your-url.doserverless.co"
    // And your DO path.
    servePath: "/api/v1/web/fn-your-uuid/inngest"
    // Add your signing key to your function env.
    signingKey: process.env["INNGEST_SIGNING_KEY"];
  },
);

async function main(args) {
  return await run(args);
}

// IMPORTANT: Makes the function available as a module in the project.
// This is required for any functions that require external dependencies.
module.exports.main = main;
```