### PR TITLE
Add deterministic signing, avoiding using buffered raw body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inngest",
-  "version": "1.2.1-signing.1",
+  "version": "1.2.1-signing.2",
   "description": "Official SDK for Inngest.com",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
+    "canonicalize": "^1.0.8",
     "cross-fetch": "^3.1.5",
     "h3": "^1.0.2",
     "hash.js": "^1.1.7",
-    "json-stringify-deterministic": "^1.0.8",
     "ms": "^2.1.3",
     "serialize-error-cjs": "^0.1.3",
     "type-fest": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inngest",
-  "version": "1.2.1-signing.3",
+  "version": "1.2.1-signing.4",
   "description": "Official SDK for Inngest.com",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inngest",
-  "version": "1.2.0",
+  "version": "1.2.1-signing.1",
   "description": "Official SDK for Inngest.com",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inngest",
-  "version": "1.2.1-signing.2",
+  "version": "1.2.1-signing.3",
   "description": "Official SDK for Inngest.com",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -934,8 +934,8 @@ class RequestSignature {
     if (mac !== this.signature) {
       const err = new Error("Invalid signature");
       err.stack = JSON.stringify({
-        expected: mac,
-        actual: this.signature,
+        expected: this.signature,
+        actual: mac,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         body,
         encoded,

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -922,6 +922,9 @@ class RequestSignature {
     }
 
     // Calculate the HMAC of the request body ourselves.
+    // We make the assumption here that a stringified body is the same as the
+    // raw bytes; it may be pertinent in the future to always parse, then
+    // canonicalize the body to ensure it's consistent.
     const encoded = typeof body === "string" ? body : canonicalize(body);
     // Remove the /signkey-[test|prod]-/ prefix from our signing key to calculate the HMAC.
     const key = signingKey.replace(/signkey-\w+-/, "");
@@ -932,16 +935,7 @@ class RequestSignature {
       .digest("hex");
 
     if (mac !== this.signature) {
-      const err = new Error("Invalid signature");
-      err.stack = JSON.stringify({
-        expected: this.signature,
-        actual: mac,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        body,
-        encoded,
-        timestamp: this.timestamp,
-      });
-      throw err;
+      throw new Error("Invalid signature");
     }
   }
 }

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -1,4 +1,5 @@
 import { hmac, sha256 } from "hash.js";
+import stringify from "json-stringify-deterministic";
 import { z } from "zod";
 import { envKeys, headerKeys, queryKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
@@ -756,7 +757,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     };
 
     // Calculate the checksum of the body... without the checksum itself being included.
-    body.hash = sha256().update(JSON.stringify(body)).digest("hex");
+    body.hash = sha256().update(stringify(body)).digest("hex");
     return body;
   }
 
@@ -851,9 +852,31 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     sig: string | undefined,
     body: Record<string, any>
   ): void {
-    /**
-     * Disabled until this has an integration test using raw buffers.
-     */
+    if (this.isProd && !sig) {
+      throw new Error(`No ${headerKeys.Signature} provided`);
+    }
+
+    if (!this.isProd && !this.signingKey) {
+      return;
+    }
+
+    if (!this.signingKey) {
+      console.warn(
+        "No signing key provided to validate signature.  Find your dev keys at https://app.inngest.com/test/secrets"
+      );
+      return;
+    }
+
+    if (!sig) {
+      console.warn(`No ${headerKeys.Signature} provided`);
+      return;
+    }
+
+    new RequestSignature(sig).verifySignature({
+      body,
+      allowExpiredSignatures: this.allowExpiredSignatures,
+      signingKey: this.signingKey,
+    });
   }
 
   protected signResponse(): string {
@@ -899,7 +922,7 @@ class RequestSignature {
     }
 
     // Calculate the HMAC of the request body ourselves.
-    const encoded = typeof body === "string" ? body : JSON.stringify(body);
+    const encoded = typeof body === "string" ? body : stringify(body);
     // Remove the /signkey-[test|prod]-/ prefix from our signing key to calculate the HMAC.
     const key = signingKey.replace(/signkey-\w+-/, "");
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -932,7 +932,16 @@ class RequestSignature {
       .digest("hex");
 
     if (mac !== this.signature) {
-      throw new Error("Invalid signature");
+      const err = new Error("Invalid signature");
+      err.stack = JSON.stringify({
+        expected: mac,
+        actual: this.signature,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        body,
+        encoded,
+        timestamp: this.timestamp,
+      });
+      throw err;
     }
   }
 }

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -1,5 +1,5 @@
+import canonicalize from "canonicalize";
 import { hmac, sha256 } from "hash.js";
-import stringify from "json-stringify-deterministic";
 import { z } from "zod";
 import { envKeys, headerKeys, queryKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
@@ -757,7 +757,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     };
 
     // Calculate the checksum of the body... without the checksum itself being included.
-    body.hash = sha256().update(stringify(body)).digest("hex");
+    body.hash = sha256().update(canonicalize(body)).digest("hex");
     return body;
   }
 
@@ -922,7 +922,7 @@ class RequestSignature {
     }
 
     // Calculate the HMAC of the request body ourselves.
-    const encoded = typeof body === "string" ? body : stringify(body);
+    const encoded = typeof body === "string" ? body : canonicalize(body);
     // Remove the /signkey-[test|prod]-/ prefix from our signing key to calculate the HMAC.
     const key = signingKey.replace(/signkey-\w+-/, "");
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -1,5 +1,5 @@
+import canonicalize from "canonicalize";
 import { sha1 } from "hash.js";
-import stringify from "json-stringify-deterministic";
 import { Jsonify } from "type-fest";
 import { timeStr } from "../helpers/strings";
 import type {
@@ -537,7 +537,7 @@ export type UnhashedOp = {
 };
 
 const hashData = (op: UnhashedOp): string => {
-  return sha1().update(stringify(op)).digest("hex");
+  return sha1().update(canonicalize(op)).digest("hex");
 };
 
 /**

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -10,6 +10,8 @@ import { ulid } from "ulid";
 import { z } from "zod";
 import { Inngest } from "../components/Inngest";
 import { ServeHandler } from "../components/InngestCommHandler";
+import { InngestFunction } from "../components/InngestFunction";
+import { headerKeys } from "../helpers/consts";
 import { version } from "../version";
 
 interface HandlerStandardReturn {
@@ -104,7 +106,7 @@ export const testFramework = (
    * Create a helper function for running tests against the given serve handler.
    */
   const run = async (
-    handlerOpts: Parameters<typeof handler["serve"]>,
+    handlerOpts: Parameters<(typeof handler)["serve"]>,
     reqOpts: Parameters<typeof httpMocks.createRequest>,
     env: Record<string, string | undefined> = {}
   ): Promise<HandlerStandardReturn> => {
@@ -509,121 +511,121 @@ export const testFramework = (
     });
 
     describe("POST (run function)", () => {
-      // describe("signature validation", () => {
-      //   const fn = new InngestFunction(
-      //     new Inngest({ name: "test" }),
-      //     { name: "Test", id: "test" },
-      //     { event: "demo/event.sent" },
-      //     () => "fn"
-      //   );
-      //   const env = {
-      //     DENO_DEPLOYMENT_ID: "1",
-      //     NODE_ENV: "production",
-      //     ENVIRONMENT: "production",
-      //   };
-      //   test("should throw an error in prod with no signature", async () => {
-      //     const ret = await run(
-      //       ["Test", [fn], { signingKey: "test" }],
-      //       [{ method: "POST", headers: {} }],
-      //       env
-      //     );
-      //     expect(ret.status).toEqual(500);
-      //     expect(JSON.parse(ret.body)).toMatchObject({
-      //       type: "internal",
-      //       message: expect.stringContaining(
-      //         `No ${headerKeys.Signature} provided`
-      //       ),
-      //     });
-      //   });
-      //   test("should throw an error with an invalid signature", async () => {
-      //     const ret = await run(
-      //       ["Test", [fn], { signingKey: "test" }],
-      //       [{ method: "POST", headers: { [headerKeys.Signature]: "t=&s=" } }],
-      //       env
-      //     );
-      //     expect(ret.status).toEqual(500);
-      //     expect(JSON.parse(ret.body)).toMatchObject({
-      //       type: "internal",
-      //       message: expect.stringContaining(
-      //         `Invalid ${headerKeys.Signature} provided`
-      //       ),
-      //     });
-      //   });
-      //   test("should throw an error with an expired signature", async () => {
-      //     const yesterday = new Date();
-      //     yesterday.setDate(yesterday.getDate() - 1);
-      //     const ret = await run(
-      //       ["Test", [fn], { signingKey: "test" }],
-      //       [
-      //         {
-      //           method: "POST",
-      //           headers: {
-      //             [headerKeys.Signature]: `t=${Math.round(
-      //               yesterday.getTime() / 1000
-      //             )}&s=expired`,
-      //           },
-      //           url: "/api/inngest?fnId=test",
-      //           body: { event: {} },
-      //         },
-      //       ],
-      //       env
-      //     );
-      //     expect(ret).toMatchObject({
-      //       status: 500,
-      //       body: expect.stringContaining("Signature has expired"),
-      //     });
-      //   });
-      //   // These signatures are randomly generated within a local development environment, matching
-      //   // what is sent from the cloud.
-      //   //
-      //   // This prevents us from having to rewrite the signature creation function in JS, which may
-      //   // differ from the cloud/CLI version.
-      //   test("should validate a signature with a key successfully", async () => {
-      //     const body = {
-      //       ctx: {
-      //         fn_id: "local-testing-local-cron",
-      //         run_id: "01GQ3HTEZ01M7R8Z9PR1DMHDN1",
-      //         step_id: "step",
-      //       },
-      //       event: {
-      //         data: {},
-      //         id: "",
-      //         name: "inngest/scheduled.timer",
-      //         ts: 1674082830001,
-      //         user: {},
-      //         v: "1",
-      //       },
-      //       steps: {},
-      //     };
-      //     const ret = await run(
-      //       [
-      //         "Test",
-      //         [fn],
-      //         {
-      //           signingKey:
-      //             "signkey-test-f00f3005a3666b359a79c2bc3380ce2715e62727ac461ae1a2618f8766029c9f",
-      //           __testingAllowExpiredSignatures: true,
-      //         } as any,
-      //       ],
-      //       [
-      //         {
-      //           method: "POST",
-      //           headers: {
-      //             [headerKeys.Signature]:
-      //               "t=1674082860&s=88b6453463050d1846743cbba0925bae7c1cf807f9c74bbd41b3d5cfc9c70d11",
-      //           },
-      //           url: "/api/inngest?fnId=test&stepId=step",
-      //           body,
-      //         },
-      //       ],
-      //       env
-      //     );
-      //     expect(ret).toMatchObject({
-      //       status: 200,
-      //       body: '"fn"',
-      //     });
-      //   });
-      // });
+      describe("signature validation", () => {
+        const fn = new InngestFunction(
+          new Inngest({ name: "test" }),
+          { name: "Test", id: "test" },
+          { event: "demo/event.sent" },
+          () => "fn"
+        );
+        const env = {
+          DENO_DEPLOYMENT_ID: "1",
+          NODE_ENV: "production",
+          ENVIRONMENT: "production",
+        };
+        test("should throw an error in prod with no signature", async () => {
+          const ret = await run(
+            ["Test", [fn], { signingKey: "test" }],
+            [{ method: "POST", headers: {} }],
+            env
+          );
+          expect(ret.status).toEqual(500);
+          expect(JSON.parse(ret.body)).toMatchObject({
+            type: "internal",
+            message: expect.stringContaining(
+              `No ${headerKeys.Signature} provided`
+            ),
+          });
+        });
+        test("should throw an error with an invalid signature", async () => {
+          const ret = await run(
+            ["Test", [fn], { signingKey: "test" }],
+            [{ method: "POST", headers: { [headerKeys.Signature]: "t=&s=" } }],
+            env
+          );
+          expect(ret.status).toEqual(500);
+          expect(JSON.parse(ret.body)).toMatchObject({
+            type: "internal",
+            message: expect.stringContaining(
+              `Invalid ${headerKeys.Signature} provided`
+            ),
+          });
+        });
+        test("should throw an error with an expired signature", async () => {
+          const yesterday = new Date();
+          yesterday.setDate(yesterday.getDate() - 1);
+          const ret = await run(
+            ["Test", [fn], { signingKey: "test" }],
+            [
+              {
+                method: "POST",
+                headers: {
+                  [headerKeys.Signature]: `t=${Math.round(
+                    yesterday.getTime() / 1000
+                  )}&s=expired`,
+                },
+                url: "/api/inngest?fnId=test",
+                body: { event: {} },
+              },
+            ],
+            env
+          );
+          expect(ret).toMatchObject({
+            status: 500,
+            body: expect.stringContaining("Signature has expired"),
+          });
+        });
+        // These signatures are randomly generated within a local development environment, matching
+        // what is sent from the cloud.
+        //
+        // This prevents us from having to rewrite the signature creation function in JS, which may
+        // differ from the cloud/CLI version.
+        test("should validate a signature with a key successfully", async () => {
+          const body = {
+            ctx: {
+              fn_id: "local-testing-local-cron",
+              run_id: "01GQ3HTEZ01M7R8Z9PR1DMHDN1",
+              step_id: "step",
+            },
+            event: {
+              data: {},
+              id: "",
+              name: "inngest/scheduled.timer",
+              ts: 1674082830001,
+              user: {},
+              v: "1",
+            },
+            steps: {},
+          };
+          const ret = await run(
+            [
+              "Test",
+              [fn],
+              {
+                signingKey:
+                  "signkey-test-f00f3005a3666b359a79c2bc3380ce2715e62727ac461ae1a2618f8766029c9f",
+                __testingAllowExpiredSignatures: true,
+              } as any,
+            ],
+            [
+              {
+                method: "POST",
+                headers: {
+                  [headerKeys.Signature]:
+                    "t=1674082860&s=88b6453463050d1846743cbba0925bae7c1cf807f9c74bbd41b3d5cfc9c70d11",
+                },
+                url: "/api/inngest?fnId=test&stepId=step",
+                body,
+              },
+            ],
+            env
+          );
+          expect(ret).toMatchObject({
+            status: 200,
+            body: '"fn"',
+          });
+        });
+      });
     });
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,6 +1742,11 @@ caniuse-lite@^1.0.30001400:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz#987437b266260b640a23cd18fbddb509d7f69f3e"
   integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
 
+canonicalize@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
+  integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
+
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -3791,11 +3796,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
-
-json-stringify-deterministic@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/json-stringify-deterministic/-/json-stringify-deterministic-1.0.8.tgz#675eaf26f18ebac0197c5e4d2d4dcc2ab3750948"
-  integrity sha512-rkJID3qeigo3VCrEcxX1333fTBBxW89YrdYcZexMnL/WdB8u0zctyG63e/DpahRJyrWCDhh7IQhiR7u2XEDQ4Q==
 
 json-stringify-safe@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Summary

Request signing was previously using `JSON.stringify()`, which has shaky guaranteed key order for nested objects, sometimes resulting in comparing two different request body shapes.

We use [json-stringify-deterministic](https://npm.im/json-stringify-deterministic) here (we already use this for op hashing to ensure consistent hashes) to ensure the body is always in the same order and shape.

For posterity, there's an RFC for a deterministic `JSON.stringify()` method (termed `JSON.canonify()`) here:

- https://www.rfc-editor.org/rfc/rfc8785

There are some further libraries based on this RFC:

- JavaScript - https://github.com/erdtman/canonicalize
- Golang - https://github.com/cyberphone/json-canonicalization/tree/master/go
- Java - https://github.com/cyberphone/json-canonicalization/tree/master/java
- Node.js - https://github.com/cyberphone/json-canonicalization/tree/master/node-es6
- Python 3 - https://github.com/cyberphone/json-canonicalization/tree/master/python3
- .NET - https://github.com/cyberphone/json-canonicalization/tree/master/dotnet

Golang already orders JSON keys when marshalling (see [`func Marshal` docs](https://pkg.go.dev/encoding/json#Marshal), so as far as I can see the method in this PR at present should suffice.

If we see any further issues, it might be reasonable to assess moving to using the libs above.