### PR TITLE
Allow branch prefixes in signing keys

### DIFF
--- a/.changeset/sweet-mangos-eat.md
+++ b/.changeset/sweet-mangos-eat.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow signing keys with multiple prefixes, as required for branch environment support

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -428,7 +428,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
 
     const prefix =
       this.signingKey.match(/^signkey-(test|prod|branch)-/)?.shift() || "";
-    const key = this.signingKey.replace(/^signkey-(test|prod|branch)-/, "");
+    const key = this.signingKey.replace(/^signkey-[\w]+-/, "");
 
     // Decode the key from its hex representation into a bytestream
     return `${prefix}${sha256().update(key, "hex").digest("hex")}`;

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -427,8 +427,8 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     }
 
     const prefix =
-      this.signingKey.match(/^signkey-(test|prod)-/)?.shift() || "";
-    const key = this.signingKey.replace(/^signkey-(test|prod)-/, "");
+      this.signingKey.match(/^signkey-(test|prod|branch)-/)?.shift() || "";
+    const key = this.signingKey.replace(/^signkey-(test|prod|branch)-/, "");
 
     // Decode the key from its hex representation into a bytestream
     return `${prefix}${sha256().update(key, "hex").digest("hex")}`;

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -427,7 +427,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
     }
 
     const prefix =
-      this.signingKey.match(/^signkey-(test|prod|branch)-/)?.shift() || "";
+      this.signingKey.match(/^signkey-[\w]+-/)?.shift() || "";
     const key = this.signingKey.replace(/^signkey-[\w]+-/, "");
 
     // Decode the key from its hex representation into a bytestream


### PR DESCRIPTION
Trim the prefix of `signkey-branch-` prefixes.