### PR TITLE
Add an exported non-retriable error to halt SDK execution

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -148,6 +148,14 @@ export interface MultiStepFnArgs<Events extends Record<string, EventPayload>, Ev
 }
 
 // @public
+export class NonRetriableError extends Error {
+    constructor(message: string, options?: {
+        cause?: any;
+    });
+    readonly cause?: any;
+}
+
+// @public
 export interface RegisterOptions {
     fetch?: typeof fetch;
     inngestRegisterUrl?: string;

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -15,6 +15,7 @@ import type {
 import { version } from "../version";
 import type { Inngest } from "./Inngest";
 import type { InngestFunction } from "./InngestFunction";
+import { NonRetriableError } from "./NonRetriableError";
 
 /**
  * A handler for serving Inngest functions. This type should be used
@@ -434,9 +435,9 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
 
         const stepRes = await this.runStep(runRes.fnId, "step", runRes.data);
 
-        if (stepRes.status === 500) {
+        if (stepRes.status === 500 || stepRes.status === 400) {
           return {
-            status: 500,
+            status: stepRes.status,
             body: stepRes.error || "",
             headers: {
               ...headers,
@@ -568,6 +569,29 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         body: ret[1],
       };
     } catch (err: unknown) {
+      /**
+       * If we've caught a non-retriable error, we'll return a 400 to Inngest
+       * to indicate that the error is not transient and should not be retried.
+       *
+       * The errors caught here are caught from the main function as well as
+       * inside individual steps, so this safely catches all areas.
+       */
+      if (err instanceof NonRetriableError) {
+        return {
+          status: 400,
+          error: JSON.stringify({
+            message: err.message,
+            stack: err.stack,
+            name: err.name,
+            cause: err.cause
+              ? err.cause instanceof Error
+                ? err.cause.stack || err.cause.message
+                : JSON.stringify(err.cause)
+              : undefined,
+          }),
+        };
+      }
+
       if (err instanceof Error) {
         return {
           status: 500,

--- a/src/components/NonRetriableError.ts
+++ b/src/components/NonRetriableError.ts
@@ -1,0 +1,33 @@
+/**
+ * An error that, when thrown, indicates to Inngest that the function should
+ * cease all execution and not retry.
+ *
+ * A `message` must be provided, and an optional `cause` can be provided to
+ * provide more context to the error.
+ *
+ * @public
+ */
+export class NonRetriableError extends Error {
+  /**
+   * The underlying cause of the error, if any.
+   *
+   * This will be serialized and sent to Inngest.
+   */
+  public readonly cause?: any;
+
+  constructor(
+    message: string,
+    options?: {
+      /**
+       * The underlying cause of the error, if any.
+       *
+       * This will be serialized and sent to Inngest.
+       */
+      cause?: any;
+    }
+  ) {
+    super(message);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    this.cause = options?.cause;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { Inngest } from "./components/Inngest";
 export { InngestCommHandler } from "./components/InngestCommHandler";
 export type { ServeHandler } from "./components/InngestCommHandler";
+export { NonRetriableError } from "./components/NonRetriableError";
 export {
   createFunction,
   createScheduledFunction,

--- a/src/types.ts
+++ b/src/types.ts
@@ -432,6 +432,10 @@ export type StepRunResponse =
   | {
       status: 206;
       body: any;
+    }
+  | {
+      status: 400;
+      error: string;
     };
 
 /**


### PR DESCRIPTION
## Summary

Adds an exported `NonRetriableError` that can be used to throw during function runs (or inside step tooling such as `tools.run()`) to cease all further execution of a function.

```ts
inngest.createStepFunction("Example", "app/user.created", () => {
  try {
    // Do something
  } catch (cause) {
    throw new NonRetriableError("Some descriptive message", { cause });
  }
});
```

Very similar implementation to #73, but submitting another PR to target the current SDK version as #73 has #45 as its base.

## Related

- #73