### PR TITLE
Refactor `InngestCommHandler` to better detect env and reduce duplication

### DIFF
--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -32,26 +32,20 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
       env: Record<string, string | undefined>;
     }) => {
       const url = new URL(req.url, `https://${req.headers.get("host") || ""}`);
-      const isProduction =
-        env.CF_PAGES === "1" || env.ENVIRONMENT === "production";
 
       return {
+        env,
+        url,
         view: () => {
           if (req.method === "GET") {
             return {
-              url,
-              env,
               isIntrospection: url.searchParams.has(queryKeys.Introspect),
-              isProduction,
             };
           }
         },
         register: () => {
           if (req.method === "PUT") {
             return {
-              env,
-              url,
-              isProduction,
               deployId: url.searchParams.get(queryKeys.DeployId),
             };
           }
@@ -62,9 +56,6 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
               fnId: url.searchParams.get(queryKeys.FnId) as string,
               stepId: url.searchParams.get(queryKeys.StepId) as string,
               data: (await req.json()) as Record<string, unknown>,
-              env,
-              isProduction,
-              url,
               signature: req.headers.get(headerKeys.Signature) || undefined,
             };
           }

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -59,7 +59,7 @@ describe("runFn", () => {
       describe(`${type} function`, () => {
         describe("success", () => {
           let fn: InngestFunction<TestEvents>;
-          let ret: Awaited<ReturnType<typeof fn["runFn"]>>;
+          let ret: Awaited<ReturnType<(typeof fn)["runFn"]>>;
 
           beforeAll(async () => {
             fn = new InngestFunction(

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -269,6 +269,7 @@ describe("sendEvent", () => {
   describe("types", () => {
     describe("no custom types", () => {
       const sendEvent: ReturnType<typeof createStepTools>[0]["sendEvent"] =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (() => undefined) as any;
 
       test("allows sending a single event with a string", () => {
@@ -302,6 +303,7 @@ describe("sendEvent", () => {
           },
           "foo"
         >
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       >[0]["sendEvent"] = (() => undefined) as any;
 
       test("disallows sending a single unknown event with a string", () => {

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -18,15 +18,13 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
     opts,
     (req: Request, env: { [index: string]: string }) => {
       const url = new URL(req.url, `https://${req.headers.get("host") || ""}`);
-      const isProduction = Boolean(env.DENO_DEPLOYMENT_ID);
 
       return {
+        url,
+        env,
         register: () => {
           if (req.method === "PUT") {
             return {
-              env,
-              isProduction,
-              url,
               deployId: url.searchParams.get(queryKeys.DeployId),
             };
           }
@@ -35,11 +33,8 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
           if (req.method === "POST") {
             return {
               data: (await req.json()) as Record<string, unknown>,
-              env,
               fnId: url.searchParams.get(queryKeys.FnId) as string,
               stepId: url.searchParams.get(queryKeys.StepId) as string,
-              url,
-              isProduction,
               signature: req.headers.get(headerKeys.Signature) || undefined,
             };
           }
@@ -47,10 +42,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         view: () => {
           if (req.method === "GET") {
             return {
-              env,
               isIntrospection: url.searchParams.has(queryKeys.Introspect),
-              url,
-              isProduction,
             };
           }
         },

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -1,7 +1,6 @@
 import type { ServeHandler } from "./components/InngestCommHandler";
 import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import { allProcessEnv } from "./helpers/env";
 
 type HTTP = {
   headers: Record<string, string>;
@@ -37,9 +36,6 @@ export const serve = (
         data = {};
       }
 
-      const env = allProcessEnv();
-      const isProduction = env.NODE_ENV !== "development";
-
       // serveHost and servePath must be defined when running in DigitalOcean in order
       // for the SDK to properly register and run functions.
       //
@@ -47,12 +43,10 @@ export const serve = (
       const url = new URL(`${opts.serveHost}${opts?.servePath || "/"}`);
 
       return {
+        url,
         register: () => {
           if (http.method === "PUT") {
             return {
-              env,
-              url,
-              isProduction,
               deployId: main[queryKeys.DeployId] as string,
             };
           }
@@ -63,9 +57,6 @@ export const serve = (
               data: data as Record<string, unknown>,
               fnId: (main[queryKeys.FnId] as string) || "",
               stepId: (main[queryKeys.StepId] as string) || "",
-              env,
-              isProduction,
-              url,
               signature: http.headers[headerKeys.Signature] as string,
             };
           }
@@ -73,13 +64,10 @@ export const serve = (
         view: () => {
           if (http.method === "GET") {
             return {
-              env,
               isIntrospection: Object.hasOwnProperty.call(
                 main,
                 queryKeys.Introspect
               ),
-              url,
-              isProduction,
             };
           }
         },

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -3,7 +3,6 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import { allProcessEnv } from "./helpers/env";
 
 /**
  * In an edge runtime, serve and register any declared functions with Inngest,
@@ -31,20 +30,13 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
       ...opts,
     },
     (req: Request) => {
-      const env = allProcessEnv();
       const url = new URL(req.url, `https://${req.headers.get("host") || ""}`);
-      const isProduction =
-        env.VERCEL_ENV === "production" ||
-        env.CONTEXT === "production" ||
-        env.ENVIRONMENT === "production";
 
       return {
+        url,
         register: () => {
           if (req.method === "PUT") {
             return {
-              env,
-              isProduction,
-              url,
               deployId: url.searchParams.get(queryKeys.DeployId) as string,
             };
           }
@@ -53,10 +45,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
           if (req.method === "POST") {
             return {
               data: (await req.json()) as Record<string, unknown>,
-              env,
               fnId: url.searchParams.get(queryKeys.FnId) as string,
-              isProduction,
-              url,
               stepId: url.searchParams.get(queryKeys.StepId) as string,
               signature: req.headers.get(headerKeys.Signature) as string,
             };
@@ -65,10 +54,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         view: () => {
           if (req.method === "GET") {
             return {
-              env,
               isIntrospection: url.searchParams.has(queryKeys.Introspect),
-              isProduction,
-              url,
             };
           }
         },

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -3,7 +3,6 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import { allProcessEnv } from "./helpers/env";
 
 /**
  * In Remix, serve and register any declared functions with Inngest, making them
@@ -34,20 +33,13 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
     fns,
     opts,
     ({ request: req }: { request: Request }) => {
-      const env = allProcessEnv();
       const url = new URL(req.url, `https://${req.headers.get("host") || ""}`);
-      const isProduction =
-        env.VERCEL_ENV === "production" ||
-        env.CONTEXT === "production" ||
-        env.ENVIRONMENT === "production";
 
       return {
+        url,
         register: () => {
           if (req.method === "PUT") {
             return {
-              env,
-              isProduction,
-              url,
               deployId: url.searchParams.get(queryKeys.DeployId),
             };
           }
@@ -56,11 +48,8 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
           if (req.method === "POST") {
             return {
               data: (await req.json()) as Record<string, unknown>,
-              env,
               fnId: url.searchParams.get(queryKeys.FnId) as string,
               stepId: url.searchParams.get(queryKeys.StepId) as string,
-              isProduction,
-              url,
               signature: req.headers.get(headerKeys.Signature) || undefined,
             };
           }
@@ -68,10 +57,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
         view: () => {
           if (req.method === "GET") {
             return {
-              env,
               isIntrospection: url.searchParams.has(queryKeys.Introspect),
-              isProduction,
-              url,
             };
           }
         },

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -106,7 +106,7 @@ export const testFramework = (
    * Create a helper function for running tests against the given serve handler.
    */
   const run = async (
-    handlerOpts: Parameters<typeof handler["serve"]>,
+    handlerOpts: Parameters<(typeof handler)["serve"]>,
     reqOpts: Parameters<typeof httpMocks.createRequest>,
     env: Record<string, string | undefined> = {}
   ): Promise<HandlerStandardReturn> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,9 +4423,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.6.tgz#5c174b29befd507f14b83e3c19f83fdc0e974b71"
+  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
 
 pretty-format@^27.0.0, pretty-format@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
## Summary

Most serve handlers provide their own logic for checking if the handler is in production mode or not, though we almost always use environment variables for this. This PR:

- Refactors an existing [`isProd()`](https://github.com/inngest/inngest-js/blob/main/src/helpers/env.ts#L34-L42) call to better check multiple env vars
- Refactors `InngestCommHandler` to use `isProd()` and fetch env internally unless an override is provided in a serve handler
- Reduce duplication in serve handlers by unifying passing of `url`, `env`, and `isProduction`

## Related

- https://github.com/inngest/inngest-js/pull/145#discussion_r1143524140
- Closes #146