### PR TITLE
Assert types instead of casting in Express

### DIFF
--- a/.changeset/clean-panthers-begin.md
+++ b/.changeset/clean-panthers-begin.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Throw error when using `inngest/express` and not using a body parser

--- a/src/express.ts
+++ b/src/express.ts
@@ -30,10 +30,10 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         run: () => {
           if (req.method === "POST") {
             return {
-              fnId: req.query[queryKeys.FnId] as string,
-              stepId: req.query[queryKeys.StepId] as string,
-              data: req.body as Record<string, unknown>,
-              signature: req.headers[headerKeys.Signature] as string,
+              fnId: getFromQuery(req, queryKeys.FnId),
+              stepId: getFromQuery(req, queryKeys.StepId),
+              data: getBody(req),
+              signature: getFromHeaders(req, headerKeys.Signature),
             };
           }
         },
@@ -67,3 +67,45 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
 
   return handler.createHandler();
 };
+
+function getBody(req: Request): Record<string, unknown> {
+  const body: unknown = req.body;
+
+  if (body === undefined) {
+    throw new Error("missing request body");
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new Error("body is not an object");
+  }
+
+  return body as Record<string, unknown>;
+}
+
+function getFromHeaders(req: Request, key: string): string {
+  const value = req.headers[key];
+
+  if (value === undefined) {
+    throw new Error(`missing ${key} in request headers`);
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${key} in request headers is not a string`);
+  }
+
+  return value;
+}
+
+function getFromQuery(req: Request, key: string): string {
+  const value = req.query[key];
+
+  if (value === undefined) {
+    throw new Error(`missing ${key} in request query`);
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${key} in request query is not a string`);
+  }
+
+  return value;
+}

--- a/src/express.ts
+++ b/src/express.ts
@@ -5,6 +5,7 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { type SupportedFrameworkName } from "./types";
+import { prettyError } from "./helpers/errors";
 
 export const name: SupportedFrameworkName = "express";
 
@@ -71,12 +72,23 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
 function getBody(req: Request): Record<string, unknown> {
   const body: unknown = req.body;
 
-  if (body === undefined) {
-    throw new Error("missing request body");
+  if (body === undefined || body === null) {
+    throw new Error(
+      prettyError({
+        toFixNow:
+          "Use middleware that can parse request bodies, like body-parser (https://expressjs.com/en/resources/middleware/body-parser.html)",
+        whatHappened: "Missing request body",
+      })
+    );
   }
 
-  if (typeof body !== "object" || body === null || Array.isArray(body)) {
-    throw new Error("body is not an object");
+  if (typeof body !== "object" || Array.isArray(body)) {
+    throw new Error(
+      prettyError({
+        toFixNow: "Ensure that request bodies are being properly parsed",
+        whatHappened: "Body is not an object",
+      })
+    );
   }
 
   return body as Record<string, unknown>;

--- a/src/express.ts
+++ b/src/express.ts
@@ -5,7 +5,6 @@ import {
 } from "./components/InngestCommHandler";
 import { headerKeys, queryKeys } from "./helpers/consts";
 import { type SupportedFrameworkName } from "./types";
-import { prettyError } from "./helpers/errors";
 
 export const name: SupportedFrameworkName = "express";
 
@@ -31,10 +30,10 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
         run: () => {
           if (req.method === "POST") {
             return {
-              fnId: getFromQuery(req, queryKeys.FnId),
-              stepId: getFromQuery(req, queryKeys.StepId),
-              data: getBody(req),
-              signature: getFromHeaders(req, headerKeys.Signature),
+              fnId: req.query[queryKeys.FnId] as string,
+              stepId: req.query[queryKeys.StepId] as string,
+              data: req.body as Record<string, unknown>,
+              signature: req.headers[headerKeys.Signature] as string,
             };
           }
         },
@@ -68,56 +67,3 @@ export const serve: ServeHandler = (nameOrInngest, fns, opts) => {
 
   return handler.createHandler();
 };
-
-function getBody(req: Request): Record<string, unknown> {
-  const body: unknown = req.body;
-
-  if (body === undefined || body === null) {
-    throw new Error(
-      prettyError({
-        toFixNow:
-          "Use middleware that can parse request bodies, like body-parser (https://expressjs.com/en/resources/middleware/body-parser.html)",
-        whatHappened: "Missing request body",
-      })
-    );
-  }
-
-  if (typeof body !== "object" || Array.isArray(body)) {
-    throw new Error(
-      prettyError({
-        toFixNow: "Ensure that request bodies are being properly parsed",
-        whatHappened: "Body is not an object",
-      })
-    );
-  }
-
-  return body as Record<string, unknown>;
-}
-
-function getFromHeaders(req: Request, key: string): string {
-  const value = req.headers[key];
-
-  if (value === undefined) {
-    throw new Error(`missing ${key} in request headers`);
-  }
-
-  if (typeof value !== "string") {
-    throw new Error(`${key} in request headers is not a string`);
-  }
-
-  return value;
-}
-
-function getFromQuery(req: Request, key: string): string {
-  const value = req.query[key];
-
-  if (value === undefined) {
-    throw new Error(`missing ${key} in request query`);
-  }
-
-  if (typeof value !== "string") {
-    throw new Error(`${key} in request query is not a string`);
-  }
-
-  return value;
-}

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -2,6 +2,7 @@ import { type Await } from "./types";
 import { prettyError } from "./errors";
 import { fnDataSchema, type FnData, type Result, ok, err } from "../types";
 import { type InngestApi } from "../api/api";
+import { ZodError } from "zod";
 
 /**
  * Wraps a function with a cache. When the returned function is run, it will
@@ -120,11 +121,17 @@ export const parseFnData = async (
     // move to something like protobuf so we don't have to deal with this
     console.error(error);
 
+    let why: string | undefined;
+    if (error instanceof ZodError) {
+      why = error.toString();
+    }
+
     return err(
       prettyError({
         whatHappened: "failed to parse data from executor",
         consequences: "function execution can't continue",
         stack: true,
+        why,
       })
     );
   }

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -1,8 +1,8 @@
-import { type Await } from "./types";
-import { prettyError } from "./errors";
-import { fnDataSchema, type FnData, type Result, ok, err } from "../types";
-import { type InngestApi } from "../api/api";
 import { ZodError } from "zod";
+import { type InngestApi } from "../api/api";
+import { err, fnDataSchema, ok, type FnData, type Result } from "../types";
+import { prettyError } from "./errors";
+import { type Await } from "./types";
 
 /**
  * Wraps a function with a cache. When the returned function is run, it will
@@ -128,8 +128,10 @@ export const parseFnData = async (
 
     return err(
       prettyError({
-        whatHappened: "failed to parse data from executor",
-        consequences: "function execution can't continue",
+        whatHappened: "Failed to parse data from executor.",
+        consequences: "Function execution can't continue.",
+        toFixNow:
+          "Make sure that your API is set up to parse incoming request bodies as JSON, like body-parser for Express (https://expressjs.com/en/resources/middleware/body-parser.html).",
         stack: true,
         why,
       })


### PR DESCRIPTION
# Description

- In the Express `serve` function, assert types instead of casting.
- When parsing function data, include Zod validation errors in the pretty error.