### PR TITLE
Add `Retry-After` header using control flow

### DIFF
--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -127,6 +127,8 @@ export enum headerKeys {
     // (undocumented)
     Platform = "x-inngest-platform",
     // (undocumented)
+    RetryAfter = "retry-after",
+    // (undocumented)
     SdkVersion = "x-inngest-sdk",
     // (undocumented)
     Signature = "x-inngest-signature"
@@ -296,6 +298,16 @@ export interface RegisterOptions {
     servePath?: string;
     signingKey?: string;
     streaming?: "allow" | "force" | false;
+}
+
+// @public
+export class RetryAfterError extends Error {
+    constructor(message: string,
+    retryAfter: number | string | Date, options?: {
+        cause?: unknown;
+    });
+    readonly cause?: unknown;
+    readonly retryAfter: string;
 }
 
 // @public

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -626,6 +626,9 @@ export class InngestCommHandler<
               headers: {
                 "Content-Type": "application/json",
                 [headerKeys.NoRetry]: result.retriable ? "false" : "true",
+                ...(typeof result.retriable === "string"
+                  ? { [headerKeys.RetryAfter]: result.retriable }
+                  : {}),
               },
               body: stringify(result.error),
             };

--- a/packages/inngest/src/components/RetryAfterError.ts
+++ b/packages/inngest/src/components/RetryAfterError.ts
@@ -1,0 +1,66 @@
+import ms from "ms";
+
+/**
+ * An error that, when thrown, indicates to Inngest that the function should be
+ * retried after a given amount of time.
+ *
+ * A `message` must be provided, as well as a `retryAfter` parameter, which can
+ * be a `number` of milliseconds, an `ms`-compatible time string, or a `Date`.
+ *
+ * An optional `cause` can be provided to provide more context to the error.
+ *
+ * @public
+ */
+export class RetryAfterError extends Error {
+  /**
+   * The underlying cause of the error, if any.
+   *
+   * This will be serialized and sent to Inngest.
+   */
+  public readonly cause?: unknown;
+
+  /**
+   * The time after which the function should be retried. Represents either a
+   * number of seconds or a RFC3339 date.
+   */
+  public readonly retryAfter: string;
+
+  constructor(
+    message: string,
+
+    /**
+     * The time after which the function should be retried. Represents either a
+     * number of seconds or a RFC3339 date.
+     */
+    retryAfter: number | string | Date,
+
+    options?: {
+      /**
+       * The underlying cause of the error, if any.
+       *
+       * This will be serialized and sent to Inngest.
+       */
+      cause?: unknown;
+    }
+  ) {
+    super(message);
+
+    if (retryAfter instanceof Date) {
+      this.retryAfter = retryAfter.toISOString();
+    } else {
+      const seconds = `${Math.ceil(
+        (typeof retryAfter === "string" ? ms(retryAfter) : retryAfter) / 1000
+      )}`;
+
+      if (!isFinite(Number(seconds))) {
+        throw new Error(
+          "retryAfter must be a number of seconds, a ms-compatible string, or a Date"
+        );
+      }
+
+      this.retryAfter = seconds;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    this.cause = options?.cause;
+  }
+}

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -122,6 +122,7 @@ export enum headerKeys {
   Platform = "x-inngest-platform",
   Framework = "x-inngest-framework",
   NoRetry = "x-inngest-no-retry",
+  RetryAfter = "retry-after",
 }
 
 export const defaultInngestBaseUrl = "https://api.inngest.com/";

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -16,6 +16,7 @@ export type {
   MiddlewareRegisterReturn,
 } from "./components/InngestMiddleware";
 export { NonRetriableError } from "./components/NonRetriableError";
+export { RetryAfterError } from "./components/RetryAfterError";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
 export type { IsStringLiteral } from "./helpers/types";
 export type {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds the ability to retry after a specified period of time.

Matches the time inputs supported in other parts of the SDK, e.g. `number | string | Date`.

```ts
throw new RetryAfterError("reason", 5000); // 5 seconds
throw new RetryAfterError("reason", "5s"); // `ms`-compatible string, 5 seconds
throw new RetryAfterError("reason", MyDate); // specific date
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Part of a larger change
- [x] Added unit/integration tests
- [ ] ~~Added changesets if applicable~~ N/A Part of a larger change

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-2058
