### PR TITLE
Hashing and automatic indexing for V3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,11 +142,7 @@ jobs:
       # Install dependencies in the example repo
       # Don't use "npm ci", "--immutable" etc., as example repos won't be
       # shipped with lock files.
-      - name: Install example dependencies
-        run: npm install
-        working-directory: examples/${{ matrix.example }}
-
-      - name: Add local SDK to example
+      - name: Add local SDK to example with dependencies
         working-directory: examples/${{ matrix.example }}
         run: npm install ./inngest.tgz
 

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -127,6 +127,8 @@ export enum headerKeys {
     // (undocumented)
     Platform = "x-inngest-platform",
     // (undocumented)
+    RequestVersion = "x-inngest-req-version",
+    // (undocumented)
     RetryAfter = "retry-after",
     // (undocumented)
     SdkVersion = "x-inngest-sdk",

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -337,7 +337,7 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
         },
         transformOutput(prev, output) {
           return {
-            result: { ...prev.result, ...output.result },
+            result: { ...prev.result, ...output?.result },
           };
         },
       }

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -788,7 +788,7 @@ export class InngestCommHandler<
       requestedRunStep: stepId === "step" ? undefined : stepId || undefined,
       timer,
       isFailureHandler: fn.onFailure,
-      disableImmediateExecution: fndata.value.disable_immediate_execution,
+      disableImmediateExecution: fndata.value.ctx?.disable_immediate_execution,
       stepCompletionOrder: ctx?.stack?.stack ?? [],
     });
 

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -459,7 +459,7 @@ type MiddlewareSendEventOutputArgs = { result: Readonly<SendEventBaseOutput> };
  */
 type MiddlewareSendEventOutput = (
   ctx: MiddlewareSendEventOutputArgs
-) => MaybePromise<{ result?: Record<string, unknown> }>;
+) => MaybePromise<{ result?: Record<string, unknown> } | void>;
 
 /**
  * @internal

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -456,7 +456,7 @@ type MiddlewareSendEventOutput = (
 type MiddlewareRunOutput = (ctx: {
   result: Readonly<Pick<OutgoingOp, "error" | "data">>;
   step?: Readonly<Omit<OutgoingOp, "id">>;
-}) => { result?: Partial<Pick<OutgoingOp, "data">> } | void;
+}) => MaybePromise<{ result?: Partial<Pick<OutgoingOp, "data">> } | void>;
 
 /**
  * @internal

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -122,6 +122,7 @@ export enum headerKeys {
   Platform = "x-inngest-platform",
   Framework = "x-inngest-framework",
   NoRetry = "x-inngest-no-retry",
+  RequestVersion = "x-inngest-req-version",
   RetryAfter = "retry-after",
 }
 

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -223,6 +223,7 @@ export const inngestHeaders = (opts?: {
     "Content-Type": "application/json",
     "User-Agent": sdkVersion,
     [headerKeys.SdkVersion]: sdkVersion,
+    [headerKeys.RequestVersion]: "1",
   };
 
   if (opts?.framework) {

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -182,6 +182,7 @@ export const deserializeError = (subject: Partial<SerializedError>): Error => {
 
 export enum ErrCode {
   NESTING_STEPS = "NESTING_STEPS",
+  AUTOMATIC_PARALLEL_INDEXING = "AUTOMATIC_PARALLEL_INDEXING",
 }
 
 export interface PrettyError {

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -69,7 +69,7 @@ export const parseFnData = async (
   try {
     const result = fnDataSchema.parse(data);
 
-    if (result.use_api) {
+    if (result.ctx?.use_api) {
       if (!result.ctx?.run_id) {
         return err(
           prettyError({

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -179,8 +179,8 @@ export type OutgoingOp = Pick<
  */
 export type HashedOp = Op & {
   /**
-   * The hashed identifier for this operation, used to confirm that the operation
-   * was completed when it is received from Inngest.
+   * The hashed identifier for this operation, used to confirm that the
+   * operation was completed when it is received from Inngest.
    */
   id: string;
 };
@@ -1067,6 +1067,8 @@ export const fnDataSchema = z.object({
     .object({
       run_id: z.string(),
       attempt: z.number().default(0),
+      disable_immediate_execution: z.boolean().default(false),
+      use_api: z.boolean().default(false),
       stack: z
         .object({
           stack: z
@@ -1081,7 +1083,6 @@ export const fnDataSchema = z.object({
     })
     .optional()
     .nullable(),
-  use_api: z.boolean().default(false),
-  disable_immediate_execution: z.boolean().default(false),
+  version: z.number().default(-1),
 });
 export type FnData = z.infer<typeof fnDataSchema>;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds hashing of step IDs, meaning step IDs passed between the SDK and Inngest are never plain text and of consistent length.

Adds automatic indexing of steps to avoid common uses of step tooling within loops and parallelism. The following example would set the step IDs to `A`, `A:1`, and `A:2`.

```ts
const runA = () => step.run("A", () => "result");

await Promise.all([runA(), runA(), runA()]);
```

Adds a new error code, `AUTOMATIC_PARALLEL_INDEXING`, which warns if these indexes are added across parallel chains of work, which is harder for the SDK to reason about in V3.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ Part of a larger change
- [x] Added unit/integration tests
- [ ] ~~Added changesets if applicable~~ N/A Part of a larger change

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-1888
- #294 
