### PR TITLE
V2 backcompatibility for V3

### DIFF
--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -193,10 +193,12 @@ export class InngestCommHandler<Input extends any[] = any[], Output = any, Strea
     protected registerBody(url: URL): RegisterRequest;
     protected reqUrl(url: URL): URL;
     // Warning: (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected runStep(functionId: string, stepId: string | null, data: unknown, timer: ServerTiming): Promise<ExecutionResult>;
+    protected runStep(functionId: string, stepId: string | null, data: unknown, timer: ServerTiming): {
+        version: ExecutionVersion;
+        result: Promise<ExecutionResult>;
+    };
     protected readonly serveHost: string | undefined;
     protected readonly servePath: string | undefined;
     protected signingKey: string | undefined;
@@ -384,6 +386,8 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
+// src/components/InngestCommHandler.ts:791:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:791:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:264:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:277:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:283:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -386,8 +386,8 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/InngestCommHandler.ts:791:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:791:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:797:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:797:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:264:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:277:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:283:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -392,8 +392,8 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/InngestCommHandler.ts:797:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:797:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:803:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:803:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:264:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:277:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:283:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -42,10 +42,11 @@ import {
   type InngestFunction,
 } from "./InngestFunction";
 import {
-  ExecutionVersion,
+  PREFERRED_EXECUTION_VERSION,
   type ExecutionResult,
   type ExecutionResultHandler,
   type ExecutionResultHandlers,
+  type ExecutionVersion,
   type InngestExecutionOptions,
 } from "./execution/InngestExecution";
 
@@ -507,7 +508,6 @@ export class InngestCommHandler<
           client: this.client,
           extras: {
             "Server-Timing": timer.getHeader(),
-            [headerKeys.RequestVersion]: ExecutionVersion.V1.toString(),
           },
         });
 
@@ -527,6 +527,13 @@ export class InngestCommHandler<
         headers: {
           ...getInngestHeaders(),
           ...res.headers,
+          ...(res.version === null
+            ? {}
+            : {
+                [headerKeys.RequestVersion]: (
+                  res.version ?? PREFERRED_EXECUTION_VERSION
+                ).toString(),
+              }),
         },
       });
 
@@ -559,6 +566,7 @@ export class InngestCommHandler<
                 status: 201,
                 headers: getInngestHeaders(),
                 body: stream,
+                version: null,
               }
             );
           });
@@ -630,56 +638,6 @@ export class InngestCommHandler<
         const body = await actions.body("processing run request");
         this.validateSignature(signature ?? undefined, body);
 
-        const resultHandlers: ExecutionResultHandlers<ActionResponse> = {
-          "function-rejected": (result) => {
-            return {
-              status: result.retriable ? 500 : 400,
-              headers: {
-                "Content-Type": "application/json",
-                [headerKeys.NoRetry]: result.retriable ? "false" : "true",
-                ...(typeof result.retriable === "string"
-                  ? { [headerKeys.RetryAfter]: result.retriable }
-                  : {}),
-              },
-              body: stringify(result.error),
-            };
-          },
-          "function-resolved": (result) => {
-            return {
-              status: 200,
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: stringify(result.data),
-            };
-          },
-          "step-not-found": (_result) => {
-            /**
-             * TODO Status decision. I think we should use a unique op code for
-             * this situation and keep the 206 status.
-             */
-            return {
-              status: 999,
-              headers: { "Content-Type": "application/json" },
-              body: "",
-            };
-          },
-          "step-ran": (result) => {
-            return {
-              status: 206,
-              headers: { "Content-Type": "application/json" },
-              body: stringify([result.step]),
-            };
-          },
-          "steps-found": (result) => {
-            return {
-              status: 206,
-              headers: { "Content-Type": "application/json" },
-              body: stringify(result.steps),
-            };
-          },
-        };
-
         const fnId = await getQuerystring(
           "processing run request",
           queryKeys.FnId
@@ -693,13 +651,69 @@ export class InngestCommHandler<
           (await getQuerystring("processing run request", queryKeys.StepId)) ||
           null;
 
-        const result = await this.runStep(fnId, stepId, body, timer);
+        const { version, result } = this.runStep(fnId, stepId, body, timer);
+        const stepOutput = await result;
+
+        const resultHandlers: ExecutionResultHandlers<ActionResponse> = {
+          "function-rejected": (result) => {
+            return {
+              status: result.retriable ? 500 : 400,
+              headers: {
+                "Content-Type": "application/json",
+                [headerKeys.NoRetry]: result.retriable ? "false" : "true",
+                ...(typeof result.retriable === "string"
+                  ? { [headerKeys.RetryAfter]: result.retriable }
+                  : {}),
+              },
+              body: stringify(result.error),
+              version,
+            };
+          },
+          "function-resolved": (result) => {
+            return {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: stringify(result.data),
+              version,
+            };
+          },
+          "step-not-found": (_result) => {
+            /**
+             * TODO Status decision. I think we should use a unique op code for
+             * this situation and keep the 206 status.
+             */
+            return {
+              status: 999,
+              headers: { "Content-Type": "application/json" },
+              body: "",
+              version,
+            };
+          },
+          "step-ran": (result) => {
+            return {
+              status: 206,
+              headers: { "Content-Type": "application/json" },
+              body: stringify([result.step]),
+              version,
+            };
+          },
+          "steps-found": (result) => {
+            return {
+              status: 206,
+              headers: { "Content-Type": "application/json" },
+              body: stringify(result.steps),
+              version,
+            };
+          },
+        };
 
         const handler = resultHandlers[
-          result.type
+          stepOutput.type
         ] as ExecutionResultHandler<ActionResponse>;
 
-        return await handler(result);
+        return await handler(stepOutput);
       }
 
       if (method === "GET") {
@@ -718,6 +732,7 @@ export class InngestCommHandler<
           headers: {
             "Content-Type": "application/json",
           },
+          version: undefined,
         };
       }
 
@@ -739,6 +754,7 @@ export class InngestCommHandler<
           headers: {
             "Content-Type": "application/json",
           },
+          version: undefined,
         };
       }
     } catch (err) {
@@ -751,6 +767,7 @@ export class InngestCommHandler<
         headers: {
           "Content-Type": "application/json",
         },
+        version: undefined,
       };
     }
 
@@ -762,60 +779,68 @@ export class InngestCommHandler<
         skipDevServer: this._skipDevServer,
       }),
       headers: {},
+      version: undefined,
     };
   }
 
-  protected async runStep(
+  protected runStep(
     functionId: string,
     stepId: string | null,
     data: unknown,
     timer: ServerTiming
-  ): Promise<ExecutionResult> {
+  ): { version: ExecutionVersion; result: Promise<ExecutionResult> } {
     const fn = this.fns[functionId];
     if (!fn) {
       // TODO PrettyError
       throw new Error(`Could not find function with ID "${functionId}"`);
     }
 
-    const fndata = await fetchAllFnData(
-      parseFnData(data),
-      this.client["inngestApi"]
-    );
-    if (!fndata.ok) {
-      throw new Error(fndata.error);
-    }
-    const { event, events, steps, ctx, version } = fndata.value;
+    const immediateFnData = parseFnData(data);
+    const { version } = immediateFnData;
 
-    const stepState = Object.entries(steps ?? {}).reduce<
-      InngestExecutionOptions["stepState"]
-    >((acc, [id, data]) => {
-      return {
-        ...acc,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        [id]: { id, data },
-      };
-    }, {});
+    const result = runAsPromise(async () => {
+      const fnData = await fetchAllFnData(
+        immediateFnData,
+        this.client["inngestApi"]
+      );
+      if (!fnData.ok) {
+        throw new Error(fnData.error);
+      }
+      const { event, events, steps, ctx, version } = fnData.value;
 
-    const execution = fn.fn["createExecution"](version, {
-      runId: ctx?.run_id || "",
-      data: {
-        event: event as EventPayload,
-        events: events as [EventPayload, ...EventPayload[]],
+      const stepState = Object.entries(steps ?? {}).reduce<
+        InngestExecutionOptions["stepState"]
+      >((acc, [id, data]) => {
+        return {
+          ...acc,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          [id]: { id, data },
+        };
+      }, {});
+
+      const execution = fn.fn["createExecution"](version, {
         runId: ctx?.run_id || "",
-        attempt: ctx?.attempt ?? 0,
-      },
-      stepState,
-      requestedRunStep: stepId === "step" ? undefined : stepId || undefined,
-      timer,
-      isFailureHandler: fn.onFailure,
-      disableImmediateExecution:
-        fndata.value.version === 1
-          ? fndata.value.ctx?.disable_immediate_execution
-          : undefined,
-      stepCompletionOrder: ctx?.stack?.stack ?? [],
+        data: {
+          event: event as EventPayload,
+          events: events as [EventPayload, ...EventPayload[]],
+          runId: ctx?.run_id || "",
+          attempt: ctx?.attempt ?? 0,
+        },
+        stepState,
+        requestedRunStep: stepId === "step" ? undefined : stepId || undefined,
+        timer,
+        isFailureHandler: fn.onFailure,
+        disableImmediateExecution:
+          fnData.value.version === 1
+            ? fnData.value.ctx?.disable_immediate_execution
+            : undefined,
+        stepCompletionOrder: ctx?.stack?.stack ?? [],
+      });
+
+      return execution.start();
     });
 
-    return execution.start();
+    return { version, result };
   }
 
   protected configs(url: URL): FunctionConfig[] {
@@ -1206,6 +1231,17 @@ export interface ActionResponse<
    * A stringified body to return.
    */
   body: TBody;
+
+  /**
+   * The version of the execution engine that was used to run this action.
+   *
+   * If the action didn't use the execution engine (for example, a GET request
+   * as a health check), this will be `undefined`.
+   *
+   * If the version should be entirely omitted from the response (for example,
+   * when sending preliminary headers when streaming), this will be `null`.
+   */
+  version: ExecutionVersion | null | undefined;
 }
 
 /**

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -37,15 +37,15 @@ import {
 import { version } from "../version";
 import { type AnyInngest } from "./Inngest";
 import {
+  type AnyInngestFunction,
+  type InngestFunction,
+} from "./InngestFunction";
+import {
   type ExecutionResult,
   type ExecutionResultHandler,
   type ExecutionResultHandlers,
   type InngestExecutionOptions,
-} from "./InngestExecution";
-import {
-  type AnyInngestFunction,
-  type InngestFunction,
-} from "./InngestFunction";
+} from "./execution/InngestExecution";
 
 export interface ServeHandlerOptions extends RegisterOptions {
   /**
@@ -791,6 +791,7 @@ export class InngestCommHandler<
     }, {});
 
     const execution = fn.fn["createExecution"]({
+      runId: ctx?.run_id || "",
       data: { event, events, runId: ctx?.run_id, attempt: ctx?.attempt },
       stepState,
       requestedRunStep: stepId === "step" ? undefined : stepId || undefined,

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -7,15 +7,15 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { jest } from "@jest/globals";
 import { EventSchemas, InngestMiddleware, type EventPayload } from "@local";
-import {
-  _internals,
-  type ExecutionResult,
-  type ExecutionResults,
-  type InngestExecutionOptions,
-} from "@local/components/InngestExecution";
 import { InngestFunction } from "@local/components/InngestFunction";
 import { STEP_INDEXING_SUFFIX } from "@local/components/InngestStepTools";
 import { NonRetriableError } from "@local/components/NonRetriableError";
+import {
+  type ExecutionResult,
+  type ExecutionResults,
+  type InngestExecutionOptions,
+} from "@local/components/execution/InngestExecution";
+import { _internals } from "@local/components/execution/v1";
 import { ServerTiming } from "@local/helpers/ServerTiming";
 import { internalEvents } from "@local/helpers/consts";
 import {
@@ -146,6 +146,7 @@ describe("runFn", () => {
 
             const execution = fn["createExecution"]({
               data: { event: { name: "foo", data: { foo: "foo" } } },
+              runId: "run",
               stepState: {},
               stepCompletionOrder: [],
             });
@@ -185,6 +186,7 @@ describe("runFn", () => {
             const execution = fn["createExecution"]({
               data: { event: { name: "foo", data: { foo: "foo" } } },
               stepState: {},
+              runId: "run",
               stepCompletionOrder: [],
             });
 
@@ -216,6 +218,7 @@ describe("runFn", () => {
     ) => {
       const execution = fn["createExecution"]({
         data: { event: opts?.event || { name: "foo", data: {} } },
+        runId: "run",
         stepState,
         stepCompletionOrder: opts?.stackOrder ?? Object.keys(stepState),
         isFailureHandler: Boolean(opts?.onFailure),

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -11,6 +11,7 @@ import { InngestFunction } from "@local/components/InngestFunction";
 import { STEP_INDEXING_SUFFIX } from "@local/components/InngestStepTools";
 import { NonRetriableError } from "@local/components/NonRetriableError";
 import {
+  ExecutionVersion,
   type ExecutionResult,
   type ExecutionResults,
   type InngestExecutionOptions,
@@ -34,6 +35,7 @@ import {
   type FailureEventPayload,
   type OutgoingOp,
 } from "@local/types";
+import { fromPartial } from "@total-typescript/shoehorn";
 import { type IsEqual } from "type-fest";
 import { assertType } from "type-plus";
 import { createClient } from "../test/helpers";
@@ -144,8 +146,10 @@ describe("runFn", () => {
               flowFn
             );
 
-            const execution = fn["createExecution"]({
-              data: { event: { name: "foo", data: { foo: "foo" } } },
+            const execution = fn["createExecution"](ExecutionVersion.V1, {
+              data: fromPartial({
+                event: { name: "foo", data: { foo: "foo" } },
+              }),
               runId: "run",
               stepState: {},
               stepCompletionOrder: [],
@@ -183,8 +187,10 @@ describe("runFn", () => {
           });
 
           test("wrap thrown error", async () => {
-            const execution = fn["createExecution"]({
-              data: { event: { name: "foo", data: { foo: "foo" } } },
+            const execution = fn["createExecution"](ExecutionVersion.V1, {
+              data: fromPartial({
+                event: { name: "foo", data: { foo: "foo" } },
+              }),
               stepState: {},
               runId: "run",
               stepCompletionOrder: [],
@@ -216,8 +222,8 @@ describe("runFn", () => {
         disableImmediateExecution?: boolean;
       }
     ) => {
-      const execution = fn["createExecution"]({
-        data: { event: opts?.event || { name: "foo", data: {} } },
+      const execution = fn["createExecution"](ExecutionVersion.V1, {
+        data: fromPartial({ event: opts?.event || { name: "foo", data: {} } }),
         runId: "run",
         stepState,
         stepCompletionOrder: opts?.stackOrder ?? Object.keys(stepState),

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -9,11 +9,12 @@ import {
   type Handler,
 } from "../types";
 import { type EventsFromOpts, type Inngest } from "./Inngest";
-import {
-  InngestExecution,
-  type InngestExecutionOptions,
-} from "./InngestExecution";
 import { type MiddlewareRegisterReturn } from "./InngestMiddleware";
+import {
+  type IInngestExecution,
+  type InngestExecutionOptions,
+} from "./execution/InngestExecution";
+import { createV1InngestExecution } from "./execution/v1";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyInngestFunction = InngestFunction<any, any, any, any>;
@@ -193,8 +194,8 @@ export class InngestFunction<
 
   private createExecution(
     options: Omit<InngestExecutionOptions, "client" | "fn">
-  ): InngestExecution {
-    return new InngestExecution({
+  ): IInngestExecution {
+    return createV1InngestExecution({
       client: this.#client,
       fn: this,
       ...options,

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -14,7 +14,6 @@ import { createClient } from "../test/helpers";
 const getStepTools = () => {
   const step = createStepTools(
     createClient({ id: "test" }),
-    {},
     ({ args, matchOp }) => {
       const stepOptions = getStepOptions(args[0]);
       return Promise.resolve(matchOp(stepOptions, ...args.slice(1)));
@@ -422,12 +421,7 @@ describe("sendEvent", () => {
       });
 
       const sendEvent: ReturnType<
-        typeof createStepTools<
-          typeof opts,
-          EventsFromOpts<typeof opts>,
-          "foo",
-          {}
-        >
+        typeof createStepTools<typeof opts, EventsFromOpts<typeof opts>, "foo">
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       >["sendEvent"] = (() => undefined) as any;
 

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -23,7 +23,7 @@ import {
   type StepOptionsOrId,
 } from "../types";
 import { type EventsFromOpts, type Inngest } from "./Inngest";
-import { _internals, type ExecutionState } from "./InngestExecution";
+import { _internals, type V1ExecutionState } from "./execution/v1";
 
 export interface FoundStep extends HashedOp {
   hashedId: string;
@@ -57,7 +57,7 @@ export const createStepTools = <
   TriggeringEvent extends keyof Events & string
 >(
   client: Inngest<TOpts>,
-  state: ExecutionState
+  state: V1ExecutionState
 ) => {
   /**
    * A list of steps that have been found and are being rolled up before being

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -45,7 +45,7 @@ export type MatchOpFn<
 export type StepHandler = (info: {
   matchOp: MatchOpFn;
   opts?: StepToolOptions;
-  args: unknown[];
+  args: [StepOptionsOrId, ...unknown[]];
 }) => Promise<unknown>;
 
 export interface StepToolOptions<
@@ -134,9 +134,9 @@ export const createStepTools = <
     matchOp: MatchOpFn<T>,
     opts?: StepToolOptions<T>
   ): T => {
-    // return (async (...args: Parameters<T>): Promise<unknown> => {
     return (async (...args: Parameters<T>): Promise<unknown> => {
-      return stepHandler({ args, matchOp, opts });
+      const parsedArgs = args as unknown as [StepOptionsOrId, ...unknown[]];
+      return stepHandler({ args: parsedArgs, matchOp, opts });
     }) as T;
   };
 
@@ -183,7 +183,7 @@ export const createStepTools = <
           id,
           op: StepOpCode.StepPlanned,
           name: "sendEvent",
-          displayName: name,
+          displayName: name ?? id,
         };
       },
       {
@@ -238,7 +238,7 @@ export const createStepTools = <
           op: StepOpCode.WaitForEvent,
           name: opts.event,
           opts: matchOpts,
-          displayName: name,
+          displayName: name ?? id,
         };
       }
     ),
@@ -287,7 +287,7 @@ export const createStepTools = <
           id,
           op: StepOpCode.StepPlanned,
           name: id,
-          displayName: name,
+          displayName: name ?? id,
         };
       },
       { fn: (stepOptions, fn) => fn() }
@@ -321,7 +321,7 @@ export const createStepTools = <
         id,
         op: StepOpCode.Sleep,
         name: timeStr(time),
-        displayName: name,
+        displayName: name ?? id,
       };
     }),
 
@@ -352,7 +352,7 @@ export const createStepTools = <
           id,
           op: StepOpCode.Sleep,
           name: date.toISOString(),
-          displayName: name,
+          displayName: name ?? id,
         };
       } catch (err) {
         /**

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -107,11 +107,9 @@ export const STEP_INDEXING_SUFFIX = ":";
 export const createStepTools = <
   TOpts extends ClientOptions,
   Events extends EventsFromOpts<TOpts>,
-  TriggeringEvent extends keyof Events & string,
-  TState
+  TriggeringEvent extends keyof Events & string
 >(
   client: Inngest<TOpts>,
-  state: TState,
   stepHandler: StepHandler
 ) => {
   /**

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -1,11 +1,4 @@
 import { type Jsonify } from "type-fest";
-import { logPrefix } from "../helpers/consts";
-import { ErrCode, prettyError } from "../helpers/errors";
-import {
-  createDeferredPromise,
-  resolveAfterPending,
-  runAsPromise,
-} from "../helpers/promises";
 import { timeStr } from "../helpers/strings";
 import {
   type ExclusiveKeys,
@@ -23,7 +16,6 @@ import {
   type StepOptionsOrId,
 } from "../types";
 import { type EventsFromOpts, type Inngest } from "./Inngest";
-import { _internals, type V1ExecutionState } from "./execution/v1";
 
 export interface FoundStep extends HashedOp {
   hashedId: string;
@@ -37,6 +29,67 @@ export interface FoundStep extends HashedOp {
    */
   handle: () => boolean;
 }
+
+export type MatchOpFn<
+  T extends (...args: unknown[]) => Promise<unknown> = (
+    ...args: unknown[]
+  ) => Promise<unknown>
+> = (
+  stepOptions: StepOptions,
+  /**
+   * Arguments passed by the user.
+   */
+  ...args: ParametersExceptFirst<T>
+) => Omit<HashedOp, "data" | "error">;
+
+export type StepHandler = (info: {
+  matchOp: MatchOpFn;
+  opts?: StepToolOptions;
+  args: unknown[];
+}) => Promise<unknown>;
+
+export interface StepToolOptions<
+  T extends (...args: unknown[]) => Promise<unknown> = (
+    ...args: unknown[]
+  ) => Promise<unknown>
+> {
+  /**
+   * Optionally, we can also provide a function that will be called when
+   * Inngest tells us to run this operation.
+   *
+   * If this function is defined, the first time the tool is used it will
+   * report the desired operation (including options) to the Inngest. Inngest
+   * will then call back to the function to tell it to run the step and then
+   * retrieve data.
+   *
+   * We do this in order to allow functionality such as per-step retries; this
+   * gives the SDK the opportunity to tell Inngest what it wants to do before
+   * it does it.
+   *
+   * This function is passed the arguments passed by the user. It will be run
+   * when we receive an operation matching this one that does not contain a
+   * `data` property.
+   */
+  fn?: (...args: Parameters<T>) => unknown;
+
+  /**
+   * If `true` and we have detected that this is a  non-step function, the
+   * provided `fn` will be called and the result returned immediately
+   * instead of being executed later.
+   *
+   * If no `fn` is provided to the tool, this will throw the same error as
+   * if this setting was `false`.
+   */
+  nonStepExecuteInline?: boolean;
+}
+
+export const getStepOptions = (options: StepOptionsOrId): StepOptions => {
+  if (typeof options === "string") {
+    return { id: options };
+  }
+
+  return options;
+};
 
 /**
  * Suffix used to namespace steps that are automatically indexed.
@@ -54,129 +107,13 @@ export const STEP_INDEXING_SUFFIX = ":";
 export const createStepTools = <
   TOpts extends ClientOptions,
   Events extends EventsFromOpts<TOpts>,
-  TriggeringEvent extends keyof Events & string
+  TriggeringEvent extends keyof Events & string,
+  TState
 >(
   client: Inngest<TOpts>,
-  state: V1ExecutionState
+  state: TState,
+  stepHandler: StepHandler
 ) => {
-  /**
-   * A list of steps that have been found and are being rolled up before being
-   * reported to the core loop.
-   */
-  let foundStepsToReport: FoundStep[] = [];
-
-  /**
-   * A promise that's used to ensure that step reporting cannot be run more than
-   * once in a given asynchronous time span.
-   */
-  let foundStepsReportPromise: Promise<void> | undefined;
-
-  /**
-   * A promise that's used to represent middleware hooks running before
-   * execution.
-   */
-  let beforeExecHooksPromise: Promise<void> | undefined;
-
-  /**
-   * A flag used to ensure that we only warn about parallel indexing once per
-   * execution to avoid spamming the console.
-   */
-  let warnOfParallelIndexing = false;
-
-  /**
-   * Given a colliding step ID, maybe warn the user about parallel indexing.
-   */
-  const maybeWarnOfParallelIndexing = (collisionId: string) => {
-    if (warnOfParallelIndexing) {
-      return;
-    }
-
-    const stepExists = Boolean(state.steps[collisionId]);
-
-    const stepFoundThisTick = foundStepsToReport.some((step) => {
-      return step.id === collisionId;
-    });
-
-    if (stepExists && !stepFoundThisTick) {
-      warnOfParallelIndexing = true;
-
-      console.warn(
-        prettyError({
-          type: "warn",
-          whatHappened:
-            "We detected that you have multiple steps with the same ID.",
-          code: ErrCode.AUTOMATIC_PARALLEL_INDEXING,
-          why: `This can happen if you're using the same ID for multiple steps across different chains of parallel work. We found the issue with step "${collisionId}".`,
-          reassurance:
-            "Your function is still running, though it may exhibit unexpected behaviour.",
-          consequences:
-            "Using the same IDs across parallel chains of work can cause unexpected behaviour.",
-          toFixNow:
-            "We recommend using a unique ID for each step, especially those happening in parallel.",
-        })
-      );
-    }
-  };
-
-  /**
-   * A helper used to report steps to the core loop. Used after adding an item
-   * to `foundStepsToReport`.
-   */
-  const reportNextTick = () => {
-    // Being explicit instead of using `??=` to appease TypeScript.
-    if (foundStepsReportPromise) {
-      return;
-    }
-
-    foundStepsReportPromise = resolveAfterPending()
-      /**
-       * Ensure that we wait for this promise to resolve before continuing.
-       *
-       * The groups in which steps are reported can affect how we detect some
-       * more complex determinism issues like parallel indexing. This promise
-       * can represent middleware hooks being run early, in the middle of
-       * ingesting steps to report.
-       *
-       * Because of this, it's important we wait for this middleware to resolve
-       * before continuing to report steps to ensure that all steps have a
-       * chance to be reported throughout this asynchronous action.
-       */
-      .then(() => beforeExecHooksPromise)
-      .then(() => {
-        foundStepsReportPromise = undefined;
-
-        for (let i = 0; i < state.stepCompletionOrder.length; i++) {
-          const handled = foundStepsToReport
-            .find((step) => {
-              return step.hashedId === state.stepCompletionOrder[i];
-            })
-            ?.handle();
-
-          if (handled) {
-            return void reportNextTick();
-          }
-        }
-
-        // If we've handled no steps in this "tick," roll up everything we've
-        // found and report it.
-        const steps = [...foundStepsToReport] as [FoundStep, ...FoundStep[]];
-        foundStepsToReport = [];
-
-        return void state.setCheckpoint({
-          type: "steps-found",
-          steps: steps,
-        });
-      });
-  };
-
-  /**
-   * A helper used to push a step to the list of steps to report.
-   */
-  const pushStepToReport = (step: FoundStep) => {
-    foundStepsToReport.push(step);
-    reportNextTick();
-  };
-
   /**
    * A local helper used to create tools that can be used to submit an op.
    *
@@ -194,167 +131,13 @@ export const createStepTools = <
      *
      * Most simple tools will likely only need to define this.
      */
-    matchOp: (
-      stepOptions: StepOptions,
-      /**
-       * Arguments passed by the user.
-       */
-      ...args: ParametersExceptFirst<T>
-    ) => Omit<HashedOp, "data" | "error">,
-
-    opts?: {
-      /**
-       * Optionally, we can also provide a function that will be called when
-       * Inngest tells us to run this operation.
-       *
-       * If this function is defined, the first time the tool is used it will
-       * report the desired operation (including options) to the Inngest. Inngest
-       * will then call back to the function to tell it to run the step and then
-       * retrieve data.
-       *
-       * We do this in order to allow functionality such as per-step retries; this
-       * gives the SDK the opportunity to tell Inngest what it wants to do before
-       * it does it.
-       *
-       * This function is passed the arguments passed by the user. It will be run
-       * when we receive an operation matching this one that does not contain a
-       * `data` property.
-       */
-      fn?: (...args: Parameters<T>) => unknown;
-
-      /**
-       * If `true` and we have detected that this is a  non-step function, the
-       * provided `fn` will be called and the result returned immediately
-       * instead of being executed later.
-       *
-       * If no `fn` is provided to the tool, this will throw the same error as
-       * if this setting was `false`.
-       */
-      nonStepExecuteInline?: boolean;
-    }
+    matchOp: MatchOpFn<T>,
+    opts?: StepToolOptions<T>
   ): T => {
+    // return (async (...args: Parameters<T>): Promise<unknown> => {
     return (async (...args: Parameters<T>): Promise<unknown> => {
-      await beforeExecHooksPromise;
-
-      if (!state.hasSteps && opts?.nonStepExecuteInline && opts.fn) {
-        return runAsPromise(() => opts.fn?.(...args));
-      }
-
-      if (state.executingStep) {
-        /**
-         * If a step is found after asynchronous actions during another step's
-         * execution, everything is fine. The problem here is if we've found
-         * that a step nested inside another a step, which is something we don't
-         * support at the time of writing.
-         *
-         * In this case, we could use something like Async Hooks to understand
-         * how the step is being triggered, though this isn't available in all
-         * environments.
-         *
-         * Therefore, we'll only show a warning here to indicate that this is
-         * potentially an issue.
-         */
-        console.warn(
-          prettyError({
-            whatHappened: "We detected that you have nested `step.*` tooling.",
-            consequences: "Nesting `step.*` tooling is not supported.",
-            type: "warn",
-            reassurance:
-              "It's possible to see this warning if steps are separated by regular asynchronous calls, which is fine.",
-            stack: true,
-            toFixNow:
-              "Make sure you're not using `step.*` tooling inside of other `step.*` tooling. If you need to compose steps together, you can create a new async function and call it from within your step function, or use promise chaining.",
-            code: ErrCode.NESTING_STEPS,
-          })
-        );
-      }
-
-      const [stepOptionsOrId, ...remainingArgs] = args as unknown as [
-        StepOptionsOrId,
-        ...ParametersExceptFirst<T>
-      ];
-
-      const stepOptions = getStepOptions(stepOptionsOrId);
-      const opId = matchOp(stepOptions, ...remainingArgs);
-
-      if (state.steps[opId.id]) {
-        const originalId = opId.id;
-        maybeWarnOfParallelIndexing(originalId);
-
-        for (let i = 1; ; i++) {
-          const newId = [originalId, STEP_INDEXING_SUFFIX, i].join("");
-
-          if (!state.steps[newId]) {
-            opId.id = newId;
-            break;
-          }
-        }
-
-        console.debug(
-          `${logPrefix} debug - Step "${originalId}" already exists; automatically indexing to "${opId.id}"`
-        );
-      }
-
-      const { promise, resolve, reject } = createDeferredPromise();
-      const hashedId = _internals.hashId(opId.id);
-      const stepState = state.stepState[hashedId];
-      if (stepState) {
-        stepState.seen = true;
-      }
-
-      const step: FoundStep = {
-        ...opId,
-        hashedId,
-        fn: opts?.fn ? () => opts.fn?.(...args) : undefined,
-        fulfilled: Boolean(stepState),
-        displayName: opId.displayName ?? opId.id,
-        handled: false,
-        handle: () => {
-          if (step.handled) {
-            return false;
-          }
-
-          step.handled = true;
-
-          if (stepState) {
-            stepState.fulfilled = true;
-
-            if (typeof stepState.data !== "undefined") {
-              resolve(stepState.data);
-            } else {
-              reject(stepState.error);
-            }
-          }
-
-          return true;
-        },
-      };
-
-      state.steps[opId.id] = step;
-      state.hasSteps = true;
-      pushStepToReport(step);
-
-      /**
-       * If this is the last piece of state we had, we've now finished
-       * memoizing.
-       */
-      if (!beforeExecHooksPromise && state.allStateUsed()) {
-        await (beforeExecHooksPromise = (async () => {
-          await state.hooks?.beforeExecution?.();
-          await state.hooks?.afterMemoization?.();
-        })());
-      }
-
-      return promise;
+      return stepHandler({ args, matchOp, opts });
     }) as T;
-  };
-
-  const getStepOptions = (options: StepOptionsOrId): StepOptions => {
-    if (typeof options === "string") {
-      return { id: options };
-    }
-
-    return options;
   };
 
   /**

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -41,7 +41,8 @@ export enum ExecutionVersion {
   V1 = 1,
 }
 
-export const PREFERRED_EXECUTION_VERSION = ExecutionVersion.V1;
+export const PREFERRED_EXECUTION_VERSION =
+  ExecutionVersion.V1 satisfies ExecutionVersion;
 
 /**
  * Options for creating a new {@link InngestExecution} instance.

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -1,0 +1,69 @@
+import Debug, { type Debugger } from "debug";
+import { type Simplify } from "type-fest";
+import { type MaybePromise } from "type-plus";
+import { type ServerTiming } from "../../helpers/ServerTiming";
+import { type IncomingOp, type OutgoingOp } from "../../types";
+import { type AnyInngest } from "../Inngest";
+import { type ActionResponse } from "../InngestCommHandler";
+import { type AnyInngestFunction } from "../InngestFunction";
+
+/**
+ * The possible results of an execution.
+ */
+export interface ExecutionResults {
+  "function-resolved": { data: unknown };
+  "step-ran": { step: OutgoingOp };
+  "function-rejected": { error: unknown; retriable: boolean | string };
+  "steps-found": { steps: [OutgoingOp, ...OutgoingOp[]] };
+  "step-not-found": { step: OutgoingOp };
+}
+
+export type ExecutionResult = {
+  [K in keyof ExecutionResults]: Simplify<{ type: K } & ExecutionResults[K]>;
+}[keyof ExecutionResults];
+
+export type ExecutionResultHandler<T = ActionResponse> = (
+  result: ExecutionResult
+) => MaybePromise<T>;
+
+export type ExecutionResultHandlers<T = ActionResponse> = {
+  [E in ExecutionResult as E["type"]]: (result: E) => MaybePromise<T>;
+};
+
+export interface MemoizedOp extends IncomingOp {
+  fulfilled?: boolean;
+  seen?: boolean;
+}
+
+/**
+ * Options for creating a new {@link InngestExecution} instance.
+ */
+export interface InngestExecutionOptions {
+  client: AnyInngest;
+  fn: AnyInngestFunction;
+  runId: string;
+  data: unknown;
+  stepState: Record<string, MemoizedOp>;
+  stepCompletionOrder: string[];
+  requestedRunStep?: string;
+  timer?: ServerTiming;
+  isFailureHandler?: boolean;
+  disableImmediateExecution?: boolean;
+}
+
+export type InngestExecutionFactory = (
+  options: InngestExecutionOptions
+) => IInngestExecution;
+
+export class InngestExecution {
+  protected debug: Debugger;
+
+  constructor(protected options: InngestExecutionOptions) {
+    this.options = options;
+    this.debug = Debug("inngest").extend(this.options.runId);
+  }
+}
+
+export interface IInngestExecution {
+  start(): Promise<ExecutionResult>;
+}

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -40,6 +40,8 @@ export enum ExecutionVersion {
   V1 = 1,
 }
 
+export const PREFERRED_EXECUTION_VERSION = ExecutionVersion.V1;
+
 /**
  * Options for creating a new {@link InngestExecution} instance.
  */

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -2,7 +2,7 @@ import Debug, { type Debugger } from "debug";
 import { type Simplify } from "type-fest";
 import { type MaybePromise } from "type-plus";
 import { type ServerTiming } from "../../helpers/ServerTiming";
-import { type IncomingOp, type OutgoingOp } from "../../types";
+import { type AnyContext, type IncomingOp, type OutgoingOp } from "../../types";
 import { type AnyInngest } from "../Inngest";
 import { type ActionResponse } from "../InngestCommHandler";
 import { type AnyInngestFunction } from "../InngestFunction";
@@ -35,6 +35,11 @@ export interface MemoizedOp extends IncomingOp {
   seen?: boolean;
 }
 
+export enum ExecutionVersion {
+  V0 = 0,
+  V1 = 1,
+}
+
 /**
  * Options for creating a new {@link InngestExecution} instance.
  */
@@ -42,7 +47,7 @@ export interface InngestExecutionOptions {
   client: AnyInngest;
   fn: AnyInngestFunction;
   runId: string;
-  data: unknown;
+  data: Omit<AnyContext, "step">;
   stepState: Record<string, MemoizedOp>;
   stepCompletionOrder: string[];
   requestedRunStep?: string;

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -411,7 +411,7 @@ export class V0InngestExecution
       });
     };
 
-    const step = createStepTools(this.options.client, this.#state, stepHandler);
+    const step = createStepTools(this.options.client, stepHandler);
 
     const fnArg = {
       ...(this.options.data as { event: EventPayload }),

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -27,7 +27,6 @@ import {
   type IncomingOp,
   type OpStack,
   type OutgoingOp,
-  type StepOptionsOrId,
 } from "../../types";
 import { getHookStack, type RunHookStack } from "../InngestMiddleware";
 import {
@@ -398,13 +397,8 @@ export class V0InngestExecution
 
       this.#state.hasUsedTools = true;
 
-      const [stepOptionsOrId, ...remainingArgs] = args as unknown as [
-        StepOptionsOrId,
-        ...unknown[]
-      ];
-
-      const stepOptions = getStepOptions(stepOptionsOrId);
-      const opId = hashOp(matchOp(stepOptions, ...remainingArgs));
+      const stepOptions = getStepOptions(args[0]);
+      const opId = hashOp(matchOp(stepOptions, ...args.slice(1)));
 
       return new Promise<unknown>((resolve, reject) => {
         this.#state.tickOps[opId.id] = {

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -1,0 +1,189 @@
+import {
+  type BaseContext,
+  type ClientOptions,
+  type HashedOp,
+} from "../../types";
+import { getHookStack, type RunHookStack } from "../InngestMiddleware";
+import {
+  InngestExecution,
+  type ExecutionResult,
+  type IInngestExecution,
+  type InngestExecutionFactory,
+  type InngestExecutionOptions,
+} from "./InngestExecution";
+
+export const createV0InngestExecution: InngestExecutionFactory = (options) => {
+  return new V0InngestExecution(options);
+};
+
+export class V0InngestExecution
+  extends InngestExecution
+  implements IInngestExecution
+{
+  #state: V0ExecutionState;
+  #execution: Promise<ExecutionResult> | undefined;
+
+  constructor(options: InngestExecutionOptions) {
+    super(options);
+
+    this.#state = this.#createExecutionState();
+  }
+
+  public start() {
+    this.debug("starting execution");
+
+    return (this.#execution ??= this.#start().then((result) => {
+      this.debug("result:", result);
+      return result;
+    }));
+  }
+
+  async #start(): Promise<ExecutionResult> {
+    this.#state.hooks = await this.#initializeMiddleware();
+
+    return { type: "function-resolved", data: {} };
+  }
+
+  async #initializeMiddleware(): Promise<RunHookStack> {
+    const ctx = this.options.data as Pick<
+      Readonly<BaseContext<ClientOptions, string>>,
+      "event" | "events" | "runId"
+    >;
+
+    const hooks = await getHookStack(
+      this.options.fn["middleware"],
+      "onFunctionRun",
+      {
+        ctx,
+        fn: this.options.fn,
+        steps: Object.values(this.options.stepState),
+      },
+      {
+        transformInput: (prev, output) => {
+          return {
+            ctx: { ...prev.ctx, ...output?.ctx },
+            fn: this.options.fn,
+            steps: prev.steps.map((step, i) => ({
+              ...step,
+              ...output?.steps?.[i],
+            })),
+          };
+        },
+        transformOutput: (prev, output) => {
+          return {
+            result: { ...prev.result, ...output?.result },
+            step: prev.step,
+          };
+        },
+      }
+    );
+
+    return hooks;
+  }
+
+  #createExecutionState(): V0ExecutionState {
+    const state: V0ExecutionState = {
+      allFoundOps: {},
+      tickOps: {},
+      tickOpHashes: {},
+      currentOp: undefined,
+      hasUsedTools: false,
+      reset: () => {
+        state.tickOpHashes = {};
+        state.allFoundOps = { ...state.allFoundOps, ...state.tickOps };
+      },
+      nonStepFnDetected: false,
+      executingStep: false,
+    };
+
+    return state;
+  }
+}
+
+interface TickOp extends HashedOp {
+  fn?: (...args: unknown[]) => unknown;
+  fulfilled: boolean;
+  resolve: (value: unknown | PromiseLike<unknown>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export interface V0ExecutionState {
+  /**
+   * The tree of all found ops in the entire invocation.
+   */
+  allFoundOps: Record<string, TickOp>;
+
+  /**
+   * All synchronous operations found in this particular tick. The array is
+   * reset every tick.
+   */
+  tickOps: Record<string, TickOp>;
+
+  /**
+   * A hash of operations found within this tick, with keys being the hashed
+   * ops themselves (without a position) and the values being the number of
+   * times that op has been found.
+   *
+   * This is used to provide some mutation resilience to the op stack,
+   * allowing us to survive same-tick mutations of code by ensuring per-tick
+   * hashes are based on uniqueness rather than order.
+   */
+  tickOpHashes: Record<string, number>;
+
+  /**
+   * Tracks the current operation being processed. This can be used to
+   * understand the contextual parent of any recorded operations.
+   */
+  currentOp: TickOp | undefined;
+
+  /**
+   * If we've found a user function to run, we'll store it here so a component
+   * higher up can invoke and await it.
+   */
+  userFnToRun?: (...args: unknown[]) => unknown;
+
+  /**
+   * A boolean to represent whether the user's function is using any step
+   * tools.
+   *
+   * If the function survives an entire tick of the event loop and hasn't
+   * touched any tools, we assume that it is a single-step async function and
+   * should be awaited as usual.
+   */
+  hasUsedTools: boolean;
+
+  /**
+   * A function that should be used to reset the state of the tools after a
+   * tick has completed.
+   */
+  reset: () => void;
+
+  /**
+   * If `true`, any use of step tools will, by default, throw an error. We do
+   * this when we detect that a function may be mixing step and non-step code.
+   *
+   * Created step tooling can decide how to manually handle this on a
+   * case-by-case basis.
+   *
+   * In the future, we can provide a way for a user to override this if they
+   * wish to and understand the danger of side-effects.
+   *
+   * Defaults to `false`.
+   */
+  nonStepFnDetected: boolean;
+
+  /**
+   * When true, we are currently executing a user's code for a single step
+   * within a step function.
+   */
+  executingStep: boolean;
+
+  /**
+   * Initialized middleware hooks for this execution.
+   *
+   * Middleware hooks are cached to ensure they can only be run once, which
+   * means that these hooks can be called in many different places to ensure we
+   * handle all possible execution paths.
+   */
+  hooks?: RunHookStack;
+}

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -185,7 +185,9 @@ export class V0InngestExecution
             return await this.#transformOutput({ data }, outgoingUserFnOp);
           });
 
-        return { type: "step-ran", step: { ...outgoingUserFnOp, ...result } };
+        const { type: _type, ...rest } = result;
+
+        return { type: "step-ran", step: { ...outgoingUserFnOp, ...rest } };
       }
 
       if (!discoveredOps.length) {

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -345,13 +345,13 @@ export class V0InngestExecution
       op: PartialK<HashedOp, "id">
     ): HashedOp => {
       /**
-       * If the op already has an ID, we don't need to generate one. This allows
-       * users to specify their own IDs.
+       * It's difficult for v0 to understand whether or not an op has
+       * historically contained a custom ID, as all step usage now require them.
+       *
+       * For this reason, we make the assumption that steps in v0 do not have a
+       * custom ID and generate one for them as we would in all recommendations
+       * and examples.
        */
-      if (op.id) {
-        return op as HashedOp;
-      }
-
       const obj = {
         parent: this.#state.currentOp?.id ?? null,
         op: op.op,

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -1,9 +1,33 @@
+import { z } from "zod";
 import {
+  ErrCode,
+  deserializeError,
+  functionStoppedRunningErr,
+  prettyError,
+  serializeError,
+} from "../../helpers/errors";
+import {
+  resolveAfterPending,
+  resolveNextTick,
+  runAsPromise,
+} from "../../helpers/promises";
+import {
+  StepOpCode,
+  failureEventErrorSchema,
+  type AnyContext,
+  type AnyHandler,
   type BaseContext,
   type ClientOptions,
+  type EventPayload,
+  type FailureEventArgs,
   type HashedOp,
+  type IncomingOp,
+  type OpStack,
+  type OutgoingOp,
 } from "../../types";
 import { getHookStack, type RunHookStack } from "../InngestMiddleware";
+import { NonRetriableError } from "../NonRetriableError";
+import { RetryAfterError } from "../RetryAfterError";
 import {
   InngestExecution,
   type ExecutionResult,
@@ -16,17 +40,32 @@ export const createV0InngestExecution: InngestExecutionFactory = (options) => {
   return new V0InngestExecution(options);
 };
 
+/**
+ * TODO timer
+ *
+ * ---
+ *
+ * Step tools
+ * fn arg, incl failure handler
+ * opts.fns
+ * run user fn
+ * pos iteration - RIP OUT OF STEPTOOLS
+ */
 export class V0InngestExecution
   extends InngestExecution
   implements IInngestExecution
 {
   #state: V0ExecutionState;
   #execution: Promise<ExecutionResult> | undefined;
+  #userFnToRun: AnyHandler;
+  #fnArg: AnyContext;
 
   constructor(options: InngestExecutionOptions) {
     super(options);
 
+    this.#userFnToRun = this.#getUserFnToRun();
     this.#state = this.#createExecutionState();
+    this.#fnArg = this.#createFnArg(this.#state);
   }
 
   public start() {
@@ -41,7 +80,168 @@ export class V0InngestExecution
   async #start(): Promise<ExecutionResult> {
     this.#state.hooks = await this.#initializeMiddleware();
 
-    return { type: "function-resolved", data: {} };
+    try {
+      await this.#transformInput();
+      await this.#state.hooks.beforeMemoization?.();
+
+      if (this.#state.opStack.length === 0 && !this.options.requestedRunStep) {
+        await this.#state.hooks.afterMemoization?.();
+        await this.#state.hooks.beforeExecution?.();
+      }
+
+      const userFnPromise = runAsPromise(() => this.#userFnToRun(this.#fnArg));
+
+      let pos = -1;
+
+      do {
+        if (pos >= 0) {
+          if (
+            !this.options.requestedRunStep &&
+            pos === this.#state.opStack.length - 1
+          ) {
+            await this.#state.hooks.afterMemoization?.();
+            await this.#state.hooks.beforeExecution?.();
+          }
+
+          this.#state.tickOps = {};
+          const incomingOp = this.#state.opStack[pos] as IncomingOp;
+          this.#state.currentOp = this.#state.allFoundOps[incomingOp.id];
+
+          if (!this.#state.currentOp) {
+            /**
+             * We're trying to resume the function, but we can't find where to go.
+             *
+             * This means that either the function has changed or there are async
+             * actions in-between steps that we haven't noticed in previous
+             * executions.
+             *
+             * Whichever the case, this is bad and we can't continue in this
+             * undefined state.
+             */
+            throw new NonRetriableError(
+              prettyError({
+                whatHappened: " Your function was stopped from running",
+                why: "We couldn't resume your function's state because it may have changed since the run started or there are async actions in-between steps that we haven't noticed in previous executions.",
+                consequences:
+                  "Continuing to run the function may result in unexpected behaviour, so we've stopped your function to ensure nothing unexpected happened!",
+                toFixNow:
+                  "Ensure that your function is either entirely step-based or entirely non-step-based, by either wrapping all asynchronous logic in `step.run()` calls or by removing all `step.*()` calls.",
+                otherwise:
+                  "For more information on why step functions work in this manner, see https://www.inngest.com/docs/functions/multi-step#gotchas",
+                stack: true,
+                code: ErrCode.NON_DETERMINISTIC_FUNCTION,
+              })
+            );
+          }
+
+          this.#state.currentOp.fulfilled = true;
+
+          if (typeof incomingOp.data !== "undefined") {
+            this.#state.currentOp.resolve(incomingOp.data);
+          } else {
+            this.#state.currentOp.reject(incomingOp.error);
+          }
+        }
+
+        await resolveAfterPending();
+        this.#state.reset();
+        pos++;
+      } while (pos < this.#state.opStack.length);
+
+      await this.#state.hooks.afterMemoization?.();
+
+      const discoveredOps = Object.values(this.#state.tickOps).map<OutgoingOp>(
+        tickOpToOutgoing
+      );
+
+      const runStep =
+        this.options.requestedRunStep ||
+        this.#getEarlyExecRunStep(discoveredOps);
+
+      if (runStep) {
+        const userFnOp = this.#state.allFoundOps[runStep];
+        const stepToRun = userFnOp?.fn;
+
+        if (!stepToRun) {
+          throw new Error(
+            `Bad stack; executor requesting to run unknown step "${runStep}"`
+          );
+        }
+
+        const outgoingUserFnOp = {
+          ...tickOpToOutgoing(userFnOp),
+          op: StepOpCode.RunStep,
+        };
+
+        await this.#state.hooks.beforeExecution?.();
+        this.#state.executingStep = true;
+
+        const result = await runAsPromise(stepToRun)
+          .finally(() => {
+            this.#state.executingStep = false;
+          })
+          .catch(async (error: Error) => {
+            return await this.#transformOutput({ error }, outgoingUserFnOp);
+          })
+          .then(async (data) => {
+            await this.#state.hooks?.afterExecution?.();
+            return await this.#transformOutput({ data }, outgoingUserFnOp);
+          });
+
+        return { type: "step-ran", step: { ...outgoingUserFnOp, ...result } };
+      }
+
+      if (!discoveredOps.length) {
+        const fnRet = await Promise.race([
+          userFnPromise.then((data) => ({ type: "complete", data } as const)),
+          resolveNextTick().then(() => ({ type: "incomplete" } as const)),
+        ]);
+
+        if (fnRet.type === "complete") {
+          await this.#state.hooks.afterExecution?.();
+
+          const allOpsFulfilled = Object.values(this.#state.allFoundOps).every(
+            (op) => {
+              return op.fulfilled;
+            }
+          );
+
+          if (allOpsFulfilled) {
+            return await this.#transformOutput({ data: fnRet.data });
+          }
+        } else if (!this.#state.hasUsedTools) {
+          this.#state.nonStepFnDetected = true;
+          const data = await userFnPromise;
+          await this.#state.hooks.afterExecution?.();
+          return await this.#transformOutput({ data });
+        } else {
+          const hasOpsPending = Object.values(this.#state.allFoundOps).some(
+            (op) => {
+              return op.fulfilled === false;
+            }
+          );
+
+          if (!hasOpsPending) {
+            throw new NonRetriableError(
+              functionStoppedRunningErr(
+                ErrCode.ASYNC_DETECTED_AFTER_MEMOIZATION
+              )
+            );
+          }
+        }
+      }
+
+      await this.#state.hooks.afterExecution?.();
+
+      return {
+        type: "steps-found",
+        steps: discoveredOps as [OutgoingOp, ...OutgoingOp[]],
+      };
+    } catch (error) {
+      return await this.#transformOutput({ error });
+    } finally {
+      await this.#state.hooks.beforeResponse?.();
+    }
   }
 
   async #initializeMiddleware(): Promise<RunHookStack> {
@@ -94,9 +294,131 @@ export class V0InngestExecution
       },
       nonStepFnDetected: false,
       executingStep: false,
+      opStack: this.options.stepCompletionOrder.reduce<IncomingOp[]>(
+        (acc, stepId) => {
+          const stepState = this.options.stepState[stepId];
+          if (!stepState) {
+            return acc;
+          }
+
+          return [...acc, stepState];
+        },
+        []
+      ),
     };
 
     return state;
+  }
+
+  #getUserFnToRun(): AnyHandler {
+    if (!this.options.isFailureHandler) {
+      return this.options.fn["fn"];
+    }
+
+    if (!this.options.fn["onFailureFn"]) {
+      /**
+       * Somehow, we've ended up detecting that this is a failure handler but
+       * doesn't have an `onFailure` function. This should never happen.
+       */
+      throw new Error("Cannot find function `onFailure` handler");
+    }
+
+    return this.options.fn["onFailureFn"];
+  }
+
+  #createFnArg(state: V0ExecutionState): AnyContext {
+    const step = {} as any; // TODO
+
+    const fnArg = {
+      ...(this.options.data as { event: EventPayload }),
+      step,
+    } as AnyContext;
+
+    if (this.options.isFailureHandler) {
+      const eventData = z
+        .object({ error: failureEventErrorSchema })
+        .parse(fnArg.event?.data);
+
+      (fnArg as Partial<Pick<FailureEventArgs, "error">>) = {
+        ...fnArg,
+        error: deserializeError(eventData.error),
+      };
+    }
+
+    return fnArg;
+  }
+
+  /**
+   * Using middleware, transform input before running.
+   */
+  async #transformInput() {
+    const inputMutations = await this.#state.hooks?.transformInput?.({
+      ctx: { ...this.#fnArg },
+      steps: Object.values(this.options.stepState),
+      fn: this.options.fn,
+    });
+
+    if (inputMutations?.ctx) {
+      this.#fnArg = inputMutations.ctx;
+    }
+
+    if (inputMutations?.steps) {
+      this.#state.opStack = [...inputMutations.steps];
+    }
+  }
+
+  #getEarlyExecRunStep(ops: OutgoingOp[]): string | undefined {
+    if (ops.length !== 1) return;
+
+    const op = ops[0];
+
+    if (
+      op &&
+      op.op === StepOpCode.StepPlanned &&
+      typeof op.opts === "undefined"
+    ) {
+      return op.id;
+    }
+  }
+
+  /**
+   * Using middleware, transform output before returning.
+   */
+  async #transformOutput(
+    dataOrError: Parameters<
+      NonNullable<RunHookStack["transformOutput"]>
+    >[0]["result"],
+    step?: Readonly<Omit<OutgoingOp, "id">>
+  ): Promise<ExecutionResult> {
+    const output = { ...dataOrError };
+
+    if (typeof output.error !== "undefined") {
+      output.data = serializeError(output.error);
+    }
+
+    const transformedOutput = await this.#state.hooks?.transformOutput?.({
+      result: { ...output },
+      step,
+    });
+
+    const { data, error } = { ...output, ...transformedOutput?.result };
+
+    if (typeof error !== "undefined") {
+      /**
+       * Ensure we give middleware the chance to decide on retriable behaviour
+       * by looking at the error returned from output transformation.
+       */
+      let retriable: boolean | string = !(error instanceof NonRetriableError);
+      if (retriable && error instanceof RetryAfterError) {
+        retriable = error.retryAfter;
+      }
+
+      const serializedError = serializeError(error);
+
+      return { type: "function-rejected", error: serializedError, retriable };
+    }
+
+    return { type: "function-resolved", data };
   }
 }
 
@@ -186,4 +508,22 @@ export interface V0ExecutionState {
    * handle all possible execution paths.
    */
   hooks?: RunHookStack;
+
+  /**
+   * The op stack to pass to the function as state, likely stored in
+   * `ctx._state` in the Inngest payload.
+   *
+   * This must be provided in order to always be cognizant of step function
+   * state and to allow for multi-step functions.
+   */
+  opStack: OpStack;
 }
+
+const tickOpToOutgoing = (op: TickOp): OutgoingOp => {
+  return {
+    op: op.op,
+    id: op.id,
+    name: op.name,
+    opts: op.opts,
+  };
+};

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -415,7 +415,7 @@ export class V0InngestExecution
 
     const step = createStepTools(this.options.client, stepHandler);
 
-    const fnArg = {
+    let fnArg = {
       ...(this.options.data as { event: EventPayload }),
       step,
     } as AnyContext;

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -66,7 +66,7 @@ export class V0InngestExecution
   }
 
   public start() {
-    this.debug("starting execution");
+    this.debug("starting V0 execution");
 
     return (this.#execution ??= this.#start().then((result) => {
       this.debug("result:", result);

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -517,12 +517,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
   }
 
   #createStepTools(): ReturnType<
-    typeof createStepTools<
-      ClientOptions,
-      Record<string, EventPayload>,
-      string,
-      V1ExecutionState
-    >
+    typeof createStepTools<ClientOptions, Record<string, EventPayload>, string>
   > {
     /**
      * A list of steps that have been found and are being rolled up before being
@@ -758,7 +753,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
       return promise;
     };
 
-    return createStepTools(this.options.client, this.#state, stepHandler);
+    return createStepTools(this.options.client, stepHandler);
   }
 
   #getUserFnToRun(): AnyHandler {

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -76,7 +76,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     this.#initializeTimer(this.#state);
 
     this.debug(
-      "created new execution for run;",
+      "created new V1 execution for run;",
       this.options.requestedRunStep
         ? `wanting to run step "${this.options.requestedRunStep}"`
         : "discovering steps"
@@ -89,7 +89,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
    * Idempotently start the execution of the user's function.
    */
   public start() {
-    this.debug("starting execution");
+    this.debug("starting V1 execution");
 
     return (this.#execution ??= this.#start().then((result) => {
       this.debug("result:", result);

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -25,7 +25,6 @@ import {
   type EventPayload,
   type FailureEventArgs,
   type OutgoingOp,
-  type StepOptionsOrId,
 } from "../../types";
 import { getHookStack, type RunHookStack } from "../InngestMiddleware";
 import {
@@ -684,14 +683,8 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         );
       }
 
-      const [stepOptionsOrId, ...remainingArgs] = args as unknown as [
-        StepOptionsOrId,
-        ...unknown[]
-      ];
-
-      const stepOptions = getStepOptions(stepOptionsOrId);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      const opId = matchOp(stepOptions, ...remainingArgs);
+      const stepOptions = getStepOptions(args[0]);
+      const opId = matchOp(stepOptions, ...args.slice(1));
 
       if (this.#state.steps[opId.id]) {
         const originalId = opId.id;

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -223,7 +223,6 @@ export const inngestHeaders = (opts?: {
     "Content-Type": "application/json",
     "User-Agent": sdkVersion,
     [headerKeys.SdkVersion]: sdkVersion,
-    [headerKeys.RequestVersion]: "1",
   };
 
   if (opts?.framework) {

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -186,14 +186,26 @@ export enum ErrCode {
   /**
    * Legacy v0 execution error code for when a function has changed and no
    * longer matches its in-progress state.
+   *
+   * @deprecated Not for use in latest execution method.
    */
   NON_DETERMINISTIC_FUNCTION = "NON_DETERMINISTIC_FUNCTION",
 
   /**
    * Legacy v0 execution error code for when a function is found to be using
    * async actions after memoziation has occurred, which v0 doesn't support.
+   *
+   * @deprecated Not for use in latest execution method.
    */
   ASYNC_DETECTED_AFTER_MEMOIZATION = "ASYNC_DETECTED_AFTER_MEMOIZATION",
+
+  /**
+   * Legacy v0 execution error code for when a function is found to be using
+   * steps after a non-step async action has occurred.
+   *
+   * @deprecated Not for use in latest execution method.
+   */
+  STEP_USED_AFTER_ASYNC = "STEP_USED_AFTER_ASYNC",
 
   AUTOMATIC_PARALLEL_INDEXING = "AUTOMATIC_PARALLEL_INDEXING",
 }

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -182,6 +182,19 @@ export const deserializeError = (subject: Partial<SerializedError>): Error => {
 
 export enum ErrCode {
   NESTING_STEPS = "NESTING_STEPS",
+
+  /**
+   * Legacy v0 execution error code for when a function has changed and no
+   * longer matches its in-progress state.
+   */
+  NON_DETERMINISTIC_FUNCTION = "NON_DETERMINISTIC_FUNCTION",
+
+  /**
+   * Legacy v0 execution error code for when a function is found to be using
+   * async actions after memoziation has occurred, which v0 doesn't support.
+   */
+  ASYNC_DETECTED_AFTER_MEMOIZATION = "ASYNC_DETECTED_AFTER_MEMOIZATION",
+
   AUTOMATIC_PARALLEL_INDEXING = "AUTOMATIC_PARALLEL_INDEXING",
 }
 
@@ -371,4 +384,23 @@ export const rethrowError = (prefix: string): ((err: any) => never) => {
       throw err;
     }
   };
+};
+
+/**
+ * Legacy v0 execution error for functions that don't support mixing steps and
+ * regular async actions.
+ */
+export const functionStoppedRunningErr = (code: ErrCode) => {
+  return prettyError({
+    whatHappened: "Your function was stopped from running",
+    why: "We detected a mix of asynchronous logic, some using step tooling and some not.",
+    consequences:
+      "This can cause unexpected behaviour when a function is paused and resumed and is therefore strongly discouraged; we stopped your function to ensure nothing unexpected happened!",
+    stack: true,
+    toFixNow:
+      "Ensure that your function is either entirely step-based or entirely non-step-based, by either wrapping all asynchronous logic in `step.run()` calls or by removing all `step.*()` calls.",
+    otherwise:
+      "For more information on why step functions work in this manner, see https://www.inngest.com/docs/functions/multi-step#gotchas",
+    code,
+  });
 };

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -1,6 +1,9 @@
 import { ZodError, z } from "zod";
 import { type InngestApi } from "../api/api";
-import { ExecutionVersion } from "../components/execution/InngestExecution";
+import {
+  ExecutionVersion,
+  PREFERRED_EXECUTION_VERSION,
+} from "../components/execution/InngestExecution";
 import { err, ok, type Result } from "../types";
 import { prettyError } from "./errors";
 import { type Await } from "./types";
@@ -62,8 +65,6 @@ export const waterfall = <TFns extends ((arg?: any) => any)[]>(
   };
 };
 
-const defaultExecutionVersion = 1;
-
 const fnDataVersionSchema = z.object({
   version: z
     .literal(-1)
@@ -73,13 +74,13 @@ const fnDataVersionSchema = z.object({
     .transform<ExecutionVersion>((v) => {
       if (typeof v === "undefined") {
         console.warn(
-          `No request version specified by executor; defaulting to v${defaultExecutionVersion}`
+          `No request version specified by executor; defaulting to v${PREFERRED_EXECUTION_VERSION}`
         );
 
-        return defaultExecutionVersion;
+        return PREFERRED_EXECUTION_VERSION;
       }
 
-      return v === -1 ? defaultExecutionVersion : v;
+      return v === -1 ? PREFERRED_EXECUTION_VERSION : v;
     }),
 });
 

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -1,6 +1,7 @@
-import { ZodError } from "zod";
+import { ZodError, z } from "zod";
 import { type InngestApi } from "../api/api";
-import { err, fnDataSchema, ok, type FnData, type Result } from "../types";
+import { ExecutionVersion } from "../components/execution/InngestExecution";
+import { err, ok, type Result } from "../types";
 import { prettyError } from "./errors";
 import { type Await } from "./types";
 
@@ -61,15 +62,131 @@ export const waterfall = <TFns extends ((arg?: any) => any)[]>(
   };
 };
 
+const defaultExecutionVersion = 1;
+
+const fnDataVersionSchema = z.object({
+  version: z
+    .literal(-1)
+    .or(z.literal(0))
+    .or(z.literal(1))
+    .optional()
+    .transform<ExecutionVersion>((v) => {
+      if (typeof v === "undefined") {
+        console.warn(
+          `No request version specified by executor; defaulting to v${defaultExecutionVersion}`
+        );
+
+        return defaultExecutionVersion;
+      }
+
+      return v === -1 ? defaultExecutionVersion : v;
+    }),
+});
+
+export const parseFnData = (data: unknown) => {
+  let version: ExecutionVersion;
+
+  try {
+    ({ version } = fnDataVersionSchema.parse(data));
+
+    const versionHandlers = {
+      [ExecutionVersion.V0]: () =>
+        ({
+          version: 0,
+          ...z
+            .object({
+              event: z.object({}).passthrough(),
+              events: z.array(z.object({}).passthrough()).default([]),
+              steps: z
+                .record(
+                  z.any().refine((v) => typeof v !== "undefined", {
+                    message: "Values in steps must be defined",
+                  })
+                )
+                .optional()
+                .nullable(),
+              ctx: z
+                .object({
+                  run_id: z.string(),
+                  attempt: z.number().default(0),
+                  stack: z
+                    .object({
+                      stack: z
+                        .array(z.string())
+                        .nullable()
+                        .transform((v) => (Array.isArray(v) ? v : [])),
+                      current: z.number(),
+                    })
+                    .passthrough()
+                    .optional()
+                    .nullable(),
+                })
+                .optional()
+                .nullable(),
+              use_api: z.boolean().default(false),
+            })
+            .parse(data),
+        } as const),
+
+      [ExecutionVersion.V1]: () =>
+        ({
+          version: 1,
+          ...z
+            .object({
+              event: z.record(z.any()),
+              events: z.array(z.record(z.any())).default([]),
+              steps: z
+                .record(
+                  z.any().refine((v) => typeof v !== "undefined", {
+                    message: "Values in steps must be defined",
+                  })
+                )
+                .optional()
+                .nullable(),
+              ctx: z
+                .object({
+                  run_id: z.string(),
+                  attempt: z.number().default(0),
+                  disable_immediate_execution: z.boolean().default(false),
+                  use_api: z.boolean().default(false),
+                  stack: z
+                    .object({
+                      stack: z
+                        .array(z.string())
+                        .nullable()
+                        .transform((v) => (Array.isArray(v) ? v : [])),
+                      current: z.number(),
+                    })
+                    .passthrough()
+                    .optional()
+                    .nullable(),
+                })
+                .optional()
+                .nullable(),
+            })
+            .parse(data),
+        } as const),
+    } satisfies Record<ExecutionVersion, () => unknown>;
+
+    return versionHandlers[version]();
+  } catch (err) {
+    throw new Error(parseFailureErr(err));
+  }
+};
+export type FnData = ReturnType<typeof parseFnData>;
+
 type ParseErr = string;
-export const parseFnData = async (
-  data: unknown,
+export const fetchAllFnData = async (
+  data: FnData,
   api: InngestApi
 ): Promise<Result<FnData, ParseErr>> => {
-  try {
-    const result = fnDataSchema.parse(data);
+  const result = { ...data };
 
-    if (result.ctx?.use_api) {
+  try {
+    if (
+      (result.version === 0 && result.use_api) ||
+      (result.version === 1 && result.ctx?.use_api)
+    ) {
       if (!result.ctx?.run_id) {
         return err(
           prettyError({
@@ -119,20 +236,22 @@ export const parseFnData = async (
     // move to something like protobuf so we don't have to deal with this
     console.error(error);
 
-    let why: string | undefined;
-    if (error instanceof ZodError) {
-      why = error.toString();
-    }
-
-    return err(
-      prettyError({
-        whatHappened: "Failed to parse data from executor.",
-        consequences: "Function execution can't continue.",
-        toFixNow:
-          "Make sure that your API is set up to parse incoming request bodies as JSON, like body-parser for Express (https://expressjs.com/en/resources/middleware/body-parser.html).",
-        stack: true,
-        why,
-      })
-    );
+    return err(parseFailureErr(error));
   }
+};
+
+const parseFailureErr = (err: unknown) => {
+  let why: string | undefined;
+  if (err instanceof ZodError) {
+    why = err.toString();
+  }
+
+  return prettyError({
+    whatHappened: "Failed to parse data from executor.",
+    consequences: "Function execution can't continue.",
+    toFixNow:
+      "Make sure that your API is set up to parse incoming request bodies as JSON, like body-parser for Express (https://expressjs.com/en/resources/middleware/body-parser.html).",
+    stack: true,
+    why,
+  });
 };

--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -168,3 +168,10 @@ export const runAsPromise = <T extends (() => any) | undefined>(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return Promise.resolve().then(fn);
 };
+
+/**
+ * Returns a Promise that resolve after the current event loop tick.
+ */
+export const resolveNextTick = (): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve));
+};

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -235,7 +235,7 @@ export type BaseContext<
   runId: string;
 
   step: ReturnType<
-    typeof createStepTools<TOpts, EventsFromOpts<TOpts>, TTrigger>
+    typeof createStepTools<TOpts, EventsFromOpts<TOpts>, TTrigger, unknown>
   >;
 
   /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -235,7 +235,7 @@ export type BaseContext<
   runId: string;
 
   step: ReturnType<
-    typeof createStepTools<TOpts, EventsFromOpts<TOpts>, TTrigger, unknown>
+    typeof createStepTools<TOpts, EventsFromOpts<TOpts>, TTrigger>
   >;
 
   /**
@@ -1084,53 +1084,3 @@ export const ok = <T>(data: T): Result<T, never> => {
 export const err = <E>(error?: E): Result<never, E> => {
   return { ok: false, error };
 };
-
-/**
- * Format of data send from the executor to the SDK
- */
-export const fnDataSchema = z.object({
-  event: z.record(z.any()),
-  events: z.array(z.record(z.any())).default([]),
-
-  /**
-   * When handling per-step errors, steps will need to be an object with
-   * either a `data` or an `error` key.
-   *
-   * For now, we support the current method of steps just being a map of
-   * step ID to step data.
-   *
-   * TODO When the executor does support per-step errors, we can uncomment
-   * the expected schema below.
-   */
-  steps: z
-    .record(
-      z.any().refine((v) => typeof v !== "undefined", {
-        message: "Values in steps must be defined",
-      })
-    )
-    .optional()
-    .nullable(),
-  // steps: z.record(incomingOpSchema.passthrough()).optional().nullable(),
-  ctx: z
-    .object({
-      run_id: z.string(),
-      attempt: z.number().default(0),
-      disable_immediate_execution: z.boolean().default(false),
-      use_api: z.boolean().default(false),
-      stack: z
-        .object({
-          stack: z
-            .array(z.string())
-            .nullable()
-            .transform((v) => (Array.isArray(v) ? v : [])),
-          current: z.number(),
-        })
-        .passthrough()
-        .optional()
-        .nullable(),
-    })
-    .optional()
-    .nullable(),
-  version: z.number().default(-1),
-});
-export type FnData = z.infer<typeof fnDataSchema>;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds backwards compatibility for in-progress `v2.x.x` runs for `v3.x.x` SDKs.

- [x] Adding `x-inngest-req-version` header appropriately from response
- [x] `v0.test.ts`
- [ ] ~~Lazily importing backwards compatibility~~ N/A Tiny foot-print; can optionally add later

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [x] Added unit/integration tests
- [ ] ~~Added changesets if applicable~~ N/A

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #294
