### PR TITLE
INN-1029 Add `env` option to `Inngest` client and find branch names from env vars

### DIFF
--- a/.changeset/dirty-shoes-heal.md
+++ b/.changeset/dirty-shoes-heal.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+INN-1186 Send `x-inngest-platform` and `x-inngest-framework` headers during registration

--- a/.changeset/proud-apes-beg.md
+++ b/.changeset/proud-apes-beg.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+INN-1029 Add `env` option to `Inngest` client to explicitly push to a particular Inngest env

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -81,6 +81,10 @@ export enum headerKeys {
     // (undocumented)
     Environment = "x-inngest-env",
     // (undocumented)
+    Framework = "x-inngest-framework",
+    // (undocumented)
+    Platform = "x-inngest-platform",
+    // (undocumented)
     SdkVersion = "x-inngest-sdk",
     // (undocumented)
     Signature = "x-inngest-signature"
@@ -131,10 +135,12 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     protected readonly logLevel: LogLevel;
     readonly name: string;
     // (undocumented)
-    protected register(url: URL, devServerHost: string | undefined, deployId?: string | undefined | null): Promise<{
+    protected register(url: URL, devServerHost: string | undefined, deployId: string | undefined | null, getHeaders: () => Record<string, string>): Promise<{
         status: number;
         message: string;
     }>;
+    // Warning: (ae-forgotten-export) The symbol "RegisterRequest" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     protected registerBody(url: URL): RegisterRequest;
     protected reqUrl(url: URL): URL;
@@ -143,12 +149,6 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     //
     // (undocumented)
     protected runStep(functionId: string, stepId: string | null, data: unknown, timer: ServerTiming): Promise<StepRunResponse>;
-    // Warning: (ae-forgotten-export) The symbol "RegisterRequest" needs to be exported by the entry point index.d.ts
-    protected get sdkHeader(): [
-    prefix: string,
-    version: RegisterRequest["sdk"],
-    suffix: string
-    ];
     protected readonly serveHost: string | undefined;
     protected readonly servePath: string | undefined;
     // (undocumented)

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -8,6 +8,7 @@ import { Jsonify } from 'type-fest';
 
 // @public
 export interface ClientOptions {
+    env?: string;
     eventKey?: string;
     fetch?: typeof fetch;
     inngestBaseUrl?: string;
@@ -77,6 +78,8 @@ export interface FunctionOptions<Events extends Record<string, EventPayload>, Ev
 // @public
 export enum headerKeys {
     // (undocumented)
+    Environment = "x-inngest-env",
+    // (undocumented)
     SdkVersion = "x-inngest-sdk",
     // (undocumented)
     Signature = "x-inngest-signature"
@@ -84,7 +87,7 @@ export enum headerKeys {
 
 // @public
 export class Inngest<Events extends Record<string, EventPayload> = Record<string, EventPayload>> {
-    constructor({ name, eventKey, inngestBaseUrl, fetch, }: ClientOptions);
+    constructor({ name, eventKey, inngestBaseUrl, fetch, env, }: ClientOptions);
     // Warning: (ae-forgotten-export) The symbol "ShimmedFns" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Handler" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "InngestFunction" needs to be exported by the entry point index.d.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,7 @@ module.exports = {
   roots: ["<rootDir>/src"],
   moduleNameMapper: {
     inngest: "<rootDir>/src",
+    "^@local$": "<rootDir>/src",
+    "^@local/(.*)": "<rootDir>/src/$1",
   },
 };

--- a/src/cloudflare.test.ts
+++ b/src/cloudflare.test.ts
@@ -1,5 +1,5 @@
+import * as CloudflareHandler from "@local/cloudflare";
 import fetch, { Headers, Response } from "cross-fetch";
-import * as CloudflareHandler from "./cloudflare";
 import { testFramework } from "./test/helpers";
 
 const originalProcess = process;

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -4,6 +4,8 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 
+export const name = "cloudflare-pages";
+
 /**
  * In Cloudflare, serve and register any declared functions with Inngest, making
  * them available to be triggered by events.
@@ -12,7 +14,7 @@ import { headerKeys, queryKeys } from "./helpers/consts";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "cloudflare-pages",
+    name,
     nameOrInngest,
     fns,
     {

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,9 +1,9 @@
-import { EventPayload } from "inngest";
+import { EventPayload } from "@local";
+import { eventKeyWarning } from "@local/components/Inngest";
+import { envKeys } from "@local/helpers/consts";
+import { IsAny } from "@local/helpers/types";
 import { assertType } from "type-plus";
-import { envKeys } from "../helpers/consts";
-import { IsAny } from "../helpers/types";
 import { createClient } from "../test/helpers";
-import { eventKeyWarning } from "./Inngest";
 
 const testEvent: EventPayload = {
   name: "test",

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -52,7 +52,7 @@ describe("instantiation", () => {
 
 describe("send", () => {
   describe("runtime", () => {
-    const originalEnvEventKey = process.env[envKeys.EventKey];
+    const originalProcessEnv = process.env;
     const originalFetch = global.fetch;
 
     beforeAll(() => {
@@ -70,18 +70,12 @@ describe("send", () => {
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
       (global.fetch as any).mockClear();
-    });
-
-    afterEach(() => {
-      if (originalEnvEventKey) {
-        process.env[envKeys.EventKey] = originalEnvEventKey;
-      } else {
-        delete process.env[envKeys.EventKey];
-      }
+      process.env = { ...originalProcessEnv };
     });
 
     afterAll(() => {
       global.fetch = originalFetch;
+      process.env = originalProcessEnv;
     });
 
     test("should fail to send if event key not specified at instantiation", async () => {

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,8 +1,8 @@
-import { envKeys, headerKeys } from "../helpers/consts";
+import { envKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import {
   devServerHost,
-  getEnvironmentName,
+  inngestHeaders,
   isProd,
   processEnv,
 } from "../helpers/env";
@@ -22,7 +22,6 @@ import type {
   ShimmedFns,
   TriggerOptions,
 } from "../types";
-import { version } from "../version";
 import { InngestFunction } from "./InngestFunction";
 
 /**
@@ -89,8 +88,6 @@ export class Inngest<
 
   private readonly fetch: FetchT;
 
-  private readonly env: string | undefined;
-
   /**
    * A client used to interact with the Inngest API by sending or reacting to
    * events.
@@ -133,17 +130,11 @@ export class Inngest<
       console.warn(eventKeyWarning);
     }
 
-    this.headers = {
-      "Content-Type": "application/json",
-      "User-Agent": `InngestJS v${version}`,
-    };
+    this.headers = inngestHeaders({
+      inngestEnv: env,
+    });
 
     this.fetch = Inngest.parseFetch(fetch);
-
-    this.env = env || getEnvironmentName();
-    if (this.env) {
-      this.headers[headerKeys.Environment] = this.env;
-    }
   }
 
   /**

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,6 +1,11 @@
-import { envKeys } from "../helpers/consts";
+import { envKeys, headerKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
-import { devServerHost, isProd, processEnv } from "../helpers/env";
+import {
+  devServerHost,
+  getBranchName,
+  isProd,
+  processEnv,
+} from "../helpers/env";
 import type {
   PartialK,
   SendEventPayload,
@@ -83,6 +88,8 @@ export class Inngest<
 
   private readonly fetch: FetchT;
 
+  private readonly env: string | undefined;
+
   /**
    * A client used to interact with the Inngest API by sending or reacting to
    * events.
@@ -111,6 +118,7 @@ export class Inngest<
     eventKey,
     inngestBaseUrl = "https://inn.gs/",
     fetch,
+    env,
   }: ClientOptions) {
     if (!name) {
       throw new Error("A name must be passed to create an Inngest instance.");
@@ -130,6 +138,11 @@ export class Inngest<
     };
 
     this.fetch = Inngest.parseFetch(fetch);
+
+    this.env = env || getBranchName();
+    if (this.env) {
+      this.headers[headerKeys.Environment] = this.env;
+    }
   }
 
   /**

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,6 +1,11 @@
 import { envKeys, headerKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
-import { devServerHost, isProd, processEnv } from "../helpers/env";
+import {
+  devServerHost,
+  getEnvironmentName,
+  isProd,
+  processEnv,
+} from "../helpers/env";
 import type {
   PartialK,
   SendEventPayload,
@@ -134,7 +139,7 @@ export class Inngest<
 
     this.fetch = Inngest.parseFetch(fetch);
 
-    this.env = env || undefined;
+    this.env = env || getEnvironmentName();
     if (this.env) {
       this.headers[headerKeys.Environment] = this.env;
     }

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,11 +1,6 @@
 import { envKeys, headerKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
-import {
-  devServerHost,
-  getBranchName,
-  isProd,
-  processEnv,
-} from "../helpers/env";
+import { devServerHost, isProd, processEnv } from "../helpers/env";
 import type {
   PartialK,
   SendEventPayload,
@@ -139,7 +134,7 @@ export class Inngest<
 
     this.fetch = Inngest.parseFetch(fetch);
 
-    this.env = env || getBranchName();
+    this.env = env || undefined;
     if (this.env) {
       this.headers[headerKeys.Environment] = this.env;
     }

--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,7 +1,7 @@
+import { serve } from "@local/next";
 import { assertType } from "type-plus";
 import { z } from "zod";
 import { IsAny } from "../helpers/types";
-import { serve } from "../next";
 import { createClient } from "../test/helpers";
 import { ServeHandler } from "./InngestCommHandler";
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { ServerTiming } from "../helpers/ServerTiming";
 import { envKeys, headerKeys, queryKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
-import { allProcessEnv, isProd } from "../helpers/env";
+import { allProcessEnv, inngestHeaders, isProd } from "../helpers/env";
 import { serializeError } from "../helpers/errors";
 import { strBoolean } from "../helpers/scalar";
 import { stringifyUnknown } from "../helpers/strings";
@@ -181,13 +181,6 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
   protected _isProd = false;
 
   /**
-   * A set of headers sent back with every request. Usually includes generic
-   * functionality such as `"Content-Type"`, alongside informational headers
-   * such as Inngest SDK version.
-   */
-  private readonly headers: Record<string, string>;
-
-  /**
    * The localized `fetch` implementation used by this handler.
    */
   private readonly fetch: FetchT;
@@ -243,6 +236,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
    * A private collection of just Inngest functions, as they have been passed
    * when instantiating the class.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly rawFns: InngestFunction<any, any, any>[];
 
   /**
@@ -405,11 +399,6 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     this.servePath = servePath;
     this.logLevel = logLevel;
 
-    this.headers = {
-      "Content-Type": "application/json",
-      "User-Agent": `inngest-js:v${version} (${this.frameworkName})`,
-    };
-
     this.fetch =
       fetch ||
       (typeof appNameOrInngest === "string"
@@ -491,12 +480,16 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     actions: ReturnType<H>,
     timer: ServerTiming
   ): Promise<ActionResponse> {
+    const env = actions.env ?? allProcessEnv();
+
     const getHeaders = () => ({
-      [headerKeys.SdkVersion]: this.sdkHeader.join(""),
+      ...inngestHeaders({
+        env: env as Record<string, string | undefined>,
+        framework: this.frameworkName,
+      }),
       "Server-Timing": timer.getHeader(),
     });
 
-    const env = actions.env ?? allProcessEnv();
     this._isProd = actions.isProduction ?? isProd(env);
 
     try {
@@ -593,7 +586,8 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         const { status, message } = await this.register(
           this.reqUrl(actions.url),
           stringifyUnknown(env[envKeys.DevServerUrl]),
-          registerRes.deployId
+          registerRes.deployId,
+          getHeaders
         );
 
         return {
@@ -769,20 +763,6 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
   }
 
   /**
-   * Returns an SDK header split in to three parts so that they can be used for
-   * different purposes.
-   *
-   * To use the entire string, run `this.sdkHeader.join("")`.
-   */
-  protected get sdkHeader(): [
-    prefix: string,
-    version: RegisterRequest["sdk"],
-    suffix: string
-  ] {
-    return ["inngest-", `js:v${version}`, ` (${this.frameworkName})`];
-  }
-
-  /**
    * Return an Inngest serve endpoint URL given a potential `path` and `host`.
    *
    * Will automatically use the `serveHost` and `servePath` if they have been
@@ -810,7 +790,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
       framework: this.frameworkName,
       appName: this.name,
       functions: this.configs(url),
-      sdk: this.sdkHeader[1],
+      sdk: `js:v${version}`,
       v: "0.1",
     };
 
@@ -822,7 +802,8 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
   protected async register(
     url: URL,
     devServerHost: string | undefined,
-    deployId?: string | undefined | null
+    deployId: string | undefined | null,
+    getHeaders: () => Record<string, string>
   ): Promise<{ status: number; message: string }> {
     const body = this.registerBody(url);
 
@@ -848,7 +829,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         method: "POST",
         body: JSON.stringify(body),
         headers: {
-          ...this.headers,
+          ...getHeaders(),
           Authorization: `Bearer ${this.hashedSigningKey}`,
         },
         redirect: "follow",

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -415,8 +415,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
       return "";
     }
 
-    const prefix =
-      this.signingKey.match(/^signkey-[\w]+-/)?.shift() || "";
+    const prefix = this.signingKey.match(/^signkey-[\w]+-/)?.shift() || "";
     const key = this.signingKey.replace(/^signkey-[\w]+-/, "");
 
     // Decode the key from its hex representation into a bytestream

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,16 +1,16 @@
 import { jest } from "@jest/globals";
-import { assertType } from "type-plus";
-import { ServerTiming } from "../helpers/ServerTiming";
-import { internalEvents } from "../helpers/consts";
-import { createClient } from "../test/helpers";
+import { InngestFunction } from "@local/components/InngestFunction";
+import { UnhashedOp, _internals } from "@local/components/InngestStepTools";
+import { internalEvents } from "@local/helpers/consts";
+import { ServerTiming } from "@local/helpers/ServerTiming";
 import {
   EventPayload,
   FailureEventPayload,
   OpStack,
   StepOpCode,
-} from "../types";
-import { InngestFunction } from "./InngestFunction";
-import { UnhashedOp, _internals } from "./InngestStepTools";
+} from "@local/types";
+import { assertType } from "type-plus";
+import { createClient } from "../test/helpers";
 
 type TestEvents = {
   foo: { name: "foo"; data: { foo: string } };

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { createStepTools, TickOp } from "@local/components/InngestStepTools";
+import { StepOpCode } from "@local/types";
 import ms from "ms";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
-import { StepOpCode } from "../types";
-import { createStepTools, TickOp } from "./InngestStepTools";
 
 describe("waitForEvent", () => {
   const client = createClient({ name: "test" });

--- a/src/deno/fresh.test.ts
+++ b/src/deno/fresh.test.ts
@@ -1,6 +1,6 @@
+import * as DenoFreshHandler from "@local/deno/fresh";
 import fetch, { Headers, Response } from "cross-fetch";
 import { testFramework } from "../test/helpers";
-import * as DenoFreshHandler from "./fresh";
 
 const originalProcess = process;
 const originalFetch = globalThis.fetch;

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -4,6 +4,8 @@ import {
 } from "../components/InngestCommHandler";
 import { headerKeys, queryKeys } from "../helpers/consts";
 
+export const name = "deno/fresh";
+
 /**
  * With Deno's Fresh framework, serve and register any declared functions with
  * Inngest, making them available to be triggered by events.
@@ -12,7 +14,7 @@ import { headerKeys, queryKeys } from "../helpers/consts";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "deno/fresh",
+    name,
     nameOrInngest,
     fns,
     opts,

--- a/src/edge.test.ts
+++ b/src/edge.test.ts
@@ -1,5 +1,5 @@
+import * as EdgeHandler from "@local/edge";
 import fetch, { Headers, Response } from "cross-fetch";
-import * as EdgeHandler from "./edge";
 import { testFramework } from "./test/helpers";
 
 const originalFetch = globalThis.fetch;

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -4,6 +4,8 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 
+export const name = "edge";
+
 /**
  * In an edge runtime, serve and register any declared functions with Inngest,
  * making them available to be triggered by events.
@@ -22,7 +24,7 @@ import { headerKeys, queryKeys } from "./helpers/consts";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "edge",
+    name,
     nameOrInngest,
     fns,
     {

--- a/src/express.test.ts
+++ b/src/express.test.ts
@@ -1,5 +1,5 @@
+import * as ExpressHandler from "@local/express";
 import { InngestCommHandler } from "./components/InngestCommHandler";
-import * as ExpressHandler from "./express";
 import { createClient, testFramework } from "./test/helpers";
 
 testFramework("Express", ExpressHandler);

--- a/src/express.ts
+++ b/src/express.ts
@@ -5,6 +5,8 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 
+export const name = "express";
+
 /**
  * Serve and register any declared functions with Inngest, making them available
  * to be triggered by events.
@@ -13,7 +15,7 @@ import { headerKeys, queryKeys } from "./helpers/consts";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "express",
+    name,
     nameOrInngest,
     fns,
     opts,

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -31,12 +31,22 @@ export enum envKeys {
   VercelBranch = "VERCEL_GIT_COMMIT_REF",
 
   /**
+   * Expected to be `"1"` if defined.
+   */
+  IsVercel = "VERCEL",
+
+  /**
    * The branch name of the current deployment. May only be accessible at build
    * time, but included here just in case.
    *
    * {@link https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables}
    */
   CloudflarePagesBranch = "CF_PAGES_BRANCH",
+
+  /**
+   * Expected to be `"1"` if defined.
+   */
+  IsCloudflarePages = "CF_PAGES",
 
   /**
    * The branch name of the deployment from Git to Netlify, if available.
@@ -46,6 +56,11 @@ export enum envKeys {
   NetlifyBranch = "BRANCH",
 
   /**
+   * Expected to be `"true"` if defined.
+   */
+  IsNetlify = "NETLIFY",
+
+  /**
    * The Git branch for a service or deploy.
    *
    * {@link https://render.com/docs/environment-variables#all-services}
@@ -53,11 +68,23 @@ export enum envKeys {
   RenderBranch = "RENDER_GIT_BRANCH",
 
   /**
+   * Expected to be `"true"` if defined.
+   */
+  IsRender = "RENDER",
+
+  /**
    * The branch that triggered the deployment. Example: `main`
    *
    * {@link https://docs.railway.app/develop/variables#railway-provided-variables}
    */
   RailwayBranch = "RAILWAY_GIT_BRANCH",
+
+  /**
+   * The railway environment for the deployment. Example: `production`
+   *
+   * {@link https://docs.railway.app/develop/variables#railway-provided-variables}
+   */
+  RailwayEnvironment = "RAILWAY_ENVIRONMENT",
 }
 
 export enum prodEnvKeys {
@@ -79,6 +106,8 @@ export enum headerKeys {
   Signature = "x-inngest-signature",
   SdkVersion = "x-inngest-sdk",
   Environment = "x-inngest-env",
+  Platform = "x-inngest-platform",
+  Framework = "x-inngest-framework",
 }
 
 export const defaultDevServerHost = "http://127.0.0.1:8288/";

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -28,7 +28,36 @@ export enum envKeys {
    *
    * {@link https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#system-environment-variables}
    */
-  VercelGitCommitRef = "VERCEL_GIT_COMMIT_REF",
+  VercelBranch = "VERCEL_GIT_COMMIT_REF",
+
+  /**
+   * The branch name of the current deployment. May only be accessible at build
+   * time, but included here just in case.
+   *
+   * {@link https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables}
+   */
+  CloudflarePagesBranch = "CF_PAGES_BRANCH",
+
+  /**
+   * The branch name of the deployment from Git to Netlify, if available.
+   *
+   * {@link https://docs.netlify.com/configure-builds/environment-variables/#git-metadata}
+   */
+  NetlifyBranch = "BRANCH",
+
+  /**
+   * The Git branch for a service or deploy.
+   *
+   * {@link https://render.com/docs/environment-variables#all-services}
+   */
+  RenderBranch = "RENDER_GIT_BRANCH",
+
+  /**
+   * The branch that triggered the deployment. Example: `main`
+   *
+   * {@link https://docs.railway.app/develop/variables#railway-provided-variables}
+   */
+  RailwayBranch = "RAILWAY_GIT_BRANCH",
 }
 
 export enum prodEnvKeys {

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -19,6 +19,16 @@ export enum envKeys {
   EventKey = "INNGEST_EVENT_KEY",
   LandingPage = "INNGEST_LANDING_PAGE",
   DevServerUrl = "INNGEST_DEVSERVER_URL",
+  Environment = "INNGEST_ENV",
+  BranchName = "BRANCH_NAME",
+
+  /**
+   * The git branch of the commit the deployment was triggered by. Example:
+   * `improve-about-page`.
+   *
+   * {@link https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#system-environment-variables}
+   */
+  VercelGitCommitRef = "VERCEL_GIT_COMMIT_REF",
 }
 
 export enum prodEnvKeys {
@@ -39,6 +49,7 @@ export enum prodEnvKeys {
 export enum headerKeys {
   Signature = "x-inngest-signature",
   SdkVersion = "x-inngest-sdk",
+  Environment = "x-inngest-env",
 }
 
 export const defaultDevServerHost = "http://127.0.0.1:8288/";

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -75,13 +75,13 @@ export const isProd = (
 };
 
 /**
- * getBranchName returns the suspected branch name for this environment by
+ * getEnvironmentName returns the suspected branch name for this environment by
  * searching through a set of common environment variables.
  *
  * This could be used to determine if we're on a branch deploy or not, though it
  * should be noted that we don't know if this is the default branch or not.
  */
-export const getBranchName = (
+export const getEnvironmentName = (
   env: Record<string, string | undefined> = allProcessEnv()
 ): string | undefined => {
   /**

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -88,7 +88,11 @@ export const getBranchName = (
   return (
     env[envKeys.Environment] ||
     env[envKeys.BranchName] ||
-    env[envKeys.VercelGitCommitRef]
+    env[envKeys.VercelBranch] ||
+    env[envKeys.NetlifyBranch] ||
+    env[envKeys.CloudflarePagesBranch] ||
+    env[envKeys.RenderBranch] ||
+    env[envKeys.RailwayBranch]
   );
 };
 

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -189,9 +189,9 @@ const getPlatformName = (
   env: Record<string, string | undefined>
 ): string | undefined => {
   const platformChecks = {
-    vercel: (env) => Boolean(env[envKeys.IsVercel]),
+    vercel: (env) => env[envKeys.IsVercel] === "1",
     netlify: (env) => env[envKeys.IsNetlify] === "true",
-    "cloudflare-pages": (env) => Boolean(env[envKeys.IsCloudflarePages]),
+    "cloudflare-pages": (env) => env[envKeys.IsCloudflarePages] === "1",
     render: (env) => env[envKeys.IsRender] === "true",
     railway: (env) => Boolean(env[envKeys.RailwayEnvironment]),
   } satisfies Record<

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -74,6 +74,24 @@ export const isProd = (
   });
 };
 
+/**
+ * getBranchName returns the suspected branch name for this environment by
+ * searching through a set of common environment variables.
+ */
+export const getBranchName = (
+  env: Record<string, string | undefined> = allProcessEnv()
+): string | undefined => {
+  /**
+   * Order is important; more than one of these env vars may be set, so ensure
+   * that we check the most specific, most reliable env vars first.
+   */
+  return (
+    env[envKeys.Environment] ||
+    env[envKeys.BranchName] ||
+    env[envKeys.VercelGitCommitRef]
+  );
+};
+
 export const processEnv = (key: string): string | undefined => {
   return allProcessEnv()[key];
 };

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -3,7 +3,8 @@
 // along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
 // string in order to read variables.
 
-import { envKeys } from "./consts";
+import { version } from "../version";
+import { envKeys, headerKeys } from "./consts";
 import { stringifyUnknown } from "./strings";
 
 /**
@@ -107,6 +108,14 @@ declare const Deno: {
   env: { toObject: () => Record<string, string | undefined> };
 };
 
+/**
+ * allProcessEnv returns the current process environment variables, or an empty
+ * object if they cannot be read, making sure we support environments other than
+ * Node such as Deno, too.
+ *
+ * Using this ensures we don't dangerously access `process.env` in environments
+ * where it may not be defined, such as Deno or the browser.
+ */
 export const allProcessEnv = (): Record<string, string | undefined> => {
   try {
     // eslint-disable-next-line @inngest/process-warn
@@ -122,4 +131,77 @@ export const allProcessEnv = (): Record<string, string | undefined> => {
   }
 
   return {};
+};
+
+/**
+ * Generate a standardised set of headers based on input and environment
+ * variables.
+ *
+ *
+ */
+export const inngestHeaders = (opts?: {
+  /**
+   * The environment variables to use instead of `process.env` or any other
+   * default source. Useful for platforms where environment variables are passed
+   * in alongside requests.
+   */
+  env?: Record<string, string | undefined>;
+
+  /**
+   * The framework name to use in the `X-Inngest-Framework` header. This is not
+   * always available, hence being optional.
+   */
+  framework?: string;
+
+  /**
+   * The environment name to use in the `X-Inngest-Env` header. This is likely
+   * to be representative of the target preview environment.
+   */
+  inngestEnv?: string;
+}): Record<string, string> => {
+  const sdkVersion = `inngest-js:v${version}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": sdkVersion,
+    [headerKeys.SdkVersion]: sdkVersion,
+  };
+
+  if (opts?.framework) {
+    headers[headerKeys.Framework] = opts.framework;
+  }
+
+  const env = opts?.env || allProcessEnv();
+
+  const inngestEnv = opts?.inngestEnv || getEnvironmentName(env);
+  if (inngestEnv) {
+    headers[headerKeys.Environment] = inngestEnv;
+  }
+
+  const platform = getPlatformName(env);
+  if (platform) {
+    headers[headerKeys.Platform] = platform;
+  }
+
+  return headers;
+};
+
+const getPlatformName = (
+  env: Record<string, string | undefined>
+): string | undefined => {
+  const platformChecks = {
+    vercel: (env) => Boolean(env[envKeys.IsVercel]),
+    netlify: (env) => env[envKeys.IsNetlify] === "true",
+    "cloudflare-pages": (env) => Boolean(env[envKeys.IsCloudflarePages]),
+    render: (env) => env[envKeys.IsRender] === "true",
+    railway: (env) => Boolean(env[envKeys.RailwayEnvironment]),
+  } satisfies Record<
+    string,
+    (env: Record<string, string | undefined>) => boolean
+  >;
+
+  return (Object.keys(platformChecks) as (keyof typeof platformChecks)[]).find(
+    (key) => {
+      return platformChecks[key](env);
+    }
+  );
 };

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -77,6 +77,9 @@ export const isProd = (
 /**
  * getBranchName returns the suspected branch name for this environment by
  * searching through a set of common environment variables.
+ *
+ * This could be used to determine if we're on a branch deploy or not, though it
+ * should be noted that we don't know if this is the default branch or not.
  */
 export const getBranchName = (
   env: Record<string, string | undefined> = allProcessEnv()

--- a/src/lambda.test.ts
+++ b/src/lambda.test.ts
@@ -1,5 +1,5 @@
+import * as LambdaHandler from "@local/lambda";
 import type { APIGatewayProxyResult } from "aws-lambda";
-import * as LambdaHandler from "./lambda";
 import { testFramework } from "./test/helpers";
 
 testFramework("AWS Lambda", LambdaHandler, {

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -10,6 +10,8 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 
+export const name = "aws-lambda";
+
 /**
  * With AWS Lambda, serve and register any declared functions with Inngest,
  * making them available to be triggered by events.
@@ -37,7 +39,7 @@ import { headerKeys, queryKeys } from "./helpers/consts";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "aws-lambda",
+    name,
     nameOrInngest,
     fns,
     { ...opts },

--- a/src/next.test.ts
+++ b/src/next.test.ts
@@ -1,4 +1,4 @@
-import * as NextHandler from "./next";
+import * as NextHandler from "@local/next";
 import { testFramework } from "./test/helpers";
 
 testFramework("Next", NextHandler);

--- a/src/next.ts
+++ b/src/next.ts
@@ -6,6 +6,8 @@ import {
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
 
+export const name = "nextjs";
+
 /**
  * In Next.js, serve and register any declared functions with Inngest, making
  * them available to be triggered by events.
@@ -14,7 +16,7 @@ import { processEnv } from "./helpers/env";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "nextjs",
+    name,
     nameOrInngest,
     fns,
     opts,

--- a/src/nuxt.test.ts
+++ b/src/nuxt.test.ts
@@ -1,6 +1,6 @@
-import * as NuxtHandler from "./nuxt";
-import { testFramework } from "./test/helpers";
+import * as NuxtHandler from "@local/nuxt";
 import { createEvent } from "h3";
+import { testFramework } from "./test/helpers";
 
 testFramework("Nuxt", NuxtHandler, {
   transformReq(req, res) {

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -7,6 +7,8 @@ import {
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
 
+export const name = "nuxt";
+
 /**
  * In Nuxt 3, serve and register any declared functions with Inngest, making
  * them available to be triggered by events.
@@ -15,7 +17,7 @@ import { processEnv } from "./helpers/env";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    "nuxt",
+    name,
     nameOrInngest,
     fns,
     opts,

--- a/src/redwood.test.ts
+++ b/src/redwood.test.ts
@@ -1,4 +1,4 @@
-import * as RedwoodHandler from "./redwood";
+import * as RedwoodHandler from "@local/redwood";
 import { testFramework } from "./test/helpers";
 
 testFramework("Redwood.js", RedwoodHandler, {

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -15,6 +15,8 @@ export interface RedwoodResponse {
   headers?: Record<string, string>;
 }
 
+export const name = "redwoodjs";
+
 /**
  * In Redwood.js, serve and register any declared functions with Inngest, making
  * them available to be triggered by events.
@@ -23,7 +25,7 @@ export interface RedwoodResponse {
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
   const handler = new InngestCommHandler(
-    "redwoodjs",
+    name,
     nameOrInngest,
     fns,
     opts,

--- a/src/remix.test.ts
+++ b/src/remix.test.ts
@@ -1,5 +1,5 @@
+import * as RemixHandler from "@local/remix";
 import { Headers } from "cross-fetch";
-import * as RemixHandler from "./remix";
 import { testFramework } from "./test/helpers";
 
 testFramework("Remix", RemixHandler, {

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -4,6 +4,8 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 
+export const name = "remix";
+
 /**
  * In Remix, serve and register any declared functions with Inngest, making them
  * available to be triggered by events.
@@ -28,7 +30,7 @@ import { headerKeys, queryKeys } from "./helpers/consts";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
   const handler = new InngestCommHandler(
-    "remix",
+    name,
     nameOrInngest,
     fns,
     opts,

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -5,7 +5,7 @@
 import { EventPayload, Inngest } from "@local";
 import type { Inngest as InternalInngest } from "@local/components/Inngest";
 import { ServeHandler } from "@local/components/InngestCommHandler";
-import { headerKeys } from "@local/helpers/consts";
+import { envKeys, headerKeys } from "@local/helpers/consts";
 import { version } from "@local/version";
 import fetch from "cross-fetch";
 import type { Request, Response } from "express";
@@ -45,14 +45,15 @@ const inngest = createClient({ name: "test", eventKey: "event-key-123" });
 
 export const testFramework = (
   /**
-   * The name of the framework to test as it will appear in test logs
+   * The name of the framework to test as it will appear in test logs. Also used
+   * to check that the correct headers are being sent.
    */
   frameworkName: string,
 
   /**
    * The serve handler exported by this handler.
    */
-  handler: { serve: ServeHandler },
+  handler: { name: string; serve: ServeHandler },
 
   /**
    * Optional tests and changes to make to this test suite.
@@ -216,6 +217,21 @@ export const testFramework = (
           body: expect.stringContaining("<!DOCTYPE html>"),
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
+          }),
+        });
+      });
+
+      test("return correct platform", async () => {
+        const ret = await run(
+          ["Test", [], { landingPage: true }],
+          [{ method: "GET" }],
+          { [envKeys.IsNetlify]: "true" }
+        );
+
+        expect(ret).toMatchObject({
+          headers: expect.objectContaining({
+            [headerKeys.Platform]: "netlify",
           }),
         });
       });
@@ -232,6 +248,7 @@ export const testFramework = (
           body: expect.stringContaining("<!DOCTYPE html>"),
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
         });
       });
@@ -246,6 +263,7 @@ export const testFramework = (
           status: 405,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
         });
       });
@@ -261,6 +279,7 @@ export const testFramework = (
           status: 405,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
         });
       });
@@ -275,6 +294,7 @@ export const testFramework = (
           body: expect.stringContaining("<!DOCTYPE html>"),
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
         });
       });
@@ -288,6 +308,7 @@ export const testFramework = (
           status: 405,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
         });
       });
@@ -306,6 +327,7 @@ export const testFramework = (
           status: 200,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
         });
 
@@ -346,6 +368,7 @@ export const testFramework = (
             status: 200,
             headers: expect.objectContaining({
               [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+              [headerKeys.Framework]: expect.stringMatching(handler.name),
             }),
           });
 
@@ -355,6 +378,22 @@ export const testFramework = (
 
           expect(retBody).toMatchObject({
             message: "Successfully registered",
+          });
+        });
+
+        test("return correct platform", async () => {
+          nock("https://api.inngest.com").post("/fn/register").reply(200, {
+            status: 200,
+          });
+
+          const ret = await run(["Test", []], [{ method: "PUT" }], {
+            [envKeys.IsNetlify]: "true",
+          });
+
+          expect(ret).toMatchObject({
+            headers: expect.objectContaining({
+              [headerKeys.Platform]: "netlify",
+            }),
           });
         });
 
@@ -384,6 +423,7 @@ export const testFramework = (
             status: 200,
             headers: expect.objectContaining({
               [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+              [headerKeys.Framework]: expect.stringMatching(handler.name),
             }),
           });
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -2,17 +2,17 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+import { EventPayload, Inngest } from "@local";
+import type { Inngest as InternalInngest } from "@local/components/Inngest";
+import { ServeHandler } from "@local/components/InngestCommHandler";
+import { headerKeys } from "@local/helpers/consts";
+import { version } from "@local/version";
 import fetch from "cross-fetch";
 import type { Request, Response } from "express";
-import { EventPayload, Inngest } from "inngest";
 import nock from "nock";
 import httpMocks from "node-mocks-http";
 import { ulid } from "ulid";
 import { z } from "zod";
-import type { Inngest as InternalInngest } from "../components/Inngest";
-import { ServeHandler } from "../components/InngestCommHandler";
-import { headerKeys } from "../helpers/consts";
-import { version } from "../version";
 
 interface HandlerStandardReturn {
   status: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -376,6 +376,15 @@ export interface ClientOptions {
    * back to a Node implementation if no global fetch can be found.
    */
   fetch?: typeof fetch;
+
+  /**
+   * The Inngest environment to send events to. Defaults to whichever
+   * environment this client's event key is associated with.
+   *
+   * It's likely you never need to change this unless you're trying to sync
+   * multiple systems together using branch names.
+   */
+  env?: string;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     "noUncheckedIndexedAccess": true,
     "strictNullChecks": true,
     "paths": {
-      "inngest": ["./src"]
+      "inngest": ["./src"],
+      "@local": ["./src"],
+      "@local/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["dist/**/*", "src/**/*.test.ts"],
+  "include": ["dist/**/*", "src/cloudflare.test.ts"],
   "compilerOptions": {
     "paths": {
-      "inngest": ["./dist"]
+      "@local": ["./dist"],
+      "@local/*": ["./dist/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary INN-1029

Adds the ability for a user to explicitly define an Inngest environment to send events to.

The workspace the event should go to is defined by the event key being used, but this can be used to direct events to another parallel workspace if allowed.

This is a relatively busy PR as it encapsulates a few changes to testing, too. Key files are:

- [src/helpers/env.ts](https://github.com/inngest/inngest-js/pull/158/files#diff-6419f12dc66fc6ed8ae4c92c68c4da1b5a4837494267428c9390a01986a8db1e)
Adding new `getEnvironmentName()` and `inngestHeaders()` exports to grab generated headers from the environment.
- [src/components/Inngest.ts](https://github.com/inngest/inngest-js/pull/158/files#diff-485bedbbee0f0a94697b7e5fa853e50e4e51d38c90f1b6df30da246314ded58b)
Adding an `env` option and building headers using `inngestHeaders()`.
- [src/components/InngestCommHandler.ts](https://github.com/inngest/inngest-js/pull/158/files#diff-5087958ec6f8b087e8827c51631a00210094a1d599c750e7ccade1b12ffc59c5)
Building headers to respond with during registration using `inngestHeaders()` and providing the `x-inngest-framework` header too.

## Related

- INN-1030