### PR TITLE
Add ability to provide Zod schemas using objects and literals

### DIFF
--- a/.changeset/warm-lemons-tan.md
+++ b/.changeset/warm-lemons-tan.md
@@ -1,0 +1,49 @@
+---
+"inngest": minor
+---
+
+Add the ability to provide Zod schemas using `z.object()` instead of requiring a record format
+
+```ts
+// Previously we supported this
+new EventSchemas().fromZod({
+  "test.event": {
+    data: z.object({ a: z.string() }),
+    user: z.object({ b: z.number() }),
+  },
+});
+
+// Now we ALSO support this
+new EventSchemas().fromZod([
+  z.object({
+    name: z.literal("test.event"),
+    data: z.object({ a: z.string() }),
+    user: z.object({ b: z.number() }),
+  }),
+]);
+```
+
+This should help if you wish to declare your events piece-by-piece instead of in a single object.
+
+```ts
+const firstEvent = z.object({
+  name: z.literal("app/user.created"),
+  data: z.object({ id: z.string() }),
+});
+
+const secondEvent = z.object({
+  name: z.literal("shop/product.deleted"),
+  data: z.object({ id: z.string() }),
+});
+
+new EventSchemas().fromZod([firstEvent, secondEvent]);
+```
+
+You can use the exported `LiteralZodEventSchema` type to provide some autocomplete when writing your events, too.
+
+```ts
+const ShopProductOrdered = z.object({
+  name: z.literal("shop/product.ordered"),
+  data: z.object({ productId: z.string() }),
+}) satisfies LiteralZodEventSchema;
+```

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -55,7 +55,13 @@ export class EventSchemas<S extends Record<string, EventPayload>> {
     } & StandardEventSchema>(): EventSchemas<Combine<S, { [K in T["name"]]: Extract<T, {
             name: K;
         }>; }>>;
-    fromZod<T extends ZodEventSchemas>(schemas: T): EventSchemas<Combine<S, { [EventName in keyof T & string]: { [Key in keyof T[EventName] & string]: T[EventName][Key] extends z.ZodTypeAny ? z.TypeOf<T[EventName][Key]> : T[EventName][Key]; }; }>>;
+    // Warning: (ae-forgotten-export) The symbol "LiteralZodEventSchemas" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ExcludeEmptyZodLiterals" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ZodToStandardSchema" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "PickLiterals" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "GetName" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "InferZodShape" needs to be exported by the entry point index.d.ts
+    fromZod<T extends ZodEventSchemas | LiteralZodEventSchemas>(schemas: ExcludeEmptyZodLiterals<T>): EventSchemas<Combine<S, ZodToStandardSchema<T extends ZodEventSchemas ? T : PickLiterals<T extends LiteralZodEventSchemas ? T extends infer T_1 extends LiteralZodEventSchemas ? { [I in keyof T_1 as GetName<T[I]>]: InferZodShape<T[I]>; } : never : T extends ZodEventSchemas ? T : never>>>>;
 }
 
 // @public
@@ -230,6 +236,13 @@ export enum internalEvents {
 //
 // @internal
 export type IsStringLiteral<T extends string> = string extends T ? false : true;
+
+// @public
+export type LiteralZodEventSchema = z.ZodObject<{
+    name: z.ZodLiteral<string>;
+    data: z.AnyZodObject | z.ZodAny;
+    user?: z.AnyZodObject | z.ZodAny;
+}>;
 
 // @public
 export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "silent";

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -25,6 +25,33 @@ export type StandardEventSchema = {
 export type StandardEventSchemas = Record<string, StandardEventSchema>;
 
 /**
+ * A helper type that ensures users cannot declare a literal Zod schema with
+ * an empty string as the event name.
+ *
+ * @public
+ */
+export type ExcludeEmptyZodLiterals<T> = T extends LiteralZodEventSchemas
+  ? {
+      [I in keyof T]: T[I] extends z.ZodObject<infer U extends z.ZodRawShape>
+        ? U extends { name: z.ZodLiteral<""> }
+          ? "ERROR: Empty event names are now allowed."
+          : T[I]
+        : never;
+    }
+  : T;
+
+/**
+ * An array of literal zod event schemas.
+ *
+ * @public
+ */
+export type LiteralZodEventSchemas = z.ZodObject<{
+  name: z.ZodLiteral<string>;
+  data: z.AnyZodObject | z.ZodAny;
+  user?: z.AnyZodObject | z.ZodAny;
+}>[];
+
+/**
  * A helper type that declares a standardised custom part of the event schema,
  * defined using Zod.
  *
@@ -37,6 +64,66 @@ export type ZodEventSchemas = Record<
     user?: z.AnyZodObject | z.ZodAny;
   }
 >;
+
+/**
+ * A helper type that takes a union of Zod schemas and extracts the literal
+ * matching event from the given schemas. Required when picking out types from
+ * a union that require inference to work.
+ *
+ * @public
+ */
+export type PickLiterals<T> = {
+  [K in keyof T]: Extract<T[K], { name: z.ZodLiteral<K> }>;
+};
+
+/**
+ * A helper type to extract the name from a given literal Zod schema.
+ *
+ * @public
+ */
+export type GetName<T> = T extends z.ZodObject<infer U extends z.ZodRawShape>
+  ? U extends { name: z.ZodLiteral<infer S extends string> }
+    ? S
+    : never
+  : never;
+
+/**
+ * Given an input T, infer the shape of the Zod schema if that input is a Zod
+ * object.
+ *
+ * @public
+ */
+export type InferZodShape<T> = T extends z.AnyZodObject ? T["shape"] : never;
+
+/**
+ * Given a set of literal Zod schemas, convert them into a record of Zod schemas
+ * with the literal name as the key.
+ *
+ * @public
+ */
+export type LiteralToRecordZodSchemas<T> = PickLiterals<
+  T extends LiteralZodEventSchemas
+    ? {
+        [I in keyof T as GetName<T[I]>]: InferZodShape<T[I]>;
+      }
+    : T extends ZodEventSchemas
+    ? T
+    : never
+>;
+
+/**
+ * Given a set of Zod schemas in a record format, convert them into a standard
+ * event schema format.
+ *
+ * @public
+ */
+export type ZodToStandardSchema<T extends ZodEventSchemas> = {
+  [EventName in keyof T & string]: {
+    [Key in keyof T[EventName] & string]: T[EventName][Key] extends z.ZodTypeAny
+      ? z.infer<T[EventName][Key]>
+      : T[EventName][Key];
+  };
+};
 
 /**
  * A helper type to convert input schemas into the format expected by the
@@ -187,19 +274,16 @@ export class EventSchemas<S extends Record<string, EventPayload>> {
    * });
    * ```
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public fromZod<T extends ZodEventSchemas>(schemas: T) {
+  public fromZod<T extends ZodEventSchemas | LiteralZodEventSchemas>(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    schemas: ExcludeEmptyZodLiterals<T>
+  ) {
     return new EventSchemas<
       Combine<
         S,
-        {
-          [EventName in keyof T & string]: {
-            [Key in keyof T[EventName] &
-              string]: T[EventName][Key] extends z.ZodTypeAny
-              ? z.infer<T[EventName][Key]>
-              : T[EventName][Key];
-          };
-        }
+        ZodToStandardSchema<
+          T extends ZodEventSchemas ? T : LiteralToRecordZodSchemas<T>
+        >
       >
     >();
   }

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -41,15 +41,24 @@ export type ExcludeEmptyZodLiterals<T> = T extends LiteralZodEventSchemas
   : T;
 
 /**
+ * A literal Zod schema, which is a Zod schema that has a literal string as the
+ * event name. This can be used to create correct Zod schemas outside of the
+ * `EventSchemas` class.
+ *
+ * @public
+ */
+export type LiteralZodEventSchema = z.ZodObject<{
+  name: z.ZodLiteral<string>;
+  data: z.AnyZodObject | z.ZodAny;
+  user?: z.AnyZodObject | z.ZodAny;
+}>;
+
+/**
  * An array of literal zod event schemas.
  *
  * @public
  */
-export type LiteralZodEventSchemas = z.ZodObject<{
-  name: z.ZodLiteral<string>;
-  data: z.AnyZodObject | z.ZodAny;
-  user?: z.AnyZodObject | z.ZodAny;
-}>[];
+export type LiteralZodEventSchemas = LiteralZodEventSchema[];
 
 /**
  * A helper type that declares a standardised custom part of the event schema,

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -1,9 +1,10 @@
 export {
-  Combine,
   EventSchemas,
-  StandardEventSchemaToPayload,
-  StandardEventSchemas,
-  ZodEventSchemas,
+  type Combine,
+  type LiteralZodEventSchema,
+  type StandardEventSchemaToPayload,
+  type StandardEventSchemas,
+  type ZodEventSchemas,
 } from "./components/EventSchemas";
 export { Inngest } from "./components/Inngest";
 export type { EventsFromOpts } from "./components/Inngest";


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds the ability to provide Zod schemas using `z.object()` instead of requiring a record format.

```ts
// Previously we supported this
new EventSchemas().fromZod({
  "test.event": {
    data: z.object({ a: z.string() }),
    user: z.object({ b: z.number() }),
  },
});

// Now we ALSO support this
new EventSchemas().fromZod([
  z.object({
    name: z.literal("test.event"),
    data: z.object({ a: z.string() }),
    user: z.object({ b: z.number() }),
  }),
]);
```

This should help users that wish to declare their events piece-by-piece instead of in a single object.

```ts
const firstEvent = z.object({
  name: z.literal("app/user.created"),
  data: z.object({ id: z.string() }),
});

const secondEvent = z.object({
  name: z.literal("shop/product.deleted"),
  data: z.object({ id: z.string() }),
});

new EventSchemas().fromZod([firstEvent, secondEvent]);
```

This _does_ encourage folks to want to share the event schemas manually and use `z.infer` to understand payload shape, but we should still encourage use of `GetEvents` where possible.

```ts
const inngest = new Inngest({
  name: "My App",
  schemas: new EventSchemas().fromZod([firstEvent, secondEvent]),
});

type Events = GetEvents<typeof inngest>;
type ShopProductDeletedEvent = Events["shop/product.deleted"];
```

There's a new type exported, `LiteralZodEventSchema`, that can be used to ensure your Zod schema matches what's expected without having to use `new EventSchemas()`. Not sure why you'd immediately need this, but it's there in case folks want to feel extra safe and can provide some autocomplete when defining events outside.

![image](https://github.com/inngest/inngest-js/assets/1736957/bcfee32c-008e-4cc9-9eed-c3f06e1c2168)

We also have a cheeky error for empty names, to ensure folks don't cause a problem for themselves.

![image](https://github.com/inngest/inngest-js/assets/1736957/0ee7fb75-563c-4861-9fb4-cc2bb8dafda9)

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- inngest/website#479
