### PR TITLE
INN-1229 Add npm package provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
   },
   "volta": {
     "node": "18.12.1",
-    "yarn": "1.22.19"
+    "yarn": "1.22.19",
+    "npm": "9.6.4"
   },
   "peerDependencies": {
     "typescript": ">=4.7.2"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -43,9 +43,13 @@ const exec = async (...args) => {
   await exec("npm", ["config", "set", "git-tag-version", "false"], {
     cwd: distDir,
   });
-  await exec("npm", ["publish", "--tag", distTag, "--access", "public"], {
-    cwd: distDir,
-  });
+  await exec(
+    "npm",
+    ["publish", "--tag", distTag, "--access", "public", "--provenance"],
+    {
+      cwd: distDir,
+    }
+  );
 
   // Tag and push the release commit
   await exec("changeset", ["tag"]);


### PR DESCRIPTION
## Summary INN-1229

Publishes provenance alongside the `inngest` package to ensure builds are verified on npm for increased trust.

See [Introducing npm package provenance | The GitHub Blog](https://github.blog/2023-04-19-introducing-npm-package-provenance/).

![image](https://user-images.githubusercontent.com/1736957/233167117-c7cf5e20-ee59-4782-8b94-92f41fea4410.png)

Thanks for the suggestion, @goodoldneon!
