### PR TITLE
Fix release script attempting to push to Yarn registry for setting tags

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -10,7 +10,7 @@ if (branch !== "main" && !branch.endsWith(".x")) {
 
 console.log("branch:", branch);
 
-const { version } = require("../package.json");
+const { version, publishConfig: { registry } } = require("../package.json");
 console.log("version:", version);
 const tag = `v${version}`;
 console.log("tag:", tag);
@@ -93,11 +93,15 @@ const exec = async (...args) => {
       latestVersion,
     );
 
+    // `npm dist-tag` doesn't obey `publishConfig.registry`, so we must
+    // explicitly pass the registry URL here
     await exec("npm", [
       "dist-tag",
       "add",
       `inngest@${latestVersion}`,
       "latest",
+      "--registry",
+      registry,
     ]);
   }
 


### PR DESCRIPTION
## Summary

The release script in #224 and #230 almost worked.

We see in run to release a `v1.x` backport that the following command failed:
https://github.com/inngest/inngest-js/actions/runs/5244055017/jobs/9469531269
```
$ npm dist-tag add inngest@2.0.1 latest

npm ERR! code E401
npm ERR! 401 Unauthorized - PUT https://registry.yarnpkg.com/-/package/inngest/dist-tags/latest
```

Looks like it's defaulting to using Yarn's registry URL instsead of npm's. We get around this during publishing as we specify `publishConfig.registry` in our `package.json`, but it seems that `npm dist-tag` doesn't obey this same property.

Let's manually set the registry for this particular command to ensure it tries to affect the right place.

## Related

- #224 
- #230 