### PR TITLE
Ensure `inngest.send()` and `step.sendEvent()` can be given empty arrays

### DIFF
--- a/.changeset/two-bottles-rush.md
+++ b/.changeset/two-bottles-rush.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Ensure `inngest.send()` and `step.sendEvent()` can be given an empty array without error

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -129,6 +129,22 @@ describe("send", () => {
       })
     );
   });
+
+  test("should succeed if an event name is given with an empty list of payloads", async () => {
+    const inngest = new Inngest({ name: "test" });
+    inngest.setEventKey(testEventKey);
+
+    await expect(inngest.send("test", [])).resolves.toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("should succeed if an empty list of payloads is given", async () => {
+    const inngest = new Inngest({ name: "test" });
+    inngest.setEventKey(testEventKey);
+
+    await expect(inngest.send([])).resolves.toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("createFunction", () => {

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -298,12 +298,12 @@ export class Inngest<Events extends Record<string, EventPayload>> {
     }
 
     /**
-     * The two overload types should never allow this to happen, but in the case
-     * the user is in JS Land and it does, let's throw.
+     * It can be valid for a user to send an empty list of events; if this
+     * happens, show a warning that this may not be intended, but don't throw.
      */
     if (!payloads.length) {
-      throw new Error(
-        "Provided a name but no events to send; make sure to send an event payload too"
+      return console.warn(
+        "Warning: You have called `inngest.send()` with an empty array; the operation will resolve, but no events have been sent. This may be intentional, in which case you can ignore this warning."
       );
     }
 


### PR DESCRIPTION
## Summary

Previously, using `inngest.send()` (or `step.sendEvent()`) with an empty list of events would throw an error.

To bolster ease of use, we should ensure that sending an empty list of events to send resolves synchronously with no error, keeping code clean for users.

```ts
const events = something.reduce( /* ... */ );

// Would previously throw
await inngest.send(events);

// Meaning we'd have to check
if (events.length) {
  await inngest.send(events);
}

// Or inaccurately try/catch
try {
  await inngest.send(events);
} catch (err) {
  // ...
}

// Now we can just send as in the original example
await inngest.send(events);
```

We'll show a warning in these cases to be confident that a user is noticing this as an error if it is unintentional, similar to leaving dangling promises in an SDK call.

```
Warning: You have called `inngest.send()` with an empty array; the operation will resolve, but no events have been sent. This may be intentional, in which case you can ignore this warning.
```