### PR TITLE
Fix creating a new comparison date when hashing step sleep IDs

### DIFF
--- a/.changeset/itchy-geckos-bathe.md
+++ b/.changeset/itchy-geckos-bathe.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix a very rare bug in which `step.sleep()` hashing could produce different IDs across different executions

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -70,7 +70,7 @@ describe("waitForEvent", () => {
     void waitForEvent("event", { timeout: upcoming });
     expect(getOp()).toMatchObject({
       opts: {
-        timeout: expect.stringContaining("6d"),
+        timeout: expect.stringMatching(upcoming.toISOString()),
       },
     });
   });

--- a/src/helpers/strings.test.ts
+++ b/src/helpers/strings.test.ts
@@ -1,4 +1,4 @@
-import { slugify } from "./strings";
+import { slugify, timeStr } from "./strings";
 
 describe("slugify", () => {
   it("Generates a slug using hyphens", () => {
@@ -26,5 +26,38 @@ describe("slugify", () => {
     for (const spec of specs) {
       expect(slugify(spec.input)).toEqual(spec.expected);
     }
+  });
+});
+
+describe("timeStr", () => {
+  test("consistently converts a string to a time string", (done) => {
+    const expected = "1h";
+
+    for (let i = 0; i < 1_000_000; i++) {
+      const actual = timeStr("1 hour");
+      if (actual !== expected) {
+        return void done.fail(
+          `Expected ${expected}, got ${actual} on iteration ${i}`
+        );
+      }
+    }
+
+    done();
+  });
+
+  test("consistently converts a number to a time string", (done) => {
+    const expected = "1h";
+    const oneHourMs = 1000 * 60 * 60;
+
+    for (let i = 0; i < 1_000_000; i++) {
+      const actual = timeStr(oneHourMs);
+      if (actual !== expected) {
+        return void done.fail(
+          `Expected ${expected}, got ${actual} on iteration ${i}`
+        );
+      }
+    }
+
+    done();
   });
 });

--- a/src/helpers/strings.test.ts
+++ b/src/helpers/strings.test.ts
@@ -1,4 +1,4 @@
-import { slugify } from "./strings";
+import { slugify, timeStr } from "./strings";
 
 describe("slugify", () => {
   it("Generates a slug using hyphens", () => {
@@ -26,5 +26,19 @@ describe("slugify", () => {
     for (const spec of specs) {
       expect(slugify(spec.input)).toEqual(spec.expected);
     }
+  });
+});
+
+describe("timeStr", () => {
+  test("Converts milliseconds to a time string", () => {
+    expect(timeStr(1000)).toEqual("1s");
+  });
+
+  test("converts ms string to a time string", () => {
+    expect(timeStr("1 day")).toEqual("1d");
+  });
+
+  test("converts a date to an ISO string", () => {
+    expect(timeStr(new Date(0))).toEqual("1970-01-01T00:00:00.000Z");
   });
 });

--- a/src/helpers/strings.test.ts
+++ b/src/helpers/strings.test.ts
@@ -1,4 +1,4 @@
-import { slugify, timeStr } from "./strings";
+import { slugify } from "./strings";
 
 describe("slugify", () => {
   it("Generates a slug using hyphens", () => {
@@ -26,38 +26,5 @@ describe("slugify", () => {
     for (const spec of specs) {
       expect(slugify(spec.input)).toEqual(spec.expected);
     }
-  });
-});
-
-describe("timeStr", () => {
-  test("consistently converts a string to a time string", (done) => {
-    const expected = "1h";
-
-    for (let i = 0; i < 1_000_000; i++) {
-      const actual = timeStr("1 hour");
-      if (actual !== expected) {
-        return void done.fail(
-          `Expected ${expected}, got ${actual} on iteration ${i}`
-        );
-      }
-    }
-
-    done();
-  });
-
-  test("consistently converts a number to a time string", (done) => {
-    const expected = "1h";
-    const oneHourMs = 1000 * 60 * 60;
-
-    for (let i = 0; i < 1_000_000; i++) {
-      const actual = timeStr(oneHourMs);
-      if (actual !== expected) {
-        return void done.fail(
-          `Expected ${expected}, got ${actual} on iteration ${i}`
-        );
-      }
-    }
-
-    done();
   });
 });

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -57,7 +57,7 @@ export const timeStr = (
 
   if (typeof date === "string" || typeof date === "number") {
     const numTimeout = typeof date === "string" ? ms(date) : date;
-    date = new Date(Date.now() + numTimeout);
+    date = new Date(now.getTime() + numTimeout);
   }
 
   now.setMilliseconds(0);

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -42,34 +42,17 @@ const periods = [
  * Can optionally provide a `now` date to use as the base for the calculation,
  * otherwise a new date will be created on invocation.
  */
-export const timeStr = (
+export const timeStr = <TInput extends string | number | Date>(
   /**
    * The future date to use to convert to a time string.
    */
-  input: string | number | Date,
-
-  /**
-   * Optionally provide a date to use as the base for the calculation.
-   */
-  now = new Date()
-): TimeStr => {
-  let date = input;
-
-  if (typeof date === "string" || typeof date === "number") {
-    const numTimeout = typeof date === "string" ? ms(date) : date;
-    date = new Date(now.getTime() + numTimeout);
+  input: TInput
+): string => {
+  if (input instanceof Date) {
+    return input.toISOString();
   }
 
-  now.setMilliseconds(0);
-  date.setMilliseconds(0);
-
-  const isValidDate = !isNaN(date.getTime());
-
-  if (!isValidDate) {
-    throw new Error("Invalid date given to convert to time string");
-  }
-
-  const timeNum = date.getTime() - now.getTime();
+  const milliseconds: number = typeof input === "string" ? ms(input) : input;
 
   const [, timeStr] = periods.reduce<[number, string]>(
     ([num, str], [suffix, period]) => {
@@ -81,7 +64,7 @@ export const timeStr = (
 
       return [num, str];
     },
-    [timeNum, ""]
+    [milliseconds, ""]
   );
 
   return timeStr as TimeStr;

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -42,11 +42,11 @@ const periods = [
  * Can optionally provide a `now` date to use as the base for the calculation,
  * otherwise a new date will be created on invocation.
  */
-export const timeStr = <TInput extends string | number | Date>(
+export const timeStr = (
   /**
    * The future date to use to convert to a time string.
    */
-  input: TInput
+  input: string | number | Date
 ): string => {
   if (input instanceof Date) {
     return input.toISOString();

--- a/src/types.ts
+++ b/src/types.ts
@@ -927,7 +927,7 @@ export interface FunctionConfig {
   cancel?: {
     event: string;
     if?: string;
-    timeout?: TimeStr;
+    timeout?: string;
   }[];
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where we use two different `Date` objects to represent "now," breaking `step.sleep()` hashing in _very rare_ circumstances.

Adds some tests that try to give the problem an opportunity to appear; it's hard to cause the problem to appear due to it being temporally reliant.