### PR TITLE
Fix param consts not always being used

### DIFF
--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -38,7 +38,7 @@ export interface FunctionOptions {
     };
 }
 
-// @public (undocumented)
+// @public
 export enum headerKeys {
     // (undocumented)
     SdkVersion = "x-inngest-sdk",
@@ -128,7 +128,7 @@ export class NonRetriableError extends Error {
     readonly cause?: any;
 }
 
-// @public (undocumented)
+// @public
 export enum queryKeys {
     // (undocumented)
     DeployId = "deployId",

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -38,6 +38,14 @@ export interface FunctionOptions {
     };
 }
 
+// @public (undocumented)
+export enum headerKeys {
+    // (undocumented)
+    SdkVersion = "x-inngest-sdk",
+    // (undocumented)
+    Signature = "x-inngest-signature"
+}
+
 // @public
 export class Inngest<Events extends Record<string, EventPayload>> {
     constructor({ name, eventKey, inngestBaseUrl, fetch, }: ClientOptions);
@@ -118,6 +126,18 @@ export class NonRetriableError extends Error {
         cause?: any;
     });
     readonly cause?: any;
+}
+
+// @public (undocumented)
+export enum queryKeys {
+    // (undocumented)
+    DeployId = "deployId",
+    // (undocumented)
+    FnId = "fnId",
+    // (undocumented)
+    Introspect = "introspect",
+    // (undocumented)
+    StepId = "stepId"
 }
 
 // @public

--- a/landing/src/components/FunctionBlock.tsx
+++ b/landing/src/components/FunctionBlock.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from "preact/hooks";
+import { queryKeys } from "../../../src/helpers/consts";
 import { FunctionConfig } from "../types";
 import { classNames } from "../utils/classnames";
-import { configErrors } from "./ConfigErrors";
 import { Button } from "./Button";
+import { configErrors } from "./ConfigErrors";
 import useToast from "./Toast";
 
 interface Props {
@@ -52,8 +53,8 @@ export const FunctionBlock = ({ config, altBg }: Props) => {
     const url = new URL(window.location.href);
 
     // Default to the default step name for crons
-    url.searchParams.set("fnId", config.id);
-    url.searchParams.set("stepId", config.steps.step.id);
+    url.searchParams.set(queryKeys.FnId, config.id);
+    url.searchParams.set(queryKeys.StepId, config.steps.step.id);
 
     push({
       type: "default",

--- a/landing/src/hooks/useFnIntrospect.tsx
+++ b/landing/src/hooks/useFnIntrospect.tsx
@@ -1,4 +1,5 @@
 import { useAsyncRetry } from "react-use";
+import { queryKeys } from "../../../src/helpers/consts";
 import {
   ExpectedIntrospection,
   FunctionConfigErr,
@@ -11,7 +12,7 @@ import {
 export const useIntrospect = () => {
   const state = useAsyncRetry(async () => {
     const url = new URL(window.location.href);
-    url.searchParams.set("introspect", "true");
+    url.searchParams.set(queryKeys.Introspect, "true");
 
     const res = await fetch(url);
     const result: ExpectedIntrospection = await res.json();

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -446,7 +446,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     timer: ServerTiming
   ): Promise<ActionResponse> {
     const getHeaders = () => ({
-      "x-inngest-sdk": this.sdkHeader.join(""),
+      [headerKeys.SdkVersion]: this.sdkHeader.join(""),
       "Server-Timing": timer.getHeader(),
     });
 
@@ -781,7 +781,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     }
 
     if (deployId) {
-      registerURL.searchParams.set("deployId", deployId);
+      registerURL.searchParams.set(queryKeys.DeployId, deployId);
     }
 
     try {

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -1,3 +1,12 @@
+/**
+ * Keys for accessing query parameters included in requests from Inngest to run
+ * functions.
+ *
+ * Used internally to create handlers using `InngestCommHandler`, but can be
+ * imported to be used if creating a custom handler outside of the package.
+ *
+ * @public
+ */
 export enum queryKeys {
   FnId = "fnId",
   StepId = "stepId",
@@ -18,6 +27,15 @@ export enum prodEnvKeys {
   NetlifyEnvKey = "CONTEXT",
 }
 
+/**
+ * Keys for accessing headers included in requests from Inngest to run
+ * functions.
+ *
+ * Used internally to create handlers using `InngestCommHandler`, but can be
+ * imported to be used if creating a custom handler outside of the package.
+ *
+ * @public
+ */
 export enum headerKeys {
   Signature = "x-inngest-signature",
   SdkVersion = "x-inngest-sdk",

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -20,6 +20,7 @@ export enum prodEnvKeys {
 
 export enum headerKeys {
   Signature = "x-inngest-signature",
+  SdkVersion = "x-inngest-sdk",
 }
 
 export const defaultDevServerHost = "http://127.0.0.1:8288/";

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -3,6 +3,8 @@
 // along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
 // string in order to read variables.
 
+import { envKeys } from "./consts";
+
 /**
  * devServerHost returns the dev server host by searching for the INNGEST_DEVSERVER_URL
  * environment variable (plus project prefixces for eg. react, such as REACT_APP_INNGEST_DEVSERVER_URL).
@@ -21,7 +23,7 @@ export const devServerHost = (): string | undefined => {
   // text replacement instead of actually understanding the AST, despite webpack
   // being fully capable of understanding the AST.
   const values = [
-    processEnv("INNGEST_DEVSERVER_URL"),
+    processEnv(envKeys.DevServerUrl),
     processEnv("REACT_APP_INNGEST_DEVSERVER_URL"),
     processEnv("NEXT_PUBLIC_INNGEST_DEVSERVER_URL"),
   ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { Inngest } from "./components/Inngest";
 export { InngestCommHandler } from "./components/InngestCommHandler";
 export type { ServeHandler } from "./components/InngestCommHandler";
 export { NonRetriableError } from "./components/NonRetriableError";
+export { headerKeys, queryKeys } from "./helpers/consts";
 export type {
   ClientOptions,
   EventPayload,

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -10,6 +10,7 @@ import { ulid } from "ulid";
 import { z } from "zod";
 import { Inngest } from "../components/Inngest";
 import { ServeHandler } from "../components/InngestCommHandler";
+import { headerKeys } from "../helpers/consts";
 import { version } from "../version";
 
 interface HandlerStandardReturn {
@@ -104,7 +105,7 @@ export const testFramework = (
    * Create a helper function for running tests against the given serve handler.
    */
   const run = async (
-    handlerOpts: Parameters<typeof handler["serve"]>,
+    handlerOpts: Parameters<(typeof handler)["serve"]>,
     reqOpts: Parameters<typeof httpMocks.createRequest>,
     env: Record<string, string | undefined> = {}
   ): Promise<HandlerStandardReturn> => {
@@ -198,7 +199,7 @@ export const testFramework = (
           status: 200,
           body: expect.stringContaining("<!DOCTYPE html>"),
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
       });
@@ -214,7 +215,7 @@ export const testFramework = (
           status: 200,
           body: expect.stringContaining("<!DOCTYPE html>"),
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
       });
@@ -228,7 +229,7 @@ export const testFramework = (
         expect(ret).toMatchObject({
           status: 405,
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
       });
@@ -243,7 +244,7 @@ export const testFramework = (
         expect(ret).toMatchObject({
           status: 405,
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
       });
@@ -257,7 +258,7 @@ export const testFramework = (
           status: 200,
           body: expect.stringContaining("<!DOCTYPE html>"),
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
       });
@@ -270,7 +271,7 @@ export const testFramework = (
         expect(ret).toMatchObject({
           status: 405,
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
       });
@@ -288,7 +289,7 @@ export const testFramework = (
         expect(ret).toMatchObject({
           status: 200,
           headers: expect.objectContaining({
-            "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+            [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
           }),
         });
 
@@ -328,7 +329,7 @@ export const testFramework = (
           expect(ret).toMatchObject({
             status: 200,
             headers: expect.objectContaining({
-              "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+              [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
             }),
           });
 
@@ -366,7 +367,7 @@ export const testFramework = (
           expect(ret).toMatchObject({
             status: 200,
             headers: expect.objectContaining({
-              "x-inngest-sdk": expect.stringContaining("inngest-js:v"),
+              [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
             }),
           });
 


### PR DESCRIPTION
## Summary

Consts for header and query param keys were not being used everywhere.

Also ensured that `headerKeys` and `queryKeys` are exported from the main package so that custom `InngestCommHandler` instances can correctly use them instead of requiring magic strings.