### PR TITLE
Add retry overrides to SDK options

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -40,6 +40,7 @@ export interface FunctionOptions {
     id?: string;
     idempotency?: string;
     name: string;
+    retries?: number;
     throttle?: {
         key?: string;
         count: number;

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -40,7 +40,7 @@ export interface FunctionOptions {
     id?: string;
     idempotency?: string;
     name: string;
-    retries?: number;
+    retries?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20;
     throttle?: {
         key?: string;
         count: number;

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -83,8 +83,13 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
     stepUrl.searchParams.set(queryKeys.FnId, fnId);
     stepUrl.searchParams.set(queryKeys.StepId, InngestFunction.stepId);
 
+    const { retries: attempts, ...opts } = this.#opts;
+
+    // Convert retries into the format required when defining function configuration. 
+    const retries = attempts ? { attempts } : undefined;
+
     return {
-      ...this.#opts,
+      ...opts,
       id: fnId,
       name: this.name,
       triggers: [this.#trigger as FunctionTrigger],
@@ -96,6 +101,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
             type: "http",
             url: stepUrl.href,
           },
+          retries,
         },
       },
     };

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -85,7 +85,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
 
     const { retries: attempts, ...opts } = this.#opts;
 
-    // Convert retries into the format required when defining function configuration. 
+    // Convert retries into the format required when defining function configuration.
     const retries = attempts ? { attempts } : undefined;
 
     return {

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -85,8 +85,16 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
 
     const { retries: attempts, ...opts } = this.#opts;
 
-    // Convert retries into the format required when defining function configuration.
-    const retries = attempts ? { attempts } : undefined;
+    /**
+     * Convert retries into the format required when defining function
+     * configuration.
+     *
+     * While we define "retries" here, the executor wants to know the number of
+     * "attempts", so we add 1 to whatever value the user provides, e.g. 2
+     * retries means 3 attempts.
+     */
+    const retries =
+      typeof attempts === "undefined" ? undefined : { attempts: attempts + 1 };
 
     return {
       ...opts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,6 +412,11 @@ export interface FunctionOptions {
      */
     period: TimeStr;
   };
+
+  /**
+   * Specifies the maximum number of retries for all steps across this function.
+   */
+  retries?: number;
 }
 
 /**
@@ -541,6 +546,9 @@ export interface FunctionConfig {
         type: "http";
         url: string;
       };
+      retries?: {
+        attempts?: number;
+      }
     }
   >;
   idempotency?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,8 +415,31 @@ export interface FunctionOptions {
 
   /**
    * Specifies the maximum number of retries for all steps across this function.
+   *
+   * Can be a number from `0` to `20`. Defaults to `3`.
    */
-  retries?: number;
+  retries?:
+    | 0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20;
 }
 
 /**
@@ -548,7 +571,7 @@ export interface FunctionConfig {
       };
       retries?: {
         attempts?: number;
-      }
+      };
     }
   >;
   idempotency?: string;


### PR DESCRIPTION
This allows users to customize the number of retries in each step.