### PR TITLE
Add workflow that allows us to automatically backport merged PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This handy action allows us to backport a PR to a particular branch when merged using labels.

![image](https://github.com/inngest/inngest-js/assets/1736957/54f4295d-8bc8-4341-a277-0344f9e86615)

Just add the label, then when the PR is merged a new PR will be opened to the relevant branch (e.g. `1.x`) to backport the squashed commit.

This does not manage releasing; we'll use changesets for that.

## Related

- #224 