### PR TITLE
Add `x-inngest-no-retry: true` header when non-retriable

### DIFF
--- a/.changeset/lovely-buckets-taste.md
+++ b/.changeset/lovely-buckets-taste.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add `x-inngest-no-retry: true` header when non-retriable for internal executor changes

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -113,6 +113,8 @@ export enum headerKeys {
     // (undocumented)
     Framework = "x-inngest-framework",
     // (undocumented)
+    NoRetry = "x-inngest-no-retry",
+    // (undocumented)
     Platform = "x-inngest-platform",
     // (undocumented)
     SdkVersion = "x-inngest-sdk",

--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -654,6 +654,14 @@ export class InngestCommHandler<
         );
 
         if (stepRes.status === 500 || stepRes.status === 400) {
+          const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+          };
+
+          if (stepRes.status === 400) {
+            headers[headerKeys.NoRetry] = "true";
+          }
+
           return {
             status: stepRes.status,
             body: stringify(
@@ -664,9 +672,7 @@ export class InngestCommHandler<
                   )
                 )
             ),
-            headers: {
-              "Content-Type": "application/json",
-            },
+            headers,
           };
         }
 

--- a/src/helpers/consts.ts
+++ b/src/helpers/consts.ts
@@ -108,6 +108,7 @@ export enum headerKeys {
   Environment = "x-inngest-env",
   Platform = "x-inngest-platform",
   Framework = "x-inngest-framework",
+  NoRetry = "x-inngest-no-retry",
 }
 
 export const defaultDevServerHost = "http://127.0.0.1:8288/";


### PR DESCRIPTION
## Summary

Send back an `x-inngest-no-retry: true` header from the SDK instead of relying on `400 Bad Request` returns.