### PR TITLE
Always add the `ts` field when sending events.

### DIFF
--- a/.changeset/five-bats-begin.md
+++ b/.changeset/five-bats-begin.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Set `ts` field on sent events if undefined

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -324,8 +324,10 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     }
 
     // Ensure that we always add a "ts" field to events.  This is auto-filled by the
-    // event server so is safe, and adding here fixes server action cache issues.
-    payloads = payloads.map(p => p.ts ? p : ({ ...p, ts: new Date().getTime() }));
+    // event server so is safe, and adding here fixes Next.js server action cache issues.
+    payloads = payloads.map((p) =>
+      p.ts ? p : { ...p, ts: new Date().getTime() }
+    );
 
     /**
      * It can be valid for a user to send an empty list of events; if this

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -323,6 +323,10 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
       payloads = [...inputChanges.payloads];
     }
 
+    // Ensure that we always add a "ts" field to events.  This is auto-filled by the
+    // event server so is safe, and adding here fixes server action cache issues.
+    payloads = payloads.map(p => p.ts ? p : ({ ...p, ts: new Date().getTime() }));
+
     /**
      * It can be valid for a user to send an empty list of events; if this
      * happens, show a warning that this may not be intended, but don't throw.


### PR DESCRIPTION
This is auto-filled by the event server when missing, and fixes any caching issues people may see if their server configs cache outgoing requests (uh... server actions :D)