### PR TITLE
Add ability to provide a function to run when another function fails

### DIFF
--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -58,7 +58,7 @@ export type ServeHandler = (
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: InngestFunction<any>[],
+  functions: InngestFunction<any>[][],
 
   /**
    * A set of options to further configure the registration of Inngest
@@ -256,7 +256,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     /**
      * An array of the functions to serve and register with Inngest.
      */
-    functions: InngestFunction<any>[],
+    functions: InngestFunction<any>[][],
     {
       inngestRegisterUrl,
       fetch,
@@ -341,18 +341,27 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     );
 
     this.fns = functions.reduce<Record<string, InngestFunction<any>>>(
-      (acc, fn) => {
-        const id = fn.id(this.name);
+      (acc, fns) => {
+        const fnMap = fns.reduce<Record<string, InngestFunction<any>>>(
+          (fnAcc, fn) => {
+            const id = fn.id(this.name);
 
-        if (acc[id]) {
-          throw new Error(
-            `Duplicate function ID "${id}"; please change a function's name or provide an explicit ID to avoid conflicts.`
-          );
-        }
+            if (acc[id]) {
+              throw new Error(
+                `Duplicate function ID "${id}"; please change a function's name or provide an explicit ID to avoid conflicts.`
+              );
+            }
+
+            return {
+              [id]: fn,
+            };
+          },
+          {}
+        );
 
         return {
           ...acc,
-          [id]: fn,
+          ...fnMap,
         };
       },
       {}

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -132,7 +132,7 @@ describe("runFn", () => {
 
     const testFn = <
       T extends {
-        fn: InngestFunction<any>;
+        fn: InngestFunction<any>[];
         steps: Record<
           string,
           jest.Mock<() => string> | jest.Mock<() => Promise<string>>
@@ -164,7 +164,11 @@ describe("runFn", () => {
             beforeAll(async () => {
               hashDataSpy = getHashDataSpy();
               tools = createTools();
-              ret = await runFnWithStack(tools.fn, t.stack || [], t.runStep);
+              ret = await runFnWithStack(
+                tools.fn[0] as InngestFunction<any>,
+                t.stack || [],
+                t.runStep
+              );
             });
 
             test("returns expected value", () => {
@@ -808,5 +812,9 @@ describe("runFn", () => {
         },
       })
     );
+  });
+
+  describe("onFailure functions", () => {
+    test.todo("specifying an onFailure function registers correctly");
   });
 });

--- a/src/express.test.ts
+++ b/src/express.test.ts
@@ -1,6 +1,5 @@
 import { Inngest } from "./components/Inngest";
 import { InngestCommHandler } from "./components/InngestCommHandler";
-import { InngestFunction } from "./components/InngestFunction";
 import * as ExpressHandler from "./express";
 import { testFramework } from "./test/helpers";
 import { RegisterRequest } from "./types";
@@ -17,8 +16,9 @@ describe("InngestCommHandler", () => {
 
   describe("registerBody", () => {
     it("Includes correct base URL for functions", () => {
-      const fn = new InngestFunction(
-        new Inngest({ name: "test" }),
+      const client = new Inngest({ name: "test" });
+
+      const fn = client.createFunction(
         { name: "Test Express Function" },
         { event: "test/event.name" },
         () => undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ export { NonRetriableError } from "./components/NonRetriableError";
 export { headerKeys, queryKeys } from "./helpers/consts";
 export type {
   ClientOptions,
+  EventNameFromTrigger,
   EventPayload,
+  FailureEventPayload,
   FunctionOptions,
   LogLevel,
   RegisterOptions,

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -10,7 +10,6 @@ import { ulid } from "ulid";
 import { z } from "zod";
 import { Inngest } from "../components/Inngest";
 import { ServeHandler } from "../components/InngestCommHandler";
-import { InngestFunction } from "../components/InngestFunction";
 import { headerKeys } from "../helpers/consts";
 import { version } from "../version";
 
@@ -512,8 +511,9 @@ export const testFramework = (
 
     describe("POST (run function)", () => {
       describe("signature validation", () => {
-        const fn = new InngestFunction(
-          new Inngest({ name: "test" }),
+        const client = new Inngest({ name: "test" });
+
+        const fn = client.createFunction(
           { name: "Test", id: "test" },
           { event: "demo/event.sent" },
           () => "fn"


### PR DESCRIPTION
## Summary

This is the SDK side of inngest/inngest#370. From that PR:

> This [PR] outlines the ability to create functions called automatically any time functions permanently fail. Failure functions can be their own step functions and should be called with the latest error and the incoming event. This allows users to run any logic necessary for eg. cleanup, alerting, logging, etc.

For users, this ensures `inngest.createFunction()` provides some syntactical sugar over simply creating a new function that listens for the correct `inngest/function.failed` event.

```ts
inngest.createFunction(
  { name: "Send welcome email", fns: { ...emailer } },
  { event: "app/user.created" },
  async ({ event, fns: { sendEmail } }) => {
    await sendEmail({ type: "welcome", to: event.data.email });
  },
  async ({ event }) => {
    await sendEmail({
      type: "alert",
      to: "engineering@example.com",
      subject: `Welcome email failed to send to ${event.data.email}`,
    });
  }
);
```

Future per-step error handling via `.catch()`, `try`/`catch`, etc., could be preferable for some functions; the example above is short enough to be cleaner with a `try`/`catch` block. For larger functions, however, this ensures you don't have to wrap your entire function in a `try`/`catch` block or otherwise reorganise your code to be able to catch errors.



## Related

- inngest/inngest#370
- #43

## Todo

- [ ] Example and integration tests
- [ ] Documentation