### PR TITLE
Include 'modified' in register response

### DIFF
--- a/src/components/InngestCommHandler.ts
+++ b/src/components/InngestCommHandler.ts
@@ -104,6 +104,7 @@ type FetchT = typeof fetch;
 const registerResSchema = z.object({
   status: z.number().default(200),
   skipped: z.boolean().optional().default(false),
+  modified: z.boolean().optional().default(false),
   error: z.string().default("Successfully registered"),
 });
 
@@ -731,7 +732,7 @@ export class InngestCommHandler<
       if (registerRes) {
         this.upsertSigningKeyFromEnv(env);
 
-        const { status, message } = await this.register(
+        const { status, message, modified } = await this.register(
           this.reqUrl(actions.url),
           stringifyUnknown(env[envKeys.DevServerUrl]),
           registerRes.deployId,
@@ -740,7 +741,7 @@ export class InngestCommHandler<
 
         return {
           status,
-          body: stringify({ message }),
+          body: stringify({ message, modified }),
           headers: {
             "Content-Type": "application/json",
           },
@@ -976,7 +977,7 @@ export class InngestCommHandler<
     devServerHost: string | undefined,
     deployId: string | undefined | null,
     getHeaders: () => Record<string, string>
-  ): Promise<{ status: number; message: string }> {
+  ): Promise<{ status: number; message: string; modified: boolean }> {
     const body = this.registerBody(url);
 
     let res: globalThis.Response;
@@ -1014,6 +1015,7 @@ export class InngestCommHandler<
         message: `Failed to register${
           err instanceof Error ? `; ${err.message}` : ""
         }`,
+        modified: false,
       };
     }
 
@@ -1026,7 +1028,7 @@ export class InngestCommHandler<
     } catch (err) {
       this.log("warn", "Couldn't unpack register response:", err);
     }
-    const { status, error, skipped } = registerResSchema.parse(data);
+    const { status, error, skipped, modified } = registerResSchema.parse(data);
 
     // The dev server polls this endpoint to register functions every few
     // seconds, but we only want to log that we've registered functions if
@@ -1043,7 +1045,7 @@ export class InngestCommHandler<
       );
     }
 
-    return { status, message: error };
+    return { status, message: error, modified };
   }
 
   private get isProd() {


### PR DESCRIPTION
# Changes

Include `modified` in register response.

# Purpose

The API will be able to forward the `modified` value to the UI during registration. This will give the UI enough information to know whether a deploy was created or deduped.

# Testing

I manually tested this with an API feature branch and the `modified` value in the response is `true` if a deploy was created and `false` if the deploy was deduped.