### PR TITLE
Ensure signatures are not validated during development

### DIFF
--- a/.changeset/long-rules-remain.md
+++ b/.changeset/long-rules-remain.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Ensure signatures are not validated during development


### PR DESCRIPTION
## Summary

Following #108, signatures are being erroneously validated during local development.

This small PR ensures that signatures are only validated in production.

## Related

- Fixes #112 