### PR TITLE
Ensure `event|cron` union is strictly adhered to when declaring a func

### DIFF
--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -86,3 +86,24 @@ export type ObjectPaths<T extends Record<string, any>> = Path<T>;
 export type KeysNotOfType<T, U> = {
   [P in keyof T]: T[P] extends U ? never : P;
 }[keyof T];
+
+/**
+ * Returns all keys from objects in the union `T`.
+ */
+type UnionKeys<T> = T extends T ? keyof T : never;
+
+/**
+ * Enforces strict union comformity by ensuring that all potential keys in a
+ * union of objects are accounted for in every object.
+ *
+ * Requires two generics to be used, so is abstracted by {@link StrictUnion}.
+ */
+type StrictUnionHelper<T, TAll> = T extends any
+  ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
+  : never;
+
+/**
+ * Enforces strict union comformity by ensuring that all potential keys in a
+ * union of objects are accounted for in every object.
+ */
+export type StrictUnion<T> = StrictUnionHelper<T, T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { createStepTools } from "./components/InngestStepTools";
-import type { KeysNotOfType } from "./helpers/types";
+import type { KeysNotOfType, StrictUnion } from "./helpers/types";
 
 /**
  * Arguments for a single-step function.
@@ -430,12 +430,14 @@ export interface RegisterOptions {
 
 export type TriggerOptions<T extends string> =
   | T
-  | {
-      event: T;
-    }
-  | {
-      cron: string;
-    };
+  | StrictUnion<
+      | {
+          event: T;
+        }
+      | {
+          cron: string;
+        }
+    >;
 
 /**
  * A set of options for configuring an Inngest function.


### PR DESCRIPTION
## Summary

#110 was shipped in `v1.3.0` but reverted in 4c1ee8d388de9f0837b11db74a74134b8a9f7e66 due to causing an event typing regression.

The fix is reintroduced here to resolve an issue where `event` and `cron` could be passed in the same object when running `inngest.createFunction()`. This includes some tests that came with the revert in 4c1ee8d388de9f0837b11db74a74134b8a9f7e66 to ensure it's working correctly.