### PR TITLE
Fix `NonRetriableError` not working when thrown from within a step

### DIFF
--- a/.changeset/dirty-laws-enjoy.md
+++ b/.changeset/dirty-laws-enjoy.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `NonRetriableError` not working when thrown from within a step


### PR DESCRIPTION
## Summary

If a `NonRetriableError` was thrown from within a step, the result was being serialized before it was being checked, resulting in these errors incorrectly being seen as retriable errors.

## Related

- Fixes #209 