### PR TITLE
Override dev server access if `INNGEST_DEVSERVER_URL` is specified

### DIFF
--- a/.changeset/twelve-geese-shave.md
+++ b/.changeset/twelve-geese-shave.md
@@ -1,0 +1,7 @@
+---
+"inngest": patch
+---
+
+Always attempt accessing the dev server if the `INNGEST_DEVSERVER_URL` environment variable is specified
+
+This helps some situations where a user may want to run integration tests against a deployed or otherwise production build, using the Inngest Dev Server to do so.

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -6,6 +6,7 @@ import { envKeys, headerKeys, queryKeys } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import {
   allProcessEnv,
+  devServerHost,
   getFetch,
   inngestHeaders,
   isProd,
@@ -621,8 +622,15 @@ export class InngestCommHandler<
       });
 
     this._isProd = actions.isProduction ?? isProd(env);
-    // If we're in production always skip.
+
     this._skipDevServer = this._isProd ?? skipDevServer(env);
+    /**
+     * If we've been explicitly passed an Inngest dev sever URL, assume that
+     * we shouldn't skip the dev server.
+     */
+    if (devServerHost(env)) {
+      this._skipDevServer = false;
+    }
 
     try {
       const runRes = await actions.run();

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -623,14 +623,13 @@ export class InngestCommHandler<
 
     this._isProd = actions.isProduction ?? isProd(env);
 
-    this._skipDevServer = this._isProd ?? skipDevServer(env);
     /**
      * If we've been explicitly passed an Inngest dev sever URL, assume that
      * we shouldn't skip the dev server.
      */
-    if (devServerHost(env)) {
-      this._skipDevServer = false;
-    }
+    this._skipDevServer = devServerHost(env)
+      ? false
+      : this._isProd ?? skipDevServer(env);
 
     try {
       const runRes = await actions.run();

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -17,7 +17,9 @@ import { stringifyUnknown } from "./strings";
  *
  * @example devServerHost()
  */
-export const devServerHost = (): string | undefined => {
+export const devServerHost = (
+  env: Record<string, unknown> = allProcessEnv()
+): string | undefined => {
   // devServerKeys are the env keys we search for to discover the dev server
   // URL.  This includes the standard key first, then includes prefixed keys
   // for use within common frameworks (eg. CRA, next).
@@ -27,12 +29,12 @@ export const devServerHost = (): string | undefined => {
   // text replacement instead of actually understanding the AST, despite webpack
   // being fully capable of understanding the AST.
   const values = [
-    processEnv(envKeys.DevServerUrl),
-    processEnv("REACT_APP_INNGEST_DEVSERVER_URL"),
-    processEnv("NEXT_PUBLIC_INNGEST_DEVSERVER_URL"),
+    env[envKeys.DevServerUrl],
+    env["REACT_APP_INNGEST_DEVSERVER_URL"],
+    env["NEXT_PUBLIC_INNGEST_DEVSERVER_URL"],
   ];
 
-  return values.find((a) => !!a);
+  return values.find((a) => !!a) as string;
 };
 
 const checkFns = (<

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -446,7 +446,6 @@ export const testFramework = (
             [envKeys.DevServerUrl]: testDevServerHost,
             NODE_ENV: "production",
             ENVIRONMENT: "production",
-            CONTEXT: "production",
           });
 
           expect(devServerCalled).toBe(true);

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -430,6 +430,27 @@ export const testFramework = (
             ],
           });
         });
+
+        test("still access dev server if URL passed as environment variable", async () => {
+          const testDevServerHost = "https://exampledevserver.com";
+          let devServerCalled = false;
+
+          nock(testDevServerHost)
+            .get("/dev", (body) => {
+              devServerCalled = true;
+              return body;
+            })
+            .reply(500, { status: 500 });
+
+          await run([inngest, []], [{ method: "PUT" }], {
+            [envKeys.DevServerUrl]: testDevServerHost,
+            NODE_ENV: "production",
+            ENVIRONMENT: "production",
+            CONTEXT: "production",
+          });
+
+          expect(devServerCalled).toBe(true);
+        });
       });
 
       describe("env detection and headers", () => {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

If the `INNGEST_DEVSERVER_URL` environment variable is set, ensure accessing the dev server is always attempted. This helps test production builds against a local dev server for integration testing.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A We need an "Environment variables" page
- [x] Added unit/integration tests
- [x] Added changesets if applicable
