### PR TITLE
Hotfix: Export `ProxyLogger` directly

### DIFF
--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -29,8 +29,6 @@ export interface ClientOptions {
 // @public
 export type Combine<TCurr extends Record<string, EventPayload>, TInc extends StandardEventSchemas> = IsStringLiteral<keyof TCurr & string> extends true ? Simplify<Omit<TCurr, keyof StandardEventSchemaToPayload<TInc>> & StandardEventSchemaToPayload<TInc>> : StandardEventSchemaToPayload<TInc>;
 
-// Warning: (ae-forgotten-export) The symbol "TriggerOptions" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type EventNameFromTrigger<Events extends Record<string, EventPayload>, T extends TriggerOptions<keyof Events & string>> = T extends string ? T : T extends {
     event: string;
@@ -367,7 +365,24 @@ export type StandardEventSchemaToPayload<T> = Simplify<{
 }>;
 
 // @public
+export type StrictUnion<T> = StrictUnionHelper<T, T>;
+
+// @public
+export type StrictUnionHelper<T, TAll> = T extends any ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>> : never;
+
+// @public
 export type TimeStr = `${`${number}w` | ""}${`${number}d` | ""}${`${number}h` | ""}${`${number}m` | ""}${`${number}s` | ""}`;
+
+// @public
+export type TriggerOptions<T extends string> = T | StrictUnion<{
+    event: T;
+    if?: string;
+} | {
+    cron: string;
+}>;
+
+// @public
+export type UnionKeys<T> = T extends T ? keyof T : never;
 
 // @public
 export type ZodEventSchemas = Record<string, {
@@ -384,7 +399,7 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:332:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:342:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
 // src/types.ts:51:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:693:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:695:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -287,6 +287,27 @@ export class NonRetriableError extends Error {
 }
 
 // @public
+export class ProxyLogger implements Logger {
+    constructor(logger: Logger);
+    // (undocumented)
+    debug(...args: LogArg[]): void;
+    // (undocumented)
+    disable(): void;
+    // (undocumented)
+    enable(): void;
+    // (undocumented)
+    error(...args: LogArg[]): void;
+    // (undocumented)
+    flush(): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "LogArg" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    info(...args: LogArg[]): void;
+    // (undocumented)
+    warn(...args: LogArg[]): void;
+}
+
+// @public
 export enum queryKeys {
     // (undocumented)
     DeployId = "deployId",

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -245,6 +245,9 @@ export type LiteralZodEventSchema = z.ZodObject<{
 }>;
 
 // @public
+export type LogArg = unknown;
+
+// @public
 export type LogLevel = "fatal" | "error" | "warn" | "info" | "debug" | "silent";
 
 // @public
@@ -299,8 +302,6 @@ export class ProxyLogger implements Logger {
     error(...args: LogArg[]): void;
     // (undocumented)
     flush(): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "LogArg" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     info(...args: LogArg[]): void;
     // (undocumented)

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -93,7 +93,12 @@
       "require": "./deno/fresh.js",
       "import": "./deno/fresh.js",
       "types": "./deno/fresh.d.ts"
-    }
+    },
+    "./api/*": "./api/*.js",
+    "./components": "./components/*.js",
+    "./deno/*": "./deno/*.js",
+    "./helpers/*": "./helpers/*.js",
+    "./middleware/*": "./middleware/*.js"
   },
   "homepage": "https://github.com/inngest/inngest-js#readme",
   "repository": {

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -91,23 +91,29 @@ export type KeysNotOfType<T, U> = {
 
 /**
  * Returns all keys from objects in the union `T`.
+ *
+ * @public
  */
-type UnionKeys<T> = T extends T ? keyof T : never;
+export type UnionKeys<T> = T extends T ? keyof T : never;
 
 /**
  * Enforces strict union comformity by ensuring that all potential keys in a
  * union of objects are accounted for in every object.
  *
  * Requires two generics to be used, so is abstracted by {@link StrictUnion}.
+ *
+ * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type StrictUnionHelper<T, TAll> = T extends any
+export type StrictUnionHelper<T, TAll> = T extends any
   ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
   : never;
 
 /**
  * Enforces strict union comformity by ensuring that all potential keys in a
  * union of objects are accounted for in every object.
+ *
+ * @public
  */
 export type StrictUnion<T> = StrictUnionHelper<T, T>;
 

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -19,6 +19,7 @@ export type {
 export { NonRetriableError } from "./components/NonRetriableError";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
 export type { IsStringLiteral } from "./helpers/types";
+export { ProxyLogger } from "./middleware/logger";
 export type {
   ClientOptions,
   EventNameFromTrigger,

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -20,6 +20,7 @@ export { NonRetriableError } from "./components/NonRetriableError";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
 export type { IsStringLiteral } from "./helpers/types";
 export { ProxyLogger } from "./middleware/logger";
+export type { LogArg } from "./middleware/logger";
 export type {
   ClientOptions,
   EventNameFromTrigger,

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -18,7 +18,12 @@ export type {
 } from "./components/InngestMiddleware";
 export { NonRetriableError } from "./components/NonRetriableError";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
-export type { IsStringLiteral } from "./helpers/types";
+export type {
+  IsStringLiteral,
+  StrictUnion,
+  StrictUnionHelper,
+  UnionKeys,
+} from "./helpers/types";
 export { ProxyLogger } from "./middleware/logger";
 export type { LogArg } from "./middleware/logger";
 export type {
@@ -32,4 +37,5 @@ export type {
   LogLevel,
   RegisterOptions,
   TimeStr,
+  TriggerOptions,
 } from "./types";

--- a/packages/inngest/src/middleware/logger.ts
+++ b/packages/inngest/src/middleware/logger.ts
@@ -7,8 +7,10 @@
  * - values used for string interpolation, basically anything
  *
  * See https://linear.app/inngest/issue/INN-1342/flush-logs-on-function-exitreturns for more details
+ *
+ * @public
  */
-type LogArg = unknown;
+export type LogArg = unknown;
 
 /**
  * Based on https://datatracker.ietf.org/doc/html/rfc5424#autoid-11

--- a/packages/inngest/src/middleware/logger.ts
+++ b/packages/inngest/src/middleware/logger.ts
@@ -46,6 +46,8 @@ export class DefaultLogger implements Logger {
  * context, so it doesn't result in duplicated logging.
  *
  * And also attempt to allow enough time for the logger to flush all logs.
+ *
+ * @public
  */
 export class ProxyLogger implements Logger {
   readonly #logger: Logger;

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -615,6 +615,8 @@ export interface InternalRegisterOptions extends RegisterOptions {
 
 /**
  * A user-friendly method of specifying a trigger for an Inngest function.
+ *
+ * @public
  */
 export type TriggerOptions<T extends string> =
   | T


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Export various types and calsses directly to ensure those adhering to ESM `exports` can use it.

Also add wildcard exports, though in v3 we track all explicit exports to ensure API breakages don't occur with API Extractor.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Hotfix
- [ ] ~~Added unit/integration tests~~ N/A
- [ ] Added changesets if applicable
