### PR TITLE
Add `"inngest/lambda"` serve handler for AWS Lambda environments

### DIFF
--- a/.changeset/chilled-bottles-grin.md
+++ b/.changeset/chilled-bottles-grin.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `"inngest/lambda"` serve handler for AWS Lambda environments

--- a/src/lambda.test.ts
+++ b/src/lambda.test.ts
@@ -1,0 +1,29 @@
+import type { APIGatewayProxyResult } from "aws-lambda";
+import * as LambdaHandler from "./lambda";
+import { testFramework } from "./test/helpers";
+
+testFramework("AWS Lambda", LambdaHandler, {
+  transformReq: (req, _res, _env) => {
+    return [
+      {
+        path: req.path,
+        headers: req.headers,
+        httpMethod: req.method,
+        queryStringParameters: req.query,
+        body:
+          typeof req.body === "string" ? req.body : JSON.stringify(req.body),
+      },
+      {},
+    ];
+  },
+
+  transformRes: async (_res, retP: Promise<APIGatewayProxyResult>) => {
+    const ret = await retP;
+
+    return {
+      status: ret.statusCode,
+      body: ret.body || "",
+      headers: (ret.headers || {}) as Record<string, string>,
+    };
+  },
+});

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -61,9 +61,15 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
       const path = eventIsV2 ? event.requestContext.http.path : event.path;
 
       const env = allProcessEnv();
-      const proto = event.headers["x-forwarded-proto"] || "https";
 
-      const url = new URL(path, `${proto}://${event.headers.host || ""}`);
+      let url: URL;
+
+      try {
+        const proto = event.headers["x-forwarded-proto"] || "https";
+        url = new URL(path, `${proto}://${event.headers.host || ""}`);
+      } catch (err) {
+        throw new Error("Could not parse URL from `event.headers.host`");
+      }
 
       const isProduction =
         env.CONTEXT === "production" ||

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,0 +1,134 @@
+import type {
+  APIGatewayEvent,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResult,
+  Context,
+} from "aws-lambda";
+import {
+  InngestCommHandler,
+  ServeHandler,
+} from "./components/InngestCommHandler";
+import { headerKeys, queryKeys } from "./helpers/consts";
+import { allProcessEnv } from "./helpers/env";
+
+/**
+ * With AWS Lambda, serve and register any declared functions with Inngest,
+ * making them available to be triggered by events.
+ *
+ * @example
+ *
+ * ```ts
+ * import { Inngest } from "inngest";
+ * import { serve } from "inngest/lambda";
+ *
+ * const inngest = new Inngest({ name: "My Lambda App" });
+ *
+ * const fn = inngest.createFunction(
+ *   { name: "Hello World" },
+ *   { event: "test/hello.world" },
+ *   async ({ event }) => {
+ *     return "Hello World";
+ *   }
+ * );
+ *
+ * export const handler = serve(inngest, [fn]);
+ * ```
+ *
+ * @public
+ */
+export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
+  const handler = new InngestCommHandler(
+    "aws-lambda",
+    nameOrInngest,
+    fns,
+    { ...opts },
+    (event: APIGatewayEvent | APIGatewayProxyEventV2, _context: Context) => {
+      /**
+       * Try to handle multiple incoming event types, as Lambda can have many
+       * triggers.
+       *
+       * This still doesn't handle all cases, but it's a start.
+       */
+      const eventIsV2 = ((
+        ev: APIGatewayEvent | APIGatewayProxyEventV2
+      ): ev is APIGatewayProxyEventV2 => {
+        return (ev as APIGatewayProxyEventV2).version === "2.0";
+      })(event);
+
+      const method = eventIsV2
+        ? event.requestContext.http.method
+        : event.httpMethod;
+      const path = eventIsV2 ? event.requestContext.http.path : event.path;
+
+      const env = allProcessEnv();
+      const proto = event.headers["x-forwarded-proto"] || "https";
+
+      const url = new URL(path, `${proto}://${event.headers.host || ""}`);
+
+      const isProduction =
+        env.CONTEXT === "production" ||
+        env.ENVIRONMENT === "production" ||
+        env.NODE_ENV?.startsWith("prod") ||
+        false;
+
+      return {
+        register: () => {
+          if (method === "PUT") {
+            return {
+              env,
+              isProduction,
+              url,
+              deployId: event.queryStringParameters?.[
+                queryKeys.DeployId
+              ] as string,
+            };
+          }
+        },
+
+        run: () => {
+          if (method === "POST") {
+            return {
+              data: JSON.parse(
+                event.body
+                  ? event.isBase64Encoded
+                    ? Buffer.from(event.body, "base64").toString()
+                    : event.body
+                  : "{}"
+              ) as Record<string, unknown>,
+              env,
+              fnId: event.queryStringParameters?.[queryKeys.FnId] as string,
+              isProduction,
+              url,
+              stepId: event.queryStringParameters?.[queryKeys.StepId] as string,
+              signature: event.headers[headerKeys.Signature] as string,
+            };
+          }
+        },
+
+        view: () => {
+          if (method === "GET") {
+            return {
+              env,
+              isIntrospection: Object.hasOwnProperty.call(
+                event.queryStringParameters || {},
+                queryKeys.Introspect
+              ),
+              isProduction,
+              url,
+            };
+          }
+        },
+      };
+    },
+
+    ({ body, status, headers }, _req): Promise<APIGatewayProxyResult> => {
+      return Promise.resolve({
+        body,
+        statusCode: status,
+        headers,
+      });
+    }
+  );
+
+  return handler.createHandler();
+};


### PR DESCRIPTION
## Summary

Adds a new supported serve handler, `"inngest/lambda"` for use with AWS Lambda.

```ts
import { Inngest } from "inngest";
import { serve } from "inngest/lambda";

const inngest = new Inngest({ name: "My Lambda App" });

const fn = inngest.createFunction(
  { name: "Hello World" },
  { event: "test/hello.world" },
  async ({ event }) => {
    return "Hello World";
  }
);

export const handler = serve(inngest, [fn]);
```

Lambda can be triggered in many different ways from many different places. The handler currently tries to support API Gateway v1/v2 (which includes Lambda Function URLs), and we can add support for more triggers in the future (SNS, S3, etc.) as needed.