### PR TITLE
Expose run ID to function executions

### DIFF
--- a/.changeset/empty-ears-bake.md
+++ b/.changeset/empty-ears-bake.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Expose run ID to function executions for user-managed logging and tracing

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -662,6 +662,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
           // steps: z.record(incomingOpSchema.passthrough()).optional().nullable(),
           ctx: z
             .object({
+              run_id: z.string(),
               stack: z
                 .object({
                   stack: z
@@ -698,7 +699,7 @@ export class InngestCommHandler<H extends Handler, TransformedRes> {
           }) ?? [];
 
       const ret = await fn.fn["runFn"](
-        { event },
+        { event, runId: ctx?.run_id },
         opStack,
         /**
          * TODO The executor is sending `"step"` as the step ID when it is not

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,11 @@ export type BaseContext<
   event: TEvents[TTrigger];
 
   /**
+   * The run ID for the current function execution
+   */
+  runId: string;
+
+  /**
    * @deprecated Use `step` instead.
    */
   tools: ReturnType<typeof createStepTools<TEvents, TTrigger>>[0];


### PR DESCRIPTION
This allows functions to get the current run ID for eg. internal console logs or tracing:

```
createFunction({ name: "foo" }, { event: "bar" }, async ({ event, step, runId }) => {
})
```