### PR TITLE
Add ability to declare and send events without payloads

### DIFF
--- a/.changeset/three-mirrors-vanish.md
+++ b/.changeset/three-mirrors-vanish.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add ability to declare and send events without payloads, e.g. `inngest.send({ name: "my.event" });`

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -38,7 +38,7 @@ export type EventNameFromTrigger<Events extends Record<string, EventPayload>, T 
 
 // @public
 export interface EventPayload {
-    data: any;
+    data?: any;
     name: string;
     ts?: number;
     user?: any;
@@ -240,7 +240,7 @@ export type IsStringLiteral<T extends string> = string extends T ? false : true;
 // @public
 export type LiteralZodEventSchema = z.ZodObject<{
     name: z.ZodLiteral<string>;
-    data: z.AnyZodObject | z.ZodAny;
+    data?: z.AnyZodObject | z.ZodAny;
     user?: z.AnyZodObject | z.ZodAny;
 }>;
 
@@ -349,7 +349,7 @@ export type TimeStr = `${`${number}w` | ""}${`${number}d` | ""}${`${number}h` | 
 
 // @public
 export type ZodEventSchemas = Record<string, {
-    data: z.AnyZodObject | z.ZodAny;
+    data?: z.AnyZodObject | z.ZodAny;
     user?: z.AnyZodObject | z.ZodAny;
 }>;
 

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -12,7 +12,7 @@ import { type EventPayload } from "../types";
  */
 export type StandardEventSchema = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: Record<string, any>;
+  data?: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   user?: Record<string, any>;
 };
@@ -49,7 +49,7 @@ export type ExcludeEmptyZodLiterals<T> = T extends LiteralZodEventSchemas
  */
 export type LiteralZodEventSchema = z.ZodObject<{
   name: z.ZodLiteral<string>;
-  data: z.AnyZodObject | z.ZodAny;
+  data?: z.AnyZodObject | z.ZodAny;
   user?: z.AnyZodObject | z.ZodAny;
 }>;
 
@@ -69,7 +69,7 @@ export type LiteralZodEventSchemas = LiteralZodEventSchema[];
 export type ZodEventSchemas = Record<
   string,
   {
-    data: z.AnyZodObject | z.ZodAny;
+    data?: z.AnyZodObject | z.ZodAny;
     user?: z.AnyZodObject | z.ZodAny;
   }
 >;

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -358,6 +358,7 @@ describe("send", () => {
           bar: {
             data: { bar: string };
           };
+          // eslint-disable-next-line @typescript-eslint/ban-types
           baz: {};
         }>(),
       });

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -338,11 +338,16 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
       payloads = [...inputChanges.payloads];
     }
 
-    // Ensure that we always add a "ts" field to events.  This is auto-filled by the
-    // event server so is safe, and adding here fixes Next.js server action cache issues.
-    payloads = payloads.map((p) =>
-      p.ts ? p : { ...p, ts: new Date().getTime() }
-    );
+    // Ensure that we always add "ts" and "data" fields to events. "ts" is auto-
+    // filled by the event server so is safe, and adding here fixes Next.js
+    // server action cache issues.
+    payloads = payloads.map((p) => {
+      return {
+        ...p,
+        ts: p.ts || new Date().getTime(),
+        data: p.data || {},
+      };
+    });
 
     /**
      * It can be valid for a user to send an empty list of events; if this

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -345,6 +345,7 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
       return {
         ...p,
         ts: p.ts || new Date().getTime(),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data: p.data || {},
       };
     });

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -313,7 +313,7 @@ export interface EventPayload {
    * Any data pertinent to the event
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any;
+  data?: any;
 
   /**
    * Any user data associated with the event


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add the ability to declare and send events without payloads. It's possible for some events to rightfully have no payload, in which case just the name can suffice.

```ts
// Previously would have failed
inngest.send({ name: "my.event" });

// Typing a no-data event means providing an empty object
new EventSchemas()
  .fromRecord<{ "my.event": {} }>()
  .fromUnion<{ name: "my.event" }>()
  .fromZod({ "my.event": {} })
  .fromZod([z.object({ name: z.literal("my.event") })]);
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A No need to directly recommend this
- [x] Added unit/integration tests
- [x] Added changesets if applicable
