### PR TITLE
Add proper error marshalling

### DIFF
--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -1,0 +1,31 @@
+import { NonRetriableError } from "../components/NonRetriableError";
+
+export const marshalError = (err: unknown): Record<string, any> | string => {
+  if (err instanceof NonRetriableError) {
+    return {
+      message: err.message,
+      stack: err.stack,
+      name: err.name,
+      cause: err.cause
+        ? err.cause instanceof Error
+          ? marshalError(err.cause)
+          : JSON.stringify(err.cause)
+        : undefined,
+    };
+  }
+
+  if (err instanceof Error) {
+    return {
+      message: err.message,
+      stack: err.stack,
+      name: err.name,
+    };
+  }
+
+  return `Unknown error: ${JSON.stringify(err)}`;
+};
+
+export const stringifyError = (err: unknown): string => {
+  const result = marshalError(err);
+  return typeof result === "string" ? result : JSON.stringify(result);
+};


### PR DESCRIPTION
In some circumstances errors returned from the SDK were opaque (we'd return '{}').  This change ensures that we uniformly marshal errors so that users can properly debug any issues.