### PR TITLE
INN-1347 INN-1349 Fix deadlock when an async function finds a step

### DIFF
--- a/.changeset/shy-buttons-wave.md
+++ b/.changeset/shy-buttons-wave.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+INN-1347 Fix deadlock when an async function finds a step

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -167,7 +167,8 @@ describe("runFn", () => {
           stack?: OpStack;
           onFailure?: boolean;
           runStep?: string;
-          expectedReturn: Awaited<ReturnType<typeof runFnWithStack>>;
+          expectedReturn?: Awaited<ReturnType<typeof runFnWithStack>>;
+          expectedThrowMessage?: string;
           expectedHashOps?: UnhashedOp[];
           expectedStepsRun?: (keyof T["steps"])[];
           event?: EventPayload;
@@ -179,7 +180,8 @@ describe("runFn", () => {
           describe(name, () => {
             let hashDataSpy: ReturnType<typeof getHashDataSpy>;
             let tools: T;
-            let ret: Awaited<ReturnType<typeof runFnWithStack>>;
+            let ret: Awaited<ReturnType<typeof runFnWithStack>> | undefined;
+            let retErr: Error | undefined;
 
             beforeAll(async () => {
               hashDataSpy = getHashDataSpy();
@@ -188,12 +190,21 @@ describe("runFn", () => {
                 runStep: t.runStep,
                 onFailure: t.onFailure || tools.onFailure,
                 event: t.event || tools.event,
+              }).catch((err: Error) => {
+                retErr = err;
+                return undefined;
               });
             });
 
-            test("returns expected value", () => {
-              expect(ret).toEqual(t.expectedReturn);
-            });
+            if (t.expectedThrowMessage) {
+              test("throws expected error", () => {
+                expect(retErr?.message).toContain(t.expectedThrowMessage);
+              });
+            } else {
+              test("returns expected value", () => {
+                expect(ret).toEqual(t.expectedReturn);
+              });
+            }
 
             if (t.expectedHashOps?.length) {
               test("hashes expected ops", () => {

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -723,6 +723,32 @@ describe("runFn", () => {
     );
 
     testFn(
+      "throw when a non-step fn becomes a step-fn",
+      () => {
+        const A = jest.fn(() => "A");
+
+        const fn = inngest.createFunction(
+          { name: "Foo" },
+          "foo",
+          async ({ step: { run } }) => {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            await run("A", A);
+          }
+        );
+
+        return { fn, steps: { A } };
+      },
+      {
+        A: "",
+      },
+      () => ({
+        "first run throws, as we find a step late": {
+          expectedThrowMessage: "Your function was stopped from running",
+        },
+      })
+    );
+
+    testFn(
       "handle onFailure calls",
       () => {
         const A = jest.fn(() => "A");

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -476,7 +476,14 @@ export class InngestFunction<
          * function.
          *
          * We should wait for the result and return it.
+         *
+         * A caveat here is that the user could use step tooling later on,
+         * resulting in a mix of step and non-step logic. This is not something
+         * we want to support without an opt-in from the user, so we should
+         * throw if this is the case.
          */
+        state.nonStepFnDetected = true;
+
         return ["complete", await userFnPromise];
       }
     }


### PR DESCRIPTION
## Summary INN-1347 INN-1349

Currently, if we detect that a user has a regular async function and is using no step tooling, we eventually await the function. In cases where the function declares a step after this decision has been made, the step never resolves, therefore the function never resolves.

We can fix this by adding an extra check at this point, either per-tick or step functions synchronously throwing an error.

This includes the fix for for INN-1349, making `step.sendEvent()` an inline action if run within a non-step function.

## Related

- #188 