### PR TITLE
Fix: Use fetch helper for environment and testing support

### DIFF
--- a/.changeset/brave-frogs-beg.md
+++ b/.changeset/brave-frogs-beg.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `cross-fetch` import issue in testing environemtnst. API package also uses custom `fetch` passed via arguments.

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,6 @@
-import { fetch } from "cross-fetch";
 import { type Result, ok, err } from "../types";
 import { hashSigningKey } from "../helpers/strings";
+import { getFetch } from "../helpers/env";
 import {
   ErrorSchema,
   type ErrorResponse,
@@ -10,21 +10,27 @@ import {
   type BatchResponse,
 } from "./schema";
 
+type FetchT = typeof fetch;
+
 interface InngestApiConstructorOpts {
   baseUrl?: string;
   signingKey: string;
+  fetch?: FetchT;
 }
 
 export class InngestApi {
   public readonly baseUrl: string;
   private signingKey: string;
+  private readonly fetch: FetchT;
 
   constructor({
     baseUrl = "https://api.inngest.com",
     signingKey,
+    fetch,
   }: InngestApiConstructorOpts) {
     this.baseUrl = baseUrl;
     this.signingKey = signingKey;
+    this.fetch = getFetch(fetch);
   }
 
   private get hashedKey(): string {
@@ -43,7 +49,7 @@ export class InngestApi {
   ): Promise<Result<StepsResponse, ErrorResponse>> {
     const url = new URL(`/v0/runs/${runId}/actions`, this.baseUrl);
 
-    return fetch(url, {
+    return this.fetch(url, {
       headers: { Authorization: `Bearer ${this.hashedKey}` },
     })
       .then(async (resp) => {
@@ -65,7 +71,7 @@ export class InngestApi {
   ): Promise<Result<BatchResponse, ErrorResponse>> {
     const url = new URL(`/v0/runs/${runId}/batch`, this.baseUrl);
 
-    return fetch(url, {
+    return this.fetch(url, {
       headers: { Authorization: `Bearer ${this.hashedKey}` },
     })
       .then(async (resp) => {

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -165,15 +165,16 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     this.headers = inngestHeaders({
       inngestEnv: env,
     });
+    this.fetch = getFetch(fetch);
 
     const signingKey = processEnv(envKeys.SigningKey) || "";
     this.inngestApi = new InngestApi({
       baseUrl:
         processEnv(envKeys.InngestApiBaseUrl) || "https://api.inngest.com",
       signingKey: signingKey,
+      fetch: this.fetch,
     });
 
-    this.fetch = getFetch(fetch);
     this.logger = logger;
 
     this.middleware = this.initializeMiddleware([


### PR DESCRIPTION
## Description

This re-uses the `getFetch` helper to mirror the way that the rest of the SDK selects what `fetch` to use or use `cross-fetch`. This also will allow folks passing their own `fetch` implementation of their choosing to use that same implementation with the `InngestApi` class for testing purposes.

This helps with two things:
- Allows the user to pass their own fetch implementation or mock during testing.
- Better support fetch in different environments like edge

[Original report from community](https://discord.com/channels/842170679536517141/1135910511616208988/1135910511616208988)