### PR TITLE
Add `console` step tooling for logging locally and to Inngest

### DIFF
--- a/src/examples/logging/index.test.ts
+++ b/src/examples/logging/index.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import fetch from "cross-fetch";
+import {
+  eventRunWithName,
+  introspectionSchema,
+  sendEvent,
+} from "../../test/helpers";
+
+describe("introspection", () => {
+  const specs = [
+    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
+    { label: "Dev server UI", url: "http://localhost:8288/dev" },
+  ];
+
+  specs.forEach(({ label, url }) => {
+    test(`should show registered functions in ${label}`, async () => {
+      const res = await fetch(url);
+      const data = introspectionSchema.parse(await res.json());
+
+      expect(data.functions).toContainEqual({
+        name: "Logging",
+        id: expect.stringMatching(/^.*-logging$/),
+        triggers: [{ event: "demo/logging" }],
+        steps: {
+          step: {
+            id: "step",
+            name: "step",
+            runtime: {
+              type: "http",
+              url: expect.stringMatching(
+                /^http.+\?fnId=.+-logging&stepId=step$/
+              ),
+            },
+          },
+        },
+      });
+    });
+  });
+});
+
+describe("run", () => {
+  let eventId: string;
+  let runId: string;
+
+  beforeAll(async () => {
+    eventId = await sendEvent("demo/logging");
+  });
+
+  test("runs in response to 'demo/logging'", async () => {
+    runId = await eventRunWithName(eventId, "Logging");
+    expect(runId).toEqual(expect.any(String));
+  });
+
+  test.todo("logs using `console.log()`");
+  test.todo("logs using `console.debug()`");
+  test.todo("logs using `console.error()`");
+  test.todo("logs using `console.info()`");
+  test.todo("logs using `console.trace()`");
+  test.todo("logs using `console.warn()`");
+  test.todo("logs inside a step to run");
+  test.todo("only logs each log once");
+});

--- a/src/examples/logging/index.ts
+++ b/src/examples/logging/index.ts
@@ -1,0 +1,25 @@
+import { inngest } from "../client";
+
+export default inngest.createFunction(
+  { name: "Logging" },
+  { event: "demo/logging" },
+  async ({ step, console }) => {
+    const obj = { foo: "bar" };
+    const etc = "etc";
+
+    console.log("Info", obj, etc);
+    console.debug("Debug", obj, etc);
+    console.error("Error", obj, etc);
+    console.info("Info", obj, etc);
+    console.trace("Trace", obj, etc);
+    console.warn("Warn", obj, etc);
+
+    await step.run("Logging works inside steps, too", async () => {
+      console.log(1);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      console.log(2);
+
+      return "Done";
+    });
+  }
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export type HandlerArgs<
   tools: ReturnType<typeof createStepTools<Events, Event>>[0];
 
   step: ReturnType<typeof createStepTools<Events, Event>>[0];
+
+  console: Console;
 } & (Opts["fns"] extends Record<string, any>
     ? {
         /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export enum StepOpCode {
   RunStep = "Step",
   StepPlanned = "StepPlanned",
   Sleep = "Sleep",
+  Log = "Log",
 }
 
 /**


### PR DESCRIPTION
## Summary

Logging is a common need which we can meet with step tooling. This PR replicates standard methods of [`console`](https://developer.mozilla.org/en-US/docs/Web/API/console) for ease of use.

```ts
async ({ step, console }) => {
  const obj = { foo: "bar" };
  const etc = "etc";

  console.log("Info", obj, etc);
  console.debug("Debug", obj, etc);
  console.error("Error", obj, etc);
  console.info("Info", obj, etc);
  console.trace("Trace", obj, etc);
  console.warn("Warn", obj, etc);

  await step.run("Logging works inside steps, too", async () => {
    console.log(1);
    await new Promise((resolve) => setTimeout(resolve, 200));
    console.log(2);

    return "Done";
  });
}
```

We make sure to proxy through to the default method for most keys, ensuring we're not standing in the way of methods such as `console.clear()`.

The proxied methods have to hook into memoization state rather tightly to ensure that--locally--we log at the very moment we should. Without this, logs may appear out of sync compared to other logs in a user's codebase, making debugging difficult.

## Related

- [x] Resolves #96 
- [ ] Integration tests from added example
  - [ ] Executor changes to handle `Log` op codes
  - [ ] Dev server changes to display logs
- [ ] Docs