### PR TITLE
Add patterns to step tooling for common compositional tasks

### DIFF
--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -173,7 +173,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
      * user's function has run, we can check the mutated state of these to see
      * if an op has been submitted or not.
      */
-    const [tools, state] = createStepTools(this.#client);
+    const [tools, state, patterns] = createStepTools(this.#client);
 
     /**
      * Create args to pass in to our function. We blindly pass in the data and
@@ -183,6 +183,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
       ...(data as EventData<string>),
       tools,
       step: tools,
+      patterns,
     } as Partial<HandlerArgs<any, any, any>>;
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type HandlerArgs<
   tools: ReturnType<typeof createStepTools<Events, Event>>[0];
 
   step: ReturnType<typeof createStepTools<Events, Event>>[0];
+  patterns: ReturnType<typeof createStepTools<Events, Event>>[2];
 } & (Opts["fns"] extends Record<string, any>
     ? {
         /**


### PR DESCRIPTION
## Summary

Add a location in step-function tooling for reusable patterns such that users can utilise baked-in, popular patterns without having to think/read about how to do this in an event-driven system.

It feels reasonable to have these separate from `tools` (or `step`/`steps`) as they'll incur differing usage based on the underlying tooling. This usage should also be clearly communicated in the description of each pattern, such that users are aware of what's happening under the hood.

This PR introduces the location and a single pattern: `poll()`, which:

> [Runs] the given `fn` every interval until it either returns a value or the `timeout` expires.
>
> The function returning any value other than `undefined` will cause the value to be returned, otherwise the function will be called again after the `interval` has elapsed.
>
> If the `timeout` expires before the function returns a value, will return `undefined`.
>
> If the function throws an error, poll will throw the same error.

```ts
inngest.createFunction(
  {
    name: "My AI Function",
    fns: { ...aiLib },
  },
  "ai/render.requested",
  async ({ patterns, fns: { requestRender, getAiResult } }) => {
    const renderId = await requestRender();
    const result = patterns.poll("30s", () => getAiResult());
  }
);
```

## Related

- #45 