### PR TITLE
Add consistent type imports

### DIFF
--- a/.changeset/two-schools-camp.md
+++ b/.changeset/two-schools-camp.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add consistent type imports for slightly better tree-shaking

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json"],
   },
-  plugins: ["@typescript-eslint", "@inngest"],
+  plugins: ["@typescript-eslint", "@inngest", "import"],
   root: true,
   ignorePatterns: ["dist/", "*.d.ts", "*.js", "deno_compat/"],
   rules: {
@@ -21,7 +21,12 @@ module.exports = {
       "warn",
       { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
     ],
-    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      { fixStyle: "inline-type-imports" },
+    ],
+    "import/consistent-type-specifier-style": ["error", "prefer-inline"],
+    "import/no-duplicates": ["error", { "prefer-inline": true }],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
       "warn",
       { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
     ],
+    "@typescript-eslint/consistent-type-imports": "error",
   },
   overrides: [
     {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/landing.ts

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { Jsonify } from 'type-fest';
+import { Jsonify } from 'type-fest';
 
 // @public
 export interface ClientOptions {

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { Jsonify } from 'type-fest';
+import type { Jsonify } from 'type-fest';
 
 // @public
 export interface ClientOptions {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "concurrently": "^7.4.0",
     "eslint": "^8.30.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "express": "^4.18.2",
     "genversion": "^3.1.1",

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -1,7 +1,9 @@
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "cloudflare-pages";
 

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -1,7 +1,5 @@
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import type { SupportedFrameworkName } from "./types";
 

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,7 +1,7 @@
-import type { EventPayload } from "@local";
+import { type EventPayload } from "@local";
 import { eventKeyWarning } from "@local/components/Inngest";
 import { envKeys, headerKeys } from "@local/helpers/consts";
-import type { IsAny } from "@local/helpers/types";
+import { type IsAny } from "@local/helpers/types";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
 

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -1,7 +1,7 @@
-import { EventPayload } from "@local";
+import type { EventPayload } from "@local";
 import { eventKeyWarning } from "@local/components/Inngest";
 import { envKeys, headerKeys } from "@local/helpers/consts";
-import { IsAny } from "@local/helpers/types";
+import type { IsAny } from "@local/helpers/types";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
 

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -7,21 +7,21 @@ import {
   isProd,
   processEnv,
 } from "../helpers/env";
-import type {
-  PartialK,
-  SendEventPayload,
-  SingleOrArray,
-  ValueOf,
+import {
+  type PartialK,
+  type SendEventPayload,
+  type SingleOrArray,
+  type ValueOf,
 } from "../helpers/types";
-import type {
-  ClientOptions,
-  EventNameFromTrigger,
-  EventPayload,
-  FailureEventArgs,
-  FunctionOptions,
-  Handler,
-  ShimmedFns,
-  TriggerOptions,
+import {
+  type ClientOptions,
+  type EventNameFromTrigger,
+  type EventPayload,
+  type FailureEventArgs,
+  type FunctionOptions,
+  type Handler,
+  type ShimmedFns,
+  type TriggerOptions,
 } from "../types";
 import { InngestFunction } from "./InngestFunction";
 

--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,9 +1,9 @@
 import { serve } from "@local/next";
 import { assertType } from "type-plus";
 import { z } from "zod";
-import { IsAny } from "../helpers/types";
+import type { IsAny } from "../helpers/types";
 import { createClient } from "../test/helpers";
-import { ServeHandler } from "./InngestCommHandler";
+import type { ServeHandler } from "./InngestCommHandler";
 
 describe("#153", () => {
   test('does not throw "type instantiation is excessively deep and possibly infinite" for looping type', () => {

--- a/src/components/InngestCommHandler.test.ts
+++ b/src/components/InngestCommHandler.test.ts
@@ -1,9 +1,9 @@
 import { serve } from "@local/next";
 import { assertType } from "type-plus";
 import { z } from "zod";
-import type { IsAny } from "../helpers/types";
+import { type IsAny } from "../helpers/types";
 import { createClient } from "../test/helpers";
-import type { ServeHandler } from "./InngestCommHandler";
+import { type ServeHandler } from "./InngestCommHandler";
 
 describe("#153", () => {
   test('does not throw "type instantiation is excessively deep and possibly infinite" for looping type', () => {

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -16,21 +16,21 @@ import { cacheFn } from "../helpers/functions";
 import { strBoolean } from "../helpers/scalar";
 import { createStream } from "../helpers/stream";
 import { stringifyUnknown } from "../helpers/strings";
-import type { MaybePromise } from "../helpers/types";
+import { type MaybePromise } from "../helpers/types";
 import { landing } from "../landing";
-import type {
-  FunctionConfig,
-  IncomingOp,
-  IntrospectRequest,
-  LogLevel,
-  RegisterOptions,
-  RegisterRequest,
-  StepRunResponse,
-  SupportedFrameworkName,
+import {
+  type FunctionConfig,
+  type IncomingOp,
+  type IntrospectRequest,
+  type LogLevel,
+  type RegisterOptions,
+  type RegisterRequest,
+  type StepRunResponse,
+  type SupportedFrameworkName,
 } from "../types";
 import { version } from "../version";
-import type { Inngest } from "./Inngest";
-import type { InngestFunction } from "./InngestFunction";
+import { type Inngest } from "./Inngest";
+import { type InngestFunction } from "./InngestFunction";
 import { NonRetriableError } from "./NonRetriableError";
 
 /**

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -18,7 +18,7 @@ import { createStream } from "../helpers/stream";
 import { stringifyUnknown } from "../helpers/strings";
 import type { MaybePromise } from "../helpers/types";
 import { landing } from "../landing";
-import {
+import type {
   FunctionConfig,
   IncomingOp,
   IntrospectRequest,
@@ -29,7 +29,7 @@ import {
   SupportedFrameworkName,
 } from "../types";
 import { version } from "../version";
-import { Inngest } from "./Inngest";
+import type { Inngest } from "./Inngest";
 import type { InngestFunction } from "./InngestFunction";
 import { NonRetriableError } from "./NonRetriableError";
 

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,11 +1,17 @@
 import { jest } from "@jest/globals";
 import { InngestFunction } from "@local/components/InngestFunction";
-import type { UnhashedOp } from "@local/components/InngestStepTools";
-import { _internals } from "@local/components/InngestStepTools";
-import { ServerTiming } from "@local/helpers/ServerTiming";
+import {
+  _internals,
+  type UnhashedOp,
+} from "@local/components/InngestStepTools";
 import { internalEvents } from "@local/helpers/consts";
-import type { EventPayload, FailureEventPayload, OpStack } from "@local/types";
-import { StepOpCode } from "@local/types";
+import { ServerTiming } from "@local/helpers/ServerTiming";
+import {
+  StepOpCode,
+  type EventPayload,
+  type FailureEventPayload,
+  type OpStack,
+} from "@local/types";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
 

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -1,14 +1,11 @@
 import { jest } from "@jest/globals";
 import { InngestFunction } from "@local/components/InngestFunction";
-import { UnhashedOp, _internals } from "@local/components/InngestStepTools";
-import { internalEvents } from "@local/helpers/consts";
+import type { UnhashedOp } from "@local/components/InngestStepTools";
+import { _internals } from "@local/components/InngestStepTools";
 import { ServerTiming } from "@local/helpers/ServerTiming";
-import {
-  EventPayload,
-  FailureEventPayload,
-  OpStack,
-  StepOpCode,
-} from "@local/types";
+import { internalEvents } from "@local/helpers/consts";
+import type { EventPayload, FailureEventPayload, OpStack } from "@local/types";
+import { StepOpCode } from "@local/types";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
 

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -1,9 +1,9 @@
 import { internalEvents, queryKeys } from "../helpers/consts";
 import { deserializeError, serializeError } from "../helpers/errors";
 import { resolveAfterPending, resolveNextTick } from "../helpers/promises";
-import { ServerTiming } from "../helpers/ServerTiming";
+import type { ServerTiming } from "../helpers/ServerTiming";
 import { slugify, timeStr } from "../helpers/strings";
-import {
+import type {
   Context,
   EventNameFromTrigger,
   EventPayload,
@@ -16,10 +16,11 @@ import {
   IncomingOp,
   OpStack,
   OutgoingOp,
-  StepOpCode,
 } from "../types";
-import { Inngest } from "./Inngest";
-import { createStepTools, TickOp } from "./InngestStepTools";
+import { StepOpCode } from "../types";
+import type { Inngest } from "./Inngest";
+import type { TickOp } from "./InngestStepTools";
+import { createStepTools } from "./InngestStepTools";
 
 /**
  * A stateless Inngest function, wrapping up function configuration and any

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -1,26 +1,25 @@
 import { internalEvents, queryKeys } from "../helpers/consts";
 import { deserializeError, serializeError } from "../helpers/errors";
 import { resolveAfterPending, resolveNextTick } from "../helpers/promises";
-import type { ServerTiming } from "../helpers/ServerTiming";
+import { type ServerTiming } from "../helpers/ServerTiming";
 import { slugify, timeStr } from "../helpers/strings";
-import type {
-  Context,
-  EventNameFromTrigger,
-  EventPayload,
-  FailureEventArgs,
-  FailureEventPayload,
-  FunctionConfig,
-  FunctionOptions,
-  FunctionTrigger,
-  Handler,
-  IncomingOp,
-  OpStack,
-  OutgoingOp,
+import {
+  StepOpCode,
+  type Context,
+  type EventNameFromTrigger,
+  type EventPayload,
+  type FailureEventArgs,
+  type FailureEventPayload,
+  type FunctionConfig,
+  type FunctionOptions,
+  type FunctionTrigger,
+  type Handler,
+  type IncomingOp,
+  type OpStack,
+  type OutgoingOp,
 } from "../types";
-import { StepOpCode } from "../types";
-import type { Inngest } from "./Inngest";
-import type { TickOp } from "./InngestStepTools";
-import { createStepTools } from "./InngestStepTools";
+import { type Inngest } from "./Inngest";
+import { createStepTools, type TickOp } from "./InngestStepTools";
 
 /**
  * A stateless Inngest function, wrapping up function configuration and any

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { createStepTools, TickOp } from "@local/components/InngestStepTools";
+import type { TickOp } from "@local/components/InngestStepTools";
+import { createStepTools } from "@local/components/InngestStepTools";
 import { StepOpCode } from "@local/types";
 import ms from "ms";
 import { assertType } from "type-plus";

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type { TickOp } from "@local/components/InngestStepTools";
-import { createStepTools } from "@local/components/InngestStepTools";
+import {
+  createStepTools,
+  type TickOp,
+} from "@local/components/InngestStepTools";
 import { StepOpCode } from "@local/types";
 import ms from "ms";
 import { assertType } from "type-plus";

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -1,6 +1,6 @@
 import canonicalize from "canonicalize";
 import { sha1 } from "hash.js";
-import { Jsonify } from "type-fest";
+import type { Jsonify } from "type-fest";
 import { timeStr } from "../helpers/strings";
 import type {
   ObjectPaths,
@@ -9,8 +9,9 @@ import type {
   SingleOrArray,
   ValueOf,
 } from "../helpers/types";
-import { EventPayload, HashedOp, Op, StepOpCode } from "../types";
-import { Inngest } from "./Inngest";
+import type { EventPayload, HashedOp, Op } from "../types";
+import { StepOpCode } from "../types";
+import type { Inngest } from "./Inngest";
 
 export interface TickOp extends HashedOp {
   fn?: (...args: unknown[]) => unknown;

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -1,17 +1,21 @@
 import canonicalize from "canonicalize";
 import { sha1 } from "hash.js";
-import type { Jsonify } from "type-fest";
+import { type Jsonify } from "type-fest";
 import { timeStr } from "../helpers/strings";
-import type {
-  ObjectPaths,
-  PartialK,
-  SendEventPayload,
-  SingleOrArray,
-  ValueOf,
+import {
+  type ObjectPaths,
+  type PartialK,
+  type SendEventPayload,
+  type SingleOrArray,
+  type ValueOf,
 } from "../helpers/types";
-import type { EventPayload, HashedOp, Op } from "../types";
-import { StepOpCode } from "../types";
-import type { Inngest } from "./Inngest";
+import {
+  StepOpCode,
+  type EventPayload,
+  type HashedOp,
+  type Op,
+} from "../types";
+import { type Inngest } from "./Inngest";
 
 export interface TickOp extends HashedOp {
   fn?: (...args: unknown[]) => unknown;

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -1,6 +1,8 @@
-import type { SupportedFrameworkName } from "inngest/types";
-import type { ServeHandler } from "../components/InngestCommHandler";
-import { InngestCommHandler } from "../components/InngestCommHandler";
+import { type SupportedFrameworkName } from "inngest/types";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "../components/InngestCommHandler";
 import { headerKeys, queryKeys } from "../helpers/consts";
 
 export const name: SupportedFrameworkName = "deno/fresh";

--- a/src/deno/fresh.ts
+++ b/src/deno/fresh.ts
@@ -1,8 +1,6 @@
 import type { SupportedFrameworkName } from "inngest/types";
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "../components/InngestCommHandler";
+import type { ServeHandler } from "../components/InngestCommHandler";
+import { InngestCommHandler } from "../components/InngestCommHandler";
 import { headerKeys, queryKeys } from "../helpers/consts";
 
 export const name: SupportedFrameworkName = "deno/fresh";

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -1,7 +1,9 @@
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 type HTTP = {
   headers: Record<string, string>;

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -1,7 +1,9 @@
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "edge";
 

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -1,7 +1,5 @@
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import type { SupportedFrameworkName } from "./types";
 

--- a/src/examples/handler.ts
+++ b/src/examples/handler.ts
@@ -1,9 +1,5 @@
-import {
-  headerKeys,
-  InngestCommHandler,
-  queryKeys,
-  ServeHandler,
-} from "inngest";
+import type { ServeHandler } from "inngest";
+import { headerKeys, InngestCommHandler, queryKeys } from "inngest";
 
 /**
  * An example serve handler to demonstrate how to create a custom serve handler

--- a/src/examples/handler.ts
+++ b/src/examples/handler.ts
@@ -1,5 +1,9 @@
-import type { ServeHandler } from "inngest";
-import { headerKeys, InngestCommHandler, queryKeys } from "inngest";
+import {
+  headerKeys,
+  InngestCommHandler,
+  queryKeys,
+  type ServeHandler,
+} from "inngest";
 
 /**
  * An example serve handler to demonstrate how to create a custom serve handler

--- a/src/express.ts
+++ b/src/express.ts
@@ -1,8 +1,10 @@
-import type { Request, Response } from "express";
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import { type Request, type Response } from "express";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "express";
 

--- a/src/express.ts
+++ b/src/express.ts
@@ -1,8 +1,6 @@
 import type { Request, Response } from "express";
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import type { SupportedFrameworkName } from "./types";
 

--- a/src/helpers/devserver.ts
+++ b/src/helpers/devserver.ts
@@ -1,4 +1,4 @@
-import type { FunctionConfig } from "../types";
+import { type FunctionConfig } from "../types";
 import { defaultDevServerHost } from "./consts";
 
 /**

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -3,7 +3,7 @@
 // along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
 // string in order to read variables.
 
-import { SupportedFrameworkName } from "../types";
+import type { SupportedFrameworkName } from "../types";
 import { version } from "../version";
 import { envKeys, headerKeys } from "./consts";
 import { stringifyUnknown } from "./strings";

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -3,7 +3,7 @@
 // along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
 // string in order to read variables.
 
-import type { SupportedFrameworkName } from "../types";
+import { type SupportedFrameworkName } from "../types";
 import { version } from "../version";
 import { envKeys, headerKeys } from "./consts";
 import { stringifyUnknown } from "./strings";

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -1,5 +1,5 @@
 import ms from "ms";
-import type { TimeStr } from "../types";
+import { type TimeStr } from "../types";
 
 /**
  * Returns a slugified string used ot generate consistent IDs.

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -1,5 +1,5 @@
 import ms from "ms";
-import { TimeStr } from "../types";
+import type { TimeStr } from "../types";
 
 /**
  * Returns a slugified string used ot generate consistent IDs.

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,4 +1,4 @@
-import type { EventPayload } from "../types";
+import { type EventPayload } from "../types";
 
 /**
  * Returns a union of all of the values in a given object, regardless of key.

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,4 +1,4 @@
-import { EventPayload } from "../types";
+import type { EventPayload } from "../types";
 
 /**
  * Returns a union of all of the values in a given object, regardless of key.

--- a/src/lambda.test.ts
+++ b/src/lambda.test.ts
@@ -1,5 +1,5 @@
 import * as LambdaHandler from "@local/lambda";
-import type { APIGatewayProxyResult } from "aws-lambda";
+import { type APIGatewayProxyResult } from "aws-lambda";
 import { testFramework } from "./test/helpers";
 
 testFramework("AWS Lambda", LambdaHandler, {

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,13 +1,15 @@
-import type {
-  APIGatewayEvent,
-  APIGatewayProxyEventV2,
-  APIGatewayProxyResult,
-  Context,
+import {
+  type APIGatewayEvent,
+  type APIGatewayProxyEventV2,
+  type APIGatewayProxyResult,
+  type Context,
 } from "aws-lambda";
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "aws-lambda";
 

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -4,12 +4,10 @@ import type {
   APIGatewayProxyResult,
   Context,
 } from "aws-lambda";
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import { SupportedFrameworkName } from "./types";
+import type { SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "aws-lambda";
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,9 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import type { NextRequest } from "next/server";
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { type NextRequest } from "next/server";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "nextjs";
 

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,10 +1,19 @@
-import type { H3Event } from "h3";
-import { getHeader, getMethod, getQuery, readBody, send, setHeaders } from "h3";
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  getHeader,
+  getMethod,
+  getQuery,
+  readBody,
+  send,
+  setHeaders,
+  type H3Event,
+} from "h3";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "nuxt";
 

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,9 +1,7 @@
 import type { H3Event } from "h3";
 import { getHeader, getMethod, getQuery, readBody, send, setHeaders } from "h3";
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
 import type { SupportedFrameworkName } from "./types";

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -2,10 +2,8 @@ import type {
   APIGatewayProxyEvent,
   Context as LambdaContext,
 } from "aws-lambda";
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
 import type { SupportedFrameworkName } from "./types";

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -1,12 +1,14 @@
-import type {
-  APIGatewayProxyEvent,
-  Context as LambdaContext,
+import {
+  type APIGatewayProxyEvent,
+  type Context as LambdaContext,
 } from "aws-lambda";
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { processEnv } from "./helpers/env";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export interface RedwoodResponse {
   statusCode: number;

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -1,7 +1,9 @@
-import type { ServeHandler } from "./components/InngestCommHandler";
-import { InngestCommHandler } from "./components/InngestCommHandler";
+import {
+  InngestCommHandler,
+  type ServeHandler,
+} from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
-import type { SupportedFrameworkName } from "./types";
+import { type SupportedFrameworkName } from "./types";
 
 export const name: SupportedFrameworkName = "remix";
 

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -1,7 +1,5 @@
-import {
-  InngestCommHandler,
-  ServeHandler,
-} from "./components/InngestCommHandler";
+import type { ServeHandler } from "./components/InngestCommHandler";
+import { InngestCommHandler } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import type { SupportedFrameworkName } from "./types";
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -2,9 +2,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import { EventPayload, Inngest } from "@local";
+import type { EventPayload } from "@local";
+import { Inngest } from "@local";
 import type { Inngest as InternalInngest } from "@local/components/Inngest";
-import { ServeHandler } from "@local/components/InngestCommHandler";
+import type { ServeHandler } from "@local/components/InngestCommHandler";
 import { envKeys, headerKeys } from "@local/helpers/consts";
 import { version } from "@local/version";
 import fetch from "cross-fetch";

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -2,14 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import type { EventPayload } from "@local";
-import { Inngest } from "@local";
-import type { Inngest as InternalInngest } from "@local/components/Inngest";
-import type { ServeHandler } from "@local/components/InngestCommHandler";
+import { Inngest, type EventPayload } from "@local";
+import { type Inngest as InternalInngest } from "@local/components/Inngest";
+import { type ServeHandler } from "@local/components/InngestCommHandler";
 import { envKeys, headerKeys } from "@local/helpers/consts";
 import { version } from "@local/version";
 import fetch from "cross-fetch";
-import type { Request, Response } from "express";
+import { type Request, type Response } from "express";
 import nock from "nock";
 import httpMocks from "node-mocks-http";
 import { ulid } from "ulid";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { createStepTools } from "./components/InngestStepTools";
-import { internalEvents } from "./helpers/consts";
+import type { internalEvents } from "./helpers/consts";
 import type {
   IsStringLiteral,
   KeysNotOfType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-import type { createStepTools } from "./components/InngestStepTools";
-import type { internalEvents } from "./helpers/consts";
-import type {
-  IsStringLiteral,
-  KeysNotOfType,
-  ObjectPaths,
-  StrictUnion,
+import { type createStepTools } from "./components/InngestStepTools";
+import { type internalEvents } from "./helpers/consts";
+import {
+  type IsStringLiteral,
+  type KeysNotOfType,
+  type ObjectPaths,
+  type StrictUnion,
 } from "./helpers/types";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
@@ -1443,15 +1448,36 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
+array-includes@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
+  integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    is-string "^1.0.7"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-array.prototype.flat@^1.2.3:
+array.prototype.flat@^1.2.3, array.prototype.flat@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz#ffc6576a7ca3efc2f46a143b9d1dda9b4b3cf5e2"
   integrity sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.flatmap@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
+  integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
@@ -2021,6 +2047,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -2160,6 +2193,43 @@ eslint-config-prettier@^8.5.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
   integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
+
+eslint-import-resolver-node@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"
+  integrity sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==
+  dependencies:
+    debug "^3.2.7"
+    is-core-module "^2.11.0"
+    resolve "^1.22.1"
+
+eslint-module-utils@^2.7.4:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"
+  integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
+  dependencies:
+    debug "^3.2.7"
+
+eslint-plugin-import@^2.27.5:
+  version "2.27.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz#876a6d03f52608a3e5bb439c2550588e51dd6c65"
+  integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flat "^1.3.1"
+    array.prototype.flatmap "^1.3.1"
+    debug "^3.2.7"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.7"
+    eslint-module-utils "^2.7.4"
+    has "^1.0.3"
+    is-core-module "^2.11.0"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.values "^1.1.6"
+    resolve "^1.22.1"
+    semver "^6.3.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-prettier@^4.2.1:
   version "4.2.1"
@@ -2924,6 +2994,13 @@ is-core-module@^2.1.0, is-core-module@^2.8.1:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.11.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
+  integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
+  dependencies:
+    has "^1.0.3"
+
 is-core-module@^2.9.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
@@ -3539,6 +3616,13 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -3787,6 +3871,11 @@ minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
+minimist@^1.2.0, minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 minimist@^1.2.3:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -3970,6 +4059,15 @@ object.assign@^4.1.4:
     define-properties "^1.1.4"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
+
+object.values@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
+  integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -4404,6 +4502,15 @@ resolve@^1.10.0:
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
     is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.1:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -4893,6 +5000,16 @@ ts-jest@^29.0.3:
     make-error "1.x"
     semver "7.x"
     yargs-parser "^21.0.1"
+
+tsconfig-paths@^3.14.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
+  integrity sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
## Summary

Small refactor to enforce only importing types if no value is ever used.

Adds some extra ESLint rules to ensure we use inline type imports (e.g. `import { type Foo } from "./foo";`) so that we're not running multiple import statements for the same file.

Should ensure we tree shake as much as possible.