### PR TITLE
Remove `preinstall` script from `inngest` package - d'oh!

### DIFF
--- a/.changeset/beige-hotels-deliver.md
+++ b/.changeset/beige-hotels-deliver.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove `preinstall` script from `inngest` package causing errors when consuming the package

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -8,7 +8,6 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "prebuild": "pnpm run pb:version",
     "pb:version": "genversion --semi --double --es6 ./src/version.ts",
     "build": "pnpm run clean && tsc --project tsconfig.build.json",


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Remove `preinstall` script from `inngest` causing installation failures when consuming the package.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Hotfix
- [ ] ~~Added unit/integration tests~~ N/A Package fix
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Closes #301
