### PR TITLE
Add typing and tests for middleware in `onFailure` functions

### DIFF
--- a/.changeset/new-poems-serve.md
+++ b/.changeset/new-poems-serve.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `onFailure` functions missing types applied by middleware

--- a/etc/inngest.api.md
+++ b/etc/inngest.api.md
@@ -132,7 +132,7 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     // Warning: (ae-forgotten-export) The symbol "ShimmedFns" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ExclusiveKeys" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Handler" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "MiddlewareStackRunInputMutation" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ExtendWithMiddleware" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "builtInMiddleware" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "InngestFunction" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "FunctionTrigger" needs to be exported by the entry point index.d.ts
@@ -140,9 +140,17 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     // (undocumented)
     createFunction<TFns extends Record<string, unknown>, TMiddleware extends MiddlewareStack, TTrigger extends TriggerOptions<keyof EventsFromOpts<TOpts> & string>, TShimmedFns extends Record<string, (...args: any[]) => any> = ShimmedFns<TFns>, TTriggerName extends keyof EventsFromOpts<TOpts> & string = EventNameFromTrigger<EventsFromOpts<TOpts>, TTrigger>>(nameOrOpts: string | ExclusiveKeys<Omit<FunctionOptions<EventsFromOpts<TOpts>, TTriggerName>, "fns" | "onFailure" | "middleware"> & {
         fns?: TFns;
-        onFailure?: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>>;
+        onFailure?: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, ExtendWithMiddleware<[
+        typeof builtInMiddleware,
+        NonNullable<TOpts["middleware"]>,
+        TMiddleware
+        ], FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>>>;
         middleware?: TMiddleware;
-    }, "batchEvents", "cancelOn" | "rateLimit">, trigger: TTrigger, handler: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, MiddlewareStackRunInputMutation<{}, typeof builtInMiddleware> & MiddlewareStackRunInputMutation<{}, NonNullable<TOpts["middleware"]>> & MiddlewareStackRunInputMutation<{}, TMiddleware>>): InngestFunction<TOpts, EventsFromOpts<TOpts>, FunctionTrigger<keyof EventsFromOpts<TOpts> & string>, FunctionOptions<EventsFromOpts<TOpts>, keyof EventsFromOpts<TOpts> & string>>;
+    }, "batchEvents", "cancelOn" | "rateLimit">, trigger: TTrigger, handler: Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, TShimmedFns, ExtendWithMiddleware<[
+    typeof builtInMiddleware,
+    NonNullable<TOpts["middleware"]>,
+    TMiddleware
+    ]>>): InngestFunction<TOpts, EventsFromOpts<TOpts>, FunctionTrigger<keyof EventsFromOpts<TOpts> & string>, FunctionOptions<EventsFromOpts<TOpts>, keyof EventsFromOpts<TOpts> & string>>;
     readonly inngestBaseUrl: URL;
     readonly name: string;
     // Warning: (ae-forgotten-export) The symbol "SendEventPayload" needs to be exported by the entry point index.d.ts

--- a/src/components/Inngest.ts
+++ b/src/components/Inngest.ts
@@ -29,10 +29,10 @@ import { InngestFunction } from "./InngestFunction";
 import {
   InngestMiddleware,
   getHookStack,
+  type ExtendWithMiddleware,
   type MiddlewareOptions,
   type MiddlewareRegisterFn,
   type MiddlewareRegisterReturn,
-  type MiddlewareStackRunInputMutation,
 } from "./InngestMiddleware";
 
 /**
@@ -455,7 +455,14 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
               EventsFromOpts<TOpts>,
               TTriggerName,
               TShimmedFns,
-              FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>
+              ExtendWithMiddleware<
+                [
+                  typeof builtInMiddleware,
+                  NonNullable<TOpts["middleware"]>,
+                  TMiddleware
+                ],
+                FailureEventArgs<EventsFromOpts<TOpts>[TTriggerName]>
+              >
             >;
 
             /**
@@ -472,12 +479,13 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
       EventsFromOpts<TOpts>,
       TTriggerName,
       TShimmedFns,
-      // eslint-disable-next-line @typescript-eslint/ban-types
-      MiddlewareStackRunInputMutation<{}, typeof builtInMiddleware> &
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        MiddlewareStackRunInputMutation<{}, NonNullable<TOpts["middleware"]>> &
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        MiddlewareStackRunInputMutation<{}, TMiddleware>
+      ExtendWithMiddleware<
+        [
+          typeof builtInMiddleware,
+          NonNullable<TOpts["middleware"]>,
+          TMiddleware
+        ]
+      >
     >
   ): InngestFunction<
     TOpts,

--- a/src/components/InngestMiddleware.test.ts
+++ b/src/components/InngestMiddleware.test.ts
@@ -27,9 +27,18 @@ describe("stacking and inference", () => {
         const inngest = new Inngest({ name: "test", middleware: [mw] });
 
         test("input context has value", () => {
-          inngest.createFunction({ name: "" }, { event: "" }, (ctx) => {
-            assertType<IsEqual<(typeof ctx)["foo"], string>>(true);
-          });
+          inngest.createFunction(
+            {
+              name: "",
+              onFailure: (ctx) => {
+                assertType<IsEqual<(typeof ctx)["foo"], string>>(true);
+              },
+            },
+            { event: "" },
+            (ctx) => {
+              assertType<IsEqual<(typeof ctx)["foo"], string>>(true);
+            }
+          );
         });
       });
 
@@ -54,9 +63,18 @@ describe("stacking and inference", () => {
         const inngest = new Inngest({ name: "test", middleware: [mw] });
 
         test("input context has value", () => {
-          inngest.createFunction({ name: "" }, { event: "" }, (ctx) => {
-            assertType<IsEqual<(typeof ctx)["foo"], "bar">>(true);
-          });
+          inngest.createFunction(
+            {
+              name: "",
+              onFailure: (ctx) => {
+                assertType<IsEqual<(typeof ctx)["foo"], "bar">>(true);
+              },
+            },
+            { event: "" },
+            (ctx) => {
+              assertType<IsEqual<(typeof ctx)["foo"], "bar">>(true);
+            }
+          );
         });
       });
 
@@ -81,9 +99,18 @@ describe("stacking and inference", () => {
         const inngest = new Inngest({ name: "test", middleware: [mw] });
 
         test("input context has value", () => {
-          inngest.createFunction({ name: "" }, { event: "" }, (ctx) => {
-            assertType<IsEqual<(typeof ctx)["event"], boolean>>(true);
-          });
+          inngest.createFunction(
+            {
+              name: "",
+              onFailure: (ctx) => {
+                assertType<IsEqual<(typeof ctx)["event"], boolean>>(true);
+              },
+            },
+            { event: "" },
+            (ctx) => {
+              assertType<IsEqual<(typeof ctx)["event"], boolean>>(true);
+            }
+          );
         });
       });
 
@@ -125,15 +152,33 @@ describe("stacking and inference", () => {
         const inngest = new Inngest({ name: "test", middleware: [mw1, mw2] });
 
         test("input context has foo value", () => {
-          inngest.createFunction({ name: "" }, { event: "" }, (ctx) => {
-            assertType<IsEqual<(typeof ctx)["foo"], string>>(true);
-          });
+          inngest.createFunction(
+            {
+              name: "",
+              onFailure: (ctx) => {
+                assertType<IsEqual<(typeof ctx)["foo"], string>>(true);
+              },
+            },
+            { event: "" },
+            (ctx) => {
+              assertType<IsEqual<(typeof ctx)["foo"], string>>(true);
+            }
+          );
         });
 
         test("input context has bar value", () => {
-          inngest.createFunction({ name: "" }, { event: "" }, (ctx) => {
-            assertType<IsEqual<(typeof ctx)["bar"], boolean>>(true);
-          });
+          inngest.createFunction(
+            {
+              name: "",
+              onFailure: (ctx) => {
+                assertType<IsEqual<(typeof ctx)["bar"], boolean>>(true);
+              },
+            },
+            { event: "" },
+            (ctx) => {
+              assertType<IsEqual<(typeof ctx)["bar"], boolean>>(true);
+            }
+          );
         });
       });
 
@@ -175,9 +220,18 @@ describe("stacking and inference", () => {
         const inngest = new Inngest({ name: "test", middleware: [mw1, mw2] });
 
         test("input context has new value", () => {
-          inngest.createFunction({ name: "" }, { event: "" }, (ctx) => {
-            assertType<IsEqual<(typeof ctx)["foo"], boolean>>(true);
-          });
+          inngest.createFunction(
+            {
+              name: "",
+              onFailure: (ctx) => {
+                assertType<IsEqual<(typeof ctx)["foo"], boolean>>(true);
+              },
+            },
+            { event: "" },
+            (ctx) => {
+              assertType<IsEqual<(typeof ctx)["foo"], boolean>>(true);
+            }
+          );
         });
       });
     });

--- a/src/components/InngestMiddleware.ts
+++ b/src/components/InngestMiddleware.ts
@@ -501,6 +501,24 @@ type GetMiddlewareRunInputMutation<
 /**
  * @internal
  */
+export type ExtendWithMiddleware<
+  TMiddlewareStacks extends MiddlewareStack[],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  TContext = {}
+> = ObjectAssign<
+  {
+    [K in keyof TMiddlewareStacks]: MiddlewareStackRunInputMutation<
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      {},
+      TMiddlewareStacks[K]
+    >;
+  },
+  TContext
+>;
+
+/**
+ * @internal
+ */
 export type MiddlewareStackRunInputMutation<
   TContext,
   TMiddleware extends MiddlewareStack


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds typing for applied middlware to `onFailure` functions, including tests.

Closes #279.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Closes #279
