### PR TITLE
Remove many `any` types

### DIFF
--- a/.changeset/old-weeks-hunt.md
+++ b/.changeset/old-weeks-hunt.md
@@ -1,0 +1,7 @@
+---
+"inngest": patch
+---
+
+Removes many `any` types from the internal and public APIs.
+
+Affects the public API, so will therefore be a package bump, but shouldn't affect any expected areas of use.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,6 @@ module.exports = {
   ignorePatterns: ["dist/", "*.d.ts", "*.js", "deno_compat/"],
   rules: {
     "prettier/prettier": "warn",
-    "@typescript-eslint/no-explicit-any": "off",
     "@inngest/process-warn": "off",
     "@typescript-eslint/no-unused-vars": [
       "warn",

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -23,10 +23,10 @@ export type EventNameFromTrigger<Events extends Record<string, EventPayload>, T 
 
 // @public
 export interface EventPayload {
-    data: unknown;
+    data: any;
     name: string;
     ts?: number;
-    user?: unknown;
+    user?: any;
     v?: string;
 }
 

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -23,10 +23,10 @@ export type EventNameFromTrigger<Events extends Record<string, EventPayload>, T 
 
 // @public
 export interface EventPayload {
-    data: any;
+    data: unknown;
     name: string;
     ts?: number;
-    user?: any;
+    user?: unknown;
     v?: string;
 }
 
@@ -60,12 +60,12 @@ export interface FunctionOptions<Events extends Record<string, EventPayload>, Ev
     cancelOn?: Cancellation<Events, Event>[];
     concurrency?: number;
     // (undocumented)
-    fns?: Record<string, any>;
+    fns?: Record<string, unknown>;
     id?: string;
     idempotency?: string;
     name: string;
     // (undocumented)
-    onFailure?: (...args: any[]) => any;
+    onFailure?: (...args: unknown[]) => unknown;
     retries?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20;
     throttle?: {
         key?: string;
@@ -83,16 +83,16 @@ export enum headerKeys {
 }
 
 // @public
-export class Inngest<Events extends Record<string, EventPayload>> {
+export class Inngest<Events extends Record<string, EventPayload> = Record<string, EventPayload>> {
     constructor({ name, eventKey, inngestBaseUrl, fetch, }: ClientOptions);
     // Warning: (ae-forgotten-export) The symbol "ShimmedFns" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Handler" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "InngestFunction" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    createFunction<TFns extends Record<string, any>, TTrigger extends TriggerOptions<keyof Events & string>, TShimmedFns extends Record<string, (...args: any[]) => any> = ShimmedFns<TFns>, TTriggerName extends keyof Events & string = EventNameFromTrigger<Events, TTrigger>>(nameOrOpts: string | (Omit<FunctionOptions<Events, TTriggerName>, "fns" | "onFailure"> & {
+    createFunction<TFns extends Record<string, unknown>, TTrigger extends TriggerOptions<keyof Events & string>, TShimmedFns extends Record<string, (...args: any[]) => any> = ShimmedFns<TFns>, TTriggerName extends keyof Events & string = EventNameFromTrigger<Events, TTrigger>>(nameOrOpts: string | (Omit<FunctionOptions<Events, TTriggerName>, "fns" | "onFailure"> & {
         fns?: TFns;
-    }), trigger: TTrigger, handler: Handler<Events, TTriggerName, TShimmedFns>): InngestFunction<Events, any, any>;
+    }), trigger: TTrigger, handler: Handler<Events, TTriggerName, TShimmedFns>): InngestFunction;
     readonly inngestBaseUrl: URL;
     readonly name: string;
     // Warning: (ae-forgotten-export) The symbol "SingleOrArray" needs to be exported by the entry point index.d.ts
@@ -110,8 +110,8 @@ export class Inngest<Events extends Record<string, EventPayload>> {
 export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     constructor(
     frameworkName: string,
-    appNameOrInngest: string | Inngest<any>,
-    functions: InngestFunction<any, any, any>[], { inngestRegisterUrl, fetch, landingPage, logLevel, signingKey, serveHost, servePath, }: RegisterOptions | undefined,
+    appNameOrInngest: string | Inngest,
+    functions: InngestFunction[], { inngestRegisterUrl, fetch, landingPage, logLevel, signingKey, serveHost, servePath, }: RegisterOptions | undefined,
     handler: H,
     transformRes: (actionRes: ActionResponse, ...args: Parameters<H>) => TransformedRes);
     // Warning: (ae-forgotten-export) The symbol "FunctionConfig" needs to be exported by the entry point index.d.ts
@@ -122,7 +122,7 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     protected readonly frameworkName: string;
     readonly handler: H;
     protected _isProd: boolean;
-    protected log(level: LogLevel, ...args: any[]): void;
+    protected log(level: LogLevel, ...args: unknown[]): void;
     protected readonly logLevel: LogLevel;
     readonly name: string;
     // (undocumented)
@@ -137,7 +137,7 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     // Warning: (ae-forgotten-export) The symbol "StepRunResponse" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected runStep(functionId: string, stepId: string | null, data: any, timer: ServerTiming): Promise<StepRunResponse>;
+    protected runStep(functionId: string, stepId: string | null, data: unknown, timer: ServerTiming): Promise<StepRunResponse>;
     // Warning: (ae-forgotten-export) The symbol "RegisterRequest" needs to be exported by the entry point index.d.ts
     protected get sdkHeader(): [
     prefix: string,
@@ -155,7 +155,7 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     // Warning: (ae-forgotten-export) The symbol "ActionResponse" needs to be exported by the entry point index.d.ts
     readonly transformRes: (res: ActionResponse, ...args: Parameters<H>) => TransformedRes;
     // (undocumented)
-    protected validateSignature(sig: string | undefined, body: Record<string, any>): void;
+    protected validateSignature(sig: string | undefined, body: Record<string, unknown>): void;
 }
 
 // @public
@@ -169,9 +169,9 @@ export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "silent";
 // @public
 export class NonRetriableError extends Error {
     constructor(message: string, options?: {
-        cause?: any;
+        cause?: unknown;
     });
-    readonly cause?: any;
+    readonly cause?: unknown;
 }
 
 // @public
@@ -199,9 +199,9 @@ export interface RegisterOptions {
 
 // @public
 export type ServeHandler = (
-nameOrInngest: string | Inngest<any>,
-functions: InngestFunction<any, any, any>[],
-opts?: RegisterOptions) => any;
+nameOrInngest: string | Inngest,
+functions: InngestFunction[],
+opts?: RegisterOptions) => unknown;
 
 // @public
 export type TimeStr = `${`${number}w` | ""}${`${number}d` | ""}${`${number}h` | ""}${`${number}m` | ""}${`${number}s` | ""}`;

--- a/src/cloudflare.test.ts
+++ b/src/cloudflare.test.ts
@@ -20,7 +20,7 @@ testFramework("Cloudflare", CloudflareHandler, {
        * `process.stderr`, we do need to provide some pieces of this, but we can
        * still remove any env vars.
        */
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       process.env = undefined as any;
 
       Object.defineProperties(globalThis, {
@@ -48,9 +48,9 @@ testFramework("Cloudflare", CloudflareHandler, {
       headers.set(k, v as string);
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (req as any).headers = headers;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (req as any).json = () => Promise.resolve(req.body);
 
     return [

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -61,7 +61,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
             return {
               fnId: url.searchParams.get(queryKeys.FnId) as string,
               stepId: url.searchParams.get(queryKeys.StepId) as string,
-              data: (await req.json()) as Record<string, any>,
+              data: (await req.json()) as Record<string, unknown>,
               env,
               isProduction,
               url,

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -54,16 +54,18 @@ describe("send", () => {
 
   beforeAll(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        status: 200,
-        json: () => Promise.resolve({}),
-      })
+    global.fetch = jest.fn(
+      () =>
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({}),
+        })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as any;
   });
 
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
     (global.fetch as any).mockClear();
   });
 
@@ -156,7 +158,7 @@ describe("createFunction", () => {
       test("allows name to be a string", () => {
         inngest.createFunction("test", { event: "test" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<any>(event.data);
+          assertType<unknown>(event.data);
         });
       });
 
@@ -166,7 +168,7 @@ describe("createFunction", () => {
           { event: "test" },
           ({ event }) => {
             assertType<string>(event.name);
-            assertType<any>(event.data);
+            assertType<unknown>(event.data);
           }
         );
       });
@@ -178,7 +180,7 @@ describe("createFunction", () => {
           { event: "test" },
           ({ event }) => {
             assertType<string>(event.name);
-            assertType<any>(event.data);
+            assertType<unknown>(event.data);
           }
         );
       });
@@ -186,21 +188,21 @@ describe("createFunction", () => {
       test("allows trigger to be a string", () => {
         inngest.createFunction("test", "test", ({ event }) => {
           assertType<string>(event.name);
-          assertType<any>(event.data);
+          assertType<unknown>(event.data);
         });
       });
 
       test("allows trigger to be an object with an event property", () => {
         inngest.createFunction("test", { event: "test" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<any>(event.data);
+          assertType<unknown>(event.data);
         });
       });
 
       test("allows trigger to be an object with a cron property", () => {
         inngest.createFunction("test", { cron: "test" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<any>(event.data);
+          assertType<unknown>(event.data);
         });
       });
 
@@ -208,7 +210,7 @@ describe("createFunction", () => {
         // @ts-expect-error Unknown property
         inngest.createFunction("test", { foo: "bar" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<any>(event.data);
+          assertType<unknown>(event.data);
         });
       });
 
@@ -219,7 +221,7 @@ describe("createFunction", () => {
           { event: "test", cron: "test" },
           ({ event }) => {
             assertType<string>(event.name);
-            assertType<any>(event.data);
+            assertType<unknown>(event.data);
           }
         );
       });

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,5 +1,6 @@
 import { assertType } from "type-plus";
 import { envKeys } from "../helpers/consts";
+import { IsAny } from "../helpers/types";
 import { EventPayload } from "../types";
 import { eventKeyWarning, Inngest } from "./Inngest";
 
@@ -158,7 +159,7 @@ describe("createFunction", () => {
       test("allows name to be a string", () => {
         inngest.createFunction("test", { event: "test" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<unknown>(event.data);
+          assertType<IsAny<typeof event.data>>(true);
         });
       });
 
@@ -168,7 +169,7 @@ describe("createFunction", () => {
           { event: "test" },
           ({ event }) => {
             assertType<string>(event.name);
-            assertType<unknown>(event.data);
+            assertType<IsAny<typeof event.data>>(true);
           }
         );
       });
@@ -180,7 +181,7 @@ describe("createFunction", () => {
           { event: "test" },
           ({ event }) => {
             assertType<string>(event.name);
-            assertType<unknown>(event.data);
+            assertType<IsAny<typeof event.data>>(true);
           }
         );
       });
@@ -188,21 +189,21 @@ describe("createFunction", () => {
       test("allows trigger to be a string", () => {
         inngest.createFunction("test", "test", ({ event }) => {
           assertType<string>(event.name);
-          assertType<unknown>(event.data);
+          assertType<IsAny<typeof event.data>>(true);
         });
       });
 
       test("allows trigger to be an object with an event property", () => {
         inngest.createFunction("test", { event: "test" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<unknown>(event.data);
+          assertType<IsAny<typeof event.data>>(true);
         });
       });
 
       test("allows trigger to be an object with a cron property", () => {
         inngest.createFunction("test", { cron: "test" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<unknown>(event.data);
+          assertType<IsAny<typeof event.data>>(true);
         });
       });
 
@@ -210,7 +211,7 @@ describe("createFunction", () => {
         // @ts-expect-error Unknown property
         inngest.createFunction("test", { foo: "bar" }, ({ event }) => {
           assertType<string>(event.name);
-          assertType<unknown>(event.data);
+          assertType<IsAny<typeof event.data>>(true);
         });
       });
 
@@ -221,7 +222,7 @@ describe("createFunction", () => {
           { event: "test", cron: "test" },
           ({ event }) => {
             assertType<string>(event.name);
-            assertType<unknown>(event.data);
+            assertType<IsAny<typeof event.data>>(true);
           }
         );
       });
@@ -241,8 +242,8 @@ describe("createFunction", () => {
 
       test("disallows unknown event as object", () => {
         // @ts-expect-error Unknown event
-        inngest.createFunction("test", { event: "unknown" }, ({ event }) => {
-          assertType<unknown>(event);
+        inngest.createFunction("test", { event: "unknown" }, () => {
+          // no-op
         });
       });
 

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,4 +1,3 @@
-import nock from "nock";
 import { assertType } from "type-plus";
 import { envKeys } from "../helpers/consts";
 import { IsAny } from "../helpers/types";
@@ -154,51 +153,23 @@ describe("send", () => {
   });
 
   describe("types", () => {
-    const mockIngestionApi = () => {
-      beforeEach(() => {
-        nock(`https://inn.gs`).post(`/e/${testEventKey}`).reply(200);
-
-        /**
-         * Ensure nock is active before each test. This is required after each
-         * use of `nock.restore()`.
-         *
-         * See https://www.npmjs.com/package/nock#restoring
-         */
-        try {
-          nock.activate();
-        } catch {
-          // no-op - will throw if Nock is already active
-        }
-      });
-
-      afterEach(() => {
-        /**
-         * Reset nock state after each test.
-         *
-         * See https://www.npmjs.com/package/nock#memory-issues-with-jest
-         */
-        nock.restore();
-        nock.cleanAll();
-      });
-    };
-
     describe("no custom types", () => {
       const inngest = new Inngest({ name: "test", eventKey: testEventKey });
-      mockIngestionApi();
 
-      test("allows sending a single event with a string", async () => {
-        await inngest.send("anything", { data: "foo" });
+      test("allows sending a single event with a string", () => {
+        const _fn = () => inngest.send("anything", { data: "foo" });
       });
 
-      test("allows sending a single event with an object", async () => {
-        await inngest.send({ name: "anything", data: "foo" });
+      test("allows sending a single event with an object", () => {
+        const _fn = () => inngest.send({ name: "anything", data: "foo" });
       });
 
-      test("allows sending multiple events", async () => {
-        await inngest.send([
-          { name: "anything", data: "foo" },
-          { name: "anything", data: "foo" },
-        ]);
+      test("allows sending multiple events", () => {
+        const _fn = () =>
+          inngest.send([
+            { name: "anything", data: "foo" },
+            { name: "anything", data: "foo" },
+          ]);
       });
     });
 
@@ -214,67 +185,69 @@ describe("send", () => {
         };
       }>({ name: "test", eventKey: testEventKey });
 
-      mockIngestionApi();
-
-      test("disallows sending a single unknown event with a string", async () => {
+      test("disallows sending a single unknown event with a string", () => {
         // @ts-expect-error Unknown event
-        await inngest.send("unknown", { data: { foo: "" } });
+        const _fn = () => inngest.send("unknown", { data: { foo: "" } });
       });
 
-      test("disallows sending a single unknown event with an object", async () => {
+      test("disallows sending a single unknown event with an object", () => {
         // @ts-expect-error Unknown event
-        await inngest.send({ name: "unknown", data: { foo: "" } });
+        const _fn = () => inngest.send({ name: "unknown", data: { foo: "" } });
       });
 
-      test("disallows sending multiple unknown events", async () => {
-        await inngest.send([
-          // @ts-expect-error Unknown event
-          { name: "unknown", data: { foo: "" } },
-          // @ts-expect-error Unknown event
-          { name: "unknown2", data: { foo: "" } },
-        ]);
+      test("disallows sending multiple unknown events", () => {
+        const _fn = () =>
+          inngest.send([
+            // @ts-expect-error Unknown event
+            { name: "unknown", data: { foo: "" } },
+            // @ts-expect-error Unknown event
+            { name: "unknown2", data: { foo: "" } },
+          ]);
       });
 
-      test("disallows sending one unknown event with multiple known events", async () => {
-        await inngest.send([
-          { name: "foo", data: { foo: "" } },
-          // @ts-expect-error Unknown event
-          { name: "unknown", data: { foo: "" } },
-        ]);
+      test("disallows sending one unknown event with multiple known events", () => {
+        const _fn = () =>
+          inngest.send([
+            { name: "foo", data: { foo: "" } },
+            // @ts-expect-error Unknown event
+            { name: "unknown", data: { foo: "" } },
+          ]);
       });
 
-      test("disallows sending a single known event with a string and invalid data", async () => {
+      test("disallows sending a single known event with a string and invalid data", () => {
         // @ts-expect-error Invalid data
-        await inngest.send("foo", { data: { foo: 1 } });
+        const _fn = () => inngest.send("foo", { data: { foo: 1 } });
       });
 
-      test("disallows sending a single known event with an object and invalid data", async () => {
+      test("disallows sending a single known event with an object and invalid data", () => {
         // @ts-expect-error Invalid data
-        await inngest.send({ name: "foo", data: { foo: 1 } });
+        const _fn = () => inngest.send({ name: "foo", data: { foo: 1 } });
       });
 
-      test("disallows sending multiple known events with invalid data", async () => {
-        await inngest.send([
-          // @ts-expect-error Invalid data
-          { name: "foo", data: { bar: "" } },
-          // @ts-expect-error Invalid data
-          { name: "bar", data: { foo: "" } },
-        ]);
+      test("disallows sending multiple known events with invalid data", () => {
+        const _fn = () =>
+          inngest.send([
+            // @ts-expect-error Invalid data
+            { name: "foo", data: { bar: "" } },
+            // @ts-expect-error Invalid data
+            { name: "bar", data: { foo: "" } },
+          ]);
       });
 
-      test("allows sending a single known event with a string", async () => {
-        await inngest.send("foo", { data: { foo: "" } });
+      test("allows sending a single known event with a string", () => {
+        const _fn = () => inngest.send("foo", { data: { foo: "" } });
       });
 
-      test("allows sending a single known event with an object", async () => {
-        await inngest.send({ name: "foo", data: { foo: "" } });
+      test("allows sending a single known event with an object", () => {
+        const _fn = () => inngest.send({ name: "foo", data: { foo: "" } });
       });
 
-      test("allows sending multiple known events", async () => {
-        await inngest.send([
-          { name: "foo", data: { foo: "" } },
-          { name: "bar", data: { bar: "" } },
-        ]);
+      test("allows sending multiple known events", () => {
+        const _fn = () =>
+          inngest.send([
+            { name: "foo", data: { foo: "" } },
+            { name: "bar", data: { bar: "" } },
+          ]);
       });
     });
   });

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -55,7 +55,9 @@ export const eventKeyError =
  *
  * @public
  */
-export class Inngest<Events extends Record<string, EventPayload>> {
+export class Inngest<
+  Events extends Record<string, EventPayload> = Record<string, EventPayload>
+> {
   /**
    * The name of this instance, most commonly the name of the application it
    * resides in.
@@ -276,16 +278,15 @@ export class Inngest<Events extends Record<string, EventPayload>> {
       /**
        * Add our payloads and ensure they all have a name.
        */
-      payloads = (
-        Array.isArray(maybePayload)
-          ? maybePayload
-          : maybePayload
-          ? [maybePayload]
-          : []
+      payloads = (Array.isArray(maybePayload)
+        ? maybePayload
+        : maybePayload
+        ? [maybePayload]
+        : []
       ).map((payload) => ({
         ...payload,
         name: nameOrPayload,
-      })) as typeof payloads;
+      })) as unknown as typeof payloads;
     } else {
       /**
        * Grab our payloads straight from the args.
@@ -337,10 +338,11 @@ export class Inngest<Events extends Record<string, EventPayload>> {
   }
 
   public createFunction<
-    TFns extends Record<string, any>,
+    TFns extends Record<string, unknown>,
     TTrigger extends TriggerOptions<keyof Events & string>,
     TShimmedFns extends Record<
       string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (...args: any[]) => any
     > = ShimmedFns<TFns>,
     TTriggerName extends keyof Events & string = EventNameFromTrigger<
@@ -400,15 +402,16 @@ export class Inngest<Events extends Record<string, EventPayload>> {
         }),
     trigger: TTrigger,
     handler: Handler<Events, TTriggerName, TShimmedFns>
-  ): InngestFunction<Events, any, any> {
-    const opts: FunctionOptions<Events, TTriggerName> =
-      typeof nameOrOpts === "string" ? { name: nameOrOpts } : nameOrOpts;
+  ): InngestFunction {
+    const opts = (
+      typeof nameOrOpts === "string" ? { name: nameOrOpts } : nameOrOpts
+    ) as FunctionOptions<Events, keyof Events & string>;
 
     return new InngestFunction(
       this,
-      opts as FunctionOptions<any, any>,
+      opts,
       typeof trigger === "string" ? { event: trigger } : trigger,
-      handler
-    );
+      handler as Handler<Events, keyof Events & string>
+    ) as unknown as InngestFunction;
   }
 }

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -58,7 +58,7 @@ describe("runFn", () => {
     ].forEach(({ type, flowFn, badFlowFn }) => {
       describe(`${type} function`, () => {
         describe("success", () => {
-          let fn: InngestFunction<TestEvents, any, any>;
+          let fn: InngestFunction<TestEvents>;
           let ret: Awaited<ReturnType<typeof fn["runFn"]>>;
 
           beforeAll(async () => {
@@ -89,7 +89,7 @@ describe("runFn", () => {
 
         describe("throws", () => {
           const stepErr = new Error("step error");
-          let fn: InngestFunction<TestEvents, any, any>;
+          let fn: InngestFunction<TestEvents>;
 
           beforeAll(() => {
             fn = new InngestFunction(
@@ -118,7 +118,7 @@ describe("runFn", () => {
 
   describe("step functions", () => {
     const runFnWithStack = (
-      fn: InngestFunction<any, any, any>,
+      fn: InngestFunction,
       stack: OpStack,
       opts?: {
         runStep?: string;
@@ -139,7 +139,7 @@ describe("runFn", () => {
 
     const testFn = <
       T extends {
-        fn: InngestFunction<any, any, any>;
+        fn: InngestFunction;
         steps: Record<
           string,
           jest.Mock<() => string> | jest.Mock<() => Promise<string>>

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -13,10 +13,10 @@ import { EventPayload, HashedOp, Op, StepOpCode } from "../types";
 import { Inngest } from "./Inngest";
 
 export interface TickOp extends HashedOp {
-  fn?: (...args: any[]) => any;
+  fn?: (...args: unknown[]) => unknown;
   fulfilled: boolean;
-  resolve: (value: any | PromiseLike<any>) => void;
-  reject: (reason?: any) => void;
+  resolve: (value: unknown | PromiseLike<unknown>) => void;
+  reject: (reason?: unknown) => void;
 }
 
 /**
@@ -29,7 +29,7 @@ export interface TickOp extends HashedOp {
  */
 export const createStepTools = <
   Events extends Record<string, EventPayload>,
-  TriggeringEvent extends keyof Events
+  TriggeringEvent extends keyof Events & string
 >(
   client: Inngest<Events>
 ) => {
@@ -66,7 +66,7 @@ export const createStepTools = <
      * If we've found a user function to run, we'll store it here so a component
      * higher up can invoke and await it.
      */
-    userFnToRun?: (...args: any[]) => any;
+    userFnToRun?: (...args: unknown[]) => unknown;
 
     /**
      * A boolean to represent whether the user's function is using any step
@@ -135,7 +135,8 @@ export const createStepTools = <
    * When using this function, a generic type should be provided which is the
    * function signature exposed to the user.
    */
-  const createTool = <T extends (...args: any[]) => Promise<any>>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const createTool = <T extends (...args: any[]) => Promise<unknown>>(
     /**
      * A function that returns an ID for this op. This is used to ensure that
      * the op stack is correctly filled, submitted, and retrieved with the same
@@ -169,14 +170,14 @@ export const createStepTools = <
      * when we receive an operation matching this one that does not contain a
      * `data` property.
      */
-    fn?: (...args: Parameters<T>) => any
+    fn?: (...args: Parameters<T>) => unknown
   ): T => {
-    return ((...args: Parameters<T>): Promise<any> => {
+    return ((...args: Parameters<T>): Promise<unknown> => {
       state.hasUsedTools = true;
 
       const opId = hashOp(matchOp(...args));
 
-      return new Promise<any>((resolve, reject) => {
+      return new Promise<unknown>((resolve, reject) => {
         state.tickOps[opId.id] = {
           ...opId,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -239,16 +240,15 @@ export const createStepTools = <
           /**
            * Add our payloads and ensure they all have a name.
            */
-          payloads = (
-            Array.isArray(maybePayload)
-              ? maybePayload
-              : maybePayload
-              ? [maybePayload]
-              : []
+          payloads = (Array.isArray(maybePayload)
+            ? maybePayload
+            : maybePayload
+            ? [maybePayload]
+            : []
           ).map((payload) => ({
             ...payload,
             name: nameOrPayload,
-          })) as typeof payloads;
+          })) as unknown as typeof payloads;
         } else {
           /**
            * Grab our payloads straight from the args.
@@ -268,11 +268,7 @@ export const createStepTools = <
         };
       },
       (nameOrPayload, maybePayload) => {
-        return client.send(
-          nameOrPayload as any,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          maybePayload as unknown as any
-        );
+        return client.send(nameOrPayload, maybePayload);
       }
     ),
 
@@ -323,6 +319,7 @@ export const createStepTools = <
         /**
          * Options to control the event we're waiting for.
          */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         opts: WaitForEventOpts<any, any> | string
       ) => {
         const matchOpts: { timeout: string; if?: string } = {
@@ -358,7 +355,7 @@ export const createStepTools = <
      * for next steps.
      */
     run: createTool<
-      <T extends () => any>(
+      <T extends () => unknown>(
         /**
          * The name of this step as it will appear in the Inngest Cloud UI. This
          * is also used as a unique identifier for the step and should not match
@@ -531,7 +528,7 @@ interface WaitForEventOpts<
 export type UnhashedOp = {
   name: string;
   op: StepOpCode;
-  opts: Record<string, any> | null;
+  opts: Record<string, unknown> | null;
   parent: string | null;
   pos?: number;
 };

--- a/src/components/NonRetriableError.ts
+++ b/src/components/NonRetriableError.ts
@@ -13,7 +13,7 @@ export class NonRetriableError extends Error {
    *
    * This will be serialized and sent to Inngest.
    */
-  public readonly cause?: any;
+  public readonly cause?: unknown;
 
   constructor(
     message: string,
@@ -23,7 +23,7 @@ export class NonRetriableError extends Error {
        *
        * This will be serialized and sent to Inngest.
        */
-      cause?: any;
+      cause?: unknown;
     }
   ) {
     super(message);

--- a/src/deno/fresh.test.ts
+++ b/src/deno/fresh.test.ts
@@ -21,7 +21,7 @@ testFramework("Deno Fresh", DenoFreshHandler, {
        * `process.stderr`, we do need to provide some pieces of this, but we can
        * still remove any env vars.
        */
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       process.env = undefined as any;
 
       Object.defineProperties(globalThis, {
@@ -33,7 +33,7 @@ testFramework("Deno Fresh", DenoFreshHandler, {
       /**
        * Fake a global Deno object, which is primarily used to access env vars.
        */
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
       (globalThis as any).Deno = {
         env: { toObject: () => originalProcess.env },
       };
@@ -49,7 +49,7 @@ testFramework("Deno Fresh", DenoFreshHandler, {
         Response: { value: originalResponse, configurable: true },
         Headers: { value: originalHeaders, configurable: true },
       });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
       delete (globalThis as any).Deno;
     });
   },
@@ -60,9 +60,9 @@ testFramework("Deno Fresh", DenoFreshHandler, {
       headers.set(k, v as string);
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (req as any).headers = headers;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (req as any).json = () => Promise.resolve(req.body);
 
     return [req, env];
@@ -88,7 +88,7 @@ testFramework("Deno Fresh", DenoFreshHandler, {
     });
 
     test("Deno.env.toObject should be defined", () => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
       expect((globalThis as any).Deno.env.toObject).toBeDefined();
     });
   },

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -34,7 +34,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         run: async () => {
           if (req.method === "POST") {
             return {
-              data: (await req.json()) as Record<string, any>,
+              data: (await req.json()) as Record<string, unknown>,
               env,
               fnId: url.searchParams.get(queryKeys.FnId) as string,
               stepId: url.searchParams.get(queryKeys.StepId) as string,

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -12,7 +12,7 @@ type HTTP = {
 type Main = {
   http: HTTP;
   // data can include any JSON-decoded post-data, and query args/saerch params.
-  [data: string]: any;
+  [data: string]: unknown;
 };
 
 export const serve = (
@@ -60,7 +60,7 @@ export const serve = (
         run: () => {
           if (http.method === "POST") {
             return {
-              data: data as Record<string, any>,
+              data: data as Record<string, unknown>,
               fnId: (main[queryKeys.FnId] as string) || "",
               stepId: (main[queryKeys.StepId] as string) || "",
               env,

--- a/src/express.test.ts
+++ b/src/express.test.ts
@@ -2,18 +2,10 @@ import { Inngest } from "./components/Inngest";
 import { InngestCommHandler } from "./components/InngestCommHandler";
 import * as ExpressHandler from "./express";
 import { testFramework } from "./test/helpers";
-import { RegisterRequest } from "./types";
 
 testFramework("Express", ExpressHandler);
 
 describe("InngestCommHandler", () => {
-  // Enable testing of protected methods
-  class InngestCommHandlerPublic extends InngestCommHandler<any, any> {
-    public override registerBody(url: URL): RegisterRequest {
-      return super.registerBody(url);
-    }
-  }
-
   describe("registerBody", () => {
     it("Includes correct base URL for functions", () => {
       const client = new Inngest({ name: "test" });
@@ -23,18 +15,19 @@ describe("InngestCommHandler", () => {
         { event: "test/event.name" },
         () => undefined
       );
-      const ch = new InngestCommHandlerPublic(
+      const ch = new InngestCommHandler(
         "test-framework",
         "test-1",
         [fn],
         {},
-        () => undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return
+        () => undefined as unknown as any,
         () => undefined
       );
 
       const url = new URL("http://localhost:8000/api/inngest");
 
-      const body = ch.registerBody(url);
+      const body = ch["registerBody"](url);
       expect(body.appName).toBe("test-1");
       expect(body.url).toBe("http://localhost:8000/api/inngest");
     });

--- a/src/express.ts
+++ b/src/express.ts
@@ -32,7 +32,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
             return {
               fnId: req.query[queryKeys.FnId] as string,
               stepId: req.query[queryKeys.StepId] as string,
-              data: req.body as Record<string, any>,
+              data: req.body as Record<string, unknown>,
               env,
               isProduction,
               url,

--- a/src/helpers/ServerTiming.ts
+++ b/src/helpers/ServerTiming.ts
@@ -70,7 +70,7 @@ export class ServerTiming {
    *
    * The return value of the function will be returned from this function.
    */
-  public async wrap<T extends (...args: any[]) => any>(
+  public async wrap<T extends (...args: unknown[]) => unknown>(
     name: string,
     fn: T,
     description?: string
@@ -78,8 +78,7 @@ export class ServerTiming {
     const stop = this.start(name, description);
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return await Promise.resolve(fn());
+      return (await Promise.resolve(fn())) as Awaited<ReturnType<T>>;
     } finally {
       stop();
     }

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -39,12 +39,13 @@ export const serializeError = (subject: unknown): SerializedError => {
 /**
  * Check if an object is a serialised error created by {@link serializeError}.
  */
-export const isSerializedError = (value: any): boolean => {
+export const isSerializedError = (value: unknown): boolean => {
   try {
     return (
       Object.prototype.hasOwnProperty.call(value, SERIALIZED_KEY) &&
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      value[SERIALIZED_KEY] === SERIALIZED_VALUE
+      (value as { [SERIALIZED_KEY]: unknown })[SERIALIZED_KEY] ===
+        SERIALIZED_VALUE
     );
   } catch {
     return false;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -126,3 +126,8 @@ export type StrictUnion<T> = StrictUnionHelper<T, T>;
  * ```
  */
 export type IsStringLiteral<T extends string> = string extends T ? false : true;
+
+/**
+ * Returns `true` if the given generic `T` is `any`, or `false` if it is not.
+ */
+export type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -3,7 +3,7 @@ import { EventPayload } from "../types";
 /**
  * Returns a union of all of the values in a given object, regardless of key.
  */
-export type ValueOf<T> = T extends Record<string, any>
+export type ValueOf<T> = T extends Record<string, unknown>
   ? {
       [K in keyof T]: T[K];
     }[keyof T]
@@ -77,6 +77,7 @@ type Path<T> = T extends Array<infer V>
  * This is an exported helper method to ensure we only try to access object
  * paths of known objects.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ObjectPaths<T extends Record<string, any>> = Path<T>;
 
 /**
@@ -98,6 +99,7 @@ type UnionKeys<T> = T extends T ? keyof T : never;
  *
  * Requires two generics to be used, so is abstracted by {@link StrictUnion}.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type StrictUnionHelper<T, TAll> = T extends any
   ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
   : never;
@@ -107,3 +109,20 @@ type StrictUnionHelper<T, TAll> = T extends any
  * union of objects are accounted for in every object.
  */
 export type StrictUnion<T> = StrictUnionHelper<T, T>;
+
+/**
+ * Returns `true` if the given generic `T` is a string literal, e.g. `"foo"`, or
+ * `false` if it is a string type, e.g. `string`.
+ *
+ * Useful for checking whether the keys of an object are known or not.
+ *
+ * @example
+ * ```ts
+ * // false
+ * type ObjIsGeneric = IsStringLiteral<keyof Record<string, boolean>>;
+ *
+ * // true
+ * type ObjIsKnown = IsStringLiteral<keyof { foo: boolean; }>; // true
+ * ```
+ */
+export type IsStringLiteral<T extends string> = string extends T ? false : true;

--- a/src/init.ts
+++ b/src/init.ts
@@ -23,7 +23,7 @@ async function init() {
   const { run } = (await import(
     path.join(process.cwd(), fnPath)
   )) as unknown as {
-    run: (...args: any[]) => unknown;
+    run: (...args: unknown[]) => unknown;
   };
 
   const result = await run(context);

--- a/src/next.ts
+++ b/src/next.ts
@@ -44,7 +44,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         run: () => {
           if (req.method === "POST") {
             return {
-              data: req.body as Record<string, any>,
+              data: req.body as Record<string, unknown>,
               fnId: req.query[queryKeys.FnId] as string,
               stepId: req.query[queryKeys.StepId] as string,
               env,

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -21,7 +21,7 @@ export interface RedwoodResponse {
  *
  * @public
  */
-export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
+export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
   const handler = new InngestCommHandler(
     "redwoodjs",
     nameOrInngest,
@@ -62,7 +62,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
                   ? Buffer.from(event.body, "base64").toString()
                   : event.body
                 : "{}"
-            ) as Record<string, any>;
+            ) as Record<string, unknown>;
 
             return {
               env,

--- a/src/remix.test.ts
+++ b/src/remix.test.ts
@@ -9,9 +9,9 @@ testFramework("Remix", RemixHandler, {
       headers.set(k, v as string);
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (req as any).headers = headers;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (req as any).json = () => Promise.resolve(req.body);
 
     return [{ request: req }];

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -27,7 +27,7 @@ import { allProcessEnv } from "./helpers/env";
  *
  * @public
  */
-export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
+export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
   const handler = new InngestCommHandler(
     "remix",
     nameOrInngest,
@@ -55,7 +55,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): any => {
         run: async () => {
           if (req.method === "POST") {
             return {
-              data: (await req.json()) as Record<string, any>,
+              data: (await req.json()) as Record<string, unknown>,
               env,
               fnId: url.searchParams.get(queryKeys.FnId) as string,
               stepId: url.searchParams.get(queryKeys.StepId) as string,

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -66,7 +66,7 @@ export const testFramework = (
       req: Request,
       res: Response,
       env: Record<string, string | undefined>
-    ) => any[] | void;
+    ) => unknown[] | void;
 
     /**
      * Specify a transformer for a given response, which will be used to
@@ -84,6 +84,7 @@ export const testFramework = (
       /**
        * The returned value from the handler.
        */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ret: any
     ) => Promise<HandlerStandardReturn>;
 
@@ -134,7 +135,8 @@ export const testFramework = (
     }
 
     const args = opts?.transformReq?.(req, res, envToPass) ?? [req, res];
-    const ret = await serveHandler(...args);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ret = await (serveHandler as (...args: any[]) => any)(...args);
 
     return (
       opts?.transformRes?.(res, ret) ?? {
@@ -605,6 +607,7 @@ export const testFramework = (
                 signingKey:
                   "signkey-test-f00f3005a3666b359a79c2bc3380ce2715e62727ac461ae1a2618f8766029c9f",
                 __testingAllowExpiredSignatures: true,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
               } as any,
             ],
             [
@@ -666,8 +669,8 @@ export const introspectionSchema = z.object({
  */
 export const sendEvent = async (
   name: string,
-  data?: Record<string, any>,
-  user?: Record<string, any>
+  data?: Record<string, unknown>,
+  user?: Record<string, unknown>
 ): Promise<string> => {
   const id = ulid();
 
@@ -745,6 +748,7 @@ export const receivedEventWithName = async (
     }
 
     const data = await res.json();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const event = data?.data?.events?.find((e: any) => e.name === name);
 
     if (event) {
@@ -799,6 +803,7 @@ export const eventRunWithName = async (
     const data = await res.json();
 
     const run = data?.data?.event?.functionRuns?.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (run: any) => run.name === name
     );
 
@@ -827,6 +832,7 @@ export const runHasTimeline = async (
     functionType?: string;
     output?: string;
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> => {
   for (let i = 0; i < 5; i++) {
     const start = new Date();
@@ -868,8 +874,10 @@ export const runHasTimeline = async (
 
     const data = await res.json();
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const timelineItem = data?.data?.functionRun?.timeline?.find((entry: any) =>
       Object.keys(timeline).every(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (key) => entry[key] === (timeline as any)[key]
       )
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import type { createStepTools } from "./components/InngestStepTools";
 import { internalEvents } from "./helpers/consts";
-import type { KeysNotOfType, ObjectPaths, StrictUnion } from "./helpers/types";
+import type {
+  IsStringLiteral,
+  KeysNotOfType,
+  ObjectPaths,
+  StrictUnion,
+} from "./helpers/types";
 
 /**
  * The payload for an internal Inngest event that is sent when a function fails.
@@ -71,13 +76,13 @@ export type Op = {
    * is not compared when confirming that the operation was completed; use `id`
    * for this.
    */
-  opts?: any;
+  opts?: Record<string, unknown>;
 
   /**
    * Any data present for this operation. If data is present, this operation is
    * treated as completed.
    */
-  data?: any;
+  data?: unknown;
 
   /**
    * An error present for this operation. If an error is present, this operation
@@ -87,7 +92,7 @@ export type Op = {
    * This allows users to handle step failures using common tools such as
    * try/catch or `.catch()`.
    */
-  error?: any;
+  error?: unknown;
 };
 
 export const incomingOpSchema = z.object({
@@ -142,7 +147,7 @@ export type TimeStr = `${`${number}w` | ""}${`${number}d` | ""}${
 export type BaseContext<
   TEvents extends Record<string, EventPayload>,
   TTrigger extends keyof TEvents & string,
-  TShimmedFns extends Record<string, (...args: any[]) => any>
+  TShimmedFns extends Record<string, (...args: unknown[]) => unknown>
 > = {
   /**
    * The event data present in the payload.
@@ -196,25 +201,22 @@ export type BaseContext<
  * Given a set of generic objects, extract any top-level functions and
  * appropriately shim their types.
  */
-export type ShimmedFns<Fns extends Record<string, any>> = Fns extends Record<
-  string,
-  any
->
-  ? {
-      /**
-       * The key omission here allows the user to pass anything to the `fns`
-       * object and have it be correctly understand and transformed.
-       *
-       * Crucially, we use a complex `Omit` here to ensure that function
-       * comments and metadata is preserved, meaning the user can still use
-       * the function exactly like they would in the rest of their codebase,
-       * even though we're shimming with `tools.run()`.
-       */
-      [K in keyof Omit<Fns, KeysNotOfType<Fns, (...args: any[]) => any>>]: (
-        ...args: Parameters<Fns[K]>
-      ) => Promise<Awaited<ReturnType<Fns[K]>>>;
-    }
-  : Record<string, never>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ShimmedFns<Fns extends Record<string, any>> = {
+  /**
+   * The key omission here allows the user to pass anything to the `fns`
+   * object and have it be correctly understand and transformed.
+   *
+   * Crucially, we use a complex `Omit` here to ensure that function
+   * comments and metadata is preserved, meaning the user can still use
+   * the function exactly like they would in the rest of their codebase,
+   * even though we're shimming with `tools.run()`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K in keyof Omit<Fns, KeysNotOfType<Fns, (...args: any[]) => any>>]: (
+    ...args: Parameters<Fns[K]>
+  ) => Promise<Awaited<ReturnType<Fns[K]>>>;
+};
 
 /**
  * Builds a context object for an Inngest handler, optionally overriding some
@@ -223,8 +225,8 @@ export type ShimmedFns<Fns extends Record<string, any>> = Fns extends Record<
 export type Context<
   TEvents extends Record<string, EventPayload>,
   TTrigger extends keyof TEvents & string,
-  TShimmedFns extends Record<string, (...args: any[]) => any>,
-  TOverrides extends Record<string, any> = Record<never, never>
+  TShimmedFns extends Record<string, (...args: unknown[]) => unknown>,
+  TOverrides extends Record<string, unknown> = Record<never, never>
 > = Omit<BaseContext<TEvents, TTrigger, TShimmedFns>, keyof TOverrides> &
   TOverrides;
 
@@ -237,15 +239,18 @@ export type Context<
 export type Handler<
   TEvents extends Record<string, EventPayload>,
   TTrigger extends keyof TEvents & string,
-  TShimmedFns extends Record<string, (...args: any[]) => any>,
-  TOverrides extends Record<string, any> = Record<never, never>
+  TShimmedFns extends Record<string, (...args: unknown[]) => unknown> = Record<
+    never,
+    never
+  >,
+  TOverrides extends Record<string, unknown> = Record<never, never>
 > = (
   /**
    * The context argument provides access to all data and tooling available to
    * the function.
    */
   ctx: Context<TEvents, TTrigger, TShimmedFns, TOverrides>
-) => any;
+) => unknown;
 
 /**
  * The shape of a single event's payload. It should be extended to enforce
@@ -263,13 +268,13 @@ export interface EventPayload {
   /**
    * Any data pertinent to the event
    */
-  data: any;
+  data: unknown;
 
   /**
    * Any user data associated with the event
    * All fields ending in "_id" will be used to attribute the event to a particular user
    */
-  user?: any;
+  user?: unknown;
 
   /**
    * A specific event schema version
@@ -318,7 +323,7 @@ export interface Response {
    *
    * {@link https://www.inngest.com/docs/functions/function-input-and-output#response-format}
    */
-  body?: any;
+  body?: unknown;
 }
 
 /**
@@ -326,7 +331,7 @@ export interface Response {
  *
  * @internal
  */
-export type Step<TContext = any> = (
+export type Step<TContext = unknown> = (
   /**
    * The context for this step, including the triggering event and any previous
    * step output.
@@ -529,7 +534,7 @@ export interface FunctionOptions<
    */
   concurrency?: number;
 
-  fns?: Record<string, any>;
+  fns?: Record<string, unknown>;
 
   /**
    * Allow the specification of an idempotency key using event data. If
@@ -589,7 +594,7 @@ export interface FunctionOptions<
     | 19
     | 20;
 
-  onFailure?: (...args: any[]) => any;
+  onFailure?: (...args: unknown[]) => unknown;
 }
 
 /**
@@ -601,11 +606,11 @@ export type Cancellation<
   Events extends Record<string, EventPayload>,
   TriggeringEvent extends keyof Events & string
 > = {
-  [K in keyof Events]: {
+  [K in keyof Events & string]: {
     /**
      * The name of the event that should cancel the function run.
      */
-    event: K & string;
+    event: K;
 
     /**
      * The expression that must evaluate to true in order to cancel the function run. There
@@ -645,7 +650,9 @@ export type Cancellation<
      *
      * {@link https://www.inngest.com/docs/functions/expressions}
      */
-    match?: ObjectPaths<Events[TriggeringEvent]> & ObjectPaths<Events[K]>;
+    match?: IsStringLiteral<keyof Events & string> extends true
+      ? ObjectPaths<Events[TriggeringEvent]> & ObjectPaths<Events[K]>
+      : string;
 
     /**
      * An optional timeout that the cancel is valid for.  If this isn't
@@ -660,7 +667,7 @@ export type Cancellation<
      */
     timeout?: number | string | Date;
   };
-}[keyof Events];
+}[keyof Events & string];
 
 /**
  * Expected responses to be used within an `InngestCommHandler` in order to
@@ -675,7 +682,7 @@ export type StepRunResponse =
     }
   | {
       status: 200;
-      body?: any;
+      body?: unknown;
     }
   | {
       status: 206;

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,13 +268,15 @@ export interface EventPayload {
   /**
    * Any data pertinent to the event
    */
-  data: unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
 
   /**
    * Any user data associated with the event
    * All fields ending in "_id" will be used to attribute the event to a particular user
    */
-  user?: unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  user?: any;
 
   /**
    * A specific event schema version


### PR DESCRIPTION
- 22 exceptions remaining in test files
- 11 exceptions remaining in built files
  - 1 for a non-TS lib with broken package typing (hash.js)
  - 1 to have fun with method overloads
  - 9 on generic types that require `any` for inference
- 0 runtime code changes, so nothing was being access unsafely! 🥳