### PR TITLE
Fix infinite type instantiation using a looping type in serve handlers

### DIFF
--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { serve } from "../next";
+import { Inngest } from "./Inngest";
+
+describe("#153", () => {
+  test('does not throw "type instantiation is excessively deep and possibly infinite" for looping type', () => {
+    const literalSchema = z.union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.null(),
+    ]);
+    type Literal = z.infer<typeof literalSchema>;
+    type Json = Literal | { [key: string]: Json } | Json[];
+
+    const inngest = new Inngest<{
+      foo: {
+        name: "foo";
+        data: {
+          json: Json;
+        };
+      };
+    }>({ name: "My App" });
+
+    /**
+     * This would throw:
+     * "Type instantiation is excessively deep and possibly infinite.ts(2589)"
+     */
+    serve(inngest, []);
+  });
+});

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -54,12 +54,14 @@ export type ServeHandler = (
    * The name of this app, used to scope and group Inngest functions, or
    * the `Inngest` instance used to declare all functions.
    */
-  nameOrInngest: string | Inngest,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nameOrInngest: string | Inngest<any>,
 
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: InngestFunction[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  functions: InngestFunction<any, any, any>[],
 
   /**
    * A set of options to further configure the registration of Inngest


### PR DESCRIPTION
## Summary

The default generic values here creating too many potential paths when a handler was being passed; we must provide `any` as the generics here to ensure we allow all variations of configuration without the compiler trying to needlessly understand what's present.

Includes a test for posterity.

## Related

- Fixes #153
_Thanks for the report, @grempe_