### PR TITLE
change to use local:pack instead of linking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,12 +102,15 @@ jobs:
           ref: main
 
       # Get the SDK ready and link it locally
-      - name: Prepare SDK for linking
-        run: yarn prelink
+      # - name: Prepare SDK for linking
+      #   run: yarn prelink
+      #   working-directory: sdk
+      # - name: Create link to SDK
+      #   run: yarn link
+      #   working-directory: sdk/dist
+      - name: Pack SDK
+        run: yarn local:pack
         working-directory: sdk
-      - name: Create link to SDK
-        run: yarn link
-        working-directory: sdk/dist
 
       # If we find a deno.json file in the example repo, we need to pull Deno on
       # to the toolchain.
@@ -151,20 +154,22 @@ jobs:
       # shim script to bend paths and adjust the target repo's import path.
       - name: Link local SDK to example
         run: |
+          ln -s ../../../sdk/inngest.tgz $PWD/inngest.tgz
+
           if test -f deno.json; then
             deno run --allow-read --allow-write ../../../sdk/deno_compat/link.ts
           else
             yarnv=$(volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn -v)
 
-            if [[ $yarnv == 3* ]]; then
-              touch ../../../sdk/dist/yarn.lock
-              yarn link ../../../sdk/dist
-            else
-              volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
-            fi
+            yarn add ./inngest.tgz
+            # if [[ $yarnv == 3* ]]; then
+            #   touch ../../../sdk/dist/yarn.lock
+            #   yarn link ../../../sdk/dist
+            # else
+            #   volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
+            # fi
           fi
         working-directory: examples/${{ matrix.repo }}
-
 
       # Copy any SDK function examples to the example repo so that we're always
       # testing many functions against many handlers.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
   push:
     branches:
-      - 'renovate/**'
+      - "renovate/**"
 
 concurrency:
   group: pr-${{ github.ref }}
@@ -39,13 +39,13 @@ jobs:
       fail-fast: false
       matrix:
         tsVersion:
-         - 'latest'
-         - 'next'
-         - '~5.1.0'
-         - '~5.0.0'
-         - '~4.9.0'
-         - '~4.8.0'
-         - "~4.7.0"
+          - "latest"
+          - "next"
+          - "~5.1.0"
+          - "~5.0.0"
+          - "~4.9.0"
+          - "~4.8.0"
+          - "~4.7.0"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-and-build
@@ -169,10 +169,11 @@ jobs:
 
       - name: Install pre-built JS SDK
         run: ls -la
+        working-directory: examples/${{ matrix.repo }}
 
       - name: Link local SDK to example
         run: |
-          ln -s ../../../sdk/inngest.tgz $PWD/inngest.tgz
+          # ln -s ../../../sdk/inngest.tgz $PWD/inngest.tgz
 
           if test -f deno.json; then
             deno run --allow-read --allow-write ../../../sdk/deno_compat/link.ts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,8 +69,23 @@ jobs:
       - uses: ./.github/actions/setup-and-build
       - run: yarn lint
 
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-and-build
+      - name: Package as tarball
+        run: yarn local:pack
+      - name: Archive package tarball
+        uses: actions/upload-artifact@v3
+        with:
+          name: inngestpkg
+          path: inngest.tgz
+
   examples:
     name: Test examples
+    needs: package
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -101,13 +116,7 @@ jobs:
           path: examples/${{ matrix.repo }}
           ref: main
 
-      # Get the SDK ready and link it locally
-      # - name: Prepare SDK for linking
-      #   run: yarn prelink
-      #   working-directory: sdk
-      # - name: Create link to SDK
-      #   run: yarn link
-      #   working-directory: sdk/dist
+      # Get the SDK ready
       - name: Pack SDK
         run: yarn local:pack
         working-directory: sdk
@@ -152,6 +161,15 @@ jobs:
       # Locally linking the lib to a Deno repo is harder, as Deno doesn't
       # support local linking between ESM and CJS. Instead, we run a manual
       # shim script to bend paths and adjust the target repo's import path.
+      - name: Download pre-built SDK
+        uses: actions/download-artifact@v3
+        with:
+          name: inngestpkg
+          path: examples/${{ matrix.repo }}
+
+      - name: Install pre-built JS SDK
+        run: ls -la
+
       - name: Link local SDK to example
         run: |
           ln -s ../../../sdk/inngest.tgz $PWD/inngest.tgz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,7 +161,7 @@ jobs:
           else
             yarnv=$(volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn -v)
 
-            yarn add ./inngest.tgz
+            volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn add ./inngest.tgz
             # if [[ $yarnv == 3* ]]; then
             #   touch ../../../sdk/dist/yarn.lock
             #   yarn link ../../../sdk/dist

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,11 +116,6 @@ jobs:
           path: examples/${{ matrix.repo }}
           ref: main
 
-      # Get the SDK ready
-      - name: Pack SDK
-        run: yarn local:pack
-        working-directory: sdk
-
       # If we find a deno.json file in the example repo, we need to pull Deno on
       # to the toolchain.
       - name: Check if Deno is used
@@ -167,26 +162,13 @@ jobs:
           name: inngestpkg
           path: examples/${{ matrix.repo }}
 
-      - name: Install pre-built JS SDK
-        run: ls -la
-        working-directory: examples/${{ matrix.repo }}
-
-      - name: Link local SDK to example
+      - name: Install pre-built SDK to example
         run: |
-          # ln -s ../../../sdk/inngest.tgz $PWD/inngest.tgz
-
           if test -f deno.json; then
             deno run --allow-read --allow-write ../../../sdk/deno_compat/link.ts
           else
             yarnv=$(volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn -v)
-
             volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn add ./inngest.tgz
-            # if [[ $yarnv == 3* ]]; then
-            #   touch ../../../sdk/dist/yarn.lock
-            #   yarn link ../../../sdk/dist
-            # else
-            #   volta run --yarn $(cat ../../../sdk/package.json | jq -r .volta.yarn) yarn link inngest
-            # fi
           fi
         working-directory: examples/${{ matrix.repo }}
 

--- a/src/examples/parallel-reduce/index.test.ts
+++ b/src/examples/parallel-reduce/index.test.ts
@@ -3,7 +3,7 @@ import {
   checkIntrospection,
   eventRunWithName,
   runHasTimeline,
-  sendEvent
+  sendEvent,
 } from "../../test/helpers";
 
 checkIntrospection({

--- a/src/examples/parallel-work/index.test.ts
+++ b/src/examples/parallel-work/index.test.ts
@@ -3,7 +3,7 @@ import {
   checkIntrospection,
   eventRunWithName,
   runHasTimeline,
-  sendEvent
+  sendEvent,
 } from "../../test/helpers";
 
 checkIntrospection({

--- a/src/examples/promise-all/index.test.ts
+++ b/src/examples/promise-all/index.test.ts
@@ -3,7 +3,7 @@ import {
   checkIntrospection,
   eventRunWithName,
   runHasTimeline,
-  sendEvent
+  sendEvent,
 } from "../../test/helpers";
 
 checkIntrospection({

--- a/src/examples/promise-race/index.test.ts
+++ b/src/examples/promise-race/index.test.ts
@@ -5,7 +5,7 @@ import {
   checkIntrospection,
   eventRunWithName,
   runHasTimeline,
-  sendEvent
+  sendEvent,
 } from "../../test/helpers";
 
 checkIntrospection({

--- a/src/examples/send-event/index.test.ts
+++ b/src/examples/send-event/index.test.ts
@@ -6,7 +6,7 @@ import {
   eventRunWithName,
   receivedEventWithName,
   runHasTimeline,
-  sendEvent
+  sendEvent,
 } from "../../test/helpers";
 
 checkIntrospection({

--- a/src/examples/sequential-reduce/index.test.ts
+++ b/src/examples/sequential-reduce/index.test.ts
@@ -3,7 +3,7 @@ import {
   checkIntrospection,
   eventRunWithName,
   runHasTimeline,
-  sendEvent
+  sendEvent,
 } from "../../test/helpers";
 
 checkIntrospection({


### PR DESCRIPTION
## Summary

Change integration testing with example repos to use tarball packaging instead of `yarn link`
due to too much false negatives.

Added a step to pre-build the SDK and allow it to be downloaded into each example repo to save build time.

Fixed some linter warnings while at it.