### PR TITLE
Add optional step IDs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -972,3 +972,19 @@ export type SupportedFrameworkName =
   | "redwoodjs"
   | "remix"
   | "deno/fresh";
+
+/**
+ * A set of options that can be passed to any step to configure it.
+ */
+export interface StepOpts {
+  /**
+   * Passing an `id` for a step will overwrite the generated hash that is used
+   * by Inngest to pause and resume a function.
+   *
+   * This is useful if you want to ensure that a step is always the same ID even
+   * if the code changes.
+   *
+   * We recommend not using this unless you have a specific reason to do so.
+   */
+  id?: string;
+}


### PR DESCRIPTION
## Summary

There are cases where function state recovery may want to be customized by the user to enable a different sort of state recovery.

This change allows that by adding the ability to add an optional `id` to all step tooling, where it'll be used as the operation's hash.

```ts
step.sendEvent(payloads, { id: "foo" });
step.waitForEvent("app/user.created", { id: "foo" });
step.run("Do something", () => {}, { id: "foo" });
step.sleep("5 days", { id: "foo" });
step.sleepUntil(someDate, { id: "foo" });
```