### PR TITLE
Fix dev server integration tests following function config change

### DIFF
--- a/src/examples/hello-world/index.test.ts
+++ b/src/examples/hello-world/index.test.ts
@@ -1,42 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   runHasTimeline,
   sendEvent,
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Hello World",
-        id: expect.stringMatching(/^.*-hello-world$/),
-        triggers: [{ event: "demo/hello.world" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-hello-world&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Hello World",
+  triggers: [{ event: "demo/hello.world" }],
 });
 
 describe("run", () => {

--- a/src/examples/parallel-reduce/index.test.ts
+++ b/src/examples/parallel-reduce/index.test.ts
@@ -1,42 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   runHasTimeline,
-  sendEvent,
+  sendEvent
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Parallel Reduce",
-        id: expect.stringMatching(/^.*-parallel-reduce$/),
-        triggers: [{ event: "demo/parallel.reduce" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-parallel-reduce&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Parallel Reduce",
+  triggers: [{ event: "demo/parallel.reduce" }],
 });
 
 describe("run", () => {

--- a/src/examples/parallel-work/index.test.ts
+++ b/src/examples/parallel-work/index.test.ts
@@ -1,42 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   runHasTimeline,
-  sendEvent,
+  sendEvent
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Parallel Work",
-        id: expect.stringMatching(/^.*-parallel-work$/),
-        triggers: [{ event: "demo/parallel.work" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-parallel-work&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Parallel Work",
+  triggers: [{ event: "demo/parallel.work" }],
 });
 
 describe("run", () => {

--- a/src/examples/polling/index.test.ts
+++ b/src/examples/polling/index.test.ts
@@ -1,35 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
-import { introspectionSchema } from "../../test/helpers";
+import { checkIntrospection } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Polling",
-        id: expect.stringMatching(/^.*-polling$/),
-        triggers: [{ event: "demo/polling" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-polling&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Polling",
+  triggers: [{ event: "demo/polling" }],
 });

--- a/src/examples/promise-all/index.test.ts
+++ b/src/examples/promise-all/index.test.ts
@@ -1,42 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   runHasTimeline,
-  sendEvent,
+  sendEvent
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Promise.all",
-        id: expect.stringMatching(/^.*-promise-all$/),
-        triggers: [{ event: "demo/promise.all" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-promise-all&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Promise.all",
+  triggers: [{ event: "demo/promise.all" }],
 });
 
 describe("run", () => {

--- a/src/examples/promise-race/index.test.ts
+++ b/src/examples/promise-race/index.test.ts
@@ -1,44 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   runHasTimeline,
-  sendEvent,
+  sendEvent
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Promise.race",
-        id: expect.stringMatching(/^.*-promise-race$/),
-        triggers: [{ event: "demo/promise.race" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-promise-race&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Promise.race",
+  triggers: [{ event: "demo/promise.race" }],
 });
 
 describe("run", () => {

--- a/src/examples/send-event/index.test.ts
+++ b/src/examples/send-event/index.test.ts
@@ -1,45 +1,17 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   receivedEventWithName,
   runHasTimeline,
-  sendEvent,
+  sendEvent
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Send event",
-        id: expect.stringMatching(/^.*-send-event$/),
-        triggers: [{ event: "demo/send.event" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-send-event&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Send event",
+  triggers: [{ event: "demo/send.event" }],
 });
 
 describe("run", () => {

--- a/src/examples/sequential-reduce/index.test.ts
+++ b/src/examples/sequential-reduce/index.test.ts
@@ -1,42 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import fetch from "cross-fetch";
 import {
+  checkIntrospection,
   eventRunWithName,
-  introspectionSchema,
   runHasTimeline,
-  sendEvent,
+  sendEvent
 } from "../../test/helpers";
 
-describe("introspection", () => {
-  const specs = [
-    { label: "SDK UI", url: "http://127.0.0.1:3000/api/inngest?introspect" },
-    { label: "Dev server UI", url: "http://localhost:8288/dev" },
-  ];
-
-  specs.forEach(({ label, url }) => {
-    test(`should show registered functions in ${label}`, async () => {
-      const res = await fetch(url);
-      const data = introspectionSchema.parse(await res.json());
-
-      expect(data.functions).toContainEqual({
-        name: "Sequential Reduce",
-        id: expect.stringMatching(/^.*-sequential-reduce$/),
-        triggers: [{ event: "demo/sequential.reduce" }],
-        steps: {
-          step: {
-            id: "step",
-            name: "step",
-            runtime: {
-              type: "http",
-              url: expect.stringMatching(
-                /^http.+\?fnId=.+-sequential-reduce&stepId=step$/
-              ),
-            },
-          },
-        },
-      });
-    });
-  });
+checkIntrospection({
+  name: "Sequential Reduce",
+  triggers: [{ event: "demo/sequential.reduce" }],
 });
 
 describe("run", () => {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -5,6 +5,8 @@
 import { Inngest } from "@local";
 import { type ServeHandler } from "@local/components/InngestCommHandler";
 import { envKeys, headerKeys } from "@local/helpers/consts";
+import { slugify } from "@local/helpers/strings";
+import { type FunctionTrigger } from "@local/types";
 import { version } from "@local/version";
 import fetch from "cross-fetch";
 import { type Request, type Response } from "express";
@@ -714,35 +716,6 @@ export const testFramework = (
 };
 
 /**
- * A Zod schema for an introspection result from the SDK UI or the dev server.
- */
-export const introspectionSchema = z.object({
-  functions: z.array(
-    z.object({
-      name: z.string(),
-      id: z.string(),
-      triggers: z.array(
-        z.object({ event: z.string() }).or(
-          z.object({
-            cron: z.string(),
-          })
-        )
-      ),
-      steps: z.object({
-        step: z.object({
-          id: z.literal("step"),
-          name: z.literal("step"),
-          runtime: z.object({
-            type: z.literal("http"),
-            url: z.string().url(),
-          }),
-        }),
-      }),
-    })
-  ),
-});
-
-/**
  * A test helper used to send events to a local, unsecured dev server.
  *
  * Generates an ID and returns that ID for future use.
@@ -970,4 +943,119 @@ export const runHasTimeline = async (
   }
 
   return;
+};
+
+interface CheckIntrospection {
+  name: string;
+  triggers: FunctionTrigger[];
+}
+
+export const checkIntrospection = ({ name, triggers }: CheckIntrospection) => {
+  describe("introspection", () => {
+    it("should be registered in SDK UI", async () => {
+      const res = await fetch("http://127.0.0.1:3000/api/inngest?introspect");
+
+      const data = z
+        .object({
+          functions: z.array(
+            z.object({
+              name: z.string(),
+              id: z.string(),
+              triggers: z.array(
+                z.object({ event: z.string() }).or(
+                  z.object({
+                    cron: z.string(),
+                  })
+                )
+              ),
+              steps: z.object({
+                step: z.object({
+                  id: z.literal("step"),
+                  name: z.literal("step"),
+                  runtime: z.object({
+                    type: z.literal("http"),
+                    url: z.string().url(),
+                  }),
+                }),
+              }),
+            })
+          ),
+        })
+        .parse(await res.json());
+
+      expect(data.functions).toContainEqual({
+        name,
+        id: expect.stringMatching(new RegExp(`^.*-${slugify(name)}$`)),
+        triggers,
+        steps: {
+          step: {
+            id: "step",
+            name: "step",
+            runtime: {
+              type: "http",
+              url: expect.stringMatching(
+                new RegExp(`^http.+\\?fnId=.+-${slugify(name)}&stepId=step$`)
+              ),
+            },
+          },
+        },
+      });
+    });
+
+    it("should be registered in Dev Server UI", async () => {
+      const res = await fetch("http://localhost:8288/dev");
+
+      const data = z
+        .object({
+          handlers: z.array(
+            z.object({
+              sdk: z.object({
+                functions: z.array(
+                  z.object({
+                    name: z.string(),
+                    id: z.string(),
+                    triggers: z.array(
+                      z.object({ event: z.string() }).or(
+                        z.object({
+                          cron: z.string(),
+                        })
+                      )
+                    ),
+                    steps: z.object({
+                      step: z.object({
+                        id: z.literal("step"),
+                        name: z.literal("step"),
+                        runtime: z.object({
+                          type: z.literal("http"),
+                          url: z.string().url(),
+                        }),
+                      }),
+                    }),
+                  })
+                ),
+              }),
+            })
+          ),
+        })
+        .parse(await res.json());
+
+      expect(data.handlers[0]?.sdk.functions).toContainEqual({
+        name,
+        id: expect.stringMatching(new RegExp(`^.*-${slugify(name)}$`)),
+        triggers,
+        steps: {
+          step: {
+            id: "step",
+            name: "step",
+            runtime: {
+              type: "http",
+              url: expect.stringMatching(
+                new RegExp(`^http.+\\?fnId=.+-${slugify(name)}&stepId=step$`)
+              ),
+            },
+          },
+        },
+      });
+    });
+  });
 };


### PR DESCRIPTION
## Summary

Internal dev server JSON provided at the `/dev` endpoint changed shape slightly. This accounts for the change and performs some vague code clean-up.

Intentionally being more explicit about the two checks in tests rather than trying to group them and abstract the underlying data; they should be allowed to drift.