### PR TITLE
Allow null data in place of steps

### DIFF
--- a/.changeset/spicy-dragons-eat.md
+++ b/.changeset/spicy-dragons-eat.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow steps to execute with null data

--- a/packages/inngest/src/api/schema.ts
+++ b/packages/inngest/src/api/schema.ts
@@ -23,7 +23,7 @@ export const stepsSchema = z
         })
       )
       .or(
-        z.null().transform(() => ({}))
+        z.null().transform(() => ({ type: "data" as const, data: null}))
       )
   )
   .default({});

--- a/packages/inngest/src/api/schema.ts
+++ b/packages/inngest/src/api/schema.ts
@@ -22,6 +22,9 @@ export const stepsSchema = z
           error: failureEventErrorSchema,
         })
       )
+      .or(
+        z.null().transform(() => ({}))
+      )
   )
   .default({});
 


### PR DESCRIPTION
## Summary

Allows steps to return null data, eg. within the executor to denote things as complete.


- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

