### PR TITLE
INN-1342: Add ProxyLogger to help handle buffering and flushing of logs (experimental)

### DIFF
--- a/.changeset/lovely-wasps-attack.md
+++ b/.changeset/lovely-wasps-attack.md
@@ -1,5 +1,5 @@
 ---
-"inngest": patch
+"inngest": minor
 ---
 
 Allow user provided logger to be used within functions (experimental)

--- a/.changeset/lovely-wasps-attack.md
+++ b/.changeset/lovely-wasps-attack.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow user provided logger to be used within functions (experimental)

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ temp/
 
 # Local dev files
 coverage/
+
+tsdoc-metadata.json

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -25,7 +25,7 @@ import {
   type TriggerOptions,
 } from "../types";
 import { InngestFunction } from "./InngestFunction";
-import { type Logger, ProxyLogger, DefaultLogger } from "../middleware/logger";
+import { type Logger, DefaultLogger } from "../middleware/logger";
 
 /**
  * Capturing the global type of fetch so that we can reliably access it below.
@@ -116,7 +116,7 @@ export class Inngest<
     inngestBaseUrl = "https://inn.gs/",
     fetch,
     env,
-    logger,
+    logger = new DefaultLogger(),
   }: ClientOptions) {
     if (!name) {
       // TODO PrettyError
@@ -147,7 +147,7 @@ export class Inngest<
     });
 
     this.fetch = getFetch(fetch);
-    this.logger = logger ? new ProxyLogger(logger) : new DefaultLogger();
+    this.logger = logger;
   }
 
   /**

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -25,7 +25,7 @@ import {
   type TriggerOptions,
 } from "../types";
 import { InngestFunction } from "./InngestFunction";
-import { type Logger, DefaultLogger } from "../middleware/logger";
+import { type Logger, ProxyLogger, DefaultLogger } from "../middleware/logger";
 
 /**
  * Capturing the global type of fetch so that we can reliably access it below.
@@ -147,9 +147,7 @@ export class Inngest<
     });
 
     this.fetch = getFetch(fetch);
-
-    // TODO: Wrap this in a proxy for non default loggers
-    this.logger = logger ? logger : new DefaultLogger();
+    this.logger = logger ? new ProxyLogger(logger) : new DefaultLogger();
   }
 
   /**

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -71,13 +71,15 @@ describe("runFn", () => {
         describe("success", () => {
           let fn: InngestFunction<TestEvents>;
           let ret: Awaited<ReturnType<(typeof fn)["runFn"]>>;
-          let flush: jest.SpiedFunction<() => {}>;
+          let flush: jest.SpiedFunction<() => void>;
 
           beforeAll(async () => {
             jest.restoreAllMocks();
             flush = jest
               .spyOn(ProxyLogger.prototype, "flush")
-              .mockImplementation(async () => { /* noop */ });
+              .mockImplementation(async () => {
+                /* noop */
+              });
 
             fn = new InngestFunction(
               createClient<TestEvents>({ name: "test" }),
@@ -194,13 +196,15 @@ describe("runFn", () => {
             let tools: T;
             let ret: Awaited<ReturnType<typeof runFnWithStack>> | undefined;
             let retErr: Error | undefined;
-            let flush: jest.SpiedFunction<() => {}>;
+            let flush: jest.SpiedFunction<() => void>;
 
             beforeAll(async () => {
               jest.restoreAllMocks();
               flush = jest
                 .spyOn(ProxyLogger.prototype, "flush")
-                .mockImplementation(async () => { /* noop */ });
+                .mockImplementation(async () => {
+                  /* noop */
+                });
               hashDataSpy = getHashDataSpy();
               tools = createTools();
               ret = await runFnWithStack(tools.fn, t.stack || [], {

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@local/types";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
+import { ProxyLogger } from "@local/middleware/logger";
 
 type TestEvents = {
   foo: { name: "foo"; data: { foo: string } };
@@ -70,8 +71,14 @@ describe("runFn", () => {
         describe("success", () => {
           let fn: InngestFunction<TestEvents>;
           let ret: Awaited<ReturnType<(typeof fn)["runFn"]>>;
+          let flush: jest.SpiedFunction<() => {}>;
 
           beforeAll(async () => {
+            jest.restoreAllMocks();
+            flush = jest
+              .spyOn(ProxyLogger.prototype, "flush")
+              .mockImplementation(async () => { /* noop */ });
+
             fn = new InngestFunction(
               createClient<TestEvents>({ name: "test" }),
               { name: "Foo" },
@@ -94,6 +101,10 @@ describe("runFn", () => {
 
           test("returns data on success", () => {
             expect(ret[1]).toBe(stepRet);
+          });
+
+          test("should attempt to flush logs", () => {
+            expect(flush).toHaveBeenCalledTimes(1);
           });
         });
 
@@ -183,8 +194,13 @@ describe("runFn", () => {
             let tools: T;
             let ret: Awaited<ReturnType<typeof runFnWithStack>> | undefined;
             let retErr: Error | undefined;
+            let flush: jest.SpiedFunction<() => {}>;
 
             beforeAll(async () => {
+              jest.restoreAllMocks();
+              flush = jest
+                .spyOn(ProxyLogger.prototype, "flush")
+                .mockImplementation(async () => { /* noop */ });
               hashDataSpy = getHashDataSpy();
               tools = createTools();
               ret = await runFnWithStack(tools.fn, t.stack || [], {
@@ -225,6 +241,11 @@ describe("runFn", () => {
                   expect(step).not.toHaveBeenCalled();
                 }
               });
+            });
+
+            test("should attempt to flush logs", () => {
+              // could be flushed multiple times so no specifying counts
+              expect(flush).toHaveBeenCalled();
             });
           });
         });

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -282,8 +282,6 @@ export class InngestFunction<
        *
        * We only use the onFailure handler if
        */
-
-      await logger.flush();
       if (!this.#onFailureFn) {
         // TODO PrettyError
         throw new Error(

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -254,7 +254,7 @@ export class InngestFunction<
     const [tools, state] = createStepTools(this.#client);
     // create new proxy logger so it doesn't share the buffer with other
     // function runs
-    const logger = new ProxyLogger(this.#client.logger);
+    const logger = new ProxyLogger(this.#client["logger"]);
 
     /**
      * Create args to pass in to our function. We blindly pass in the data and
@@ -264,7 +264,7 @@ export class InngestFunction<
       ...(data as { event: EventPayload }),
       tools,
       step: tools,
-      logger: this.#client["logger"] as Logger,
+      logger: logger as Logger,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as Partial<Context<any, any, any>>;
 

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -348,6 +348,7 @@ export class InngestFunction<
            * Whichever the case, this is bad and we can't continue in this
            * undefined state.
            */
+          await logger.flush();
           throw new NonRetriableError(
             functionStoppedRunningErr(ErrCode.ASYNC_DETECTED_DURING_MEMOIZATION)
           );

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -426,17 +426,16 @@ export class InngestFunction<
              * to Inngest as the response for this step. The function didn't
              * fail, only this step, so Inngest can decide what we do next.
              *
-             * Make sure to log this so the user sees what has happened in the
-             * console.
+             * Make sure to log this so the user sees what has happened.
              */
-            console.error(err);
+            logger.error(err);
 
             try {
               return {
                 error: serializeError(err),
               };
             } catch (serializationErr) {
-              console.warn(
+              logger.warn(
                 "Could not serialize error to return to Inngest; stringifying instead",
                 serializationErr
               );
@@ -503,7 +502,7 @@ export class InngestFunction<
            * be unintentional, but otherwise carry on as normal.
            */
           // TODO PrettyError
-          console.warn(
+          logger.warn(
             `Warning: Your "${this.name}" function has returned a value, but not all ops have been resolved, i.e. you have used step tooling without \`await\`. This may be intentional, but if you expect your ops to be resolved in order, you should \`await\` them. If you are knowingly leaving ops unresolved using \`.catch()\` or \`void\`, you can ignore this warning.`
           );
         } else if (!state.hasUsedTools) {

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -328,8 +328,8 @@ export class InngestFunction<
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           resolve(await userFnToRun(fnArg as Context<any, any, any>));
         } catch (err) {
-          reject(err);
           logger.error(err);
+          reject(err);
         }
         logger.disable();
       });

--- a/src/components/InngestFunction.ts
+++ b/src/components/InngestFunction.ts
@@ -256,294 +256,292 @@ export class InngestFunction<
     // function runs
     const logger = new ProxyLogger(this.#client["logger"]);
 
-    /**
-     * Create args to pass in to our function. We blindly pass in the data and
-     * add tools.
-     */
-    const fnArg = {
-      ...(data as { event: EventPayload }),
-      tools,
-      step: tools,
-      logger: logger as Logger,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as Partial<Context<any, any, any>>;
-
-    let userFnToRun = this.#fn;
-
-    /**
-     * If the incoming event is an Inngest function failure event, we also want
-     * to pass some extra data to the function to act as shortcuts to the event
-     * payload.
-     */
-    if (isFailureHandler) {
+    try {
       /**
-       * The user could have created a function that intentionally listens for
-       * these events. In this case, we may want to use the original handler.
-       *
-       * We only use the onFailure handler if
+       * Create args to pass in to our function. We blindly pass in the data and
+       * add tools.
        */
-      if (!this.#onFailureFn) {
-        // TODO PrettyError
-        throw new Error(
-          `Function "${this.name}" received a failure event to handle, but no failure handler was defined.`
-        );
-      }
-
-      userFnToRun = this.#onFailureFn;
-
-      (fnArg as FailureEventArgs).error = deserializeError(
-        (fnArg.event as FailureEventPayload).data.error
-      );
-    }
-
-    /**
-     * If the user has passed functions they wish to use in their step, add them
-     * here.
-     *
-     * We simply place a thin `tools.run()` wrapper around the function and
-     * nothing else.
-     */
-    if (this.#opts.fns) {
-      fnArg.fns = Object.entries(this.#opts.fns).reduce((acc, [key, fn]) => {
-        if (typeof fn !== "function") {
-          return acc;
-        }
-
-        return {
-          ...acc,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-          [key]: (...args: unknown[]) => tools.run(key, () => fn(...args)),
-        };
-      }, {});
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
-    const userFnPromise = new Promise(async (resolve, reject) => {
-      try {
+      const fnArg = {
+        ...(data as { event: EventPayload }),
+        tools,
+        step: tools,
+        logger: logger as Logger,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        resolve(await userFnToRun(fnArg as Context<any, any, any>));
-      } catch (err) {
-        reject(err);
-      }
-    });
+      } as Partial<Context<any, any, any>>;
 
-    let pos = -1;
+      let userFnToRun = this.#fn;
 
-    do {
-      if (pos >= 0) {
-        state.tickOps = {};
-        const incomingOp = opStack[pos] as IncomingOp;
-        state.currentOp = state.allFoundOps[incomingOp.id];
-
-        if (!state.currentOp) {
-          /**
-           * We're trying to resume the function, but we can't find where to go.
-           *
-           * This means that either the function has changed or there are async
-           * actions in-between steps that we haven't noticed in previous
-           * executions.
-           *
-           * Whichever the case, this is bad and we can't continue in this
-           * undefined state.
-           */
-          await logger.flush();
-          throw new NonRetriableError(
-            functionStoppedRunningErr(ErrCode.ASYNC_DETECTED_DURING_MEMOIZATION)
+      /**
+       * If the incoming event is an Inngest function failure event, we also want
+       * to pass some extra data to the function to act as shortcuts to the event
+       * payload.
+       */
+      if (isFailureHandler) {
+        /**
+         * The user could have created a function that intentionally listens for
+         * these events. In this case, we may want to use the original handler.
+         *
+         * We only use the onFailure handler if
+         */
+        if (!this.#onFailureFn) {
+          // TODO PrettyError
+          throw new Error(
+            `Function "${this.name}" received a failure event to handle, but no failure handler was defined.`
           );
         }
 
-        state.currentOp.fulfilled = true;
+        userFnToRun = this.#onFailureFn;
 
-        if (typeof incomingOp.data !== "undefined") {
-          state.currentOp.resolve(incomingOp.data);
-          logger.reset();
-        } else {
-          state.currentOp.reject(incomingOp.error);
-        }
-      }
-
-      await timer.wrap("memoizing-ticks", resolveAfterPending);
-
-      state.reset();
-      pos++;
-    } while (pos < opStack.length);
-
-    memoizingStop();
-
-    const discoveredOps = Object.values(state.tickOps).map<OutgoingOp>(
-      tickOpToOutgoing
-    );
-
-    /**
-     * We make an optimization here by immediately invoking an op if it's the
-     * only one we've discovered. The alternative is to plan the step and then
-     * complete it, so we skip at least one entire execution with this.
-     */
-    const runStep = requestedRunStep || getEarlyExecRunStep(discoveredOps);
-
-    if (runStep) {
-      const userFnOp = state.allFoundOps[runStep];
-      const userFnToRun = userFnOp?.fn;
-
-      if (!userFnToRun) {
-        await logger.flush();
-        // TODO PrettyError
-        throw new Error(
-          `Bad stack; executor requesting to run unknown step "${runStep}"`
+        (fnArg as FailureEventArgs).error = deserializeError(
+          (fnArg.event as FailureEventPayload).data.error
         );
       }
 
-      const runningStepStop = timer.start("running-step");
-      state.executingStep = true;
-
-      const result = await new Promise((resolve) => {
-        return resolve(userFnToRun());
-      })
-        .finally(() => {
-          state.executingStep = false;
-        })
-        .then((data) => {
-          return {
-            data: typeof data === "undefined" ? null : data,
-          };
-        })
-        .catch((err: Error) => {
-          /**
-           * If the user-defined code throws an error, we should return this
-           * to Inngest as the response for this step. The function didn't
-           * fail, only this step, so Inngest can decide what we do next.
-           *
-           * Make sure to log this so the user sees what has happened in the
-           * console.
-           */
-          console.error(err);
-
-          try {
-            return {
-              error: serializeError(err),
-            };
-          } catch (serializationErr) {
-            console.warn(
-              "Could not serialize error to return to Inngest; stringifying instead",
-              serializationErr
-            );
-
-            return {
-              error: err,
-            };
+      /**
+       * If the user has passed functions they wish to use in their step, add them
+       * here.
+       *
+       * We simply place a thin `tools.run()` wrapper around the function and
+       * nothing else.
+       */
+      if (this.#opts.fns) {
+        fnArg.fns = Object.entries(this.#opts.fns).reduce((acc, [key, fn]) => {
+          if (typeof fn !== "function") {
+            return acc;
           }
-        })
-        .finally(() => {
-          runningStepStop();
-        });
 
-      await logger.flush();
-      return [
-        "run",
-        { ...tickOpToOutgoing(userFnOp), ...result, op: StepOpCode.RunStep },
-      ];
-    }
+          return {
+            ...acc,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+            [key]: (...args: unknown[]) => tools.run(key, () => fn(...args)),
+          };
+        }, {});
+      }
 
-    /**
-     * Now we're here, we've memoised any function state and we know that this
-     * request was a discovery call to find out next steps.
-     *
-     * We've already given the user's function a lot of chance to register any
-     * more ops, so we can assume that this list of discovered ops is final.
-     *
-     * With that in mind, if this list is empty AND we haven't previously used
-     * any step tools, we can assume that the user's function is not one that'll
-     * be using step tooling, so we'll just wait for it to complete and return
-     * the result.
-     *
-     * An empty list while also using step tooling is a valid state when the end
-     * of a chain of promises is reached, so we MUST also check if step tooling
-     * has previously been used.
-     */
-    if (!discoveredOps.length) {
-      const fnRet = await Promise.race([
-        userFnPromise.then((data) => ({ type: "complete", data } as const)),
-        resolveNextTick().then(() => ({ type: "incomplete" } as const)),
-      ]);
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
+      const userFnPromise = new Promise(async (resolve, reject) => {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          resolve(await userFnToRun(fnArg as Context<any, any, any>));
+        } catch (err) {
+          reject(err);
+        }
+      });
 
-      await logger.flush();
-      if (fnRet.type === "complete") {
-        /**
-         * The function has returned a value, so we should return this to
-         * Inngest. Doing this will cause the function to be marked as
-         * complete, so we should only do this if we're sure that all
-         * registered ops have been resolved.
-         */
-        const allOpsFulfilled = Object.values(state.allFoundOps).every((op) => {
-          return op.fulfilled;
-        });
+      let pos = -1;
 
-        if (allOpsFulfilled) {
-          return ["complete", fnRet.data];
+      do {
+        if (pos >= 0) {
+          state.tickOps = {};
+          const incomingOp = opStack[pos] as IncomingOp;
+          state.currentOp = state.allFoundOps[incomingOp.id];
+
+          if (!state.currentOp) {
+            /**
+             * We're trying to resume the function, but we can't find where to go.
+             *
+             * This means that either the function has changed or there are async
+             * actions in-between steps that we haven't noticed in previous
+             * executions.
+             *
+             * Whichever the case, this is bad and we can't continue in this
+             * undefined state.
+             */
+            throw new NonRetriableError(
+              functionStoppedRunningErr(ErrCode.ASYNC_DETECTED_DURING_MEMOIZATION)
+            );
+          }
+
+          state.currentOp.fulfilled = true;
+
+          if (typeof incomingOp.data !== "undefined") {
+            state.currentOp.resolve(incomingOp.data);
+            logger.reset();
+          } else {
+            state.currentOp.reject(incomingOp.error);
+          }
         }
 
-        /**
-         * If we're here, it means that the user's function has returned a
-         * value but not all ops have been resolved. This might be intentional
-         * if they are purposefully pushing work to the background, but also
-         * might be unintentional and a bug in the user's code where they
-         * expected an order to be maintained.
-         *
-         * To be safe, we'll show a warning here to tell users that this might
-         * be unintentional, but otherwise carry on as normal.
-         */
-        // TODO PrettyError
-        console.warn(
-          `Warning: Your "${this.name}" function has returned a value, but not all ops have been resolved, i.e. you have used step tooling without \`await\`. This may be intentional, but if you expect your ops to be resolved in order, you should \`await\` them. If you are knowingly leaving ops unresolved using \`.catch()\` or \`void\`, you can ignore this warning.`
-        );
-      } else if (!state.hasUsedTools) {
-        /**
-         * If we're here, it means that the user's function has not returned
-         * a value, but also has not used step tooling. This is a valid
-         * state, indicating that the function is a single-action async
-         * function.
-         *
-         * We should wait for the result and return it.
-         *
-         * A caveat here is that the user could use step tooling later on,
-         * resulting in a mix of step and non-step logic. This is not something
-         * we want to support without an opt-in from the user, so we should
-         * throw if this is the case.
-         */
-        state.nonStepFnDetected = true;
+        await timer.wrap("memoizing-ticks", resolveAfterPending);
 
-        const result = await userFnPromise;
-        await logger.flush();
-        return ["complete", result];
-      } else {
-        /**
-         * If we're here, the user's function has not returned a value, has not
-         * reported any new, ops, but has also previously used step tools and
-         * successfully memoized state.
-         *
-         * This indicates that the user has mixed step and non-step logic, which
-         * is not something we want to support without an opt-in from the user.
-         *
-         * We should throw here to let the user know that this is not supported.
-         *
-         * We need to be careful, though; it's a valid state for a chain of
-         * promises to return no further actions, so we should only throw if
-         * this state is reached and there are no other pending steps.
-         */
-        const hasOpsPending = Object.values(state.allFoundOps).some((op) => {
-          return op.fulfilled === false;
-        });
+        state.reset();
+        pos++;
+      } while (pos < opStack.length);
 
-        if (!hasOpsPending) {
-          throw new NonRetriableError(
-            functionStoppedRunningErr(ErrCode.ASYNC_DETECTED_AFTER_MEMOIZATION)
+      memoizingStop();
+
+      const discoveredOps = Object.values(state.tickOps).map<OutgoingOp>(
+        tickOpToOutgoing
+      );
+
+      /**
+       * We make an optimization here by immediately invoking an op if it's the
+       * only one we've discovered. The alternative is to plan the step and then
+       * complete it, so we skip at least one entire execution with this.
+       */
+      const runStep = requestedRunStep || getEarlyExecRunStep(discoveredOps);
+
+      if (runStep) {
+        const userFnOp = state.allFoundOps[runStep];
+        const userFnToRun = userFnOp?.fn;
+
+        if (!userFnToRun) {
+          // TODO PrettyError
+          throw new Error(
+            `Bad stack; executor requesting to run unknown step "${runStep}"`
           );
         }
-      }
-    }
 
-    await logger.flush();
-    return ["discovery", discoveredOps];
+        const runningStepStop = timer.start("running-step");
+        state.executingStep = true;
+
+        const result = await new Promise((resolve) => {
+          return resolve(userFnToRun());
+        })
+          .finally(() => {
+            state.executingStep = false;
+          })
+          .then((data) => {
+            return {
+              data: typeof data === "undefined" ? null : data,
+            };
+          })
+          .catch((err: Error) => {
+            /**
+             * If the user-defined code throws an error, we should return this
+             * to Inngest as the response for this step. The function didn't
+             * fail, only this step, so Inngest can decide what we do next.
+             *
+             * Make sure to log this so the user sees what has happened in the
+             * console.
+             */
+            console.error(err);
+
+            try {
+              return {
+                error: serializeError(err),
+              };
+            } catch (serializationErr) {
+              console.warn(
+                "Could not serialize error to return to Inngest; stringifying instead",
+                serializationErr
+              );
+
+              return {
+                error: err,
+              };
+            }
+          })
+          .finally(() => {
+            runningStepStop();
+          });
+
+        return [
+          "run",
+          { ...tickOpToOutgoing(userFnOp), ...result, op: StepOpCode.RunStep },
+        ];
+      }
+
+      /**
+       * Now we're here, we've memoised any function state and we know that this
+       * request was a discovery call to find out next steps.
+       *
+       * We've already given the user's function a lot of chance to register any
+       * more ops, so we can assume that this list of discovered ops is final.
+       *
+       * With that in mind, if this list is empty AND we haven't previously used
+       * any step tools, we can assume that the user's function is not one that'll
+       * be using step tooling, so we'll just wait for it to complete and return
+       * the result.
+       *
+       * An empty list while also using step tooling is a valid state when the end
+       * of a chain of promises is reached, so we MUST also check if step tooling
+       * has previously been used.
+       */
+      if (!discoveredOps.length) {
+        const fnRet = await Promise.race([
+          userFnPromise.then((data) => ({ type: "complete", data } as const)),
+          resolveNextTick().then(() => ({ type: "incomplete" } as const)),
+        ]);
+
+        if (fnRet.type === "complete") {
+          /**
+           * The function has returned a value, so we should return this to
+           * Inngest. Doing this will cause the function to be marked as
+           * complete, so we should only do this if we're sure that all
+           * registered ops have been resolved.
+           */
+          const allOpsFulfilled = Object.values(state.allFoundOps).every((op) => {
+            return op.fulfilled;
+          });
+
+          if (allOpsFulfilled) {
+            return ["complete", fnRet.data];
+          }
+
+          /**
+           * If we're here, it means that the user's function has returned a
+           * value but not all ops have been resolved. This might be intentional
+           * if they are purposefully pushing work to the background, but also
+           * might be unintentional and a bug in the user's code where they
+           * expected an order to be maintained.
+           *
+           * To be safe, we'll show a warning here to tell users that this might
+           * be unintentional, but otherwise carry on as normal.
+           */
+          // TODO PrettyError
+          console.warn(
+            `Warning: Your "${this.name}" function has returned a value, but not all ops have been resolved, i.e. you have used step tooling without \`await\`. This may be intentional, but if you expect your ops to be resolved in order, you should \`await\` them. If you are knowingly leaving ops unresolved using \`.catch()\` or \`void\`, you can ignore this warning.`
+          );
+        } else if (!state.hasUsedTools) {
+          /**
+           * If we're here, it means that the user's function has not returned
+           * a value, but also has not used step tooling. This is a valid
+           * state, indicating that the function is a single-action async
+           * function.
+           *
+           * We should wait for the result and return it.
+           *
+           * A caveat here is that the user could use step tooling later on,
+           * resulting in a mix of step and non-step logic. This is not something
+           * we want to support without an opt-in from the user, so we should
+           * throw if this is the case.
+           */
+          state.nonStepFnDetected = true;
+
+          const result = await userFnPromise;
+          return ["complete", result];
+        } else {
+          /**
+           * If we're here, the user's function has not returned a value, has not
+           * reported any new, ops, but has also previously used step tools and
+           * successfully memoized state.
+           *
+           * This indicates that the user has mixed step and non-step logic, which
+           * is not something we want to support without an opt-in from the user.
+           *
+           * We should throw here to let the user know that this is not supported.
+           *
+           * We need to be careful, though; it's a valid state for a chain of
+           * promises to return no further actions, so we should only throw if
+           * this state is reached and there are no other pending steps.
+           */
+          const hasOpsPending = Object.values(state.allFoundOps).some((op) => {
+            return op.fulfilled === false;
+          });
+
+          if (!hasOpsPending) {
+            throw new NonRetriableError(
+              functionStoppedRunningErr(ErrCode.ASYNC_DETECTED_AFTER_MEMOIZATION)
+            );
+          }
+        }
+      }
+
+      return ["discovery", discoveredOps];
+    } finally {
+      await logger.flush();
+    }
   }
 
   /**

--- a/src/middleware/logger.test.ts
+++ b/src/middleware/logger.test.ts
@@ -1,4 +1,5 @@
-import { LogBuffer, ProxyLogger, DefaultLogger } from "./logger";
+import { jest } from "@jest/globals";
+import { type Logger, LogBuffer, ProxyLogger, DefaultLogger } from "./logger";
 
 describe("LogBuffer", () => {
   describe("initialize", () => {
@@ -14,45 +15,99 @@ describe("LogBuffer", () => {
 });
 
 describe("ProxyLogger", () => {
+  const buffer = [
+    { level: "info", args: ["hello", "%s!!", "world"] }, // string interpolation for some libs
+    { level: "warn", args: ["do not recommend"] },
+    { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
+  ];
+
+  const info = jest.spyOn(console, "info").mockImplementation(() => { });
+  const warn = jest.spyOn(console, "warn").mockImplementation(() => { });
+  const error = jest.spyOn(console, "error").mockImplementation(() => { });
+
+  let _internal: Logger;
   let logger: ProxyLogger;
 
   beforeEach(() => {
-    logger = new ProxyLogger(new DefaultLogger());
+    _internal = new DefaultLogger()
+    logger = new ProxyLogger(_internal);
   });
+
+  const populateBuf = () => {
+    buffer.forEach(({ level, args }) => {
+      const method = level as keyof ProxyLogger;
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      logger[method](...args);
+    });
+  }
 
   describe("std API interfaces", () => {
     test("should have the expected number of buffered logs", () => {
-      [
-        { level: "info", args: ["hello", "%s!!", "world"] }, // string interpolation for some libs
-        { level: "warn", args: ["do not recommend"] },
-        { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
-      ].forEach(({ level, args }) => {
-        const method = level as keyof ProxyLogger;
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        logger[method](...args);
-      });
-
+      populateBuf();
       expect(logger.bufSize()).toEqual(3);
     });
   });
 
   describe("reset", () => {
     test("should reset to buffer to zero", () => {
-      [
-        { level: "info", args: ["hello", "%s!!", "world"] }, // string interpolation for some libs
-        { level: "warn", args: ["do not recommend"] },
-        { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
-      ].forEach(({ level, args }) => {
-        const method = level as keyof ProxyLogger;
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        logger[method](...args);
-      });
-
+      populateBuf();
       expect(logger.bufSize()).toEqual(3);
 
       logger.reset();
-
       expect(logger.bufSize()).toEqual(0);
     });
   });
+
+  describe("flush", () => {
+    let reset: jest.SpiedFunction<() => void>;
+    let timeout: jest.SpiedFunction<typeof setTimeout>;
+
+    beforeEach(() => {
+      reset = jest
+        .spyOn(ProxyLogger.prototype, "reset")
+        .mockImplementation(() => { });
+
+      timeout = jest.spyOn(global, 'setTimeout');
+    });
+
+    afterEach(() => {
+      reset.mockClear();
+      timeout.mockClear();
+    });
+
+    test("don't do anything with an empty buffer", async () => {
+      await logger.flush();
+      expect(reset).toBeCalledTimes(0);
+    });
+
+    test("should attempt to reset buffer", async () => {
+      populateBuf();
+      await logger.flush();
+      expect(reset).toBeCalledTimes(1);
+    });
+
+    test("should not try to wait for flushing if _logger is DefaultLogger", async () => {
+      populateBuf();
+      await logger.flush();
+      expect(reset).toBeCalledTimes(1);
+      expect(timeout).toBeCalledTimes(0);
+    });
+
+    test("should attempt to wait for flushing with non DefaultLogger", async () => {
+      _internal = new (
+        class DummyLogger implements Logger {
+          info(...args: unknown[]) { }
+          warn(...args: unknown[]) { }
+          error(...args: unknown[]) { }
+          debug(...args: unknown[]) { }
+        }
+      );
+      logger = new ProxyLogger(_internal);
+
+      populateBuf();
+      await logger.flush();
+      expect(reset).toBeCalledTimes(1);
+      expect(timeout).toBeCalledTimes(1);
+    });
+  })
 });

--- a/src/middleware/logger.test.ts
+++ b/src/middleware/logger.test.ts
@@ -1,0 +1,56 @@
+import { LogBuffer, ProxyLogger, DefaultLogger } from "./logger";
+
+describe("LogBuffer", () => {
+  describe("initialize", () => {
+    test("should store the provided values", () => {
+      const level = "info";
+      const args = ["hello", "%s!!", "world"];
+      const buf = new LogBuffer(level, ...args);
+
+      expect(buf.level).toEqual("info");
+      expect(buf.args).toEqual(args);
+    });
+  });
+});
+
+describe("ProxyLogger", () => {
+  let logger: ProxyLogger;
+
+  beforeEach(() => {
+    logger = new ProxyLogger(new DefaultLogger());
+  });
+
+  describe("std API interfaces", () => {
+    test("should have the expected number of buffered logs", () => {
+      [
+        { level: "info", args: ["hello", "%s!!", "world"] }, // string interpolation for some libs
+        { level: "warn", args: ["do not recommend"] },
+        { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
+      ].forEach(({ level, args }) => {
+        const method = level as keyof ProxyLogger;
+        logger[method](...args);
+      });
+
+      expect(logger.bufSize()).toEqual(3);
+    });
+  });
+
+  describe("reset", () => {
+    test("should reset to buffer to zero", () => {
+      [
+        { level: "info", args: ["hello", "%s!!", "world"] }, // string interpolation for some libs
+        { level: "warn", args: ["do not recommend"] },
+        { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
+      ].forEach(({ level, args }) => {
+        const method = level as keyof ProxyLogger;
+        logger[method](...args);
+      });
+
+      expect(logger.bufSize()).toEqual(3);
+
+      logger.reset();
+
+      expect(logger.bufSize()).toEqual(0);
+    });
+  });
+});

--- a/src/middleware/logger.test.ts
+++ b/src/middleware/logger.test.ts
@@ -28,6 +28,7 @@ describe("ProxyLogger", () => {
         { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
       ].forEach(({ level, args }) => {
         const method = level as keyof ProxyLogger;
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         logger[method](...args);
       });
 
@@ -43,6 +44,7 @@ describe("ProxyLogger", () => {
         { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
       ].forEach(({ level, args }) => {
         const method = level as keyof ProxyLogger;
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         logger[method](...args);
       });
 

--- a/src/middleware/logger.test.ts
+++ b/src/middleware/logger.test.ts
@@ -1,18 +1,5 @@
 import { jest } from "@jest/globals";
-import { type Logger, LogBuffer, ProxyLogger, DefaultLogger } from "./logger";
-
-describe("LogBuffer", () => {
-  describe("initialize", () => {
-    test("should store the provided values", () => {
-      const level = "info";
-      const args = ["hello", "%s!!", "world"];
-      const buf = new LogBuffer(level, ...args);
-
-      expect(buf.level).toEqual("info");
-      expect(buf.args).toEqual(args);
-    });
-  });
-});
+import { type Logger, ProxyLogger, DefaultLogger } from "./logger";
 
 describe("ProxyLogger", () => {
   const buffer = [
@@ -37,57 +24,20 @@ describe("ProxyLogger", () => {
     });
   };
 
-  describe("std API interfaces", () => {
-    test("should have the expected number of buffered logs", () => {
-      populateBuf();
-      expect(logger.bufSize()).toEqual(3);
-    });
-  });
-
-  describe("reset", () => {
-    test("should reset to buffer to zero", () => {
-      populateBuf();
-      expect(logger.bufSize()).toEqual(3);
-
-      logger.reset();
-      expect(logger.bufSize()).toEqual(0);
-    });
-  });
-
   describe("flush", () => {
-    let reset: jest.SpiedFunction<() => void>;
     let timeout: jest.SpiedFunction<typeof setTimeout>;
 
     beforeEach(() => {
-      reset = jest
-        .spyOn(ProxyLogger.prototype, "reset")
-        .mockImplementation(() => {
-          /* noop */
-        });
-
       timeout = jest.spyOn(global, "setTimeout");
     });
 
     afterEach(() => {
-      reset.mockClear();
       timeout.mockClear();
-    });
-
-    test("don't do anything with an empty buffer", async () => {
-      await logger.flush();
-      expect(reset).toBeCalledTimes(0);
-    });
-
-    test("should attempt to reset buffer", async () => {
-      populateBuf();
-      await logger.flush();
-      expect(reset).toBeCalledTimes(1);
     });
 
     test("should not try to wait for flushing if _logger is DefaultLogger", async () => {
       populateBuf();
       await logger.flush();
-      expect(reset).toBeCalledTimes(1);
       expect(timeout).toBeCalledTimes(0);
     });
 
@@ -106,7 +56,6 @@ describe("ProxyLogger", () => {
 
       populateBuf();
       await logger.flush();
-      expect(reset).toBeCalledTimes(1);
       expect(timeout).toBeCalledTimes(1);
     });
   });

--- a/src/middleware/logger.test.ts
+++ b/src/middleware/logger.test.ts
@@ -21,15 +21,11 @@ describe("ProxyLogger", () => {
     { level: "error", args: [3, "things", "seems to have", "gone wrong"] },
   ];
 
-  const info = jest.spyOn(console, "info").mockImplementation(() => { });
-  const warn = jest.spyOn(console, "warn").mockImplementation(() => { });
-  const error = jest.spyOn(console, "error").mockImplementation(() => { });
-
   let _internal: Logger;
   let logger: ProxyLogger;
 
   beforeEach(() => {
-    _internal = new DefaultLogger()
+    _internal = new DefaultLogger();
     logger = new ProxyLogger(_internal);
   });
 
@@ -39,7 +35,7 @@ describe("ProxyLogger", () => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       logger[method](...args);
     });
-  }
+  };
 
   describe("std API interfaces", () => {
     test("should have the expected number of buffered logs", () => {
@@ -65,9 +61,11 @@ describe("ProxyLogger", () => {
     beforeEach(() => {
       reset = jest
         .spyOn(ProxyLogger.prototype, "reset")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {
+          /* noop */
+        });
 
-      timeout = jest.spyOn(global, 'setTimeout');
+      timeout = jest.spyOn(global, "setTimeout");
     });
 
     afterEach(() => {
@@ -94,14 +92,16 @@ describe("ProxyLogger", () => {
     });
 
     test("should attempt to wait for flushing with non DefaultLogger", async () => {
+      /* eslint-disable @typescript-eslint/no-empty-function, prettier/prettier */
       _internal = new (
         class DummyLogger implements Logger {
-          info(...args: unknown[]) { }
-          warn(...args: unknown[]) { }
-          error(...args: unknown[]) { }
-          debug(...args: unknown[]) { }
+          info(..._args: unknown[]) { }
+          warn(..._args: unknown[]) { }
+          error(..._args: unknown[]) { }
+          debug(..._args: unknown[]) { }
         }
       );
+      /* eslint-enable */
       logger = new ProxyLogger(_internal);
 
       populateBuf();
@@ -109,5 +109,5 @@ describe("ProxyLogger", () => {
       expect(reset).toBeCalledTimes(1);
       expect(timeout).toBeCalledTimes(1);
     });
-  })
+  });
 });

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -39,3 +39,62 @@ export class DefaultLogger implements Logger {
     console.debug(...args);
   }
 }
+
+/**
+ * LogBuffer hold the args that will be passed on to the actual
+ * logger when attempting to flush.
+ */
+class LogBuffer {
+  public readonly level: string;
+  public readonly args: LogArg[];
+
+  constructor(level: string, ...args: LogArg[]) {
+    this.level = level;
+    this.args = args;
+  }
+}
+
+/**
+ * ProxyLogger attempts to temporarily hold user's logs
+ * during the function run, and attempt to flush it through
+ * the provided logger when the function returns.
+ *
+ * The expected usage of this class is,
+ * 1. store the log attempt with its arguments and level
+ * 2. if function hits a step that has been memorized, clear the _buffer
+ * 3. on function return, flush all buffers
+ *
+ * And it should be invisible to the user as much as possible.
+ */
+export class ProxyLogger implements Logger {
+  private readonly _logger: Logger;
+  private _buffer: LogBuffer[] = [];
+
+  constructor(logger: Logger) {
+    this._logger = logger;
+  }
+
+  info(...args: LogArg[]) {
+    this._buffer.push(new LogBuffer("info", ...args));
+  }
+
+  warn(...args: LogArg[]) {
+    this._buffer.push(new LogBuffer("warn", ...args));
+  }
+
+  error(...args: LogArg[]) {
+    this._buffer.push(new LogBuffer("error", ...args));
+  }
+
+  debug(...args: LogArg[]) {
+    this._buffer.push(new LogBuffer("debug", ...args));
+  }
+
+  reset() {
+    this._buffer = [];
+  }
+
+  flush() {
+    throw new Error("TO BE IMPLEMENTED");
+  }
+}

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -44,7 +44,7 @@ export class DefaultLogger implements Logger {
  * LogBuffer hold the args that will be passed on to the actual
  * logger when attempting to flush.
  */
-class LogBuffer {
+export class LogBuffer {
   public readonly level: string;
   public readonly args: LogArg[];
 
@@ -96,5 +96,12 @@ export class ProxyLogger implements Logger {
 
   flush() {
     throw new Error("TO BE IMPLEMENTED");
+  }
+
+  /**
+   * Helper function for tests to check current buffer size
+   */
+  bufSize(): number {
+    return this._buffer.length;
   }
 }

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -103,10 +103,19 @@ export class ProxyLogger implements Logger {
       const method = log["level"] as keyof Logger;
       return this._logger[method](...args);
     });
+    // NOTE: timestamp will likely not be linear as expected.
     await Promise.all(deliveries);
+    this.reset();
 
     // Allow 1s for the provided logger to handle flushing since the ones that do
     // flushing usually has some kind of timeout of up to 1s.
+    //
+    // TODO:
+    // This should only happen when using a serverless environment because it's very
+    // costly from the compute perspective.
+    // server runtimes should just let the logger do their thing since most of them
+    // should have already figured what to do in those environments, be it threading or
+    // something else.
     if (this._logger.constructor.name !== DefaultLogger.name) {
       await new Promise((resolve) => {
         setTimeout(() => resolve(null), 1000);

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,7 @@ export type BaseContext<
 
   /**
    * The passed in logger from the user.
+   * Defaults to a console logger if not provided.
    */
   logger: Logger;
 
@@ -411,10 +412,6 @@ export interface ClientOptions {
    * which most loggers already do.
    *
    * Defaults to a dummy logger that just log things to the console if nothing is provided.
-   *
-   * TODO: Wrap the logger with a Proxy to make it operate like a step.
-   * This is currently only a passthrough, hence no difference compared to
-   * just importing the logger and using it.
    */
   logger?: Logger;
 }


### PR DESCRIPTION
## Summary

Built on #189.
Resolves INN-1343 as well.

Wrap the passed in `Logger`, and at function returns, wait a little to allow provided logger to flush.

This change is not expected to be widely used yet, and more as an experimental feature that we can start using ourselves to see if it works as expected.

### Notes
Even with the current implementation, there could be a minor impact on function execution.
Something to address in the future is to make the 1s wait only run on serverless environments.

When ran as part of an application server, the whole `flush` method is very likely to be irrelevant completely.
This is all easier to address once we have some kind of middleware interface that can be plugged in.

The approach of enable/disable logger is a temporary solution until we provide a middleware solution.