### PR TITLE
Add ability for `step.sendEvent()` to send multiple events

### DIFF
--- a/src/examples/send-event/index.test.ts
+++ b/src/examples/send-event/index.test.ts
@@ -70,4 +70,46 @@ describe("run", () => {
     expect(event).toBeDefined();
     expect(JSON.parse(event?.payload ?? {})).toMatchObject({ foo: "bar" });
   });
+
+  test("ran Step 'app/my.event.happened'", async () => {
+    await expect(
+      runHasTimeline(runId, {
+        __typename: "StepEvent",
+        stepType: "COMPLETED",
+        name: "app/my.event.happened.single",
+      })
+    ).resolves.toBeDefined();
+  });
+
+  test("sent event 'app/my.event.happened.single'", async () => {
+    const event = await receivedEventWithName("app/my.event.happened.single");
+    expect(event).toBeDefined();
+    expect(JSON.parse(event?.payload ?? {})).toMatchObject({ foo: "bar" });
+  });
+
+  test("ran Step 'app/my.event.happened.multiple.1'", async () => {
+    await expect(
+      runHasTimeline(runId, {
+        __typename: "StepEvent",
+        stepType: "COMPLETED",
+        name: "app/my.event.happened.multiple.1",
+      })
+    ).resolves.toBeDefined();
+  });
+
+  test("sent event 'app/my.event.happened.multiple.1'", async () => {
+    const event = await receivedEventWithName(
+      "app/my.event.happened.multiple.1"
+    );
+    expect(event).toBeDefined();
+    expect(JSON.parse(event?.payload ?? {})).toMatchObject({ foo: "bar" });
+  });
+
+  test("sent event 'app/my.event.happened.multiple.2'", async () => {
+    const event = await receivedEventWithName(
+      "app/my.event.happened.multiple.2"
+    );
+    expect(event).toBeDefined();
+    expect(JSON.parse(event?.payload ?? {})).toMatchObject({ foo: "bar" });
+  });
 });

--- a/src/examples/send-event/index.ts
+++ b/src/examples/send-event/index.ts
@@ -4,6 +4,27 @@ export default inngest.createFunction(
   { name: "Send event" },
   "demo/send.event",
   async ({ step }) => {
-    await step.sendEvent("app/my.event.happened", { data: { foo: "bar" } });
+    await Promise.all([
+      // Send a single event
+      step.sendEvent("app/my.event.happened", { data: { foo: "bar" } }),
+
+      // Send a single event as an object
+      step.sendEvent({
+        name: "app/my.event.happened.single",
+        data: { foo: "bar" },
+      }),
+
+      // Send multiple events
+      step.sendEvent([
+        {
+          name: "app/my.event.happened.multiple.1",
+          data: { foo: "bar" },
+        },
+        {
+          name: "app/my.event.happened.multiple.2",
+          data: { foo: "bar" },
+        },
+      ]),
+    ]);
   }
 );


### PR DESCRIPTION
## Summary

`step.sendEvent()` can now send multiple events, matching its call signature with `inngest.send()`.

```ts
// Send a single event
await step.sendEvent("app/user.created", { data: { id: 123 } });

// Send a single event as an object
await step.sendEvent({ name: "app/user.created", data: { id: 123 } });

// Send multiple events
await step.sendEvent([
  {
    name: "app/user.created",
    data: { id: 123 },
  },
  {
    name: "app/user.feed.created",
    data: { id: 123 },
  },
]);
```