### PR TITLE
Fix missing name on NonRetriableError

### DIFF
--- a/.changeset/dry-months-sparkle.md
+++ b/.changeset/dry-months-sparkle.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+(Internal) Fix missing name on `NonRetriableError`, ensuring it's correctly (de)serialized

--- a/packages/inngest/src/components/NonRetriableError.ts
+++ b/packages/inngest/src/components/NonRetriableError.ts
@@ -29,5 +29,7 @@ export class NonRetriableError extends Error {
     super(message);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this.cause = options?.cause;
+
+    this.name = "NonRetriableError";
   }
 }


### PR DESCRIPTION
## Summary

Set `NonRetriableError.name`

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [x] Added changesets if applicable
