### PR TITLE
INN-1240 Add `queueMicrotask()` fallback for restrictive environments

### DIFF
--- a/.changeset/selfish-rules-jog.md
+++ b/.changeset/selfish-rules-jog.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+INN-1240 Add `queueMicrotask()` fallback for restrictive environments

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "h3": "^1.0.2",
     "hash.js": "^1.1.7",
     "ms": "^2.1.3",
+    "queue-microtask": "^1.2.3",
     "serialize-error-cjs": "^0.1.3",
     "type-fest": "^3.5.1",
     "zod": "^3.19.1"

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -1,4 +1,22 @@
 /**
+ * Some environments don't allow access to the global queueMicrotask(). While we
+ * had assumed this was only true for those powered by earlier versions of Node
+ * (<14) that we don't officially support, Vercel's Edge Functions also obscure
+ * the function, even though the platform it's based on (Cloudflare Workers)
+ * appropriately exposes it.
+ *
+ * Therefore, we can fall back to a reasonable alternative of
+ * `Promise.resolve().then(fn)` instead. This will be slightly slower, but at
+ * least we can still work in these environments.
+ *
+ * This package does exactly that, enabling us to use `queueMicrotask()` in all
+ * modern JS engines.
+ *
+ * See {@link https://www.npmjs.com/package/queue-microtask}.
+ */
+import queueMicrotask from "queue-microtask";
+
+/**
  * A helper function to create a `Promise` that will never settle.
  *
  * It purposefully creates no references to `resolve` or `reject` so that the

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,7 +4252,7 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
-queue-microtask@^1.2.2:
+queue-microtask@^1.2.2, queue-microtask@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==


### PR DESCRIPTION
## Summary INN-1240

Some environments don't allow access to the global `queueMicrotask()`. While I had assumed this was only true for those powered by earlier versions of Node (`<14`) that we don't officially support, Vercel's Edge Functions also obscure the function, even though the platform it's based on (Cloudflare Workers) appropriately exposes it.

Therefore, we can fall back to a reasonable alternative of `Promise.resolve().then(fn)` instead. This will be slightly slower, but at least we can still work in these environments.

## Related

- Needed for #163 