### PR TITLE
Ensure `fromRecord<>()` doesn't accept clashing names

### DIFF
--- a/.changeset/pretty-doors-wait.md
+++ b/.changeset/pretty-doors-wait.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Ensure `fromRecord<>()` doesn't accept clashing names

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -46,7 +46,9 @@ export interface EventPayload {
 // @public
 export class EventSchemas<S extends Record<string, EventPayload>> {
     fromGenerated<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
-    fromRecord<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
+    // Warning: (ae-forgotten-export) The symbol "PreventClashingNames" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ClashingNameError" needs to be exported by the entry point index.d.ts
+    fromRecord<T extends StandardEventSchemas>(..._args: PreventClashingNames<T> extends ClashingNameError ? [ClashingNameError] : []): EventSchemas<Combine<S, T>>;
     // Warning: (ae-forgotten-export) The symbol "StandardEventSchema" needs to be exported by the entry point index.d.ts
     fromUnion<T extends {
         name: string;

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -73,6 +73,17 @@ describe("EventSchemas", () => {
       assertType<IsAny<Schemas<typeof schemas>["test.event"]["data"]>>(true);
     });
 
+    test("can set 'any' type for data alongside populated events", () => {
+      const schemas = new EventSchemas().fromRecord<{
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        "test.event": { data: any };
+        "test.event2": { data: { foo: string } };
+      }>();
+
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["data"]>>(true);
+      assertType<Schemas<typeof schemas>["test.event2"]["data"]>({ foo: "" });
+    });
+
     test("can set 'any' type for user", () => {
       const schemas = new EventSchemas().fromRecord<{
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,11 +100,114 @@ describe("EventSchemas", () => {
       }>();
     });
 
+    test("can set event with matching 'name'", () => {
+      const schemas = new EventSchemas().fromRecord<{
+        "test.event": { name: "test.event"; data: { foo: string } };
+      }>();
+
+      assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+      assertType<Schemas<typeof schemas>["test.event"]["data"]>({ foo: "" });
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["user"]>>(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["ts"], number | undefined>
+      >(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["v"], string | undefined>
+      >(true);
+    });
+
+    test("cannot set event with clashing 'name'", () => {
+      // @ts-expect-error - name must match
+      new EventSchemas().fromRecord<{
+        "test.event": { name: "test.event2"; data: { foo: string } };
+      }>();
+    });
+
+    test("cannot set event with clashing 'name' alongside valid event", () => {
+      // @ts-expect-error - name must match
+      new EventSchemas().fromRecord<{
+        "test.event": { name: "test.event2"; data: { foo: string } };
+        "test.event2": { name: "test.event2"; data: { foo: string } };
+        "test.event3": { data: { foo: string } };
+      }>();
+    });
+
     test("cannot set non-object type for user", () => {
       // @ts-expect-error User must be object type or any
       new EventSchemas().fromRecord<{
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         "test.event": { data: any; user: string };
+      }>();
+    });
+
+    test("can set empty event", () => {
+      const schemas = new EventSchemas().fromRecord<{
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        "test.event": {};
+      }>();
+
+      assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["data"]>>(true);
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["user"]>>(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["ts"], number | undefined>
+      >(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["v"], string | undefined>
+      >(true);
+    });
+
+    test("can set empty event alongside populated event", () => {
+      const schemas = new EventSchemas().fromRecord<{
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        "test.event": {};
+        "test.event2": { data: { foo: string } };
+      }>();
+
+      assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["data"]>>(true);
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["user"]>>(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["ts"], number | undefined>
+      >(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["v"], string | undefined>
+      >(true);
+
+      assertType<Schemas<typeof schemas>["test.event2"]["name"]>("test.event2");
+      assertType<Schemas<typeof schemas>["test.event2"]["data"]>({ foo: "" });
+      assertType<IsAny<Schemas<typeof schemas>["test.event2"]["user"]>>(true);
+      assertType<
+        IsEqual<
+          Schemas<typeof schemas>["test.event2"]["ts"],
+          number | undefined
+        >
+      >(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event2"]["v"], string | undefined>
+      >(true);
+    });
+
+    test("can set empty event with matching 'name'", () => {
+      const schemas = new EventSchemas().fromRecord<{
+        "test.event": { name: "test.event" };
+      }>();
+
+      assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["data"]>>(true);
+      assertType<IsAny<Schemas<typeof schemas>["test.event"]["user"]>>(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["ts"], number | undefined>
+      >(true);
+      assertType<
+        IsEqual<Schemas<typeof schemas>["test.event"]["v"], string | undefined>
+      >(true);
+    });
+
+    test("cannot set empty event with clashing 'name'", () => {
+      // @ts-expect-error - name must match
+      new EventSchemas().fromRecord<{
+        "test.event": { name: "test.event2" };
       }>();
     });
 

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -454,6 +454,7 @@ describe("send", () => {
         eventKey: testEventKey,
         schemas: new EventSchemas().fromRecord<{
           foo: {
+            name: "foo";
             data: { foo: string };
           };
           bar: {

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { EventSchemas } from "@local/components/EventSchemas";
 import { type EventsFromOpts } from "@local/components/Inngest";
@@ -410,9 +409,10 @@ describe("sendEvent", () => {
           data: { foo: string };
         };
         bar: {
-          name: "bar";
           data: { bar: string };
         };
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        baz: {};
       }>();
 
       const opts = (<T extends ClientOptions>(x: T): T => x)({

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -187,3 +187,17 @@ export type ParametersExceptFirst<T> = T extends (
 any
   ? U
   : never;
+
+/**
+ * Given an object `T`, return `true` if it contains no keys, or `false` if it
+ * contains any keys.
+ *
+ * Useful for detecting the passing of a `{}` (any non-nullish) type.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type IsEmptyObject<T> = {} extends T
+  ? // eslint-disable-next-line @typescript-eslint/ban-types
+    T extends {}
+    ? true
+    : false
+  : false;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`new EventSchemas().fromRecord()` can silently fail and drop all type inference if the user has given a `name` inside an event _as well as a key_ and the two are not the same.

In this case, it's hard to know what the user is intending to do and which name they'd prefer, so instead we show an error stating that they should probably omit `name`.

Previously, this would not fail, but drop all type inference.
```ts
type MyEvent = {
  name: "my-event";
};

new EventSchemas().fromRecord<{
  "my.event": MyEvent;
}>();
```

Instead, this will throw a hacky TS error stating you should probably omit `name`.

```ts
Expected 1 arguments, but got 0.

(method) EventSchemas<Record<string, EventPayload>>.fromRecord<{
    "my.event": MyEvent;
}>(_args_0: "Error: Omit 'name' from event schemas or make sure it matches the key."): EventSchemas<Simplify<{
    "my.event": {};
}>>
```

A tad hacky, but better than type inference silently turning off.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
