### PR TITLE
Reveal `key` in `concurrency` options

### DIFF
--- a/.changeset/famous-experts-explain.md
+++ b/.changeset/famous-experts-explain.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add `key` to `concurrency` types

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -90,6 +90,7 @@ export interface FunctionOptions<Events extends Record<string, EventPayload>, Ev
     cancelOn?: Cancellation<Events, Event>[];
     concurrency?: number | {
         limit: number;
+        key?: string;
     };
     // (undocumented)
     fns?: Record<string, unknown>;

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -662,7 +662,7 @@ export interface FunctionOptions<
    *
    * Specifying just a number means specifying only the concurrency limit.
    */
-  concurrency?: number | { limit: number };
+  concurrency?: number | { limit: number; key?: string };
 
   /**
    * batchEvents specifies the batch configuration on when this function


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Reveals the `key` option when setting `concurrency`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable
