### PR TITLE
fix: Wait a while for nested promises to resolve

### DIFF
--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -654,7 +654,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         timer
       );
 
-      if (ret[0] === "single" || ret[0] === "multi-complete") {
+      if (ret[0] === "complete") {
         return {
           status: 200,
           body: ret[1],
@@ -672,7 +672,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
        * TODO When the executor does support per-step errors, we can remove this
        * comment and check and functionality should resume as normal.
        */
-      if (ret[0] === "multi-run" && ret[1].error) {
+      if (ret[0] === "run" && ret[1].error) {
         throw ret[1].error;
       }
 

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -78,7 +78,7 @@ describe("runFn", () => {
           });
 
           test("returns is not op on success", () => {
-            expect(ret[0]).toBe("single");
+            expect(ret[0]).toBe("complete");
           });
 
           test("returns data on success", () => {
@@ -114,7 +114,7 @@ describe("runFn", () => {
     });
   });
 
-  describe("multi-step functions", () => {
+  describe("step functions", () => {
     const runFnWithStack = (
       fn: InngestFunction<any>,
       stack: OpStack,
@@ -219,7 +219,7 @@ describe("runFn", () => {
       ({ A, B }) => ({
         "first run reports A step": {
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: A,
@@ -232,7 +232,7 @@ describe("runFn", () => {
         "requesting to run A runs A": {
           runStep: A,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: A,
               name: "A",
@@ -250,7 +250,7 @@ describe("runFn", () => {
             },
           ],
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: B,
@@ -269,7 +269,7 @@ describe("runFn", () => {
           ],
           runStep: B,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: B,
               name: "B",
@@ -290,7 +290,7 @@ describe("runFn", () => {
               data: "B",
             },
           ],
-          expectedReturn: ["multi-complete", undefined],
+          expectedReturn: ["complete", undefined],
         },
       })
     );
@@ -325,7 +325,7 @@ describe("runFn", () => {
       ({ foo, A, B }) => ({
         "first run reports waitForEvent": {
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 op: StepOpCode.WaitForEvent,
@@ -338,7 +338,7 @@ describe("runFn", () => {
         "request with event foo.data.foo:foo reports A step": {
           stack: [{ id: foo, data: { data: { foo: "foo" } } }],
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: A,
@@ -352,7 +352,7 @@ describe("runFn", () => {
           stack: [{ id: foo, data: { data: { foo: "foo" } } }],
           runStep: A,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: A,
               name: "A",
@@ -365,7 +365,7 @@ describe("runFn", () => {
         "request with event foo.data.foo:bar reports B step": {
           stack: [{ id: foo, data: { data: { foo: "bar" } } }],
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: B,
@@ -379,7 +379,7 @@ describe("runFn", () => {
           stack: [{ id: foo, data: { data: { foo: "bar" } } }],
           runStep: B,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: B,
               name: "B",
@@ -400,7 +400,7 @@ describe("runFn", () => {
               data: "B",
             },
           ],
-          expectedReturn: ["multi-complete", undefined],
+          expectedReturn: ["complete", undefined],
         },
       })
     );
@@ -431,7 +431,7 @@ describe("runFn", () => {
       ({ A, B, C }) => ({
         "first run reports A and B steps": {
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: A,
@@ -450,7 +450,7 @@ describe("runFn", () => {
         "requesting to run B runs B": {
           runStep: B,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: B,
               name: "B",
@@ -468,13 +468,13 @@ describe("runFn", () => {
               data: "B",
             },
           ],
-          expectedReturn: ["multi-discovery", []],
+          expectedReturn: ["discovery", []],
         },
 
         "requesting to run A runs A": {
           runStep: A,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: A,
               name: "A",
@@ -497,7 +497,7 @@ describe("runFn", () => {
             },
           ],
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: C,
@@ -521,7 +521,7 @@ describe("runFn", () => {
             },
           ],
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: C,
               name: "C",
@@ -547,7 +547,7 @@ describe("runFn", () => {
               data: "C",
             },
           ],
-          expectedReturn: ["multi-complete", undefined],
+          expectedReturn: ["complete", undefined],
         },
       })
     );
@@ -585,7 +585,7 @@ describe("runFn", () => {
       ({ A, B, BWins }) => ({
         "first run reports A and B steps": {
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: A,
@@ -604,7 +604,7 @@ describe("runFn", () => {
         "requesting to run B runs B": {
           runStep: B,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: B,
               name: "B",
@@ -623,7 +623,7 @@ describe("runFn", () => {
             },
           ],
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: BWins,
@@ -637,7 +637,7 @@ describe("runFn", () => {
         "requesting to run A runs A": {
           runStep: A,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: A,
               name: "A",
@@ -659,7 +659,7 @@ describe("runFn", () => {
               data: "A",
             },
           ],
-          expectedReturn: ["multi-discovery", []],
+          expectedReturn: ["discovery", []],
         },
 
         "requesting to run 'B wins' runs 'B wins'": {
@@ -671,7 +671,7 @@ describe("runFn", () => {
             },
           ],
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: BWins,
               name: "B wins",
@@ -714,7 +714,7 @@ describe("runFn", () => {
       ({ A, B, BFailed }) => ({
         "first run reports A and B steps": {
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: A,
@@ -733,7 +733,7 @@ describe("runFn", () => {
         "requesting to run A runs A": {
           runStep: A,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: A,
               name: "A",
@@ -746,13 +746,13 @@ describe("runFn", () => {
 
         "request following A returns empty response": {
           stack: [{ id: A, data: "A" }],
-          expectedReturn: ["multi-discovery", []],
+          expectedReturn: ["discovery", []],
         },
 
         "requesting to run B runs B, which fails": {
           runStep: B,
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: B,
               name: "B",
@@ -769,7 +769,7 @@ describe("runFn", () => {
             { id: B, error: "B" },
           ],
           expectedReturn: [
-            "multi-discovery",
+            "discovery",
             [
               expect.objectContaining({
                 id: BFailed,
@@ -787,7 +787,7 @@ describe("runFn", () => {
             { id: B, error: "B" },
           ],
           expectedReturn: [
-            "multi-run",
+            "run",
             expect.objectContaining({
               id: BFailed,
               name: "B failed",
@@ -804,7 +804,7 @@ describe("runFn", () => {
             { id: B, error: "B" },
             { id: BFailed, data: "B failed" },
           ],
-          expectedReturn: ["multi-complete", ["A", "B failed"]],
+          expectedReturn: ["complete", ["A", "B failed"]],
         },
       })
     );

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -245,7 +245,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
         }
       }
 
-      await resolveAfterPending();
+      await timer.wrap("memoizing-ticks", resolveAfterPending);
 
       state.reset();
       pos++;

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -162,7 +162,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
     | [type: "multi-run", op: OutgoingOp]
     | [type: "multi-complete", data: unknown]
   > {
-    const memoisingStop = timer.start("memoising");
+    const memoizingStop = timer.start("memoizing");
 
     /**
      * Create some values to be mutated and passed to the step tools. Once the
@@ -218,7 +218,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
      * Await the user function as normal.
      */
     if (!state.hasUsedTools) {
-      memoisingStop();
+      memoizingStop();
       return ["single", await userFnPromise];
     }
 
@@ -251,7 +251,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
       pos++;
     } while (pos < opStack.length);
 
-    memoisingStop();
+    memoizingStop();
 
     if (runStep) {
       const userFnOp = state.allFoundOps[runStep];

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -162,10 +162,9 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
 
     timer: ServerTiming
   ): Promise<
-    | [type: "single", data: unknown]
-    | [type: "multi-discovery", ops: OutgoingOp[]]
-    | [type: "multi-run", op: OutgoingOp]
-    | [type: "multi-complete", data: unknown]
+    | [type: "complete", data: unknown]
+    | [type: "discovery", ops: OutgoingOp[]]
+    | [type: "run", op: OutgoingOp]
   > {
     const memoizingStop = timer.start("memoizing");
 
@@ -215,17 +214,6 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
         reject(err);
       }
     });
-
-    /**
-     * If we haven't sychronously touched any tools yet, we can assume we're not
-     * looking at a step function.
-     *
-     * Await the user function as normal.
-     */
-    if (!state.hasUsedTools) {
-      memoizingStop();
-      return ["single", await userFnPromise];
-    }
 
     let pos = -1;
 
@@ -309,7 +297,7 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
         });
 
       return [
-        "multi-run",
+        "run",
         { ...tickOpToOutgoing(userFnOp), ...result, op: StepOpCode.RunStep },
       ];
     }
@@ -319,9 +307,20 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
     );
 
     /**
-     * If we haven't discovered any ops, it's possible that the user's function
-     * has completed. In this case, we should return any returned data to
-     * Inngest as the response.
+     * Now we're here, we've memoised any function state and we know that this
+     * request was a discovery call to find out next steps.
+     *
+     * We've already given the user's function a lot of chance to register any
+     * more ops, so we can assume that this list of discovered ops is final.
+     *
+     * With that in mind, if this list is empty AND we haven't previously used
+     * any step tools, we can assume that the user's function is not one that'll
+     * be using step tooling, so we'll just wait for it to complete and return
+     * the result.
+     *
+     * An empty list while also using step tooling is a valid state when the end
+     * of a chain of promises is reached, so we MUST also check if step tooling
+     * has previously been used.
      */
     if (!discoveredOps.length) {
       const fnRet = await Promise.race([
@@ -333,23 +332,23 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
         /**
          * The function has returned a value, so we should return this to
          * Inngest. Doing this will cause the function to be marked as
-         * complete, so we should only do this if we're sure that all registered
-         * ops have been resolved.
+         * complete, so we should only do this if we're sure that all
+         * registered ops have been resolved.
          */
         const allOpsFulfilled = Object.values(state.allFoundOps).every((op) => {
           return op.fulfilled;
         });
 
         if (allOpsFulfilled) {
-          return ["multi-complete", fnRet.data];
+          return ["complete", fnRet.data];
         }
 
         /**
-         * If we're here, it means that the user's function has returned a value
-         * but not all ops have been resolved. This might be intentional if they
-         * are purposefully pushing work to the background, but also might be
-         * unintentional and a bug in the user's code where they expected an
-         * order to be maintained.
+         * If we're here, it means that the user's function has returned a
+         * value but not all ops have been resolved. This might be intentional
+         * if they are purposefully pushing work to the background, but also
+         * might be unintentional and a bug in the user's code where they
+         * expected an order to be maintained.
          *
          * To be safe, we'll show a warning here to tell users that this might
          * be unintentional, but otherwise carry on as normal.
@@ -357,10 +356,20 @@ export class InngestFunction<Events extends Record<string, EventPayload>> {
         console.warn(
           `Warning: Your "${this.name}" function has returned a value, but not all ops have been resolved, i.e. you have used step tooling without \`await\`. This may be intentional, but if you expect your ops to be resolved in order, you should \`await\` them. If you are knowingly leaving ops unresolved using \`.catch()\` or \`void\`, you can ignore this warning.`
         );
+      } else if (!state.hasUsedTools) {
+        /**
+         * If we're here, it means that the user's function has not returned
+         * a value, but also has not used step tooling. This is a valid
+         * state, indicating that the function is a single-action async
+         * function.
+         *
+         * We should wait for the result and return it.
+         */
+        return ["complete", await userFnPromise];
       }
     }
 
-    return ["multi-discovery", discoveredOps];
+    return ["discovery", discoveredOps];
   }
 
   /**

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -4,6 +4,7 @@ import parallelWork from "./parallel-work";
 import polling from "./polling";
 import promiseAll from "./promise-all";
 import promiseRace from "./promise-race";
+import sequentialReduce from "./sequential-reduce";
 
 export default [
   helloWorld,
@@ -11,5 +12,6 @@ export default [
   promiseRace,
   parallelWork,
   parallelReduce,
+  sequentialReduce,
   polling,
 ];

--- a/src/examples/sequential-reduce/README.md
+++ b/src/examples/sequential-reduce/README.md
@@ -1,0 +1,17 @@
+# Sequential Reduce Example
+
+This example demonstrates how to run multiple steps in sequence to accumulate a value using `Array.prototype.reduce`.
+
+It is triggered by a `demo/sequential.reduce` event, runs three steps sequentially to fetch scores from a database, and accumulates the total of all of the scores.
+
+To see a parallel version of this pattern, see the [parallel reduce example](/src/examples/parallel-reduce).
+
+```mermaid
+graph TD
+Inngest -->|demo/sequential.reduce| Function
+Function -->|Run step| blue[Get blue team score]
+blue -->|Run step| red[Get red team score]
+red -->|Run step| green[Get green team score]
+green --> total[Accumulate score]
+total -->|Returns| done[150]
+```

--- a/src/examples/sequential-reduce/index.test.ts
+++ b/src/examples/sequential-reduce/index.test.ts
@@ -54,14 +54,15 @@ describe("run", () => {
 
   ["blue", "red", "green"].forEach((team) => {
     test(`ran "Get ${team} team score" step`, async () => {
-      await expect(
-        runHasTimeline(runId, {
-          __typename: "StepEvent",
-          stepType: "COMPLETED",
-          name: `Get ${team} team score`,
-          output: expect.any(String),
-        })
-      ).resolves.toBeDefined();
+      const step = await runHasTimeline(runId, {
+        __typename: "StepEvent",
+        stepType: "COMPLETED",
+        name: `Get ${team} team score`,
+      });
+
+      expect(step).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(step.output).toEqual(expect.any(String));
     });
   });
 
@@ -70,7 +71,7 @@ describe("run", () => {
       runHasTimeline(runId, {
         __typename: "StepEvent",
         stepType: "COMPLETED",
-        output: "150",
+        output: JSON.stringify({ body: "150", status: 200 }),
       })
     ).resolves.toBeDefined();
   });

--- a/src/examples/sequential-reduce/index.test.ts
+++ b/src/examples/sequential-reduce/index.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import fetch from "cross-fetch";
+import {
+  eventRunWithName,
+  introspectionSchema,
+  runHasTimeline,
+  sendEvent,
+} from "../../test/helpers";
+
+describe("introspection", () => {
+  const specs = [
+    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
+    { label: "Dev server UI", url: "http://localhost:8288/dev" },
+  ];
+
+  specs.forEach(({ label, url }) => {
+    test(`should show registered functions in ${label}`, async () => {
+      const res = await fetch(url);
+      const data = introspectionSchema.parse(await res.json());
+
+      expect(data.functions).toContainEqual({
+        name: "Sequential Reduce",
+        id: expect.stringMatching(/^.*-sequential-reduce$/),
+        triggers: [{ event: "demo/sequential.reduce" }],
+        steps: {
+          step: {
+            id: "step",
+            name: "step",
+            runtime: {
+              type: "http",
+              url: expect.stringMatching(
+                /^http.+\?fnId=.+-sequential-reduce&stepId=step$/
+              ),
+            },
+          },
+        },
+      });
+    });
+  });
+});
+
+describe("run", () => {
+  let eventId: string;
+  let runId: string;
+
+  beforeAll(async () => {
+    eventId = await sendEvent("demo/sequential.reduce");
+  });
+
+  test("runs in response to 'demo/sequential.reduce'", async () => {
+    runId = await eventRunWithName(eventId, "Sequential Reduce");
+    expect(runId).toEqual(expect.any(String));
+  });
+
+  ["blue", "red", "green"].forEach((team) => {
+    test(`ran "Get ${team} team score" step`, async () => {
+      await expect(
+        runHasTimeline(runId, {
+          __typename: "StepEvent",
+          stepType: "COMPLETED",
+          name: `Get ${team} team score`,
+          output: expect.any(String),
+        })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  test("Returned total score", async () => {
+    await expect(
+      runHasTimeline(runId, {
+        __typename: "StepEvent",
+        stepType: "COMPLETED",
+        output: "150",
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/examples/sequential-reduce/index.ts
+++ b/src/examples/sequential-reduce/index.ts
@@ -1,0 +1,29 @@
+import { inngest } from "../client";
+
+const scoresDb: Record<string, number> = {
+  blue: 50,
+  red: 25,
+  green: 75,
+};
+
+export default inngest.createFunction(
+  { name: "Sequential Reduce" },
+  { event: "demo/sequential.reduce" },
+  async ({ step }) => {
+    const teams = Object.keys(scoresDb);
+
+    // Fetch every team's score sequentially and add them up
+    const totalScores = await teams.reduce(async (score, team) => {
+      const currentScore = await score;
+
+      const teamScore = await step.run(
+        `Get ${team} team score`,
+        () => scoresDb[team]
+      );
+
+      return currentScore + teamScore;
+    }, Promise.resolve(0));
+
+    return totalScores;
+  }
+);


### PR DESCRIPTION
## Summary

Resolves an issue where nested promises could result in missing steps when running a step function.

- Adds a `memoizing-ticks` to the `Server-Timing` header so that we can track the performance of this over time (when benchmarking, this resolves in ~0.1ms)
- Adds an integration test that was previously breaking, a sequential reduce

