### PR TITLE
Return event IDs when sending events

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,11 +142,7 @@ jobs:
       # Install dependencies in the example repo
       # Don't use "npm ci", "--immutable" etc., as example repos won't be
       # shipped with lock files.
-      - name: Install example dependencies
-        run: npm install
-        working-directory: examples/${{ matrix.example }}
-
-      - name: Add local SDK to example
+      - name: Add local SDK to example with dependencies
         working-directory: examples/${{ matrix.example }}
         run: npm install ./inngest.tgz
 

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -159,7 +159,8 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     ]>>): InngestFunction<TOpts, EventsFromOpts<TOpts>, FunctionTrigger<keyof EventsFromOpts<TOpts> & string>, FunctionOptions<EventsFromOpts<TOpts>, keyof EventsFromOpts<TOpts> & string>>;
     readonly id: string;
     // Warning: (ae-forgotten-export) The symbol "SendEventPayload" needs to be exported by the entry point index.d.ts
-    send<Payload extends SendEventPayload<EventsFromOpts<TOpts>>>(payload: Payload): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "SendEventOutput" needs to be exported by the entry point index.d.ts
+    send<Payload extends SendEventPayload<EventsFromOpts<TOpts>>>(payload: Payload): Promise<SendEventOutput<TOpts>>;
     setEventKey(
     eventKey: string): void;
 }
@@ -344,15 +345,15 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/InngestMiddleware.ts:259:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:272:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:278:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:311:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:330:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:340:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:357:3 - (ae-forgotten-export) The symbol "AnyInngestFunction" needs to be exported by the entry point index.d.ts
-// src/types.ts:73:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:676:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:264:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:277:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:283:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:316:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:335:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:342:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
+// src/components/InngestMiddleware.ts:359:3 - (ae-forgotten-export) The symbol "AnyInngestFunction" needs to be exported by the entry point index.d.ts
+// src/types.ts:76:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
+// src/types.ts:721:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -423,7 +423,6 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
 
       return await applyHookToOutput({ result: { ids: body.ids } });
     } catch (err) {
-      console.warn("gluhdflioghuisdfhgiusdfhguisdhgiuhsdighusd", err);
       throw await this.#getResponseError(response);
     }
   }

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -279,14 +279,28 @@ describe("stacking and inference", () => {
           fetch: mockFetch,
         });
 
+        const payload = { name: "foo", data: { foo: "bar" } };
+
         test("output context has value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["foo"], string>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["foo"], string>>(true);
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["foo"], string>>(true);
+          });
         });
 
         test("output context retains default 'ids' value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["ids"], string[]>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["ids"], string[]>>(
+              true
+            );
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["ids"], string[]>>(true);
+          });
         });
       });
 
@@ -316,14 +330,28 @@ describe("stacking and inference", () => {
           fetch: mockFetch,
         });
 
+        const payload = { name: "foo", data: { foo: "bar" } };
+
         test("output context has value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["foo"], "bar">>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["foo"], "bar">>(true);
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["foo"], "bar">>(true);
+          });
         });
 
         test("output context retains default 'ids' value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["ids"], string[]>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["ids"], string[]>>(
+              true
+            );
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["ids"], string[]>>(true);
+          });
         });
       });
 
@@ -353,9 +381,18 @@ describe("stacking and inference", () => {
           fetch: mockFetch,
         });
 
+        const payload = { name: "foo", data: { foo: "bar" } };
+
         test("output context has value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["ids"], boolean>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["ids"], boolean>>(
+              true
+            );
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["ids"], boolean>>(true);
+          });
         });
       });
 
@@ -402,14 +439,28 @@ describe("stacking and inference", () => {
           fetch: mockFetch,
         });
 
+        const payload = { name: "foo", data: { foo: "bar" } };
+
         test("output context has foo value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["foo"], string>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["foo"], string>>(true);
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["foo"], string>>(true);
+          });
         });
 
         test("output context has bar value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["bar"], boolean>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["bar"], boolean>>(
+              true
+            );
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["bar"], boolean>>(true);
+          });
         });
       });
 
@@ -456,9 +507,18 @@ describe("stacking and inference", () => {
           fetch: mockFetch,
         });
 
+        const payload = { name: "foo", data: { foo: "bar" } };
+
         test("output context has new value", () => {
-          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
-          assertType<IsEqual<Awaited<typeof res>["foo"], boolean>>(true);
+          inngest.createFunction({ id: "" }, { event: "" }, ({ step }) => {
+            const directRes = inngest.send(payload);
+            assertType<IsEqual<Awaited<typeof directRes>["foo"], boolean>>(
+              true
+            );
+
+            const res = step.sendEvent("id", payload);
+            assertType<IsEqual<Awaited<typeof res>["foo"], boolean>>(true);
+          });
         });
       });
     });

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -236,4 +236,225 @@ describe("stacking and inference", () => {
       });
     });
   });
+
+  describe("onSendEvent", () => {
+    describe("transformOutput", () => {
+      const originalFetch = global.fetch;
+
+      beforeAll(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ status: 200, json: () => Promise.resolve({}) })
+        ) as any;
+      });
+
+      beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        (global.fetch as any).mockClear();
+      });
+
+      afterAll(() => {
+        global.fetch = originalFetch;
+      });
+
+      describe("can add a value to output context", () => {
+        const mw = new InngestMiddleware({
+          name: "mw",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { foo: "bar" },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          middleware: [mw],
+          eventKey: "123",
+        });
+
+        test("output context has value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["foo"], string>>(true);
+        });
+
+        test("output context retains default 'ids' value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["ids"], string[]>>(true);
+        });
+      });
+
+      describe("can add a literal value to output context", () => {
+        const mw = new InngestMiddleware({
+          name: "mw",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { foo: "bar" },
+                    } as const;
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          middleware: [mw],
+          eventKey: "123",
+        });
+
+        test("output context has value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["foo"], "bar">>(true);
+        });
+
+        test("output context retains default 'ids' value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["ids"], string[]>>(true);
+        });
+      });
+
+      describe("can mutate an existing output context value", () => {
+        const mw = new InngestMiddleware({
+          name: "mw",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { ids: true },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          middleware: [mw],
+          eventKey: "123",
+        });
+
+        test("output context has value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["ids"], boolean>>(true);
+        });
+      });
+
+      describe("can add multiple output context values via stacking", () => {
+        const mw1 = new InngestMiddleware({
+          name: "mw1",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { foo: "foo" },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const mw2 = new InngestMiddleware({
+          name: "mw2",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { bar: true },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          middleware: [mw1, mw2],
+          eventKey: "123",
+        });
+
+        test("output context has foo value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["foo"], string>>(true);
+        });
+
+        test("output context has bar value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["bar"], boolean>>(true);
+        });
+      });
+
+      describe("can overwrite a new value in output context", () => {
+        const mw1 = new InngestMiddleware({
+          name: "mw1",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { foo: "bar" },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const mw2 = new InngestMiddleware({
+          name: "mw2",
+          init() {
+            return {
+              onSendEvent() {
+                return {
+                  transformOutput() {
+                    return {
+                      result: { foo: true },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          middleware: [mw1, mw2],
+          eventKey: "123",
+        });
+
+        test("output context has new value", () => {
+          const res = inngest.send({ name: "foo", data: { foo: "bar" } });
+          assertType<IsEqual<Awaited<typeof res>["foo"], boolean>>(true);
+        });
+      });
+    });
+  });
 });

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -239,22 +239,18 @@ describe("stacking and inference", () => {
 
   describe("onSendEvent", () => {
     describe("transformOutput", () => {
-      const originalFetch = global.fetch;
-
-      beforeAll(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        global.fetch = jest.fn(() =>
-          Promise.resolve({ status: 200, json: () => Promise.resolve({}) })
-        ) as any;
-      });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const mockFetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({ ids: [], status: 200 }),
+          text: () => Promise.resolve(""),
+        })
+      ) as any;
 
       beforeEach(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        (global.fetch as any).mockClear();
-      });
-
-      afterAll(() => {
-        global.fetch = originalFetch;
+        mockFetch.mockClear();
       });
 
       describe("can add a value to output context", () => {
@@ -279,6 +275,8 @@ describe("stacking and inference", () => {
           id: "test",
           middleware: [mw],
           eventKey: "123",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          fetch: mockFetch,
         });
 
         test("output context has value", () => {
@@ -314,6 +312,8 @@ describe("stacking and inference", () => {
           id: "test",
           middleware: [mw],
           eventKey: "123",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          fetch: mockFetch,
         });
 
         test("output context has value", () => {
@@ -349,6 +349,8 @@ describe("stacking and inference", () => {
           id: "test",
           middleware: [mw],
           eventKey: "123",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          fetch: mockFetch,
         });
 
         test("output context has value", () => {
@@ -396,6 +398,8 @@ describe("stacking and inference", () => {
           id: "test",
           middleware: [mw1, mw2],
           eventKey: "123",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          fetch: mockFetch,
         });
 
         test("output context has foo value", () => {
@@ -448,6 +452,8 @@ describe("stacking and inference", () => {
           id: "test",
           middleware: [mw1, mw2],
           eventKey: "123",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          fetch: mockFetch,
         });
 
         test("output context has new value", () => {

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -77,10 +77,10 @@ describe("waitForEvent", () => {
     });
   });
 
-  test("returns no name by default", () => {
+  test("returns ID by default", () => {
     void waitForEvent("id", { event: "event", timeout: "2h" });
     expect(getOp()).toMatchObject({
-      displayName: undefined,
+      displayName: "id",
     });
   });
 
@@ -190,10 +190,10 @@ describe("run", () => {
     });
   });
 
-  test("return no name by default", () => {
+  test("return ID by default", () => {
     void run("id", () => undefined);
     expect(getOp()).toMatchObject({
-      displayName: undefined,
+      displayName: "id",
     });
   });
 
@@ -273,10 +273,10 @@ describe("sleep", () => {
     });
   });
 
-  test("return no name by default", () => {
+  test("return ID by default", () => {
     void sleep("id", "1m");
     expect(getOp()).toMatchObject({
-      displayName: undefined,
+      displayName: "id",
     });
   });
 
@@ -309,13 +309,13 @@ describe("sleepUntil", () => {
     });
   });
 
-  test("return no name by default", () => {
+  test("return ID by default", () => {
     const future = new Date();
     future.setDate(future.getDate() + 1);
 
     void sleepUntil("id", future);
     expect(getOp()).toMatchObject({
-      displayName: undefined,
+      displayName: "id",
     });
   });
 
@@ -431,10 +431,10 @@ describe("sendEvent", () => {
       expect(getOp()).toMatchObject({ op: StepOpCode.StepPlanned });
     });
 
-    test("return no name by default", () => {
+    test("return ID by default", () => {
       void sendEvent("id", { name: "step", data: "foo" });
 
-      expect(getOp()).toMatchObject({ displayName: undefined });
+      expect(getOp()).toMatchObject({ displayName: "id" });
     });
 
     test("return specific name if given", () => {

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -12,7 +12,11 @@ import {
   createStepTools,
   type FoundStep,
 } from "@local/components/InngestStepTools";
-import { StepOpCode, type ClientOptions } from "@local/types";
+import {
+  StepOpCode,
+  type ClientOptions,
+  type EventPayload,
+} from "@local/types";
 import ms from "ms";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
@@ -371,8 +375,19 @@ describe("sleepUntil", () => {
 
 describe("sendEvent", () => {
   describe("runtime", () => {
-    const fetchMock = jest.fn(() =>
-      Promise.resolve({ status: 200 })
+    const fetchMock = jest.fn(
+      (url: string, opts: { body: string }) =>
+        Promise.resolve({
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              status: 200,
+              ids: (JSON.parse(opts.body) as EventPayload[]).map(
+                () => "test-id"
+              ),
+            }),
+        })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as unknown as typeof fetch;
 
     const client = createClient({

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -19,6 +19,7 @@ import {
   type ClientOptions,
   type EventPayload,
   type HashedOp,
+  type SendEventOutput,
   type StepOptions,
   type StepOptionsOrId,
 } from "../types";
@@ -245,7 +246,7 @@ export const createStepTools = <
       <Payload extends SendEventPayload<EventsFromOpts<TOpts>>>(
         idOrOptions: StepOptionsOrId,
         payload: Payload
-      ): Promise<void>;
+      ): Promise<SendEventOutput<TOpts>>;
     }>(
       ({ id, name }) => {
         return {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -333,7 +333,12 @@ export const sendEventResponseSchema = z.object({
   /**
    * HTTP Status Code. Will be undefined if no request was sent.
    */
-  status: z.number().min(200).max(299),
+  status: z.number(),
+
+  /**
+   * Error message. Will be undefined if no error occurred.
+   */
+  error: z.string().optional(),
 });
 
 /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -4,15 +4,18 @@ import {
   type AnyInngest,
   type EventsFromOpts,
   type Inngest,
+  type builtInMiddleware,
 } from "./components/Inngest";
 import {
   type InngestMiddleware,
   type MiddlewareOptions,
+  type MiddlewareStackSendEventOutputMutation,
 } from "./components/InngestMiddleware";
 import { type createStepTools } from "./components/InngestStepTools";
 import { type internalEvents } from "./helpers/consts";
 import {
   type IsStringLiteral,
+  type ObjectAssign,
   type ObjectPaths,
   type StrictUnion,
 } from "./helpers/types";
@@ -320,6 +323,43 @@ export interface EventPayload {
    */
   ts?: number;
 }
+
+export const sendEventResponseSchema = z.object({
+  /**
+   * Event IDs
+   */
+  ids: z.array(z.string()),
+
+  /**
+   * HTTP Status Code. Will be undefined if no request was sent.
+   */
+  status: z.number().min(200).max(299),
+});
+
+/**
+ * The response from the Inngest Event API
+ */
+export type SendEventResponse = z.output<typeof sendEventResponseSchema>;
+
+/**
+ * The response in code from sending an event to Inngest.
+ */
+export type SendEventBaseOutput = {
+  ids: SendEventResponse["ids"];
+};
+
+export type SendEventOutput<TOpts extends ClientOptions> = ObjectAssign<
+  [
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    MiddlewareStackSendEventOutputMutation<{}, typeof builtInMiddleware>,
+    MiddlewareStackSendEventOutputMutation<
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      {},
+      NonNullable<TOpts["middleware"]>
+    >
+  ],
+  SendEventBaseOutput
+>;
 
 /**
  * An HTTP-like, standardised response format that allows Inngest to help


### PR DESCRIPTION
## Summary

We should return the response data from the Event API, including `ids` when events are sent. This returns an object for future extensibility beyond `ids`.

Applies the changes in #195, but in a post-2.0, post-Middleware setup.

- [x] Add return data to `inngest.send()`
- [ ] Add return data to `steps.sendEvent()`