### PR TITLE
[Backport v1.x] Add optional step IDs

### DIFF
--- a/.changeset/lucky-ants-juggle.md
+++ b/.changeset/lucky-ants-juggle.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add optional `id` property to all step tooling, allowing users to override state recovery

--- a/src/components/InngestStepTools.test.ts
+++ b/src/components/InngestStepTools.test.ts
@@ -89,6 +89,13 @@ describe("waitForEvent", () => {
       },
     });
   });
+
+  test("uses custom `id` if given", () => {
+    void waitForEvent("event", { id: "custom", timeout: "2h" });
+    expect(getOp()).toMatchObject({
+      id: "custom",
+    });
+  });
 });
 
 describe("run", () => {
@@ -158,6 +165,13 @@ describe("run", () => {
       }>
     >(output);
   });
+
+  test("uses custom `id` if given", () => {
+    void run("step", () => undefined, { id: "custom" });
+    expect(getOp()).toMatchObject({
+      id: "custom",
+    });
+  });
 });
 
 describe("sleep", () => {
@@ -182,6 +196,13 @@ describe("sleep", () => {
     void sleep("1m");
     expect(getOp()).toMatchObject({
       name: "1m",
+    });
+  });
+
+  test("uses custom `id` if given", () => {
+    void sleep("1m", { id: "custom" });
+    expect(getOp()).toMatchObject({
+      id: "custom",
     });
   });
 });
@@ -240,6 +261,13 @@ describe("sleepUntil", () => {
       "Invalid date or date string passed"
     );
   });
+
+  test("uses custom `id` if given", () => {
+    void sleepUntil(new Date(), { id: "custom" });
+    expect(getOp()).toMatchObject({
+      id: "custom",
+    });
+  });
 });
 
 describe("sendEvent", () => {
@@ -284,6 +312,14 @@ describe("sendEvent", () => {
 
       expect(getOp()).toBeUndefined();
       expect(sendSpy).toHaveBeenCalledWith("step", { data: "foo" });
+    });
+
+    test("uses custom `id` if given", () => {
+      void sendEvent({ name: "step", data: "foo" }, { id: "custom" });
+
+      expect(getOp()).toMatchObject({
+        id: "custom",
+      });
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -916,3 +916,19 @@ export type SupportedFrameworkName =
   | "redwoodjs"
   | "remix"
   | "deno/fresh";
+
+/**
+ * A set of options that can be passed to any step to configure it.
+ */
+export interface StepOpts {
+  /**
+   * Passing an `id` for a step will overwrite the generated hash that is used
+   * by Inngest to pause and resume a function.
+   *
+   * This is useful if you want to ensure that a step is always the same ID even
+   * if the code changes.
+   *
+   * We recommend not using this unless you have a specific reason to do so.
+   */
+  id?: string;
+}


### PR DESCRIPTION
## Summary

There are cases where function state recovery may want to be customized by the user to enable a different sort of state recovery.

This change allows that by adding the ability to add an optional `id` to all step tooling, where it'll be used as the operation's hash.

```ts
step.sendEvent(payloads, { id: "foo" });
step.waitForEvent("app/user.created", { id: "foo" });
step.run("Do something", () => {}, { id: "foo" });
step.sleep("5 days", { id: "foo" });
step.sleepUntil(someDate, { id: "foo" });
```

(cherry picked from commit b74477f371efd7e417b6b13a2edeedaad4eb405b)

## Related

- Backport of #245 