### PR TITLE
Harden error serialization

### DIFF
--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -903,15 +903,11 @@ export class InngestCommHandler<
        */
       const isOutgoingOpError = unserializedErr instanceof OutgoingResultError;
 
-      let error: string;
-      if (isOutgoingOpError) {
-        error =
-          typeof unserializedErr.result.data === "string"
-            ? unserializedErr.result.data
-            : stringify(unserializedErr.result.data);
-      } else {
-        error = stringify(serializeError(unserializedErr));
-      }
+      const error = stringify(
+        serializeError(
+          isOutgoingOpError ? unserializedErr.result.data : unserializedErr
+        )
+      );
 
       const isNonRetriableError = isOutgoingOpError
         ? unserializedErr.result.error instanceof NonRetriableError

--- a/src/components/NonRetriableError.ts
+++ b/src/components/NonRetriableError.ts
@@ -16,7 +16,7 @@ export class NonRetriableError extends Error {
   public readonly cause?: unknown;
 
   constructor(
-    message: string,
+    message?: string | undefined,
     options?: {
       /**
        * The underlying cause of the error, if any.


### PR DESCRIPTION
## Summary

There are some edge cases around error serialization that causes some non-useful errors to bubble up to users.

Here we aim to cover more of these edge cases to return first-party errors when possible.