### PR TITLE
INN-1054 Ensure `ServeHandler` always returns `any`

### DIFF
--- a/.changeset/late-kings-admire.md
+++ b/.changeset/late-kings-admire.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+INN-1054 Ensure serve handlers return `any` instead of `unknown` so that they don't needlessly conflict with user types

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -201,7 +201,19 @@ export interface RegisterOptions {
 export type ServeHandler = (
 nameOrInngest: string | Inngest<any>,
 functions: InngestFunction<any, any, any>[],
-opts?: RegisterOptions) => unknown;
+opts?: RegisterOptions
+/**
+* This `any` return is appropriate.
+*
+* While we can infer the signature of the returned value, we cannot guarantee
+* that we have used the same types as the framework we are integrating with,
+* which sometimes can cause frustrating collisions for a user that result in
+* `as unknown as X` casts.
+*
+* Instead, we will use `any` here and have the user be able to place it
+* anywhere they need.
+*/
+) => any;
 
 // @public
 export type TimeStr = `${`${number}w` | ""}${`${number}d` | ""}${`${number}h` | ""}${`${number}m` | ""}${`${number}s` | ""}`;

--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,6 +1,9 @@
+import { assertType } from "type-plus";
 import { z } from "zod";
+import { IsAny } from "../helpers/types";
 import { serve } from "../next";
 import { createClient } from "../test/helpers";
+import { ServeHandler } from "./InngestCommHandler";
 
 describe("#153", () => {
   test('does not throw "type instantiation is excessively deep and possibly infinite" for looping type', () => {
@@ -27,5 +30,11 @@ describe("#153", () => {
      * "Type instantiation is excessively deep and possibly infinite.ts(2589)"
      */
     serve(inngest, []);
+  });
+});
+
+describe("ServeHandler", () => {
+  test("serve handlers return any", () => {
+    assertType<IsAny<ReturnType<ServeHandler>>>(true);
   });
 });

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -69,7 +69,19 @@ export type ServeHandler = (
    * functions.
    */
   opts?: RegisterOptions
-) => unknown;
+  /**
+   * This `any` return is appropriate.
+   *
+   * While we can infer the signature of the returned value, we cannot guarantee
+   * that we have used the same types as the framework we are integrating with,
+   * which sometimes can cause frustrating collisions for a user that result in
+   * `as unknown as X` casts.
+   *
+   * Instead, we will use `any` here and have the user be able to place it
+   * anywhere they need.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => any;
 
 /**
  * Capturing the global type of fetch so that we can reliably access it below.


### PR DESCRIPTION
## Summary INN-1054

Serve handlers used to all return any in the past, but have changed to unknown in #135.

This is a mistake. We need any so that the output can be appropriately slotted into any requirement the user has.

`any` feels dangerous here, but is appropriate: we can infer the types for the returned function appropriately, e.g. `(req: NextRequest, res: NextResponse) => NextResponse`, but this is also a misstep. To do this, we must install a package for the `NextRequest` and `NextResponse` types, but the package we use could be different to the one the user uses. This can create a drift in types and cause a collision where there shouldn't be one.

The fix is just to revert all handlers to appropriately return `any`.

## Related

- #135
- INN-1054