### PR TITLE
No longer double-wrap following changes in inngest/inngest#343

### DIFF
--- a/src/examples/test/helloWorld.test.ts
+++ b/src/examples/test/helloWorld.test.ts
@@ -57,7 +57,7 @@ describe("run", () => {
       runHasTimeline(runId, {
         __typename: "StepEvent",
         stepType: "COMPLETED",
-        output: JSON.stringify({ body: '"Hello, Inngest!"', status: 200 }),
+        output: JSON.stringify({ body: "Hello, Inngest!", status: 200 }),
       })
     ).resolves.toBe(true);
   });


### PR DESCRIPTION
## Summary

#343 introduced a change in the parsing of the JSON output of steps. Fixing the integration test here, which was previously expecting wrapped values. 