### PR TITLE
Add `attempt` number to SDK function context

### DIFF
--- a/.changeset/slimy-rats-shake.md
+++ b/.changeset/slimy-rats-shake.md
@@ -1,0 +1,15 @@
+---
+"inngest": minor
+---
+
+Add `attempt` number to SDK function context
+
+```ts
+inngest.createFunction(
+  { name: "Example Function" },
+  { event: "app/user.created" },
+  async ({ attempt }) => {
+    // ...
+  }
+);
+```

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -348,7 +348,7 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:332:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:342:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
 // src/types.ts:51:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:678:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:685:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -400,6 +400,25 @@ describe("send", () => {
 
 describe("createFunction", () => {
   describe("types", () => {
+    describe("function input", () => {
+      const inngest = createClient({ name: "test" });
+
+      test("has attempt number", () => {
+        inngest.createFunction(
+          {
+            name: "test",
+            onFailure: ({ attempt }) => {
+              assertType<number>(attempt);
+            },
+          },
+          { event: "test" },
+          ({ attempt }) => {
+            assertType<number>(attempt);
+          }
+        );
+      });
+    });
+
     describe("no custom types", () => {
       const inngest = createClient({ name: "test" });
 

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -774,7 +774,7 @@ export class InngestCommHandler<
           }) ?? [];
 
       const ret = await fn.fn["runFn"](
-        { event, events, runId: ctx?.run_id },
+        { event, events, runId: ctx?.run_id, attempt: ctx?.attempt },
         opStack,
         /**
          * TODO The executor is sending `"step"` as the step ID when it is not

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -268,7 +268,7 @@ export class InngestFunction<
           Record<string, (...args: unknown[]) => unknown>
         >
       >,
-      "event" | "events" | "runId"
+      "event" | "events" | "runId" | "attempt"
     >;
 
     const hookStack = await getHookStack(

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -230,6 +230,13 @@ export type BaseContext<
    * ```
    */
   fns: TShimmedFns;
+
+  /**
+   * The current zero-indexed attempt number for this function execution. The
+   * first attempt will be `0`, the second `1`, and so on. The attempt number
+   * is incremented every time the function throws an error and is retried.
+   */
+  attempt: number;
 };
 
 /**
@@ -1078,6 +1085,7 @@ export const fnDataSchema = z.object({
   ctx: z
     .object({
       run_id: z.string(),
+      attempt: z.number().default(0),
       stack: z
         .object({
           stack: z


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds an `attempt` number to SDK function context. It is described as:

> The current zero-indexed attempt number for this function execution. The first attempt will be `0`, the second `1`, and so on. The attempt number is incremented every time the function throws an error and is retried.

```ts
inngest.createFunction(
  { name: "Example Function" },
  { event: "app/user.created" },
  async ({ attempt }) => {
    // ...
  }
);
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-1917
- inngest/website#477
