### PR TITLE
Add more info to 405s and ensure rejected GET is a 403

### DIFF
--- a/.changeset/early-pots-fly.md
+++ b/.changeset/early-pots-fly.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add better visibility into serve handlers issues

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -689,8 +689,13 @@ export class InngestCommHandler<
 
         if (this._isProd || !showLandingPage) {
           return {
-            status: 405,
-            body: "",
+            status: 403,
+            body: JSON.stringify({
+              message: "Landing page requested but is disabled",
+              isProd: this._isProd,
+              skipDevServer: this._skipDevServer,
+              showLandingPage,
+            }),
             headers: {},
           };
         }
@@ -756,7 +761,11 @@ export class InngestCommHandler<
 
     return {
       status: 405,
-      body: "",
+      body: JSON.stringify({
+        message: "No action found; request was likely not POST, PUT, or GET",
+        isProd: this._isProd,
+        skipDevServer: this._skipDevServer,
+      }),
       headers: {},
     };
   }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -272,11 +272,14 @@ export const testFramework = (
         );
 
         expect(ret).toMatchObject({
-          status: 405,
+          status: 403,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
             [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
+          body: expect.stringContaining(
+            "Landing page requested but is disabled"
+          ),
         });
       });
 
@@ -288,11 +291,14 @@ export const testFramework = (
         );
 
         expect(ret).toMatchObject({
-          status: 405,
+          status: 403,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
             [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
+          body: expect.stringContaining(
+            "Landing page requested but is disabled"
+          ),
         });
       });
 
@@ -317,11 +323,14 @@ export const testFramework = (
         });
 
         expect(ret).toMatchObject({
-          status: 405,
+          status: 403,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
             [headerKeys.Framework]: expect.stringMatching(handler.name),
           }),
+          body: expect.stringContaining(
+            "Landing page requested but is disabled"
+          ),
         });
       });
 


### PR DESCRIPTION
## Summary

Add more information when responding with a failure from the SDK.

- Rejected `GET` now returns `403 Forbidden` instead of `405 Method Not Allowed`
- Rejected `GET` now returns `isProd`, `skipDevServer`, and `showLandingPage` values
- No actions being found remains a `405 Method Not Allowed` response
- No actions being found now returns `isProd` and `skipDevServer` values