### PR TITLE
INN-1087 Add edge streaming support to all serve handlers

### DIFF
--- a/.changeset/violet-tools-watch.md
+++ b/.changeset/violet-tools-watch.md
@@ -2,4 +2,4 @@
 "inngest": minor
 ---
 
-INN-1087 Add edge streaming support to all serve handlers
+INN-1087 Add edge streaming support to `"inngest/next"` serve handler

--- a/.changeset/violet-tools-watch.md
+++ b/.changeset/violet-tools-watch.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+INN-1087 Add edge streaming support to all serve handlers

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -114,22 +114,24 @@ export class Inngest<Events extends Record<string, EventPayload> = Record<string
 }
 
 // Warning: (ae-forgotten-export) The symbol "Handler_2" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ActionResponse" needs to be exported by the entry point index.d.ts
 //
 // @public
-export class InngestCommHandler<H extends Handler_2, TransformedRes> {
+export class InngestCommHandler<H extends Handler_2, TResTransform extends (res: ActionResponse<string>, ...args: Parameters<H>) => any, TStreamTransform extends (res: ActionResponse<ReadableStream>, ...args: Parameters<H>) => any> {
     constructor(
     frameworkName: string,
     appNameOrInngest: string | Inngest<any>,
     functions: InngestFunction<any, any, any>[], { inngestRegisterUrl, fetch, landingPage, logLevel, signingKey, serveHost, servePath, allowEdgeStreaming, }: RegisterOptions | undefined,
     handler: H,
-    transformRes: (actionRes: ActionResponse, ...args: Parameters<H>) => TransformedRes);
+    transformRes: TResTransform,
+    streamTransformRes?: TStreamTransform);
     // (undocumented)
     protected readonly allowEdgeStreaming: boolean;
     // Warning: (ae-forgotten-export) The symbol "FunctionConfig" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     protected configs(url: URL): FunctionConfig[];
-    createHandler(): (...args: Parameters<H>) => Promise<TransformedRes>;
+    createHandler(): (...args: Parameters<H>) => Promise<Awaited<ReturnType<TResTransform>>>;
     protected readonly frameworkName: string;
     readonly handler: H;
     protected _isProd: boolean;
@@ -159,8 +161,9 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     protected signingKey: string | undefined;
     // (undocumented)
     protected signResponse(): string;
-    // Warning: (ae-forgotten-export) The symbol "ActionResponse" needs to be exported by the entry point index.d.ts
-    readonly transformRes: (res: ActionResponse, ...args: Parameters<H>) => TransformedRes;
+    // (undocumented)
+    readonly streamTransformRes: TStreamTransform | undefined;
+    readonly transformRes: TResTransform;
     // (undocumented)
     protected validateSignature(sig: string | undefined, body: Record<string, unknown>): void;
 }

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -171,6 +171,9 @@ export enum internalEvents {
 }
 
 // @public
+export const isEdgeRuntime: () => boolean;
+
+// @public
 export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "silent";
 
 // @public

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -198,7 +198,6 @@ export enum queryKeys {
 
 // @public
 export interface RegisterOptions {
-    // (undocumented)
     allowEdgeStreaming?: boolean;
     fetch?: typeof fetch;
     inngestRegisterUrl?: string;

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -171,9 +171,6 @@ export enum internalEvents {
 }
 
 // @public
-export const isEdgeRuntime: () => boolean;
-
-// @public
 export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "silent";
 
 // @public

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -121,12 +121,10 @@ export class InngestCommHandler<H extends Handler_2, TResTransform extends (res:
     constructor(
     frameworkName: string,
     appNameOrInngest: string | Inngest<any>,
-    functions: InngestFunction<any, any, any>[], { inngestRegisterUrl, fetch, landingPage, logLevel, signingKey, serveHost, servePath, allowEdgeStreaming, }: RegisterOptions | undefined,
+    functions: InngestFunction<any, any, any>[], { inngestRegisterUrl, fetch, landingPage, logLevel, signingKey, serveHost, servePath, streaming, }: RegisterOptions | undefined,
     handler: H,
     transformRes: TResTransform,
     streamTransformRes?: TStreamTransform);
-    // (undocumented)
-    protected readonly allowEdgeStreaming: boolean;
     // Warning: (ae-forgotten-export) The symbol "FunctionConfig" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -161,6 +159,8 @@ export class InngestCommHandler<H extends Handler_2, TResTransform extends (res:
     protected signingKey: string | undefined;
     // (undocumented)
     protected signResponse(): string;
+    // (undocumented)
+    protected readonly streaming: RegisterOptions["streaming"];
     // (undocumented)
     readonly streamTransformRes: TStreamTransform | undefined;
     readonly transformRes: TResTransform;
@@ -198,7 +198,6 @@ export enum queryKeys {
 
 // @public
 export interface RegisterOptions {
-    allowEdgeStreaming?: boolean;
     fetch?: typeof fetch;
     inngestRegisterUrl?: string;
     landingPage?: boolean;
@@ -206,6 +205,7 @@ export interface RegisterOptions {
     serveHost?: string;
     servePath?: string;
     signingKey?: string;
+    streaming?: "allow" | "force" | false;
 }
 
 // @public

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "build:landing": "cd landing && yarn run build",
     "build:check": "api-extractor run --verbose",
     "build:copy": "cp package.json LICENSE.md README.md CHANGELOG.md dist",
-    "prelink": "yarn run build:copy"
+    "prelink": "yarn run build:copy",
+    "local:pack": "yarn build && yarn prelink && yarn pack --verbose --frozen-lockfile --filename inngest.tgz --cwd dist"
   },
   "homepage": "https://github.com/inngest/inngest-js#readme",
   "repository": {

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -3,8 +3,9 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
+import type { SupportedFrameworkName } from "./types";
 
-export const name = "cloudflare-pages";
+export const name: SupportedFrameworkName = "cloudflare-pages";
 
 /**
  * In Cloudflare, serve and register any declared functions with Inngest, making

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -2,6 +2,7 @@ import { envKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import {
   devServerHost,
+  getFetch,
   inngestHeaders,
   isProd,
   processEnv,
@@ -134,32 +135,7 @@ export class Inngest<
       inngestEnv: env,
     });
 
-    this.fetch = Inngest.parseFetch(fetch);
-  }
-
-  /**
-   * Given a potential fetch function, return the fetch function to use based on
-   * this and the environment.
-   */
-  private static parseFetch(fetchArg: FetchT | undefined): FetchT {
-    if (fetchArg) {
-      return fetchArg;
-    }
-
-    try {
-      if (typeof globalThis !== "undefined" && "fetch" in globalThis) {
-        return fetch.bind(globalThis);
-      }
-    } catch (err) {
-      // no-op
-    }
-
-    if (typeof fetch !== "undefined") {
-      return fetch;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require("cross-fetch") as FetchT;
+    this.fetch = getFetch(fetch);
   }
 
   /**

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -146,6 +146,14 @@ export class Inngest<
       return fetchArg;
     }
 
+    try {
+      if (typeof globalThis !== "undefined" && "fetch" in globalThis) {
+        return fetch.bind(globalThis);
+      }
+    } catch (err) {
+      // no-op
+    }
+
     if (typeof fetch !== "undefined") {
       return fetch;
     }

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -26,6 +26,7 @@ import {
   RegisterOptions,
   RegisterRequest,
   StepRunResponse,
+  SupportedFrameworkName,
 } from "../types";
 import { version } from "../version";
 import { Inngest } from "./Inngest";
@@ -560,6 +561,7 @@ export class InngestCommHandler<
         this.allowEdgeStreaming &&
         this.streamTransformRes &&
         platformSupportsStreaming(
+          this.frameworkName as SupportedFrameworkName,
           actions.env as Record<string, string | undefined>
         )
       ) {

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -490,9 +490,6 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         ])
       ) as typeof rawActions;
 
-      /**
-       * TODO Allow trailing header ONLY IF the incoming request allows it
-       */
       const getHeaders = () => ({
         ...inngestHeaders({
           env: actions.env as Record<string, string | undefined>,
@@ -511,11 +508,13 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         const runRes = await actions.run();
         if (runRes) {
           const { stream, finalize } = await this.createStream();
+
           /**
-           * Is it okay if this throws?
+           * Errors are handled by `handleAction` here to ensure that an
+           * appropriate response is always given.
            */
           void actionRes.then(finalize);
-          res = { status: 200, body: stream, headers: getHeaders() };
+          res = { status: 201, body: stream, headers: getHeaders() };
         }
       }
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -1103,7 +1103,9 @@ type Handler = (...args: any[]) => {
  * The response from the Inngest SDK before it is transformed in to a
  * framework-compatible response by an {@link InngestCommHandler} instance.
  */
-export interface ActionResponse {
+export interface ActionResponse<
+  TBody extends string | ReadableStream = string
+> {
   /**
    * The HTTP status code to return.
    */
@@ -1117,7 +1119,7 @@ export interface ActionResponse {
   /**
    * A stringified body to return.
    */
-  body: string | ReadableStream;
+  body: TBody;
 }
 
 /**

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -452,7 +452,7 @@ export class InngestCommHandler<
     this.serveHost = serveHost;
     this.servePath = servePath;
     this.logLevel = logLevel;
-    this.allowEdgeStreaming = allowEdgeStreaming ?? true;
+    this.allowEdgeStreaming = allowEdgeStreaming ?? false;
 
     this.fetch = getFetch(
       fetch ||

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -490,7 +490,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
         ])
       ) as typeof rawActions;
 
-      const getHeaders = () => ({
+      const getHeaders = (): Record<string, string> => ({
         ...inngestHeaders({
           env: actions.env as Record<string, string | undefined>,
           framework: this.frameworkName,

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -361,7 +361,28 @@ export class InngestCommHandler<
     transformRes: TResTransform,
 
     /**
-     * TODO Document
+     * The `streamTransformRes` function, if defined, declares that this handler
+     * supports streaming responses back to Inngest. This is useful for
+     * functions that are expected to take a long time, as edge streaming can
+     * often circumvent restrictive request timeouts and other limitations.
+     *
+     * If your handler does not support streaming, do not define this function.
+     *
+     * It receives the output of the Inngest SDK and can decide how to package
+     * up that information to appropriately return the information in a stream
+     * to Inngest.
+     *
+     * Mostly, this is taking the given parameters and returning a new
+     * `Response`.
+     *
+     * The function is passed an {@link ActionResponse} (an object containing a
+     * `status` code, a `headers` object, and `body`, a `ReadableStream`), as
+     * well as every parameter passed to the given `handler` function. This
+     * ensures you can appropriately handle the response, including use of any
+     * required parameters such as `res` in Express-/Connect-like frameworks.
+     *
+     * This should never be defined by the user; a {@link ServeHandler} should
+     * abstract this.
      */
     streamTransformRes?: TStreamTransform
   ) {

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -589,12 +589,12 @@ export class InngestCommHandler<
         }
       }
 
-      return timer.wrap("res", async () =>
-        actionRes.then((res) =>
+      return timer.wrap("res", async () => {
+        return actionRes.then((res) => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          this.transformRes(prepareActionRes(res), ...args)
-        )
-      );
+          return this.transformRes(prepareActionRes(res), ...args);
+        });
+      });
     };
   }
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -12,6 +12,7 @@ import {
   platformSupportsStreaming,
 } from "../helpers/env";
 import { serializeError } from "../helpers/errors";
+import { cacheFn } from "../helpers/functions";
 import { strBoolean } from "../helpers/scalar";
 import { createStream } from "../helpers/stream";
 import { stringifyUnknown } from "../helpers/strings";
@@ -1210,16 +1211,3 @@ type HandlerAction =
   | {
       action: "bad-method";
     };
-
-const cacheFn = <T extends (...args: unknown[]) => unknown>(fn: T): T => {
-  const key = "value";
-  const cache = new Map<typeof key, ReturnType<T>>();
-
-  return ((...args) => {
-    if (!cache.has(key)) {
-      cache.set(key, fn(...args) as ReturnType<T>);
-    }
-
-    return cache.get(key);
-  }) as T;
-};

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -6,6 +6,7 @@ import { envKeys, headerKeys, queryKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import {
   allProcessEnv,
+  getFetch,
   inngestHeaders,
   isProd,
   platformSupportsStreaming,
@@ -451,7 +452,7 @@ export class InngestCommHandler<
     this.logLevel = logLevel;
     this.allowEdgeStreaming = allowEdgeStreaming ?? true;
 
-    this.fetch = Inngest["parseFetch"](
+    this.fetch = getFetch(
       fetch ||
         (typeof appNameOrInngest === "string"
           ? undefined

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -1,10 +1,11 @@
+import type { SupportedFrameworkName } from "inngest/types";
 import {
   InngestCommHandler,
   ServeHandler,
 } from "../components/InngestCommHandler";
 import { headerKeys, queryKeys } from "../helpers/consts";
 
-export const name = "deno/fresh";
+export const name: SupportedFrameworkName = "deno/fresh";
 
 /**
  * With Deno's Fresh framework, serve and register any declared functions with
@@ -14,7 +15,7 @@ export const name = "deno/fresh";
  */
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const handler = new InngestCommHandler(
-    name,
+    name as string,
     nameOrInngest,
     fns,
     opts,

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -1,6 +1,7 @@
 import type { ServeHandler } from "./components/InngestCommHandler";
 import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
+import type { SupportedFrameworkName } from "./types";
 
 type HTTP = {
   headers: Record<string, string>;
@@ -14,15 +15,17 @@ type Main = {
   [data: string]: unknown;
 };
 
+export const name: SupportedFrameworkName = "digitalocean";
+
 export const serve = (
-  name: Parameters<ServeHandler>[0],
+  nameOrInngest: Parameters<ServeHandler>[0],
   fns: Parameters<ServeHandler>[1],
   opts: Parameters<ServeHandler>[2] &
     Required<Pick<NonNullable<Parameters<ServeHandler>[2]>, "serveHost">>
 ) => {
   const handler = new InngestCommHandler(
-    "digitalocean",
     name,
+    nameOrInngest,
     fns,
     opts,
     (main: Main) => {

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -3,8 +3,9 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
+import type { SupportedFrameworkName } from "./types";
 
-export const name = "edge";
+export const name: SupportedFrameworkName = "edge";
 
 /**
  * In an edge runtime, serve and register any declared functions with Inngest,

--- a/src/express.ts
+++ b/src/express.ts
@@ -4,8 +4,9 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
+import type { SupportedFrameworkName } from "./types";
 
-export const name = "express";
+export const name: SupportedFrameworkName = "express";
 
 /**
  * Serve and register any declared functions with Inngest, making them available

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -191,7 +191,13 @@ export const inngestHeaders = (opts?: {
  * environment is running on the platform with the given name.
  */
 const platformChecks = {
-  vercel: (env) => env[envKeys.IsVercel] === "1",
+  /**
+   * Vercel Edge Functions don't have access to environment variables unless
+   * they are explicitly referenced in the top level code, but they do have a
+   * global `EdgeRuntime` variable set that we can use to detect this.
+   */
+  vercel: (env) =>
+    env[envKeys.IsVercel] === "1" || typeof EdgeRuntime === "string",
   netlify: (env) => env[envKeys.IsNetlify] === "true",
   "cloudflare-pages": (env) => env[envKeys.IsCloudflarePages] === "1",
   render: (env) => env[envKeys.IsRender] === "true",

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -232,10 +232,13 @@ const streamingChecks: Partial<
    * "Vercel supports streaming for Serverless Functions, Edge Functions, and
    * React Server Components in Next.js projects."
    *
+   * In practice, however, there are many reports of streaming not working as
+   * expected on Serverless Functions, so we resort to only allowing streaming
+   * for Edge Functions here.
+   *
    * See {@link https://vercel.com/docs/frameworks/nextjs#streaming}
    */
-  vercel: (framework) =>
-    framework === "nextjs" || typeof EdgeRuntime === "string",
+  vercel: (_framework, _env) => typeof EdgeRuntime === "string",
 };
 
 const getPlatformName = (env: Record<string, string | undefined>) => {

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -137,6 +137,8 @@ declare const EdgeRuntime: string | undefined;
 
 /**
  * Tries to detect whether this is running in an Edge runtime.
+ *
+ * @public
  */
 export const isEdgeRuntime = (): boolean => {
   return typeof EdgeRuntime === "string";

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -235,3 +235,37 @@ export const platformSupportsStreaming = (
     ) ?? false
   );
 };
+
+/**
+ * Given a potential fetch function, return the fetch function to use based on
+ * this and the environment.
+ */
+export const getFetch = (givenFetch?: typeof fetch): typeof fetch => {
+  if (givenFetch) {
+    return givenFetch;
+  }
+
+  /**
+   * Browser or Node 18+
+   */
+  try {
+    if (typeof globalThis !== "undefined" && "fetch" in globalThis) {
+      return fetch.bind(globalThis);
+    }
+  } catch (err) {
+    // no-op
+  }
+
+  /**
+   * Existing polyfilled fetch
+   */
+  if (typeof fetch !== "undefined") {
+    return fetch;
+  }
+
+  /**
+   * Environments where fetch cannot be found and must be polyfilled
+   */
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require("cross-fetch") as typeof fetch;
+};

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -98,3 +98,12 @@ export const allProcessEnv = (): Record<string, string | undefined> => {
 
   return {};
 };
+
+declare const EdgeRuntime: string | undefined;
+
+/**
+ * Tries to detect whether this is running in an Edge runtime.
+ */
+export const isEdgeRuntime = (): boolean => {
+  return typeof EdgeRuntime === "string";
+};

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -208,6 +208,9 @@ declare const EdgeRuntime: string | undefined;
  *
  * Streaming capability is both framework and platform-based. Frameworks are
  * supported in serve handlers, and platforms are checked here.
+ *
+ * As such, this record declares which platforms we explicitly support for
+ * streaming and is used by {@link platformSupportsStreaming}.
  */
 const streamingChecks = {
   vercel: (_env) => typeof EdgeRuntime === "string",
@@ -226,6 +229,13 @@ const getPlatformName = (env: Record<string, string | undefined>) => {
   );
 };
 
+/**
+ * Returns `true` if we believe the current environment supports streaming
+ * responses back to Inngest.
+ *
+ * We run a check directly related to the platform we believe we're running on,
+ * usually based on environment variables.
+ */
 export const platformSupportsStreaming = (
   env: Record<string, string | undefined> = allProcessEnv()
 ): boolean => {

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -224,7 +224,7 @@ const streamingChecks: Partial<
 > = {
   /**
    * "Vercel supports streaming for Serverless Functions, Edge Functions, and
-   * React Server Components in Next.js projects.""
+   * React Server Components in Next.js projects."
    *
    * See {@link https://vercel.com/docs/frameworks/nextjs#streaming}
    */

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -1,0 +1,18 @@
+/**
+ * Wraps a function with a cache. When the returned function is run, it will
+ * cache the result and return it on subsequent calls.
+ */
+export const cacheFn = <T extends (...args: unknown[]) => unknown>(
+  fn: T
+): T => {
+  const key = "value";
+  const cache = new Map<typeof key, unknown>();
+
+  return ((...args) => {
+    if (!cache.has(key)) {
+      cache.set(key, fn(...args));
+    }
+
+    return cache.get(key);
+  }) as T;
+};

--- a/src/helpers/stream.ts
+++ b/src/helpers/stream.ts
@@ -1,0 +1,67 @@
+/**
+ * Creates a {@link ReadableStream} that sends a `value` every `interval`
+ * milliseconds as a heartbeat, intended to keep a stream open.
+ *
+ * Returns the `stream` itself and a `finalize` function that can be used to
+ * close the stream and send a final value.
+ */
+export const createStream = (opts?: {
+  /**
+   * The interval in milliseconds to send a heartbeat.
+   *
+   * Defaults to `3000`.
+   */
+  interval?: number;
+
+  /**
+   * The value to send as a heartbeat.
+   *
+   * Defaults to `" "`.
+   */
+  value?: string;
+}): Promise<{ finalize: (data: unknown) => void; stream: ReadableStream }> => {
+  /**
+   * We need to resolve this promise with both the stream and the `finalize`
+   * function, but having them both instantiated synchronously is difficult, as
+   * we need access to the stream's internals too.
+   *
+   * We create this cheeky deferred promise to grab the internal `finalize`
+   * value. Be warned that simpler solutions may appear to compile, but fail at
+   * runtime due to variables not being assigned; make sure to test your code!
+   */
+  let passFinalize: (value: (data: unknown) => void) => void;
+
+  const finalizeP = new Promise<(data: unknown) => void>((resolve) => {
+    passFinalize = resolve;
+  });
+
+  const interval = opts?.interval ?? 3000;
+  const value = opts?.value ?? " ";
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
+  return new Promise(async (resolve, reject) => {
+    try {
+      const stream = new ReadableStream({
+        start(controller) {
+          const encoder = new TextEncoder();
+
+          const heartbeat = setInterval(() => {
+            controller.enqueue(encoder.encode(value));
+          }, interval);
+
+          const finalize = (data: unknown) => {
+            clearInterval(heartbeat);
+            controller.enqueue(encoder.encode(JSON.stringify(data)));
+            controller.close();
+          };
+
+          passFinalize(finalize);
+        },
+      });
+
+      resolve({ stream, finalize: await finalizeP });
+    } catch (err) {
+      reject(err);
+    }
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { InngestCommHandler } from "./components/InngestCommHandler";
 export type { ServeHandler } from "./components/InngestCommHandler";
 export { NonRetriableError } from "./components/NonRetriableError";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
+export { isEdgeRuntime } from "./helpers/env";
 export type {
   ClientOptions,
   EventNameFromTrigger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ export { InngestCommHandler } from "./components/InngestCommHandler";
 export type { ServeHandler } from "./components/InngestCommHandler";
 export { NonRetriableError } from "./components/NonRetriableError";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
-export { isEdgeRuntime } from "./helpers/env";
 export type {
   ClientOptions,
   EventNameFromTrigger,

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -9,8 +9,9 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
+import { SupportedFrameworkName } from "./types";
 
-export const name = "aws-lambda";
+export const name: SupportedFrameworkName = "aws-lambda";
 
 /**
  * With AWS Lambda, serve and register any declared functions with Inngest,

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -112,12 +112,12 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
       };
     },
 
-    ({ body, status, headers }, _req): Promise<APIGatewayProxyResult> => {
+    ({ body, status, headers }): Promise<APIGatewayProxyResult> => {
       return Promise.resolve({
         body,
         statusCode: status,
         headers,
-      } as APIGatewayProxyResult);
+      });
     }
   );
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -5,7 +5,7 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import { processEnv } from "./helpers/env";
+import { isEdgeRuntime, processEnv } from "./helpers/env";
 import { RegisterOptions } from "./types";
 
 export const name = "nextjs";
@@ -29,7 +29,7 @@ const isEdgeRequest = (
 export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
   const optsWithFetch: RegisterOptions = { ...opts };
 
-  if (typeof fetch !== "undefined") {
+  if (typeof fetch !== "undefined" && isEdgeRuntime()) {
     optsWithFetch.fetch = fetch.bind(globalThis);
   }
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -4,9 +4,9 @@ import type { ServeHandler } from "./components/InngestCommHandler";
 import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
-import type { RegisterOptions } from "./types";
+import type { RegisterOptions, SupportedFrameworkName } from "./types";
 
-export const name = "nextjs";
+export const name: SupportedFrameworkName = "nextjs";
 
 /**
  * In Next.js, serve and register any declared functions with Inngest, making

--- a/src/next.ts
+++ b/src/next.ts
@@ -88,11 +88,15 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
       };
     },
     ({ body, headers, status }, _req, res) => {
-      for (const [key, value] of Object.entries(headers)) {
-        res.setHeader(key, value);
+      if ("send" in res) {
+        for (const [key, value] of Object.entries(headers)) {
+          res.setHeader(key, value);
+        }
+
+        return void res.status(status).send(body);
       }
 
-      res.status(status).send(body);
+      return new Response(body, { status, headers });
     },
     ({ body, headers, status }) => {
       return new Response(body, { status, headers });

--- a/src/next.ts
+++ b/src/next.ts
@@ -17,7 +17,7 @@ export const name = "nextjs";
 const isEdgeRequest = (
   req: NextApiRequest | NextRequest
 ): req is NextRequest => {
-  return typeof req.headers.get === "function";
+  return typeof req?.headers?.get === "function";
 };
 
 /**

--- a/src/next.ts
+++ b/src/next.ts
@@ -114,16 +114,16 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         },
       };
     },
-    ({ body, headers, status }, _method, _req, res) => {
-      if ("send" in res) {
-        for (const [key, value] of Object.entries(headers)) {
-          res.setHeader(key, value);
-        }
-
-        return void res.status(status).send(body);
+    ({ body, headers, status }, _method, req, res) => {
+      if (isNextEdgeRequest(req)) {
+        return new Response(body, { status, headers });
       }
 
-      return new Response(body, { status, headers });
+      for (const [key, value] of Object.entries(headers)) {
+        res.setHeader(key, value);
+      }
+
+      res.status(status).send(body);
     },
     ({ body, headers, status }) => {
       return new Response(body, { status, headers });

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -6,8 +6,9 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
+import type { SupportedFrameworkName } from "./types";
 
-export const name = "nuxt";
+export const name: SupportedFrameworkName = "nuxt";
 
 /**
  * In Nuxt 3, serve and register any declared functions with Inngest, making

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -29,14 +29,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
     name,
     nameOrInngest,
     fns,
-    {
-      ...opts,
-
-      /**
-       * RedwoodJS doesn't support streaming responses.
-       */
-      allowEdgeStreaming: false,
-    },
+    opts,
     (event: APIGatewayProxyEvent, _context: LambdaContext) => {
       const scheme =
         processEnv("NODE_ENV") === "development" ? "http" : "https";

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -8,6 +8,7 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
+import type { SupportedFrameworkName } from "./types";
 
 export interface RedwoodResponse {
   statusCode: number;
@@ -15,7 +16,7 @@ export interface RedwoodResponse {
   headers?: Record<string, string>;
 }
 
-export const name = "redwoodjs";
+export const name: SupportedFrameworkName = "redwoodjs";
 
 /**
  * In Redwood.js, serve and register any declared functions with Inngest, making

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -90,7 +90,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts): unknown => {
     (actionRes): RedwoodResponse => {
       return {
         statusCode: actionRes.status,
-        body: actionRes.body as string,
+        body: actionRes.body,
         headers: actionRes.headers,
       };
     }

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -3,8 +3,9 @@ import {
   ServeHandler,
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
+import type { SupportedFrameworkName } from "./types";
 
-export const name = "remix";
+export const name: SupportedFrameworkName = "remix";
 
 /**
  * In Remix, serve and register any declared functions with Inngest, making them

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -125,7 +125,16 @@ export const testFramework = (
     reqOpts: Parameters<typeof httpMocks.createRequest>,
     env: Record<string, string | undefined> = {}
   ): Promise<HandlerStandardReturn> => {
-    const serveHandler = handler.serve(...handlerOpts);
+    const [nameOrInngest, functions, givenOpts] = handlerOpts;
+    const serveHandler = handler.serve(nameOrInngest, functions, {
+      ...givenOpts,
+
+      /**
+       * For testing, the fetch implementation has to be stable for just to
+       * appropriately mock out the network requests.
+       */
+      fetch,
+    });
 
     const [req, res] = createReqRes({
       hostname: "localhost",

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -130,7 +130,7 @@ export const testFramework = (
       ...givenOpts,
 
       /**
-       * For testing, the fetch implementation has to be stable for just to
+       * For testing, the fetch implementation has to be stable for us to
        * appropriately mock out the network requests.
        */
       fetch,

--- a/src/types.ts
+++ b/src/types.ts
@@ -478,6 +478,8 @@ export interface RegisterOptions {
    * Default level: "info"
    */
   logLevel?: LogLevel;
+
+  allowEdgeStreaming?: boolean;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,20 +495,25 @@ export interface RegisterOptions {
   logLevel?: LogLevel;
 
   /**
-   * If this is `true`, and streaming is supported by your serve handler (e.g.
-   * `"inngest/next"`) and your platform (e.g. Vercel), the SDK will attempt to
-   * stream responses back to Inngest.
+   * Some serverless providers (especially those with edge compute) may support
+   * streaming responses back to Inngest. This can be used to circumvent
+   * restrictive request timeouts and other limitations. It is only available if
+   * the serve handler being used supports streaming.
    *
-   * This is highly recommended for functions that are expected to take a long
-   * time, as edge streaming can often circumvent restrictive request timeouts
-   * and other limitations.
+   * If this is `"allow"`, the SDK will attempt to stream responses back to
+   * Inngest if it can confidently detect support for it by verifyng that the
+   * platform and the serve handler supports streaming.
    *
-   * Some serve handlers may override this to `false` if streaming is not
-   * supported.
+   * If this is `"force"`, the SDK will always attempt to stream responses back
+   * to Inngest regardless of whether we can detect support for it or not. This
+   * will override `allowStreaming`, but will still not attempt to stream if
+   * the serve handler does not support it.
    *
-   * Defaults to `true`.
+   * If this is `false`, streaming will never be used.
+   *
+   * Defaults to `false`.
    */
-  allowEdgeStreaming?: boolean;
+  streaming?: "allow" | "force" | false;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -494,6 +494,20 @@ export interface RegisterOptions {
    */
   logLevel?: LogLevel;
 
+  /**
+   * If this is `true`, and streaming is supported by your serve handler (e.g.
+   * `"inngest/next"`) and your platform (e.g. Vercel), the SDK will attempt to
+   * stream responses back to Inngest.
+   *
+   * This is highly recommended for functions that are expected to take a long
+   * time, as edge streaming can often circumvent restrictive request timeouts
+   * and other limitations.
+   *
+   * Some serve handlers may override this to `false` if streaming is not
+   * supported.
+   *
+   * Defaults to `true`.
+   */
   allowEdgeStreaming?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -872,3 +872,19 @@ export type EventNameFromTrigger<
   Events extends Record<string, EventPayload>,
   T extends TriggerOptions<keyof Events & string>
 > = T extends string ? T : T extends { event: string } ? T["event"] : string;
+
+/**
+ * A union to represent known names of supported frameworks that we can use
+ * internally to assess functionality based on a mix of framework and platform.
+ */
+export type SupportedFrameworkName =
+  | "cloudflare-pages"
+  | "digitalocean"
+  | "edge"
+  | "express"
+  | "aws-lambda"
+  | "nextjs"
+  | "nuxt"
+  | "redwoodjs"
+  | "remix"
+  | "deno/fresh";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "strictNullChecks": true,
     "paths": {
       "inngest": ["./src"],
+      "inngest/*": ["./src/*"],
       "@local": ["./src"],
       "@local/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary INN-1087

Adds the ability for the SDK to stream responses back to Inngest, enabling longer timeouts in edge runtimes such as Deno, Cloudflare, or Next.js.

- **Add edge streaming support**
  > We're currently very strict about streaming support, only allowing it for `"inngest/next"`, ensuring users must opt in using `allowEdgeStreaming: true` and only allowing Next.js projects on Vercel.
  >
  > Following this being tested in production for a while, streaming support for other supported platforms is trivial to add, just writing code to turn it on.
- **Add support for Next.js Edge Functions**
  > The `"inngest/next"` handler now supports both Serverless Functions and Edge Functions; users can switch between both using Next.js conventions without having to change any of our code or imports.
- **Add support for Next.js 13+ [Route Handlers](https://beta.nextjs.org/docs/routing/route-handlers)**
  > Ended up wanting this as part of testing; if folks are using edge/streaming then it feels more likely that they're happy to use a beta version of Next.js itself too, so we might as well support this.
  > 
  > Route handlers use the same `"inngest/next"` serve handler, but users must export differently:
  > ```ts
  > export default serve(...);
  > // to
  > export const { GET, POST, PUT } = serve(...);
  > ```

## Related

- inngest/inngest#429