### PR TITLE
INN-1270 Create a handler to enforce more actionable errors

### DIFF
--- a/.changeset/unlucky-buttons-develop.md
+++ b/.changeset/unlucky-buttons-develop.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+INN-1270 Create an internal handler to enforce more actionable user-facing errors

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "canonicalize": "^1.0.8",
+    "chalk": "^5.2.0",
     "cross-fetch": "^3.1.5",
     "h3": "^1.0.2",
     "hash.js": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "canonicalize": "^1.0.8",
-    "chalk": "^5.2.0",
+    "chalk": "^4.1.2",
     "cross-fetch": "^3.1.5",
     "h3": "^1.0.2",
     "hash.js": "^1.1.7",

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,5 +1,4 @@
 import { EventPayload } from "@local";
-import { eventKeyWarning } from "@local/components/Inngest";
 import { envKeys, headerKeys } from "@local/helpers/consts";
 import { IsAny } from "@local/helpers/types";
 import { assertType } from "type-plus";
@@ -34,7 +33,9 @@ describe("instantiation", () => {
 
     test("should log a warning if event key not specified", () => {
       createClient({ name: "test" });
-      expect(warnSpy).toHaveBeenCalledWith(eventKeyWarning);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not find event key")
+      );
     });
 
     test("should not log a warning if event key is specified", () => {
@@ -82,7 +83,7 @@ describe("send", () => {
       const inngest = createClient({ name: "test" });
 
       await expect(() => inngest.send(testEvent)).rejects.toThrowError(
-        "Could not find an event key"
+        "Failed to send event"
       );
     });
 

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -7,6 +7,7 @@ import {
   isProd,
   processEnv,
 } from "../helpers/env";
+import { prettyError } from "../helpers/errors";
 import type {
   PartialK,
   SendEventPayload,
@@ -29,12 +30,6 @@ import { InngestFunction } from "./InngestFunction";
  * Capturing the global type of fetch so that we can reliably access it below.
  */
 type FetchT = typeof fetch;
-
-export const eventKeyWarning =
-  "Could not find an event key to send events; sending will throw unless an event key is added. Please pass one to the constructor, set the INNGEST_EVENT_KEY environment variable, or use inngest.setEventKey() at runtime.";
-
-export const eventKeyError =
-  "Could not find an event key to send events. Please pass one to the constructor, set the INNGEST_EVENT_KEY environment variable, or use inngest.setEventKey() at runtime.";
 
 /**
  * A client used to interact with the Inngest API by sending or reacting to
@@ -128,7 +123,22 @@ export class Inngest<
     this.setEventKey(eventKey || processEnv(envKeys.EventKey) || "");
 
     if (!this.eventKey) {
-      console.warn(eventKeyWarning);
+      console.warn(
+        prettyError({
+          type: "warn",
+          whatHappened: "Could not find event key",
+          consequences:
+            "Sending events will throw in production unless an event key is added.",
+          toFixNow: [
+            "Pass a key to the `new Inngest()` constructor using the `eventKey` option",
+            "Set the `INNGEST_EVENT_KEY` environment variable",
+            "Use `inngest.setEventKey()` at runtime",
+          ],
+          why: "We couldn't find an event key to use to send events to Inngest.",
+          otherwise:
+            "Create a new production event key at https://app.inngest.com/env/production/manage/keys.",
+        })
+      );
     }
 
     this.headers = inngestHeaders({
@@ -258,7 +268,22 @@ export class Inngest<
     >
   ): Promise<void> {
     if (!this.eventKey) {
-      throw new Error(eventKeyError);
+      throw new Error(
+        prettyError({
+          whatHappened: "Failed to send event",
+          consequences: "Your event or events were not sent to Inngest.",
+          why: "We couldn't find an event key to use to send events to Inngest.",
+          toFixNow: [
+            `Pass a key to the \`new Inngest()\` constructor using the \`${
+              "eventKey" satisfies keyof ClientOptions
+            }\` option`,
+            "Set the `INNGEST_EVENT_KEY` environment variable",
+            `Use \`inngest.${
+              "setEventKey" satisfies keyof Inngest
+            }()\` at runtime`,
+          ],
+        })
+      );
     }
 
     let payloads: ValueOf<Events>[];
@@ -293,7 +318,15 @@ export class Inngest<
      */
     if (!payloads.length) {
       return console.warn(
-        "Warning: You have called `inngest.send()` with an empty array; the operation will resolve, but no events have been sent. This may be intentional, in which case you can ignore this warning."
+        prettyError({
+          type: "warn",
+          whatHappened: "`inngest.send()` called with no events",
+          reassurance:
+            "This is not an error, but you may not have intended to do this.",
+          consequences:
+            "The returned promise will resolve, but no events have been sent to Inngest.",
+          stack: true,
+        })
       );
     }
 

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -115,6 +115,7 @@ export class Inngest<
     env,
   }: ClientOptions) {
     if (!name) {
+      // TODO PrettyError
       throw new Error("A name must be passed to create an Inngest instance.");
     }
 

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -412,6 +412,7 @@ export class InngestCommHandler<
     this.rawFns = functions.filter(Boolean);
 
     if (this.rawFns.length !== functions.length) {
+      // TODO PrettyError
       console.warn(
         `Some functions passed to serve() are undefined and misconfigured.  Please check your imports.`
       );
@@ -431,6 +432,7 @@ export class InngestCommHandler<
 
       configs.forEach(({ id }) => {
         if (acc[id]) {
+          // TODO PrettyError
           throw new Error(
             `Duplicate function ID "${id}"; please change a function's name or provide an explicit ID to avoid conflicts.`
           );
@@ -757,9 +759,11 @@ export class InngestCommHandler<
     try {
       const fn = this.fns[functionId];
       if (!fn) {
+        // TODO PrettyError
         throw new Error(`Could not find function with ID "${functionId}"`);
       }
 
+      // TODO PrettyError on parse failure; serve handler may be set up badly
       const { event, steps, ctx } = z
         .object({
           event: z.object({}).passthrough(),
@@ -813,6 +817,7 @@ export class InngestCommHandler<
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const step = steps?.[opId];
             if (typeof step === "undefined") {
+              // TODO PrettyError
               throw new Error(`Could not find step with ID "${opId}"`);
             }
 
@@ -1025,6 +1030,7 @@ export class InngestCommHandler<
     if (!this.isProd) {
       // In dev, warning users about signing keys ensures that it's considered
       if (!this.signingKey) {
+        // TODO PrettyError
         console.warn(
           "No signing key provided to validate signature. Find your dev keys at https://app.inngest.com/test/secrets"
         );
@@ -1035,6 +1041,7 @@ export class InngestCommHandler<
 
     // If we're here, we're in production; lack of a signing key is an error.
     if (!this.signingKey) {
+      // TODO PrettyError
       throw new Error(
         `No signing key found in client options or ${envKeys.SigningKey} env var. Find your keys at https://app.inngest.com/secrets`
       );
@@ -1042,6 +1049,7 @@ export class InngestCommHandler<
 
     // If we're here, we're in production; lack of a req signature is an error.
     if (!sig) {
+      // TODO PrettyError
       throw new Error(`No ${headerKeys.Signature} provided`);
     }
 
@@ -1100,6 +1108,7 @@ class RequestSignature {
     this.signature = params.get("s") || "";
 
     if (!this.timestamp || !this.signature) {
+      // TODO PrettyError
       throw new Error(`Invalid ${headerKeys.Signature} provided`);
     }
   }
@@ -1124,6 +1133,7 @@ class RequestSignature {
     allowExpiredSignatures: boolean;
   }): void {
     if (this.hasExpired(allowExpiredSignatures)) {
+      // TODO PrettyError
       throw new Error("Signature has expired");
     }
 
@@ -1141,6 +1151,7 @@ class RequestSignature {
       .digest("hex");
 
     if (mac !== this.signature) {
+      // TODO PrettyError
       throw new Error("Invalid signature");
     }
   }

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -273,6 +273,7 @@ export class InngestFunction<
        */
 
       if (!this.#onFailureFn) {
+        // TODO PrettyError
         throw new Error(
           `Function "${this.name}" received a failure event to handle, but no failure handler was defined.`
         );
@@ -325,6 +326,7 @@ export class InngestFunction<
         state.currentOp = state.allFoundOps[incomingOp.id];
 
         if (!state.currentOp) {
+          // TODO PrettyError
           throw new Error(
             `Bad stack; could not find local op "${incomingOp.id}" at position ${pos}`
           );
@@ -363,6 +365,7 @@ export class InngestFunction<
       const userFnToRun = userFnOp?.fn;
 
       if (!userFnToRun) {
+        // TODO PrettyError
         throw new Error(
           `Bad stack; executor requesting to run unknown step "${runStep}"`
         );
@@ -461,6 +464,7 @@ export class InngestFunction<
          * To be safe, we'll show a warning here to tell users that this might
          * be unintentional, but otherwise carry on as normal.
          */
+        // TODO PrettyError
         console.warn(
           `Warning: Your "${this.name}" function has returned a value, but not all ops have been resolved, i.e. you have used step tooling without \`await\`. This may be intentional, but if you expect your ops to be resolved in order, you should \`await\` them. If you are knowingly leaving ops unresolved using \`.catch()\` or \`void\`, you can ignore this warning.`
         );

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -450,8 +450,10 @@ export const createStepTools = <
          * If we're here, it's because the date is invalid. We'll throw a custom
          * error here to standardise this response.
          */
+        // TODO PrettyError
         console.warn("Invalid date or date string passed to sleepUntil;", err);
 
+        // TODO PrettyError
         throw new Error(
           `Invalid date or date string passed to sleepUntil: ${time.toString()}`
         );

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -68,6 +68,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         const proto = event.headers["x-forwarded-proto"] || "https";
         url = new URL(path, `${proto}://${event.headers.host || ""}`);
       } catch (err) {
+        // TODO PrettyError
         throw new Error("Could not parse URL from `event.headers.host`");
       }
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -48,6 +48,7 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
        */
       const method = reqMethod || req.method;
       if (!method) {
+        // TODO PrettyError
         throw new Error(
           "No method found on request; check that your exports are correct."
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,6 +1691,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,11 +1691,6 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
-
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
## Summary INN-1270

Many errors within the SDK are handled in code, but not logged for users to see, meaning it can be unclear for users how failures should be remedied. We can fix this by providing a number of more in-depth, user-facing errors across the SDK.

This PR creates a small helper we can use across the app to take in and error and enforce that we:

- Say what happened
- Provide reassurance if we can
- Say why it happened
- Say how to fix it now
- Give them a back-up plan

It replaces some existing warnings, and adds TODOs for all other areas we must address.

## Example

![image](https://user-images.githubusercontent.com/1736957/234666512-e708d4c6-db2c-443f-8d2f-112b60503ca4.png)
