### PR TITLE
Return event IDs when sending events

### DIFF
--- a/.changeset/unlucky-snails-attack.md
+++ b/.changeset/unlucky-snails-attack.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Return event IDs when sending events using `inngest.send()` and `step.sendEvent()`

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -106,9 +106,9 @@ export class Inngest<Events extends Record<string, EventPayload> = Record<string
     readonly name: string;
     // Warning: (ae-forgotten-export) The symbol "SingleOrArray" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "PartialK" needs to be exported by the entry point index.d.ts
-    send<Event extends keyof Events>(name: Event, payload: SingleOrArray<PartialK<Omit<Events[Event], "name" | "v">, "ts">>): Promise<void>;
+    send<Event extends keyof Events>(name: Event, payload: SingleOrArray<PartialK<Omit<Events[Event], "name" | "v">, "ts">>): Promise<string[]>;
     // Warning: (ae-forgotten-export) The symbol "SendEventPayload" needs to be exported by the entry point index.d.ts
-    send<Payload extends SendEventPayload<Events>>(payload: Payload): Promise<void>;
+    send<Payload extends SendEventPayload<Events>>(payload: Payload): Promise<string[]>;
     setEventKey(
     eventKey: string): void;
 }

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -59,10 +59,14 @@ describe("send", () => {
     beforeAll(() => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       global.fetch = jest.fn(
-        () =>
+        (input: unknown) =>
           Promise.resolve({
             status: 200,
-            json: () => Promise.resolve({}),
+            json: () =>
+              Promise.resolve({
+                ids: Array.isArray(input) ? input.map((_, i) => `${i}`) : ["0"],
+                status: 200,
+              }),
           })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ) as any;
@@ -90,7 +94,7 @@ describe("send", () => {
     test("should succeed if event key specified at instantiation", async () => {
       const inngest = createClient({ name: "test", eventKey: testEventKey });
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
@@ -105,7 +109,7 @@ describe("send", () => {
       process.env[envKeys.EventKey] = testEventKey;
       const inngest = createClient({ name: "test" });
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
@@ -120,7 +124,7 @@ describe("send", () => {
       const inngest = createClient({ name: "test" });
       inngest.setEventKey(testEventKey);
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
@@ -135,7 +139,7 @@ describe("send", () => {
       const inngest = createClient({ name: "test" });
       inngest.setEventKey(testEventKey);
 
-      await expect(inngest.send("test", [])).resolves.toBeUndefined();
+      await expect(inngest.send("test", [])).resolves.toEqual([]);
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
@@ -143,7 +147,7 @@ describe("send", () => {
       const inngest = createClient({ name: "test" });
       inngest.setEventKey(testEventKey);
 
-      await expect(inngest.send([])).resolves.toBeUndefined();
+      await expect(inngest.send([])).resolves.toEqual([]);
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
@@ -154,7 +158,7 @@ describe("send", () => {
         env: "foo",
       });
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
         expect.objectContaining({
@@ -175,7 +179,7 @@ describe("send", () => {
         eventKey: testEventKey,
       });
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
         expect.objectContaining({
@@ -197,7 +201,7 @@ describe("send", () => {
         env: "foo",
       });
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
         expect.objectContaining({
@@ -218,7 +222,7 @@ describe("send", () => {
         eventKey: testEventKey,
       });
 
-      await expect(inngest.send(testEvent)).resolves.toBeUndefined();
+      await expect(inngest.send(testEvent)).resolves.toEqual(["0"]);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/e/${testEventKey}`),
         expect.objectContaining({

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -244,8 +244,15 @@ describe("sleepUntil", () => {
 
 describe("sendEvent", () => {
   describe("runtime", () => {
-    const fetchMock = jest.fn(() =>
-      Promise.resolve({ status: 200 })
+    const fetchMock = jest.fn((input: unknown) =>
+      Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            ids: Array.isArray(input) ? input.map((_, i) => `${i}`) : ["0"],
+            status: 200,
+          }),
+      })
     ) as unknown as typeof fetch;
 
     const client = createClient({

--- a/src/components/InngestStepTools.ts
+++ b/src/components/InngestStepTools.ts
@@ -265,15 +265,15 @@ export const createStepTools = <
      * Returns a promise that will resolve once the event has been sent.
      */
     sendEvent: createTool<{
-      <Payload extends SendEventPayload<Events>>(
-        payload: Payload
-      ): Promise<void>;
+      <Payload extends SendEventPayload<Events>>(payload: Payload): ReturnType<
+        Inngest["send"]
+      >;
       <Event extends keyof Events & string>(
         name: Event,
         payload: SingleOrArray<
           PartialK<Omit<Events[Event], "name" | "v">, "ts">
         >
-      ): Promise<void>;
+      ): ReturnType<Inngest["send"]>;
     }>(
       (nameOrPayload, maybePayload) => {
         let payloads: ValueOf<Events>[];


### PR DESCRIPTION
## Summary

When events are sent to Inngest, return the event IDs from the response.