### PR TITLE
Show the actual HTTP response error message for unknow HTTP status.

### DIFF
--- a/.changeset/dull-ligers-change.md
+++ b/.changeset/dull-ligers-change.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Expose raw error message if status is unknown

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -244,7 +244,11 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
       case 500:
         errorMessage = "Internal server error";
         break;
+      default:
+        errorMessage = await response.text();
+        break;
     }
+
     return new Error(`Inngest API Error: ${response.status} ${errorMessage}`);
   }
 


### PR DESCRIPTION
We're getting reports of unknown error messages when sending events to Inngest's event API, but the LB has no record of them.
Change the body parsing here to actually use the error body instead of just `Unknown Error` to give us a better idea of what's going on.