### PR TITLE
Add support for publishing legacy versions in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
       - 'v*.x'
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.workflow }}
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Releasing earlier versions to npm is a pain. This PR ensures we:

1. Find the actual latest version of the package
2. Publish the legacy version using the `latest` tag, ensuring semver updates work as expected
3. Re-tag `latest` as the version found in step 1

Following this, we should be ready to support backporting and legacy releases purely with labels and PRs. 🥳

## Related

- https://github.com/mermaid-js/mermaid/issues/4200
- https://github.com/bower/bower/issues/2041
- https://github.com/npm/npm/issues/6778