### PR TITLE
Add batch-related mutual exclusivity to createFunction

### DIFF
--- a/.changeset/eight-dryers-hide.md
+++ b/.changeset/eight-dryers-hide.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Ensure users are not allowed to configure batching with cancellation or rate limiting, as these features do not yet function together

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -130,6 +130,7 @@ export enum headerKeys {
 export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     constructor({ name, eventKey, inngestBaseUrl, fetch, env, logger, middleware, }: TOpts);
     // Warning: (ae-forgotten-export) The symbol "ShimmedFns" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ExclusiveKeys" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Handler" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "MiddlewareStackRunInputMutation" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "builtInMiddleware" needs to be exported by the entry point index.d.ts
@@ -137,11 +138,11 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     // Warning: (ae-forgotten-export) The symbol "FunctionTrigger" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    createFunction<TFns extends Record<string, unknown>, TMiddleware extends MiddlewareStack, TTrigger extends TriggerOptions<keyof EventsFromOpts<TOpts> & string>, TShimmedFns extends Record<string, (...args: any[]) => any> = ShimmedFns<TFns>, TTriggerName extends keyof EventsFromOpts<TOpts> & string = EventNameFromTrigger<EventsFromOpts<TOpts>, TTrigger>>(nameOrOpts: string | (Omit<FunctionOptions<EventsFromOpts<TOpts>, TTriggerName>, "fns" | "onFailure" | "middleware"> & {
+    createFunction<TFns extends Record<string, unknown>, TMiddleware extends MiddlewareStack, TTrigger extends TriggerOptions<keyof EventsFromOpts<TOpts> & string>, TShimmedFns extends Record<string, (...args: any[]) => any> = ShimmedFns<TFns>, TTriggerName extends keyof EventsFromOpts<TOpts> & string = EventNameFromTrigger<EventsFromOpts<TOpts>, TTrigger>>(nameOrOpts: string | ExclusiveKeys<Omit<FunctionOptions<EventsFromOpts<TOpts>, TTriggerName>, "fns" | "onFailure" | "middleware"> & {
         fns?: TFns;
         onFailure?: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>>;
         middleware?: TMiddleware;
-    }), trigger: TTrigger, handler: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, MiddlewareStackRunInputMutation<{}, typeof builtInMiddleware> & MiddlewareStackRunInputMutation<{}, NonNullable<TOpts["middleware"]>> & MiddlewareStackRunInputMutation<{}, TMiddleware>>): InngestFunction<TOpts, EventsFromOpts<TOpts>, FunctionTrigger<keyof EventsFromOpts<TOpts> & string>, FunctionOptions<EventsFromOpts<TOpts>, keyof EventsFromOpts<TOpts> & string>>;
+    }, "batchEvents", "cancelOn" | "rateLimit">, trigger: TTrigger, handler: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, MiddlewareStackRunInputMutation<{}, typeof builtInMiddleware> & MiddlewareStackRunInputMutation<{}, NonNullable<TOpts["middleware"]>> & MiddlewareStackRunInputMutation<{}, TMiddleware>>): InngestFunction<TOpts, EventsFromOpts<TOpts>, FunctionTrigger<keyof EventsFromOpts<TOpts> & string>, FunctionOptions<EventsFromOpts<TOpts>, keyof EventsFromOpts<TOpts> & string>>;
     readonly inngestBaseUrl: URL;
     readonly name: string;
     // Warning: (ae-forgotten-export) The symbol "SendEventPayload" needs to be exported by the entry point index.d.ts

--- a/src/components/Inngest.test.ts
+++ b/src/components/Inngest.test.ts
@@ -433,6 +433,36 @@ describe("createFunction", () => {
         );
       });
 
+      test("disallows specifying cancellation with batching", () => {
+        inngest.createFunction(
+          {
+            name: "test",
+            batchEvents: { maxSize: 5, timeout: "5s" },
+            // @ts-expect-error Cannot specify cancellation with batching
+            cancelOn: [{ event: "test2" }],
+          },
+          { event: "test" },
+          () => {
+            // no-op
+          }
+        );
+      });
+
+      test("disallows specifying rate limit with batching", () => {
+        inngest.createFunction(
+          {
+            name: "test",
+            batchEvents: { maxSize: 5, timeout: "5s" },
+            // @ts-expect-error Cannot specify rate limit with batching
+            rateLimit: { limit: 5, period: "5s" },
+          },
+          { event: "test" },
+          () => {
+            // no-op
+          }
+        );
+      });
+
       test("allows trigger to be a string", () => {
         inngest.createFunction("test", "test", ({ event }) => {
           assertType<string>(event.name);

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -10,10 +10,9 @@ import {
 } from "../helpers/env";
 import { fixEventKeyMissingSteps, prettyError } from "../helpers/errors";
 import { stringify } from "../helpers/strings";
-import { type SendEventPayload } from "../helpers/types";
+import { type ExclusiveKeys, type SendEventPayload } from "../helpers/types";
 import { DefaultLogger, ProxyLogger, type Logger } from "../middleware/logger";
 import {
-  type ExclusiveKeys,
   type ClientOptions,
   type EventNameFromTrigger,
   type EventPayload,

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -13,6 +13,7 @@ import { stringify } from "../helpers/strings";
 import { type SendEventPayload } from "../helpers/types";
 import { DefaultLogger, ProxyLogger, type Logger } from "../middleware/logger";
 import {
+  type ExclusiveKeys,
   type ClientOptions,
   type EventNameFromTrigger,
   type EventPayload,
@@ -402,65 +403,69 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
   >(
     nameOrOpts:
       | string
-      | (Omit<
-          FunctionOptions<EventsFromOpts<TOpts>, TTriggerName>,
-          "fns" | "onFailure" | "middleware"
-        > & {
-          /**
-           * Pass in an object of functions that will be wrapped in Inngest
-           * tooling and passes to your handler. This wrapping ensures that each
-           * function is automatically separated and retried.
-           *
-           * @example
-           *
-           * Both examples behave the same; it's preference as to which you
-           * prefer.
-           *
-           * ```ts
-           * import { userDb } from "./db";
-           *
-           * // Specify `fns` and be able to use them in your Inngest function
-           * inngest.createFunction(
-           *   { name: "Create user from PR", fns: { ...userDb } },
-           *   { event: "github/pull_request" },
-           *   async ({ fns: { createUser } }) => {
-           *     await createUser("Alice");
-           *   }
-           * );
-           *
-           * // Or always use `run()` to run inline steps and use them directly
-           * inngest.createFunction(
-           *   { name: "Create user from PR" },
-           *   { event: "github/pull_request" },
-           *   async ({ step: { run } }) => {
-           *     await run("createUser", () => userDb.createUser("Alice"));
-           *   }
-           * );
-           * ```
-           */
-          fns?: TFns;
+      | ExclusiveKeys<
+          Omit<
+            FunctionOptions<EventsFromOpts<TOpts>, TTriggerName>,
+            "fns" | "onFailure" | "middleware"
+          > & {
+            /**
+             * Pass in an object of functions that will be wrapped in Inngest
+             * tooling and passes to your handler. This wrapping ensures that each
+             * function is automatically separated and retried.
+             *
+             * @example
+             *
+             * Both examples behave the same; it's preference as to which you
+             * prefer.
+             *
+             * ```ts
+             * import { userDb } from "./db";
+             *
+             * // Specify `fns` and be able to use them in your Inngest function
+             * inngest.createFunction(
+             *   { name: "Create user from PR", fns: { ...userDb } },
+             *   { event: "github/pull_request" },
+             *   async ({ fns: { createUser } }) => {
+             *     await createUser("Alice");
+             *   }
+             * );
+             *
+             * // Or always use `run()` to run inline steps and use them directly
+             * inngest.createFunction(
+             *   { name: "Create user from PR" },
+             *   { event: "github/pull_request" },
+             *   async ({ step: { run } }) => {
+             *     await run("createUser", () => userDb.createUser("Alice"));
+             *   }
+             * );
+             * ```
+             */
+            fns?: TFns;
 
-          /**
-           * Provide a function to be called if your function fails, meaning
-           * that it ran out of retries and was unable to complete successfully.
-           *
-           * This is useful for sending warning notifications or cleaning up
-           * after a failure and supports all the same functionality as a
-           * regular handler.
-           */
-          onFailure?: Handler<
-            TOpts,
-            EventsFromOpts<TOpts>,
-            TTriggerName,
-            TShimmedFns,
-            FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>
-          >;
+            /**
+             * Provide a function to be called if your function fails, meaning
+             * that it ran out of retries and was unable to complete successfully.
+             *
+             * This is useful for sending warning notifications or cleaning up
+             * after a failure and supports all the same functionality as a
+             * regular handler.
+             */
+            onFailure?: Handler<
+              TOpts,
+              EventsFromOpts<TOpts>,
+              TTriggerName,
+              TShimmedFns,
+              FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>
+            >;
 
-          /**
-           * TODO
-           */
-          middleware?: TMiddleware;
-        }),
+            /**
+             * TODO
+             */
+            middleware?: TMiddleware;
+          },
+          "batchEvents",
+          "cancelOn" | "rateLimit"
+        >,
     trigger: TTrigger,
     handler: Handler<
       TOpts,

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -155,3 +155,34 @@ export type ObjectAssign<TArr, TAcc = {}> = TArr extends [
 ]
   ? Simplify<ObjectAssign<TRest, Omit<TAcc, keyof TFirst> & TFirst>>
   : TAcc;
+
+/**
+ * Make a type's keys mutually exclusive.
+ *
+ * @example
+ * Make 1 key mutually exclusive with 1 other key.
+ *
+ * ```ts
+ * type MyType = ExclusiveKeys<{a: number, b: number}, "a", "b">
+ *
+ * const valid1: MyType = { a: 1 }
+ * const valid2: MyType = { b: 1 }
+ * const invalid1: MyType = { a: 1, b: 1 }
+ * ```
+ *
+ * @example
+ * Make 1 key mutually exclusive with 2 other keys.
+ *
+ * ```ts
+ * type MyType = ExclusiveKeys<{a: number, b: number, c: number}, "a", "b" | "c">
+ *
+ * const valid1: MyType = { a: 1 };
+ * const valid2: MyType = { b: 1, c: 1 };
+ * const invalid1: MyType = { a: 1, b: 1 };
+ * const invalid2: MyType = { a: 1, c: 1 };
+ * const invalid3: MyType = { a: 1, b: 1, c: 1 };
+ * ```
+ */
+export type ExclusiveKeys<T, Keys1 extends keyof T, Keys2 extends keyof T> =
+  | (Omit<T, Keys1> & { [K in Keys1]?: never })
+  | (Omit<T, Keys2> & { [K in Keys2]?: never });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1085,34 +1085,3 @@ export const fnDataSchema = z.object({
   use_api: z.boolean().default(false),
 });
 export type FnData = z.infer<typeof fnDataSchema>;
-
-/**
- * Make a type's keys mutually exclusive.
- *
- * @example
- * Make 1 key mutually exclusive with 1 other key.
- *
- * ```ts
- * type MyType = ExclusiveKeys<{a: number, b: number}, "a", "b">
- *
- * const valid1: MyType = { a: 1 }
- * const valid2: MyType = { b: 1 }
- * const invalid1: MyType = { a: 1, b: 1 }
- * ```
- *
- * @example
- * Make 1 key mutually exclusive with 2 other keys.
- *
- * ```ts
- * type MyType = ExclusiveKeys<{a: number, b: number, c: number}, "a", "b" | "c">
- *
- * const valid1: MyType = { a: 1 };
- * const valid2: MyType = { b: 1, c: 1 };
- * const invalid1: MyType = { a: 1, b: 1 };
- * const invalid2: MyType = { a: 1, c: 1 };
- * const invalid3: MyType = { a: 1, b: 1, c: 1 };
- * ```
- */
-export type ExclusiveKeys<T, Keys1 extends keyof T, Keys2 extends keyof T> =
-  | (Omit<T, Keys1> & { [K in Keys1]?: never })
-  | (Omit<T, Keys2> & { [K in Keys2]?: never });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1085,3 +1085,34 @@ export const fnDataSchema = z.object({
   use_api: z.boolean().default(false),
 });
 export type FnData = z.infer<typeof fnDataSchema>;
+
+/**
+ * Make a type's keys mutually exclusive.
+ *
+ * @example
+ * Make 1 key mutually exclusive with 1 other key.
+ *
+ * ```ts
+ * type MyType = ExclusiveKeys<{a: number, b: number}, "a", "b">
+ *
+ * const valid1: MyType = { a: 1 }
+ * const valid2: MyType = { b: 1 }
+ * const invalid1: MyType = { a: 1, b: 1 }
+ * ```
+ *
+ * @example
+ * Make 1 key mutually exclusive with 2 other keys.
+ *
+ * ```ts
+ * type MyType = ExclusiveKeys<{a: number, b: number, c: number}, "a", "b" | "c">
+ *
+ * const valid1: MyType = { a: 1 };
+ * const valid2: MyType = { b: 1, c: 1 };
+ * const invalid1: MyType = { a: 1, b: 1 };
+ * const invalid2: MyType = { a: 1, c: 1 };
+ * const invalid3: MyType = { a: 1, b: 1, c: 1 };
+ * ```
+ */
+export type ExclusiveKeys<T, Keys1 extends keyof T, Keys2 extends keyof T> =
+  | (Omit<T, Keys1> & { [K in Keys1]?: never })
+  | (Omit<T, Keys2> & { [K in Keys2]?: never });


### PR DESCRIPTION
# Description

Add type errors to `createFunction` when combining batching with unsupported features. We don't support rate limiting or cancellation when batching is enabled ([docs](https://www.inngest.com/docs/guides/batching)).