### PR TITLE
INN-1009 Add CI tests for different TS versions to ensure back compat

### DIFF
--- a/.changeset/popular-dogs-sniff.md
+++ b/.changeset/popular-dogs-sniff.md
@@ -1,0 +1,7 @@
+---
+"inngest": patch
+---
+
+INN-1009 Show warnings when using the package with TS versions `<4.7.2` and Node versions `<14`
+
+This includes tests to assert we appropriately support these versions now and in the future.

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -16,9 +16,23 @@ runs:
         restore-keys: |
           ${{ runner.os }}-volta-
 
-    - name: Install volta
+    - name: Install Volta
       shell: bash
       run: curl https://get.volta.sh | bash
+      env:
+        VOLTA_HOME: ~/.volta
+
+    - name: List dirs
+      shell: bash
+      run: |
+        ls -lah ~/.volta
+        ls -lah ~/.volta/bin
+
+    - name: Add Volta to path
+      shell: bash
+      run: ~/.volta/bin/volta setup
+      env:
+        VOLTA_HOME: ~/.volta
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -8,7 +8,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: volta-cli/action@v4
+    - uses: actions/cache@v3
+      id: volta-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ~/.volta
+        key: ${{ runner.os }}-volta-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-volta-
+
+    - name: Install volta
+      shell: bash
+      run: curl https://get.volta.sh | bash
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -8,31 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3
-      id: volta-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      with:
-        path: ~/.volta
-        key: ${{ runner.os }}-volta-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          ${{ runner.os }}-volta-
-
-    - name: Install Volta
-      shell: bash
-      run: curl https://get.volta.sh | bash
-      env:
-        VOLTA_HOME: ~/.volta
-
-    - name: List dirs
-      shell: bash
-      run: |
-        ls -lah ~/.volta
-        ls -lah ~/.volta/bin
-
-    - name: Add Volta to path
-      shell: bash
-      run: ~/.volta/bin/volta setup
-      env:
-        VOLTA_HOME: ~/.volta
+    - uses: volta-cli/action@v4
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,8 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build
+      - run: yarn prelink
       - run: yarn add -D typescript@${{ matrix.tsVersion }}
-      - run: yarn test
+      - run: yarn test:types
 
   api_diff:
     name: Local API diff

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,7 @@ jobs:
          - '~5.0.0'
          - '~4.9.0'
          - '~4.8.0'
+         - "~4.7.0"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,16 +17,37 @@ env:
 
 jobs:
   test:
-    name: Test
+    name: Runtime
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        nodeVersion: [14, 16, 18, lts]
+        nodeVersion:
+          - 14
+          - 16
+          - 18
+          - lts
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build
       - run: volta run --node ${{ matrix.nodeVersion }} yarn test
+
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tsVersion:
+         - 'latest'
+         - '~5.0.0'
+         - '~4.9.0'
+         - '~4.8.0'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-and-build
+      - run: yarn add -D typescript@${{ matrix.tsVersion }}
+      - run: yarn test
 
   api_diff:
     name: Local API diff

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   NODE_AUTH_TOKEN: nothing
+  VOLTA_HOME: "~/.volta"
 
 jobs:
   test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   NODE_AUTH_TOKEN: nothing
-  VOLTA_HOME: "~/.volta"
 
 jobs:
   test:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "deno.enablePaths": ["./deno_compat"]
+  "deno.enablePaths": ["./deno_compat"],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,8 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: ["<rootDir>/src/**/*.test.ts", "!**/examples/**/*.test.ts"],
+  roots: ["<rootDir>/src"],
+  moduleNameMapper: {
+    inngest: "<rootDir>/src",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -99,5 +99,8 @@
   },
   "peerDependencies": {
     "typescript": ">=4.7.2"
+  },
+  "engines": {
+    "node": ">=14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "yarn run clean && tsc --project tsconfig.build.json",
     "test": "node --expose-gc --max-old-space-size=4096 ./node_modules/.bin/jest --silent --logHeapUsage --maxWorkers=8 --coverage --ci --verbose",
     "test:examples": "node --expose-gc --max-old-space-size=4096 ./node_modules/.bin/jest --logHeapUsage --maxWorkers=8 --testMatch \"**/examples/**/*.test.ts\" --ci --verbose",
+    "test:types": "tsc --noEmit --project tsconfig.types.json",
     "clean": "rm -rf ./dist",
     "lint": "eslint .",
     "postversion": "yarn run build && yarn run build:copy",

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
   "volta": {
     "node": "18.12.1",
     "yarn": "1.22.19"
+  },
+  "peerDependencies": {
+    "typescript": ">=4.7.2"
   }
 }

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,8 +1,8 @@
+import { EventPayload, Inngest } from "inngest";
 import { assertType } from "type-plus";
 import { envKeys } from "../helpers/consts";
 import { IsAny } from "../helpers/types";
-import { EventPayload } from "../types";
-import { eventKeyWarning, Inngest } from "./Inngest";
+import { eventKeyWarning } from "./Inngest";
 
 const testEvent: EventPayload = {
   name: "test",

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,7 +1,8 @@
-import { EventPayload, Inngest } from "inngest";
+import { EventPayload } from "inngest";
 import { assertType } from "type-plus";
 import { envKeys } from "../helpers/consts";
 import { IsAny } from "../helpers/types";
+import { createClient } from "../test/helpers";
 import { eventKeyWarning } from "./Inngest";
 
 const testEvent: EventPayload = {
@@ -32,18 +33,18 @@ describe("instantiation", () => {
     });
 
     test("should log a warning if event key not specified", () => {
-      new Inngest({ name: "test" });
+      createClient({ name: "test" });
       expect(warnSpy).toHaveBeenCalledWith(eventKeyWarning);
     });
 
     test("should not log a warning if event key is specified", () => {
-      new Inngest({ name: "test", eventKey: testEventKey });
+      createClient({ name: "test", eventKey: testEventKey });
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
     test("should not log a warning if event key is specified in env", () => {
       process.env[envKeys.EventKey] = testEventKey;
-      new Inngest({ name: "test" });
+      createClient({ name: "test" });
       expect(warnSpy).not.toHaveBeenCalled();
     });
   });
@@ -84,7 +85,7 @@ describe("send", () => {
     });
 
     test("should fail to send if event key not specified at instantiation", async () => {
-      const inngest = new Inngest({ name: "test" });
+      const inngest = createClient({ name: "test" });
 
       await expect(() => inngest.send(testEvent)).rejects.toThrowError(
         "Could not find an event key"
@@ -92,7 +93,7 @@ describe("send", () => {
     });
 
     test("should succeed if event key specified at instantiation", async () => {
-      const inngest = new Inngest({ name: "test", eventKey: testEventKey });
+      const inngest = createClient({ name: "test", eventKey: testEventKey });
 
       await expect(inngest.send(testEvent)).resolves.toBeUndefined();
 
@@ -107,7 +108,7 @@ describe("send", () => {
 
     test("should succeed if event key specified in env", async () => {
       process.env[envKeys.EventKey] = testEventKey;
-      const inngest = new Inngest({ name: "test" });
+      const inngest = createClient({ name: "test" });
 
       await expect(inngest.send(testEvent)).resolves.toBeUndefined();
 
@@ -121,7 +122,7 @@ describe("send", () => {
     });
 
     test("should succeed if event key given at runtime", async () => {
-      const inngest = new Inngest({ name: "test" });
+      const inngest = createClient({ name: "test" });
       inngest.setEventKey(testEventKey);
 
       await expect(inngest.send(testEvent)).resolves.toBeUndefined();
@@ -136,7 +137,7 @@ describe("send", () => {
     });
 
     test("should succeed if an event name is given with an empty list of payloads", async () => {
-      const inngest = new Inngest({ name: "test" });
+      const inngest = createClient({ name: "test" });
       inngest.setEventKey(testEventKey);
 
       await expect(inngest.send("test", [])).resolves.toBeUndefined();
@@ -144,7 +145,7 @@ describe("send", () => {
     });
 
     test("should succeed if an empty list of payloads is given", async () => {
-      const inngest = new Inngest({ name: "test" });
+      const inngest = createClient({ name: "test" });
       inngest.setEventKey(testEventKey);
 
       await expect(inngest.send([])).resolves.toBeUndefined();
@@ -154,7 +155,7 @@ describe("send", () => {
 
   describe("types", () => {
     describe("no custom types", () => {
-      const inngest = new Inngest({ name: "test", eventKey: testEventKey });
+      const inngest = createClient({ name: "test", eventKey: testEventKey });
 
       test("allows sending a single event with a string", () => {
         const _fn = () => inngest.send("anything", { data: "foo" });
@@ -174,7 +175,7 @@ describe("send", () => {
     });
 
     describe("multiple custom types", () => {
-      const inngest = new Inngest<{
+      const inngest = createClient<{
         foo: {
           name: "foo";
           data: { foo: string };
@@ -256,7 +257,7 @@ describe("send", () => {
 describe("createFunction", () => {
   describe("types", () => {
     describe("no custom types", () => {
-      const inngest = new Inngest({ name: "test" });
+      const inngest = createClient({ name: "test" });
 
       test("allows name to be a string", () => {
         inngest.createFunction("test", { event: "test" }, ({ event }) => {
@@ -331,7 +332,7 @@ describe("createFunction", () => {
     });
 
     describe("multiple custom types", () => {
-      const inngest = new Inngest<{
+      const inngest = createClient<{
         foo: {
           name: "foo";
           data: { title: string };

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -291,13 +291,11 @@ export class Inngest<
       /**
        * Grab our payloads straight from the args.
        */
-      payloads = (
-        Array.isArray(nameOrPayload)
-          ? nameOrPayload
-          : nameOrPayload
-          ? [nameOrPayload]
-          : []
-      ) as typeof payloads;
+      payloads = (Array.isArray(nameOrPayload)
+        ? nameOrPayload
+        : nameOrPayload
+        ? [nameOrPayload]
+        : []) as unknown as typeof payloads;
     }
 
     /**

--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { serve } from "../next";
-import { Inngest } from "./Inngest";
+import { createClient } from "../test/helpers";
 
 describe("#153", () => {
   test('does not throw "type instantiation is excessively deep and possibly infinite" for looping type', () => {
@@ -13,7 +13,7 @@ describe("#153", () => {
     type Literal = z.infer<typeof literalSchema>;
     type Json = Literal | { [key: string]: Json } | Json[];
 
-    const inngest = new Inngest<{
+    const inngest = createClient<{
       foo: {
         name: "foo";
         data: {

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -866,7 +866,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
 
   private upsertSigningKeyFromEnv(env: Record<string, unknown>) {
     if (!this.signingKey && env[envKeys.SigningKey]) {
-      this.signingKey = env[envKeys.SigningKey].toString();
+      this.signingKey = String(env[envKeys.SigningKey]);
     }
   }
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -7,6 +7,7 @@ import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import { allProcessEnv, isProd } from "../helpers/env";
 import { serializeError } from "../helpers/errors";
 import { strBoolean } from "../helpers/scalar";
+import { stringifyUnknown } from "../helpers/strings";
 import type { MaybePromise } from "../helpers/types";
 import { landing } from "../landing";
 import {
@@ -514,7 +515,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         this.upsertSigningKeyFromEnv(env);
 
         const showLandingPage = this.shouldShowLandingPage(
-          env[envKeys.LandingPage]?.toString()
+          stringifyUnknown(env[envKeys.LandingPage])
         );
 
         if (this._isProd || !showLandingPage) {
@@ -528,8 +529,9 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         if (viewRes.isIntrospection) {
           const introspection: IntrospectRequest = {
             ...this.registerBody(this.reqUrl(actions.url)),
-            devServerURL: devServerUrl(env[envKeys.DevServerUrl]?.toString())
-              .href,
+            devServerURL: devServerUrl(
+              stringifyUnknown(env[envKeys.DevServerUrl])
+            ).href,
             hasSigningKey: Boolean(this.signingKey),
           };
 
@@ -559,7 +561,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
 
         const { status, message } = await this.register(
           this.reqUrl(actions.url),
-          env[envKeys.DevServerUrl]?.toString(),
+          stringifyUnknown(env[envKeys.DevServerUrl]),
           registerRes.deployId
         );
 

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -5,6 +5,7 @@ import { InngestFunction } from "./InngestFunction";
 import { UnhashedOp, _internals } from "./InngestStepTools";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { jest } from "@jest/globals";
+import { createClient } from "../test/helpers";
 
 type TestEvents = {
   foo: { name: "foo"; data: { foo: string } };
@@ -12,7 +13,7 @@ type TestEvents = {
   baz: { name: "baz"; data: { baz: string } };
 };
 
-const inngest = new Inngest<TestEvents>({
+const inngest = createClient<TestEvents>({
   name: "test",
   eventKey: "event-key-123",
 });
@@ -23,7 +24,7 @@ describe("#generateID", () => {
   it("Returns a correct name", () => {
     const fn = () =>
       new InngestFunction(
-        new Inngest({ name: "test" }),
+        createClient({ name: "test" }),
         { name: "HELLO 👋 there mr Wolf 🥳!" },
         { event: "test/event.name" },
         () => undefined
@@ -63,7 +64,7 @@ describe("runFn", () => {
 
           beforeAll(async () => {
             fn = new InngestFunction(
-              new Inngest<TestEvents>({ name: "test" }),
+              createClient<TestEvents>({ name: "test" }),
               { name: "Foo" },
               { event: "foo" },
               flowFn
@@ -93,7 +94,7 @@ describe("runFn", () => {
 
           beforeAll(() => {
             fn = new InngestFunction(
-              new Inngest<TestEvents>({ name: "test" }),
+              createClient<TestEvents>({ name: "test" }),
               { name: "Foo" },
               { event: "foo" },
               badFlowFn

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,6 +1,6 @@
+import { EventPayload, Inngest } from "inngest";
 import { ServerTiming } from "../helpers/ServerTiming";
-import { EventPayload, OpStack, StepOpCode } from "../types";
-import { Inngest } from "./Inngest";
+import { OpStack, StepOpCode } from "../types";
 import { InngestFunction } from "./InngestFunction";
 import { UnhashedOp, _internals } from "./InngestStepTools";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,4 +1,4 @@
-import { EventPayload, Inngest } from "inngest";
+import { EventPayload } from "inngest";
 import { ServerTiming } from "../helpers/ServerTiming";
 import { OpStack, StepOpCode } from "../types";
 import { InngestFunction } from "./InngestFunction";
@@ -947,7 +947,7 @@ describe("runFn", () => {
   // describe("onFailure functions", () => {
   //   describe("types", () => {
   //     describe("no custom types", () => {
-  //       const inngest = new Inngest({ name: "test" });
+  //       const inngest = createClient({ name: "test" });
 
   //       test("onFailure function has unknown internal event", () => {
   //         inngest.createFunction(
@@ -968,7 +968,7 @@ describe("runFn", () => {
   //     });
 
   //     describe("multiple custom types", () => {
-  //       const inngest = new Inngest<{
+  //       const inngest = createClient<{
   //         foo: {
   //           name: "foo";
   //           data: { title: string };
@@ -1002,7 +1002,7 @@ describe("runFn", () => {
   //     });
 
   //     describe("passed fns have correct types", () => {
-  //       const inngest = new Inngest({ name: "test" });
+  //       const inngest = createClient({ name: "test" });
 
   //       const lib = {
   //         foo: true,
@@ -1046,7 +1046,7 @@ describe("runFn", () => {
   //   });
 
   //   test("specifying an onFailure function registers correctly", () => {
-  //     const inngest = new Inngest<{
+  //     const inngest = createClient<{
   //       foo: {
   //         name: "foo";
   //         data: { title: string };
@@ -1118,7 +1118,7 @@ describe("runFn", () => {
   describe("cancellation", () => {
     describe("types", () => {
       describe("no custom types", () => {
-        const inngest = new Inngest({ name: "test" });
+        const inngest = createClient({ name: "test" });
 
         test("allows any event name", () => {
           inngest.createFunction(
@@ -1145,7 +1145,7 @@ describe("runFn", () => {
       });
 
       describe("multiple custom types", () => {
-        const inngest = new Inngest<{
+        const inngest = createClient<{
           foo: {
             name: "foo";
             data: { title: string; foo: string };
@@ -1215,7 +1215,7 @@ describe("runFn", () => {
     });
 
     test("specifying a cancellation event registers correctly", () => {
-      const inngest = new Inngest<{
+      const inngest = createClient<{
         foo: {
           name: "foo";
           data: { title: string };

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { Inngest } from "inngest";
 import ms from "ms";
 import { assertType } from "type-plus";
 import { StepOpCode } from "../types";
-import { Inngest } from "./Inngest";
 import { createStepTools, TickOp } from "./InngestStepTools";
 
 describe("waitForEvent", () => {

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Inngest } from "inngest";
 import ms from "ms";
 import { assertType } from "type-plus";
+import { createClient } from "../test/helpers";
 import { StepOpCode } from "../types";
 import { createStepTools, TickOp } from "./InngestStepTools";
 
 describe("waitForEvent", () => {
-  const client = new Inngest({ name: "test" });
+  const client = createClient({ name: "test" });
   let waitForEvent: ReturnType<typeof createStepTools>[0]["waitForEvent"];
   let state: ReturnType<typeof createStepTools>[1];
   let getOp: () => TickOp | undefined;
@@ -89,7 +89,7 @@ describe("waitForEvent", () => {
 });
 
 describe("run", () => {
-  const client = new Inngest({ name: "test" });
+  const client = createClient({ name: "test" });
   let run: ReturnType<typeof createStepTools>[0]["run"];
   let state: ReturnType<typeof createStepTools>[1];
   let getOp: () => TickOp | undefined;
@@ -158,7 +158,7 @@ describe("run", () => {
 });
 
 describe("sleep", () => {
-  const client = new Inngest({ name: "test" });
+  const client = createClient({ name: "test" });
   let sleep: ReturnType<typeof createStepTools>[0]["sleep"];
   let state: ReturnType<typeof createStepTools>[1];
   let getOp: () => TickOp | undefined;
@@ -184,7 +184,7 @@ describe("sleep", () => {
 });
 
 describe("sleepUntil", () => {
-  const client = new Inngest({ name: "test" });
+  const client = createClient({ name: "test" });
   let sleepUntil: ReturnType<typeof createStepTools>[0]["sleepUntil"];
   let state: ReturnType<typeof createStepTools>[1];
   let getOp: () => TickOp | undefined;
@@ -241,7 +241,7 @@ describe("sleepUntil", () => {
 
 describe("sendEvent", () => {
   describe("runtime", () => {
-    const client = new Inngest({ name: "test" });
+    const client = createClient({ name: "test" });
     let sendEvent: ReturnType<typeof createStepTools>[0]["sendEvent"];
     let state: ReturnType<typeof createStepTools>[1];
     let getOp: () => TickOp | undefined;

--- a/src/express.test.ts
+++ b/src/express.test.ts
@@ -1,14 +1,13 @@
-import { Inngest } from "./components/Inngest";
 import { InngestCommHandler } from "./components/InngestCommHandler";
 import * as ExpressHandler from "./express";
-import { testFramework } from "./test/helpers";
+import { createClient, testFramework } from "./test/helpers";
 
 testFramework("Express", ExpressHandler);
 
 describe("InngestCommHandler", () => {
   describe("registerBody", () => {
     it("Includes correct base URL for functions", () => {
-      const client = new Inngest({ name: "test" });
+      const client = createClient({ name: "test" });
 
       const fn = client.createFunction(
         { name: "Test Express Function" },

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -4,6 +4,7 @@
 // string in order to read variables.
 
 import { envKeys } from "./consts";
+import { stringifyUnknown } from "./strings";
 
 /**
  * devServerHost returns the dev server host by searching for the INNGEST_DEVSERVER_URL
@@ -69,7 +70,7 @@ export const isProd = (
   env: Record<string, unknown> = allProcessEnv()
 ): boolean => {
   return prodChecks.some(([key, checkKey, expected]) => {
-    return prodCheckFns[checkKey](env[key]?.toString(), expected);
+    return prodCheckFns[checkKey](stringifyUnknown(env[key]), expected);
   });
 };
 

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -78,30 +78,20 @@ export const processEnv = (key: string): string | undefined => {
   return allProcessEnv()[key];
 };
 
-declare const Deno: unknown;
+declare const Deno: {
+  env: { toObject: () => Record<string, string | undefined> };
+};
 
 export const allProcessEnv = (): Record<string, string | undefined> => {
   try {
-    if (typeof process === "object" && process && "env" in process) {
-      // eslint-disable-next-line @inngest/process-warn
-      return process.env;
-    }
+    // eslint-disable-next-line @inngest/process-warn
+    return process.env;
   } catch (_err) {
     // noop
   }
 
   try {
-    if (
-      typeof Deno === "object" &&
-      Deno &&
-      "env" in Deno &&
-      typeof Deno.env === "object" &&
-      Deno.env &&
-      "toObject" in Deno.env &&
-      typeof Deno.env.toObject === "function"
-    ) {
-      return Deno.env.toObject() as Record<string, string | undefined>;
-    }
+    return Deno.env.toObject();
   } catch (_err) {
     // noop
   }

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -31,15 +31,19 @@ export const devServerHost = (): string | undefined => {
   return values.find((a) => !!a);
 };
 
-const prodCheckFns = {
+const prodCheckFns = (<
+  T extends Record<
+    string,
+    (actual: string | undefined, expected: string | undefined) => boolean
+  >
+>(
+  checks: T
+): T => checks)({
   equals: (actual, expected) => actual === expected,
   "starts with": (actual, expected) =>
     expected ? actual?.startsWith(expected) ?? false : false,
   "is truthy": (actual) => Boolean(actual),
-} satisfies Record<
-  string,
-  (actual: string | undefined, expected: string | undefined) => boolean
->;
+});
 
 const prodChecks: [
   key: string,

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -85,3 +85,17 @@ export const timeStr = (
 
   return timeStr as TimeStr;
 };
+
+/**
+ * Given an unknown input, stringify it if it's a boolean, a number, or a
+ * string, else return `undefined`.
+ */
+export const stringifyUnknown = (input: unknown): string | undefined => {
+  if (
+    typeof input === "boolean" ||
+    typeof input === "number" ||
+    typeof input === "string"
+  ) {
+    return input.toString();
+  }
+};

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -527,7 +527,7 @@ export const testFramework = (
 
     describe("POST (run function)", () => {
       describe("signature validation", () => {
-        const client = new Inngest({ name: "test" });
+        const client = createClient({ name: "test" });
 
         const fn = client.createFunction(
           { name: "Test", id: "test" },

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -4,11 +4,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import fetch from "cross-fetch";
 import type { Request, Response } from "express";
+import { EventPayload, Inngest } from "inngest";
 import nock from "nock";
 import httpMocks from "node-mocks-http";
 import { ulid } from "ulid";
 import { z } from "zod";
-import { Inngest } from "../components/Inngest";
+import type { Inngest as InternalInngest } from "../components/Inngest";
 import { ServeHandler } from "../components/InngestCommHandler";
 import { headerKeys } from "../helpers/consts";
 import { version } from "../version";
@@ -27,7 +28,20 @@ const createReqRes = (...args: Parameters<typeof httpMocks.createRequest>) => {
   return [req, res] as [typeof req, typeof res];
 };
 
-const inngest = new Inngest({ name: "test", eventKey: "event-key-123" });
+/**
+ * This is hack to get around the fact that the internal Inngest class exposes
+ * certain methods that aren't exposed outside of the library. This is
+ * exacerbated by the fact that we import from `"inngest"` and use a mapping in
+ * the `tsconfig.json` to point to the local version of the library, which we do
+ * to ensure we can test types against multiple TypeScript versions.
+ */
+export const createClient = <T extends Record<string, EventPayload>>(
+  ...args: ConstructorParameters<typeof InternalInngest>
+): InternalInngest<T> => {
+  return new Inngest(...args) as unknown as InternalInngest<T>;
+};
+
+const inngest = createClient({ name: "test", eventKey: "event-key-123" });
 
 export const testFramework = (
   /**

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["dist/**/*", "src/**/*.test.ts"],
+  "compilerOptions": {
+    "paths": {
+      "inngest": ["./dist"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary INN-1009

Providing a TS library means supporting various versions of TypeScript. Above just watching public API changes, this means:

- Ensuring we have an explicit earliest supported TS version
- Ensuring we have an explicit earliest supported Node version
- Ensuring that earlier TS versions maintain the same level of inference across all tooling

TypeScript introduce breaking changes with minor increments, which seems to be the norm among tooling with a large surface area (see [Follow SemVer · Issue #2888 · jashkenas/backbone (github.com)](https://github.com/jashkenas/backbone/issues/2888#issuecomment-29076249)). This also means that TS changes faster than it appears to and that it's harder for users to upgrade TS versions, even though semver might suggest otherwise.

Most TS configs will also type-check any installed libraries every time code is built, which results in errors on TS `<4.7.0` as the earlier compiler can't even parse the file due to unexpected characters (see #150).

## Actions

There are some fantastic resources covering this problem (see https://www.semver-ts.org/), but even tooling such as [downlevel-dts](https://github.com/sandersn/downlevel-dts) takes a long time to support the latest TS releases (it currently still doesn't support some 4.7 features) _and_ some of the "down-leveling" just falls back to wider types such as `any` or `unknown`, which could be insufficient depending on where it is.

The easiest step to take is to add some CI testing for various TypeScript versions and ensure that tests pass and compile. We have a lot of type-only unit tests to assert inference functionality, so testing that against earlier TS versions should do the trick.

With this, we can pretty easily support >=4.7.0, though going any further would require some chonky rewrites. The main culprit being [instantiation expressions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#instantiation-expressions) released in [TypeScript 4.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html). This PR is mostly about adding a framework for asserting and committing to a specific TS version support, then support for earlier versions can be added in further PRs.

Time-wise, it means we can comfortably support TS versions within the last 10 months, and specify that fact in our `peerDependencies`.

- ✅ **TypeScript 5.0** - March 2023 (<1mo)
- ✅ **TypeScript 4.9** - November 2022 (~4mo)
- ✅ **TypeScript 4.8** - August 2022 (~7mo)
- ✅ **TypeScript 4.7** - May 2022 (~10mo)
- ❌ **TypeScript 4.6** - Feb 2022 (~1y1mo)
- ❌ **TypeScript 4.5** - November 2021 (~1y4mo)
- ❌ **TypeScript 4.4** - August 2021 (~1y7mo)
- ❌ **TypeScript 4.3** - May 2021 (~1y10mo)
- ❌ **TypeScript 4.2** - Feb 2021 (~2y1m)
- ❌ **TypeScript 4.1** - November 2020 (~2y4m)
- ❌ **TypeScript 4.0** - August 2020 (~2y7mo)

To test types, we'll do a couple of actions:

- [x] Add a new `test:types` script that will test that `dist/` and `src/**/*.test.ts` compile correctly.
This will ensure that users with the default of `skipLibCheck: false` can properly build the code, and compiling test files ensures that all type tests are also working.
- [x] Add CI matrix to test multiple TS versions against the above files

## Related

- #150 