### PR TITLE
INN-1186 Send `x-inngest-platform` header during registration

### DIFF
--- a/.changeset/dirty-shoes-heal.md
+++ b/.changeset/dirty-shoes-heal.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+INN-1186 Send `x-inngest-platform` and `x-inngest-framework` headers during registration

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -81,6 +81,10 @@ export enum headerKeys {
     // (undocumented)
     Environment = "x-inngest-env",
     // (undocumented)
+    Framework = "x-inngest-framework",
+    // (undocumented)
+    Platform = "x-inngest-platform",
+    // (undocumented)
     SdkVersion = "x-inngest-sdk",
     // (undocumented)
     Signature = "x-inngest-signature"
@@ -131,10 +135,12 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     protected readonly logLevel: LogLevel;
     readonly name: string;
     // (undocumented)
-    protected register(url: URL, devServerHost: string | undefined, deployId?: string | undefined | null): Promise<{
+    protected register(url: URL, devServerHost: string | undefined, deployId: string | undefined | null, getHeaders: () => Record<string, string>): Promise<{
         status: number;
         message: string;
     }>;
+    // Warning: (ae-forgotten-export) The symbol "RegisterRequest" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     protected registerBody(url: URL): RegisterRequest;
     protected reqUrl(url: URL): URL;
@@ -143,12 +149,6 @@ export class InngestCommHandler<H extends Handler_2, TransformedRes> {
     //
     // (undocumented)
     protected runStep(functionId: string, stepId: string | null, data: unknown, timer: ServerTiming): Promise<StepRunResponse>;
-    // Warning: (ae-forgotten-export) The symbol "RegisterRequest" needs to be exported by the entry point index.d.ts
-    protected get sdkHeader(): [
-    prefix: string,
-    version: RegisterRequest["sdk"],
-    suffix: string
-    ];
     protected readonly serveHost: string | undefined;
     protected readonly servePath: string | undefined;
     // (undocumented)

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,7 @@ module.exports = {
   roots: ["<rootDir>/src"],
   moduleNameMapper: {
     inngest: "<rootDir>/src",
+    "^@local$": "<rootDir>/src",
+    "^@local/(.*)": "<rootDir>/src/$1",
   },
 };

--- a/src/cloudflare.test.ts
+++ b/src/cloudflare.test.ts
@@ -1,5 +1,5 @@
+import * as CloudflareHandler from "@local/cloudflare";
 import fetch, { Headers, Response } from "cross-fetch";
-import * as CloudflareHandler from "./cloudflare";
 import { testFramework } from "./test/helpers";
 
 const originalProcess = process;

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,9 +1,9 @@
-import { EventPayload } from "inngest";
+import { EventPayload } from "@local";
+import { eventKeyWarning } from "@local/components/Inngest";
+import { envKeys } from "@local/helpers/consts";
+import { IsAny } from "@local/helpers/types";
 import { assertType } from "type-plus";
-import { envKeys } from "../helpers/consts";
-import { IsAny } from "../helpers/types";
 import { createClient } from "../test/helpers";
-import { eventKeyWarning } from "./Inngest";
 
 const testEvent: EventPayload = {
   name: "test",

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -1,8 +1,8 @@
-import { envKeys, headerKeys } from "../helpers/consts";
+import { envKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import {
   devServerHost,
-  getEnvironmentName,
+  inngestHeaders,
   isProd,
   processEnv,
 } from "../helpers/env";
@@ -22,7 +22,6 @@ import type {
   ShimmedFns,
   TriggerOptions,
 } from "../types";
-import { version } from "../version";
 import { InngestFunction } from "./InngestFunction";
 
 /**
@@ -89,8 +88,6 @@ export class Inngest<
 
   private readonly fetch: FetchT;
 
-  private readonly env: string | undefined;
-
   /**
    * A client used to interact with the Inngest API by sending or reacting to
    * events.
@@ -133,17 +130,11 @@ export class Inngest<
       console.warn(eventKeyWarning);
     }
 
-    this.headers = {
-      "Content-Type": "application/json",
-      "User-Agent": `InngestJS v${version}`,
-    };
+    this.headers = inngestHeaders({
+      inngestEnv: env,
+    });
 
     this.fetch = Inngest.parseFetch(fetch);
-
-    this.env = env || getEnvironmentName();
-    if (this.env) {
-      this.headers[headerKeys.Environment] = this.env;
-    }
   }
 
   /**

--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,7 +1,7 @@
+import { serve } from "@local/next";
 import { assertType } from "type-plus";
 import { z } from "zod";
 import { IsAny } from "../helpers/types";
-import { serve } from "../next";
 import { createClient } from "../test/helpers";
 import { ServeHandler } from "./InngestCommHandler";
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -243,6 +243,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
    * A private collection of just Inngest functions, as they have been passed
    * when instantiating the class.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly rawFns: InngestFunction<any, any, any>[];
 
   /**

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,16 +1,16 @@
 import { jest } from "@jest/globals";
-import { assertType } from "type-plus";
-import { ServerTiming } from "../helpers/ServerTiming";
-import { internalEvents } from "../helpers/consts";
-import { createClient } from "../test/helpers";
+import { InngestFunction } from "@local/components/InngestFunction";
+import { UnhashedOp, _internals } from "@local/components/InngestStepTools";
+import { internalEvents } from "@local/helpers/consts";
+import { ServerTiming } from "@local/helpers/ServerTiming";
 import {
   EventPayload,
   FailureEventPayload,
   OpStack,
   StepOpCode,
-} from "../types";
-import { InngestFunction } from "./InngestFunction";
-import { UnhashedOp, _internals } from "./InngestStepTools";
+} from "@local/types";
+import { assertType } from "type-plus";
+import { createClient } from "../test/helpers";
 
 type TestEvents = {
   foo: { name: "foo"; data: { foo: string } };

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { createStepTools, TickOp } from "@local/components/InngestStepTools";
+import { StepOpCode } from "@local/types";
 import ms from "ms";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
-import { StepOpCode } from "../types";
-import { createStepTools, TickOp } from "./InngestStepTools";
 
 describe("waitForEvent", () => {
   const client = createClient({ name: "test" });

--- a/src/deno/fresh.test.ts
+++ b/src/deno/fresh.test.ts
@@ -1,6 +1,6 @@
+import * as DenoFreshHandler from "@local/deno/fresh";
 import fetch, { Headers, Response } from "cross-fetch";
 import { testFramework } from "../test/helpers";
-import * as DenoFreshHandler from "./fresh";
 
 const originalProcess = process;
 const originalFetch = globalThis.fetch;

--- a/src/edge.test.ts
+++ b/src/edge.test.ts
@@ -1,5 +1,5 @@
+import * as EdgeHandler from "@local/edge";
 import fetch, { Headers, Response } from "cross-fetch";
-import * as EdgeHandler from "./edge";
 import { testFramework } from "./test/helpers";
 
 const originalFetch = globalThis.fetch;

--- a/src/express.test.ts
+++ b/src/express.test.ts
@@ -1,5 +1,5 @@
+import * as ExpressHandler from "@local/express";
 import { InngestCommHandler } from "./components/InngestCommHandler";
-import * as ExpressHandler from "./express";
 import { createClient, testFramework } from "./test/helpers";
 
 testFramework("Express", ExpressHandler);

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -31,12 +31,22 @@ export enum envKeys {
   VercelBranch = "VERCEL_GIT_COMMIT_REF",
 
   /**
+   * Expected to be `"1"` if defined.
+   */
+  IsVercel = "VERCEL",
+
+  /**
    * The branch name of the current deployment. May only be accessible at build
    * time, but included here just in case.
    *
    * {@link https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables}
    */
   CloudflarePagesBranch = "CF_PAGES_BRANCH",
+
+  /**
+   * Expected to be `"1"` if defined.
+   */
+  IsCloudflarePages = "CF_PAGES",
 
   /**
    * The branch name of the deployment from Git to Netlify, if available.
@@ -46,6 +56,11 @@ export enum envKeys {
   NetlifyBranch = "BRANCH",
 
   /**
+   * Expected to be `"true"` if defined.
+   */
+  IsNetlify = "NETLIFY",
+
+  /**
    * The Git branch for a service or deploy.
    *
    * {@link https://render.com/docs/environment-variables#all-services}
@@ -53,11 +68,23 @@ export enum envKeys {
   RenderBranch = "RENDER_GIT_BRANCH",
 
   /**
+   * Expected to be `"true"` if defined.
+   */
+  IsRender = "RENDER",
+
+  /**
    * The branch that triggered the deployment. Example: `main`
    *
    * {@link https://docs.railway.app/develop/variables#railway-provided-variables}
    */
   RailwayBranch = "RAILWAY_GIT_BRANCH",
+
+  /**
+   * The railway environment for the deployment. Example: `production`
+   *
+   * {@link https://docs.railway.app/develop/variables#railway-provided-variables}
+   */
+  RailwayEnvironment = "RAILWAY_ENVIRONMENT",
 }
 
 export enum prodEnvKeys {
@@ -79,6 +106,8 @@ export enum headerKeys {
   Signature = "x-inngest-signature",
   SdkVersion = "x-inngest-sdk",
   Environment = "x-inngest-env",
+  Platform = "x-inngest-platform",
+  Framework = "x-inngest-framework",
 }
 
 export const defaultDevServerHost = "http://127.0.0.1:8288/";

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -108,6 +108,14 @@ declare const Deno: {
   env: { toObject: () => Record<string, string | undefined> };
 };
 
+/**
+ * allProcessEnv returns the current process environment variables, or an empty
+ * object if they cannot be read, making sure we support environments other than
+ * Node such as Deno, too.
+ *
+ * Using this ensures we don't dangerously access `process.env` in environments
+ * where it may not be defined, such as Deno or the browser.
+ */
 export const allProcessEnv = (): Record<string, string | undefined> => {
   try {
     // eslint-disable-next-line @inngest/process-warn

--- a/src/lambda.test.ts
+++ b/src/lambda.test.ts
@@ -1,5 +1,5 @@
+import * as LambdaHandler from "@local/lambda";
 import type { APIGatewayProxyResult } from "aws-lambda";
-import * as LambdaHandler from "./lambda";
 import { testFramework } from "./test/helpers";
 
 testFramework("AWS Lambda", LambdaHandler, {

--- a/src/next.test.ts
+++ b/src/next.test.ts
@@ -1,4 +1,4 @@
-import * as NextHandler from "./next";
+import * as NextHandler from "@local/next";
 import { testFramework } from "./test/helpers";
 
 testFramework("Next", NextHandler);

--- a/src/nuxt.test.ts
+++ b/src/nuxt.test.ts
@@ -1,6 +1,6 @@
-import * as NuxtHandler from "./nuxt";
-import { testFramework } from "./test/helpers";
+import * as NuxtHandler from "@local/nuxt";
 import { createEvent } from "h3";
+import { testFramework } from "./test/helpers";
 
 testFramework("Nuxt", NuxtHandler, {
   transformReq(req, res) {

--- a/src/redwood.test.ts
+++ b/src/redwood.test.ts
@@ -1,4 +1,4 @@
-import * as RedwoodHandler from "./redwood";
+import * as RedwoodHandler from "@local/redwood";
 import { testFramework } from "./test/helpers";
 
 testFramework("Redwood.js", RedwoodHandler, {

--- a/src/remix.test.ts
+++ b/src/remix.test.ts
@@ -1,5 +1,5 @@
+import * as RemixHandler from "@local/remix";
 import { Headers } from "cross-fetch";
-import * as RemixHandler from "./remix";
 import { testFramework } from "./test/helpers";
 
 testFramework("Remix", RemixHandler, {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -2,17 +2,17 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+import { EventPayload, Inngest } from "@local";
+import type { Inngest as InternalInngest } from "@local/components/Inngest";
+import { ServeHandler } from "@local/components/InngestCommHandler";
+import { headerKeys } from "@local/helpers/consts";
+import { version } from "@local/version";
 import fetch from "cross-fetch";
 import type { Request, Response } from "express";
-import { EventPayload, Inngest } from "inngest";
 import nock from "nock";
 import httpMocks from "node-mocks-http";
 import { ulid } from "ulid";
 import { z } from "zod";
-import type { Inngest as InternalInngest } from "../components/Inngest";
-import { ServeHandler } from "../components/InngestCommHandler";
-import { headerKeys } from "../helpers/consts";
-import { version } from "../version";
 
 interface HandlerStandardReturn {
   status: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     "noUncheckedIndexedAccess": true,
     "strictNullChecks": true,
     "paths": {
-      "inngest": ["./src"]
+      "inngest": ["./src"],
+      "@local": ["./src"],
+      "@local/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["dist/**/*", "src/**/*.test.ts"],
+  "include": ["dist/**/*", "src/cloudflare.test.ts"],
   "compilerOptions": {
     "paths": {
-      "inngest": ["./dist"]
+      "@local": ["./dist"],
+      "@local/*": ["./dist/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary INN-1186

The SDK needs to send the platform it believes it is on, so that the executor can ensure it's only explicitly supporting select platforms.

To do this, we should scan environment variables to assume the platform we are on, then send a standardised platform string as an x-inngest-platform header.

This needs to be done in every communication with Inngest or the Inngest dev server. This means we should probably refactor the setting of all headers across the SDK to always contain a default set.

## Related

- Based on #158 