### PR TITLE
Add support for step-based `Promise.race()`

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -786,6 +786,7 @@ export class InngestCommHandler<
       timer,
       isFailureHandler: fn.onFailure,
       disableImmediateExecution: fndata.value.disable_immediate_execution,
+      stepCompletionOrder: ctx?.stack?.stack ?? [],
     });
 
     return execution.start();

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -808,7 +808,7 @@ describe("runFn", () => {
         AWins: "A wins",
         BWins: "B wins",
       },
-      ({ A, B, B2, AWins, BWins }) => ({
+      ({ A, B, B2, BWins }) => ({
         "if B chain wins without 'A', reports 'A' and 'B wins' steps": {
           stack: { [B]: { id: B, data: "B" }, [B2]: { id: B2, data: "B2" } },
           expectedReturn: {

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -109,6 +109,7 @@ describe("runFn", () => {
             const execution = fn["createExecution"]({
               data: { event: { name: "foo", data: { foo: "foo" } } },
               stepState: {},
+              stepCompletionOrder: [],
             });
 
             ret = await execution.start();
@@ -146,6 +147,7 @@ describe("runFn", () => {
             const execution = fn["createExecution"]({
               data: { event: { name: "foo", data: { foo: "foo" } } },
               stepState: {},
+              stepCompletionOrder: [],
             });
 
             const ret = await execution.start();
@@ -170,12 +172,14 @@ describe("runFn", () => {
         runStep?: string;
         onFailure?: boolean;
         event?: EventPayload;
+        stackOrder?: InngestExecutionOptions["stepCompletionOrder"];
         disableImmediateExecution?: boolean;
       }
     ) => {
       const execution = fn["createExecution"]({
         data: { event: opts?.event || { name: "foo", data: {} } },
         stepState,
+        stepCompletionOrder: opts?.stackOrder ?? Object.keys(stepState),
         isFailureHandler: Boolean(opts?.onFailure),
         requestedRunStep: opts?.runStep,
         timer,
@@ -210,6 +214,7 @@ describe("runFn", () => {
         string,
         {
           stack?: InngestExecutionOptions["stepState"];
+          stackOrder?: InngestExecutionOptions["stepCompletionOrder"];
           onFailure?: boolean;
           runStep?: string;
           expectedReturn?: Awaited<ReturnType<typeof runFnWithStack>>;
@@ -246,6 +251,7 @@ describe("runFn", () => {
 
             beforeAll(async () => {
               ret = await runFnWithStack(tools.fn, t.stack || {}, {
+                stackOrder: t.stackOrder,
                 runStep: t.runStep,
                 onFailure: t.onFailure || tools.onFailure,
                 event: t.event || tools.event,
@@ -621,6 +627,225 @@ describe("runFn", () => {
             type: "function-resolved",
             data: undefined,
           },
+        },
+      })
+    );
+
+    testFn(
+      "Promise.race",
+      () => {
+        const A = jest.fn(() => Promise.resolve("A"));
+        const B = jest.fn(() => Promise.resolve("B"));
+        const AWins = jest.fn(() => Promise.resolve("A wins"));
+        const BWins = jest.fn(() => Promise.resolve("B wins"));
+
+        const fn = inngest.createFunction(
+          { id: "name" },
+          { event: "foo" },
+          async ({ step: { run } }) => {
+            const winner = await Promise.race([run("A", A), run("B", B)]);
+
+            if (winner === "A") {
+              await run("A wins", AWins);
+            } else if (winner === "B") {
+              await run("B wins", BWins);
+            }
+          }
+        );
+
+        return { fn, steps: { A, B, AWins, BWins } };
+      },
+      {
+        A: "A",
+        B: "B",
+        AWins: "A wins",
+        BWins: "B wins",
+      },
+      ({ A, B, AWins, BWins }) => ({
+        "first run reports A and B steps": {
+          expectedReturn: {
+            type: "steps-found",
+            steps: [
+              expect.objectContaining({
+                id: A,
+                name: "A",
+                op: StepOpCode.StepPlanned,
+              }),
+              expect.objectContaining({
+                id: B,
+                name: "B",
+                op: StepOpCode.StepPlanned,
+              }),
+            ],
+          },
+        },
+
+        "requesting to run B runs B": {
+          runStep: B,
+          expectedReturn: {
+            type: "step-ran",
+            step: expect.objectContaining({
+              id: B,
+              name: "B",
+              op: StepOpCode.RunStep,
+              data: "B",
+            }),
+          },
+          expectedStepsRun: ["B"],
+          disableImmediateExecution: true,
+        },
+
+        "request following B reports 'A' and 'B wins' steps": {
+          stack: { [B]: { id: B, data: "B" } },
+          expectedReturn: {
+            type: "steps-found",
+            steps: [
+              expect.objectContaining({
+                id: A,
+                name: "A",
+                op: StepOpCode.StepPlanned,
+              }),
+              expect.objectContaining({
+                id: BWins,
+                name: "B wins",
+                op: StepOpCode.StepPlanned,
+              }),
+            ],
+          },
+          disableImmediateExecution: true,
+        },
+
+        "requesting to run A runs A": {
+          runStep: A,
+          expectedReturn: {
+            type: "step-ran",
+            step: expect.objectContaining({
+              id: A,
+              name: "A",
+              op: StepOpCode.RunStep,
+              data: "A",
+            }),
+          },
+          expectedStepsRun: ["A"],
+          disableImmediateExecution: true,
+        },
+
+        "request following 'B wins' resolves": {
+          stack: {
+            [B]: { id: B, data: "B" },
+            [BWins]: { id: BWins, data: "B wins" },
+          },
+          stackOrder: [B, BWins],
+          expectedReturn: { type: "function-resolved", data: undefined },
+          disableImmediateExecution: true,
+        },
+
+        "request following A completion resolves": {
+          stack: {
+            [A]: { id: A, data: "A" },
+            [B]: { id: B, data: "B" },
+            [BWins]: { id: BWins, data: "B wins" },
+          },
+          stackOrder: [B, BWins, A],
+          expectedReturn: { type: "function-resolved", data: undefined },
+          disableImmediateExecution: true,
+        },
+
+        "request if 'A' is complete reports 'B' and 'A wins' steps": {
+          stack: { [A]: { id: A, data: "A" } },
+          expectedReturn: {
+            type: "steps-found",
+            steps: [
+              expect.objectContaining({
+                id: B,
+                name: "B",
+                op: StepOpCode.StepPlanned,
+              }),
+              expect.objectContaining({
+                id: AWins,
+                name: "A wins",
+                op: StepOpCode.StepPlanned,
+              }),
+            ],
+          },
+          disableImmediateExecution: true,
+        },
+      })
+    );
+
+    testFn(
+      "Deep Promise.race",
+      () => {
+        const A = jest.fn(() => Promise.resolve("A"));
+        const B = jest.fn(() => Promise.resolve("B"));
+        const B2 = jest.fn(() => Promise.resolve("B2"));
+        const AWins = jest.fn(() => Promise.resolve("A wins"));
+        const BWins = jest.fn(() => Promise.resolve("B wins"));
+
+        const fn = inngest.createFunction(
+          { id: "name" },
+          { event: "foo" },
+          async ({ step: { run } }) => {
+            const winner = await Promise.race([
+              run("A", A),
+              run("B", B).then(() => run("B2", B2)),
+            ]);
+
+            if (winner === "A") {
+              await run("A wins", AWins);
+            } else if (winner === "B2") {
+              await run("B wins", BWins);
+            }
+          }
+        );
+
+        return { fn, steps: { A, B, B2, AWins, BWins } };
+      },
+      {
+        A: "A",
+        B: "B",
+        B2: "B2",
+        AWins: "A wins",
+        BWins: "B wins",
+      },
+      ({ A, B, B2, AWins, BWins }) => ({
+        "if B chain wins without 'A', reports 'A' and 'B wins' steps": {
+          stack: { [B]: { id: B, data: "B" }, [B2]: { id: B2, data: "B2" } },
+          expectedReturn: {
+            type: "steps-found",
+            steps: [
+              expect.objectContaining({
+                id: A,
+                name: "A",
+                op: StepOpCode.StepPlanned,
+              }),
+              expect.objectContaining({
+                id: BWins,
+                name: "B wins",
+                op: StepOpCode.StepPlanned,
+              }),
+            ],
+          },
+          disableImmediateExecution: true,
+        },
+        "if B chain wins after with 'A' afterwards, reports 'B wins' step": {
+          stack: {
+            [B]: { id: B, data: "B" },
+            [B2]: { id: B2, data: "B2" },
+            [A]: { id: A, data: "A" },
+          },
+          stackOrder: [B, B2, A],
+          expectedReturn: {
+            type: "steps-found",
+            steps: [
+              expect.objectContaining({
+                id: BWins,
+                name: "B wins",
+                op: StepOpCode.StepPlanned,
+              }),
+            ],
+          },
+          disableImmediateExecution: true,
         },
       })
     );

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -36,6 +36,7 @@ const getStepTools = ({
     fn,
     data: {},
     stepState,
+    stepCompletionOrder: Object.keys(stepState),
   });
 
   const tools = createStepTools(client, execution.state);

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -57,7 +57,12 @@ export const createStepTools = <
   let foundStepsReportPromise: Promise<void> | undefined;
 
   const reportNextTick = () => {
-    foundStepsReportPromise ??= resolveAfterPending().then(() => {
+    // Being explicit instead of using `??=` to appease TypeScript.
+    if (foundStepsReportPromise) {
+      return;
+    }
+
+    foundStepsReportPromise = resolveAfterPending().then(() => {
       foundStepsReportPromise = undefined;
 
       for (let i = 0; i < state.stepCompletionOrder.length; i++) {
@@ -202,7 +207,7 @@ export const createStepTools = <
         ...opId,
         fn: opts?.fn ? () => opts.fn?.(...args) : undefined,
         fulfilled: Boolean(stepState),
-        handled: !Boolean(stepState),
+        handled: !stepState,
         handle: () => {
           if (step.handled) {
             return false;

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -3,7 +3,7 @@ import { sha1 } from "hash.js";
 import { type Jsonify } from "type-fest";
 import { ErrCode, prettyError } from "../helpers/errors";
 import {
-  createFrozenPromise,
+  createDeferredPromise,
   resolveAfterPending,
   runAsPromise,
 } from "../helpers/promises";
@@ -28,6 +28,13 @@ import { type ExecutionState } from "./InngestExecution";
 export interface FoundStep extends HashedOp {
   fn?: (...args: unknown[]) => unknown;
   fulfilled: boolean;
+  handled: boolean;
+
+  /**
+   * Returns a boolean representing whether or not the step was handled on this
+   * invocation.
+   */
+  handle: () => boolean;
 }
 
 /**
@@ -49,20 +56,37 @@ export const createStepTools = <
   let foundStepsToReport: FoundStep[] = [];
   let foundStepsReportPromise: Promise<void> | undefined;
 
+  const reportNextTick = () => {
+    foundStepsReportPromise ??= resolveAfterPending().then(() => {
+      foundStepsReportPromise = undefined;
+
+      for (let i = 0; i < state.stepCompletionOrder.length; i++) {
+        const handled = foundStepsToReport
+          .find((step) => {
+            return step.id === state.stepCompletionOrder[i];
+          })
+          ?.handle();
+
+        if (handled) {
+          return void reportNextTick();
+        }
+      }
+
+      // If we've handled no steps in this "tick," roll up everything we've
+      // found and report it.
+      const steps = [...foundStepsToReport] as [FoundStep, ...FoundStep[]];
+      foundStepsToReport = [];
+
+      return void state.setCheckpoint({
+        type: "steps-found",
+        steps: steps,
+      });
+    });
+  };
+
   const pushStepToReport = (step: FoundStep) => {
     foundStepsToReport.push(step);
-
-    if (!foundStepsReportPromise) {
-      foundStepsReportPromise = resolveAfterPending().then(() => {
-        const steps = [...foundStepsToReport] as [FoundStep, ...FoundStep[]];
-
-        // Reset
-        foundStepsToReport = [];
-        foundStepsReportPromise = undefined;
-
-        void state.setCheckpoint({ type: "steps-found", steps });
-      });
-    }
+    reportNextTick();
   };
 
   /**
@@ -168,36 +192,51 @@ export const createStepTools = <
         throw new Error("TODO: Step already exists?");
       }
 
-      const step = (state.steps[opId.id] = {
-        ...opId,
-        fn: opts?.fn ? () => opts.fn?.(...args) : undefined,
-        fulfilled: Boolean(state.stepState[opId.id]),
-      });
-      state.hasSteps = true;
-
-      pushStepToReport(step);
-
+      const { promise, resolve, reject } = createDeferredPromise();
       const stepState = state.stepState[opId.id];
-
       if (stepState) {
-        stepState.fulfilled = true;
-        /**
-         * If this is the last piece of state we had, we've now finished
-         * memoizing.
-         */
-        if (state.allStateUsed()) {
-          await state.hooks?.afterMemoization?.();
-          await state.hooks?.beforeExecution?.();
-        }
-
-        if (typeof stepState?.data !== "undefined") {
-          return Promise.resolve(stepState?.data);
-        } else {
-          return Promise.reject(stepState?.error);
-        }
+        stepState.seen = true;
       }
 
-      return createFrozenPromise();
+      const step: FoundStep = (state.steps[opId.id] = {
+        ...opId,
+        fn: opts?.fn ? () => opts.fn?.(...args) : undefined,
+        fulfilled: Boolean(stepState),
+        handled: !Boolean(stepState),
+        handle: () => {
+          if (step.handled) {
+            return false;
+          }
+
+          step.handled = true;
+
+          if (stepState) {
+            stepState.fulfilled = true;
+
+            if (typeof stepState.data !== "undefined") {
+              resolve(stepState.data);
+            } else {
+              reject(stepState.error);
+            }
+          }
+
+          return true;
+        },
+      });
+
+      /**
+       * If this is the last piece of state we had, we've now finished
+       * memoizing.
+       */
+      if (state.allStateUsed()) {
+        await state.hooks?.afterMemoization?.();
+        await state.hooks?.beforeExecution?.();
+      }
+
+      state.hasSteps = true;
+      pushStepToReport(step);
+
+      return promise;
     }) as T;
   };
 

--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -65,27 +65,35 @@ export const resolveAfterPending = (): Promise<void> => {
 type DeferredPromiseReturn<T> = {
   promise: Promise<T>;
   resolve: (value: T) => DeferredPromiseReturn<T>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason: any) => DeferredPromiseReturn<T>;
 };
 
 /**
- * Creates and returns Promise that can be resolved with the returned resolve
- * function.
+ * Creates and returns Promise that can be resolved or rejected with the
+ * returned `resolve` and `reject` functions.
  *
- * Resolving the function will return a new set of Promise and resolve function.
- * These can be ignored if the original Promise is all that's needed.
+ * Resolving or rejecting the function will return a new set of Promise control
+ * functions. These can be ignored if the original Promise is all that's needed.
  */
 export const createDeferredPromise = <T>(): DeferredPromiseReturn<T> => {
-  let resolve: (value: T) => DeferredPromiseReturn<T>;
+  let resolve: DeferredPromiseReturn<T>["resolve"];
+  let reject: DeferredPromiseReturn<T>["reject"];
 
-  const promise = new Promise<T>((_resolve) => {
+  const promise = new Promise<T>((_resolve, _reject) => {
     resolve = (value: T) => {
       _resolve(value);
+      return createDeferredPromise<T>();
+    };
+
+    reject = (reason) => {
+      _reject(reason);
       return createDeferredPromise<T>();
     };
   });
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return { promise, resolve: resolve! };
+  return { promise, resolve: resolve!, reject: reject! };
 };
 
 interface TimeoutPromise extends Promise<void> {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Re-adding `Promise.race()` support for V3 (#294) when only using steps within the race.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ Part of a larger change
- [x] Added unit/integration tests
- [ ] ~~Added changesets if applicable~~ Part of a larger change

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #294
