### PR TITLE
Fix output hooks not running when main function body throws

### DIFF
--- a/.changeset/flat-fans-nail.md
+++ b/.changeset/flat-fans-nail.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix middleware `transformOutput` hook not running if an asynchronous, non-step function's body threw

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -12,7 +12,7 @@ import {
   platformSupportsStreaming,
   skipDevServer,
 } from "../helpers/env";
-import { OutgoingOpError, serializeError } from "../helpers/errors";
+import { OutgoingResultError, serializeError } from "../helpers/errors";
 import { cacheFn } from "../helpers/functions";
 import { strBoolean } from "../helpers/scalar";
 import { createStream } from "../helpers/stream";
@@ -874,7 +874,10 @@ export class InngestCommHandler<
          * altered by middleware, whereas `error` is the initial triggering
          * error.
          */
-        throw new OutgoingOpError(ret[1]);
+        throw new OutgoingResultError({
+          data: ret[1].data,
+          error: ret[1].error,
+        });
       }
 
       return {
@@ -889,20 +892,20 @@ export class InngestCommHandler<
        *
        * See {@link https://www.npmjs.com/package/serialize-error}
        */
-      const isOutgoingOpError = unserializedErr instanceof OutgoingOpError;
+      const isOutgoingOpError = unserializedErr instanceof OutgoingResultError;
 
       let error: string;
       if (isOutgoingOpError) {
         error =
-          typeof unserializedErr.op.data === "string"
-            ? unserializedErr.op.data
-            : stringify(unserializedErr.op.data);
+          typeof unserializedErr.result.data === "string"
+            ? unserializedErr.result.data
+            : stringify(unserializedErr.result.data);
       } else {
         error = stringify(serializeError(unserializedErr));
       }
 
       const isNonRetriableError = isOutgoingOpError
-        ? unserializedErr.op.error instanceof NonRetriableError
+        ? unserializedErr.result.error instanceof NonRetriableError
         : unserializedErr instanceof NonRetriableError;
 
       /**

--- a/src/components/InngestFunction.test.ts
+++ b/src/components/InngestFunction.test.ts
@@ -9,7 +9,7 @@ import {
   type UnhashedOp,
 } from "@local/components/InngestStepTools";
 import { ServerTiming } from "@local/helpers/ServerTiming";
-import { ErrCode } from "@local/helpers/errors";
+import { ErrCode, OutgoingResultError } from "@local/helpers/errors";
 import {
   DefaultLogger,
   ProxyLogger,
@@ -138,7 +138,7 @@ describe("runFn", () => {
             );
           });
 
-          test("bubble thrown error", async () => {
+          test("wrap thrown error", async () => {
             await expect(
               fn["runFn"](
                 { event: { name: "foo", data: { foo: "foo" } } },
@@ -147,7 +147,13 @@ describe("runFn", () => {
                 timer,
                 false
               )
-            ).rejects.toThrow(stepErr);
+            ).rejects.toThrow(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              expect.objectContaining({
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                result: expect.objectContaining({ error: stepErr }),
+              })
+            );
           });
         });
       });
@@ -245,7 +251,11 @@ describe("runFn", () => {
 
             if (t.expectedThrowMessage) {
               test("throws expected error", () => {
-                expect(retErr?.message ?? "").toContain(t.expectedThrowMessage);
+                expect(
+                  retErr instanceof OutgoingResultError
+                    ? (retErr.result.error as Error)?.message
+                    : retErr?.message ?? ""
+                ).toContain(t.expectedThrowMessage);
               });
             } else {
               test("returns expected value", () => {

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -266,11 +266,11 @@ export const fixEventKeyMissingSteps = [
  *
  * @internal
  */
-export class OutgoingOpError extends Error {
-  public readonly op: OutgoingOp;
+export class OutgoingResultError extends Error {
+  public readonly result: Pick<OutgoingOp, "data" | "error">;
 
-  constructor(op: OutgoingOp) {
+  constructor(result: Pick<OutgoingOp, "data" | "error">) {
     super("OutgoingOpError");
-    this.op = op;
+    this.result = result;
   }
 }


### PR DESCRIPTION
## Summary

Output hooks were not running if an asynchronous, non-step function's body threw. We expect to handle all errors, so the output hook should be appropriately reporting the problem here.

This also ensures that the built-in logger middleware logs any error from a function's execution, as is expected.