### PR TITLE
INN-1418: Provide additional metadata with child loggers if applicable

### DIFF
--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -498,13 +498,14 @@ const builtInMiddleware = (<T extends MiddlewareStack>(m: T): T => m)([
             functionName: arg.fn.name,
           };
 
+          /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/ban-ts-comment */
           // create a child logger if the provided logger has child logger implementation
-          /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment */
           const providedLogger: Logger =
             "child" in client["logger"]
+              // @ts-ignore-TS2571
               ? client["logger"].child(metadata)
               : client["logger"];
-          /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment */
+          /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/ban-ts-comment */
           const logger = new ProxyLogger(providedLogger);
 
           return {

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -499,21 +499,18 @@ const builtInMiddleware = (<T extends MiddlewareStack>(m: T): T => m)([
           };
 
           let providedLogger: Logger = client["logger"];
-          /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/ban-ts-comment */
           // create a child logger if the provided logger has child logger implementation
           try {
-            if ("child" in client["logger"]) {
+            if ("child" in providedLogger) {
               type ChildLoggerFn = (
                 metadata: Record<string, unknown>
               ) => Logger;
-              // @ts-ignore-2339: ignore child method is not defined error since it's already checked above
               providedLogger = (providedLogger.child as ChildLoggerFn)(metadata)
             }
           } catch (err) {
             console.error('failed to create "childLogger" with error: ', err);
             // no-op
           }
-          /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/ban-ts-comment */
           const logger = new ProxyLogger(providedLogger);
 
           return {


### PR DESCRIPTION
## Summary
Some of the commonly used loggers provide a `child` implementation, which is a syntactic sugar to simplify adding additional metadata for logging.

If the user provided logger has such implementation, we will automatically add certain runtime metadata when a user uses the default logger middlware.