### PR TITLE
Add ESM exports to `inngest` package to avoid extension imports

### DIFF
--- a/.changeset/twenty-meals-destroy.md
+++ b/.changeset/twenty-meals-destroy.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add ESM exports to `inngest` package to avoid extension imports

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -202,6 +202,8 @@ jobs:
           HOST: "0.0.0.0"
           PORT: 3000
           DO_NOT_TRACK: 1
+          INNGEST_BASE_URL: "http://127.0.0.1:8288/"
+          INNGEST_DEVSERVER_URL: "http://127.0.0.1:8288/"
       - name: Wait for the example to start
         uses: mydea/action-wait-for-api@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -202,6 +202,7 @@ jobs:
           HOST: "0.0.0.0"
           PORT: 3000
           DO_NOT_TRACK: 1
+          NODE_ENV: "development"
           INNGEST_BASE_URL: "http://127.0.0.1:8288/"
           INNGEST_DEVSERVER_URL: "http://127.0.0.1:8288/"
       - name: Wait for the example to start

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -190,7 +190,12 @@ jobs:
 
       # Run the example
       - name: Run the example's dev server
-        run: (npm run dev > dev.log 2>&1 &)
+        run: |
+          if [[ $(jq '.scripts["start"]' < package.json;) != null ]]; then
+            (npm run start > dev.log 2>&1 &)
+          else
+            (npm run dev > dev.log 2>&1 &)
+          fi
         working-directory: examples/${{ matrix.example }}
         # Provide the example any env vars it might need
         env:

--- a/examples/framework-nuxt/package.json
+++ b/examples/framework-nuxt/package.json
@@ -5,7 +5,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "start": "node .output/server/index.mjs"
   },
   "devDependencies": {
     "nuxt": "^3.0.0"

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -28,6 +28,73 @@
     "local:pack": "pnpm run build && pnpm run build:copy && yarn pack --verbose --frozen-lockfile --filename inngest.tgz --cwd dist",
     "dev:example": "tsx scripts/runExample.ts"
   },
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./cloudflare": {
+      "require": "./cloudflare.js",
+      "import": "./cloudflare.js",
+      "types": "./cloudflare.d.ts"
+    },
+    "./digitalocean": {
+      "require": "./digitalocean.js",
+      "import": "./digitalocean.js",
+      "types": "./digitalocean.d.ts"
+    },
+    "./edge": {
+      "require": "./edge.js",
+      "import": "./edge.js",
+      "types": "./edge.d.ts"
+    },
+    "./express": {
+      "require": "./express.js",
+      "import": "./express.js",
+      "types": "./express.d.ts"
+    },
+    "./fastify": {
+      "require": "./fastify.js",
+      "import": "./fastify.js",
+      "types": "./fastify.d.ts"
+    },
+    "./h3": {
+      "require": "./h3.js",
+      "import": "./h3.js",
+      "types": "./h3.d.ts"
+    },
+    "./lambda": {
+      "require": "./lambda.js",
+      "import": "./lambda.js",
+      "types": "./lambda.d.ts"
+    },
+    "./next": {
+      "require": "./next.js",
+      "import": "./next.js",
+      "types": "./next.d.ts"
+    },
+    "./nuxt": {
+      "require": "./nuxt.js",
+      "import": "./nuxt.js",
+      "types": "./nuxt.d.ts"
+    },
+    "./redwood": {
+      "require": "./redwood.js",
+      "import": "./redwood.js",
+      "types": "./redwood.d.ts"
+    },
+    "./remix": {
+      "require": "./remix.js",
+      "import": "./remix.js",
+      "types": "./remix.d.ts"
+    },
+    "./deno/fresh": {
+      "require": "./deno/fresh.js",
+      "import": "./deno/fresh.js",
+      "types": "./deno/fresh.d.ts"
+    }
+  },
   "homepage": "https://github.com/inngest/inngest-js#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

ESM-only frameworks, or at least those that are ESM-first, are becoming more prevalent, meaning we need to add this mapping to ensure users don't need to add file extensions when adding these subpath imports.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Closes #318
