### PR TITLE
Add automated legacy releases to `*.x` branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*.x'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -21,10 +22,14 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-and-build
+      - run: node scripts/generateReleaseConfig.js
+        env:
+          BRANCH: ${{ github.ref_name }}
       - uses: changesets/action@v1
         id: changesets
         with:
           publish: yarn release
+          title: ${{ github.ref_name == 'main' && 'Release @latest' || format('Release @{0}', github.ref_name) }}
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_ENV: test # disable npm access checks; they don't work in CI
+          BRANCH: ${{ github.ref_name }}

--- a/scripts/generateReleaseConfig.js
+++ b/scripts/generateReleaseConfig.js
@@ -1,0 +1,30 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const config = {
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": process.env.BRANCH || "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [],
+};
+
+console.log("Writing release config:", config);
+
+const rootDir = path.join(__dirname, "..");
+process.chdir(rootDir);
+
+const changesetDir = path.join(rootDir, ".changeset");
+const configName = "config.json";
+const configPath = path.join(changesetDir, configName);
+
+const serializedConfig = JSON.stringify(config, null, 2);
+
+fs.writeFileSync(
+  configPath,
+  serializedConfig,
+);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,6 +1,13 @@
 const path = require("path");
 const { exec: rawExec, getExecOutput } = require("@actions/exec");
 
+const branch = process.env.BRANCH;
+if (branch !== "main" && !branch.endsWith(".x")) {
+  throw new Error(
+    `Stopping release from branch ${branch}; only "main" and "*.x" branches are allowed to release`,
+  );
+}
+
 const { version } = require("../package.json");
 const tag = `v${version}`;
 
@@ -25,12 +32,12 @@ const exec = async (...args) => {
     ["ls-remote", "--exit-code", "origin", "--tags", `refs/tags/${tag}`],
     {
       ignoreReturnCode: true,
-    }
+    },
   );
 
   if (exitCode === 0) {
     console.log(
-      `Action is not being published because version ${tag} is already published`
+      `Action is not being published because version ${tag} is already published`,
     );
     return;
   }
@@ -48,10 +55,10 @@ const exec = async (...args) => {
     ["publish", "--tag", distTag, "--access", "public", "--provenance"],
     {
       cwd: distDir,
-    }
+    },
   );
 
   // Tag and push the release commit
   await exec("changeset", ["tag"]);
-  await exec("git", ["push", "--follow-tags", "origin", "main"]);
+  await exec("git", ["push", "--follow-tags", "origin", branch]);
 })();


### PR DESCRIPTION
## Summary

Use `*.x` branches such as `1.x` with changesets to create automated release PRs, similar to those to `@latest`.

Here, we add a small script to generate a dynamic config for these branches so that changesets knows what to compare against.

Also includes a small change to rename release PRs to either `Release @latest` or (for example) `Release @1.x`.

## Related

- #223 