### PR TITLE
Hotfix: `waitForEvent` data parsing

### DIFF
--- a/.changeset/many-bananas-lick.md
+++ b/.changeset/many-bananas-lick.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `waitForEvent` potentially dropping some fields when being parsed

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -1,11 +1,12 @@
 import { type fetch } from "cross-fetch";
+import { type ExecutionVersion } from "../components/execution/InngestExecution";
 import { getFetch } from "../helpers/env";
 import { hashSigningKey } from "../helpers/strings";
 import { err, ok, type Result } from "../types";
 import {
   batchSchema,
   errorSchema,
-  stepsSchema,
+  stepsSchemas,
   type BatchResponse,
   type ErrorResponse,
   type StepsResponse,
@@ -46,7 +47,8 @@ export class InngestApi {
   }
 
   async getRunSteps(
-    runId: string
+    runId: string,
+    version: ExecutionVersion
   ): Promise<Result<StepsResponse, ErrorResponse>> {
     const url = new URL(`/v0/runs/${runId}/actions`, this.baseUrl);
 
@@ -57,7 +59,7 @@ export class InngestApi {
         const data: unknown = await resp.json();
 
         if (resp.ok) {
-          return ok(stepsSchema.parse(data));
+          return ok(stepsSchemas[version].parse(data));
         } else {
           return err(errorSchema.parse(data));
         }

--- a/packages/inngest/src/api/schema.test.ts
+++ b/packages/inngest/src/api/schema.test.ts
@@ -1,84 +1,121 @@
-import { stepsSchema } from "./schema";
+import { stepsSchemas } from "@local/api/schema";
+import { ExecutionVersion } from "@local/components/execution/InngestExecution";
 
-describe("stepsSchema", () => {
-  test("handles v1 { data } objects", () => {
-    const expected = {
-      id: {
-        type: "data",
-        data: "something",
-      },
-    };
+describe("stepsSchemas", () => {
+  describe("v0", () => {
+    const schema = stepsSchemas[ExecutionVersion.V0];
 
-    const actual = stepsSchema.safeParse({
-      id: {
-        data: "something",
-      },
+    test("handles any data", () => {
+      const expected = {
+        id: "something",
+        id2: "something else",
+        id3: true,
+        id4: { data: false },
+      };
+
+      const actual = schema.safeParse({
+        id: "something",
+        id2: "something else",
+        id3: true,
+        id4: { data: false },
+      });
+
+      expect(actual.success).toBe(true);
+      expect(actual.success && actual.data).toEqual(expected);
     });
 
-    expect(actual.success).toBe(true);
-    expect(actual.success && actual.data).toEqual(expected);
+    test("throws if finding undefined value", () => {
+      const result = schema.safeParse({
+        id: "something",
+        id2: undefined,
+      });
+
+      expect(result.success).toBe(false);
+    });
   });
 
-  test("handles v1 { error } objects", () => {
-    const expected = {
-      id: {
-        type: "error",
-        error: {
-          name: "Error",
-          message: "something",
+  describe("v1", () => {
+    const schema = stepsSchemas[ExecutionVersion.V1];
+
+    test("handles v1 { data } objects", () => {
+      const expected = {
+        id: {
+          type: "data",
+          data: "something",
         },
-      },
-    };
+      };
 
-    const actual = stepsSchema.safeParse({
-      id: {
-        error: {
-          name: "Error",
-          message: "something",
+      const actual = schema.safeParse({
+        id: {
+          data: "something",
         },
-      },
+      });
+
+      expect(actual.success).toBe(true);
+      expect(actual.success && actual.data).toEqual(expected);
     });
 
-    expect(actual.success).toBe(true);
-    expect(actual.success && actual.data).toEqual(expected);
-  });
-  test("handles null from a v0 or v1 sleep or waitForEvent", () => {
-    const expected = {
-      id: {
-        type: "data",
-        data: null,
-      },
-    };
+    test("handles v1 { error } objects", () => {
+      const expected = {
+        id: {
+          type: "error",
+          error: {
+            name: "Error",
+            message: "something",
+          },
+        },
+      };
 
-    const actual = stepsSchema.safeParse({
-      id: null,
+      const actual = schema.safeParse({
+        id: {
+          error: {
+            name: "Error",
+            message: "something",
+          },
+        },
+      });
+
+      expect(actual.success).toBe(true);
+      expect(actual.success && actual.data).toEqual(expected);
+    });
+    test("handles null from a v0 or v1 sleep or waitForEvent", () => {
+      const expected = {
+        id: {
+          type: "data",
+          data: null,
+        },
+      };
+
+      const actual = schema.safeParse({
+        id: null,
+      });
+
+      expect(actual.success).toBe(true);
+      expect(actual.success && actual.data).toEqual(expected);
     });
 
-    expect(actual.success).toBe(true);
-    expect(actual.success && actual.data).toEqual(expected);
-  });
+    test("handles event from v0 or v1 waitForEvent", () => {
+      const expected = {
+        id: {
+          type: "data",
+          data: {
+            name: "event",
+            data: { some: "data" },
+            ts: 123,
+          },
+        },
+      };
 
-  test("handles event from v0 or v1 waitForEvent", () => {
-    const expected = {
-      id: {
-        type: "data",
-        data: {
+      const actual = schema.safeParse({
+        id: {
           name: "event",
           data: { some: "data" },
           ts: 123,
         },
-      },
-    };
+      });
 
-    const actual = stepsSchema.safeParse({
-      id: {
-        name: "event",
-        data: { some: "data" },
-        ts: 123,
-      },
+      expect(actual.success).toBe(true);
+      expect(actual.success && actual.data).toEqual(expected);
     });
-
-    expect(actual.success).toBe(true);
-    expect(actual.success && actual.data).toEqual(expected);
   });
 });

--- a/packages/inngest/src/api/schema.test.ts
+++ b/packages/inngest/src/api/schema.test.ts
@@ -1,0 +1,84 @@
+import { stepsSchema } from "./schema";
+
+describe("stepsSchema", () => {
+  test("handles v1 { data } objects", () => {
+    const expected = {
+      id: {
+        type: "data",
+        data: "something",
+      },
+    };
+
+    const actual = stepsSchema.safeParse({
+      id: {
+        data: "something",
+      },
+    });
+
+    expect(actual.success).toBe(true);
+    expect(actual.success && actual.data).toEqual(expected);
+  });
+
+  test("handles v1 { error } objects", () => {
+    const expected = {
+      id: {
+        type: "error",
+        error: {
+          name: "Error",
+          message: "something",
+        },
+      },
+    };
+
+    const actual = stepsSchema.safeParse({
+      id: {
+        error: {
+          name: "Error",
+          message: "something",
+        },
+      },
+    });
+
+    expect(actual.success).toBe(true);
+    expect(actual.success && actual.data).toEqual(expected);
+  });
+  test("handles null from a v0 or v1 sleep or waitForEvent", () => {
+    const expected = {
+      id: {
+        type: "data",
+        data: null,
+      },
+    };
+
+    const actual = stepsSchema.safeParse({
+      id: null,
+    });
+
+    expect(actual.success).toBe(true);
+    expect(actual.success && actual.data).toEqual(expected);
+  });
+
+  test("handles event from v0 or v1 waitForEvent", () => {
+    const expected = {
+      id: {
+        type: "data",
+        data: {
+          name: "event",
+          data: { some: "data" },
+          ts: 123,
+        },
+      },
+    };
+
+    const actual = stepsSchema.safeParse({
+      id: {
+        name: "event",
+        data: { some: "data" },
+        ts: 123,
+      },
+    });
+
+    expect(actual.success).toBe(true);
+    expect(actual.success && actual.data).toEqual(expected);
+  });
+});

--- a/packages/inngest/src/api/schema.ts
+++ b/packages/inngest/src/api/schema.ts
@@ -16,15 +16,25 @@ export const stepsSchema = z
           message: "Data in steps must be defined",
         }),
       })
+      .strict()
       .or(
-        z.object({
-          type: z.literal("error").optional().default("error"),
-          error: failureEventErrorSchema,
-        })
+        z
+          .object({
+            type: z.literal("error").optional().default("error"),
+            error: failureEventErrorSchema,
+          })
+          .strict()
       )
-      .or(
-        z.null().transform(() => ({ type: "data" as const, data: null}))
-      )
+
+      /**
+       * If the result isn't a distcint `data` or `error` object, then it's
+       * likely that the executor has set this directly to a value, for example
+       * in the case of `sleep` or `waitForEvent`.
+       *
+       * In this case, pull the entire value through as data.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      .or(z.any().transform((v) => ({ type: "data" as const, data: v })))
   )
   .default({});
 

--- a/packages/inngest/src/api/schema.ts
+++ b/packages/inngest/src/api/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ExecutionVersion } from "../components/execution/InngestExecution";
 import { failureEventErrorSchema, type EventPayload } from "../types";
 
 export const errorSchema = z.object({
@@ -7,38 +8,50 @@ export const errorSchema = z.object({
 });
 export type ErrorResponse = z.infer<typeof errorSchema>;
 
-export const stepsSchema = z
-  .record(
-    z
-      .object({
-        type: z.literal("data").optional().default("data"),
-        data: z.any().refine((v) => typeof v !== "undefined", {
-          message: "Data in steps must be defined",
-        }),
+export const stepsSchemas = {
+  [ExecutionVersion.V0]: z
+    .record(
+      z.any().refine((v) => typeof v !== "undefined", {
+        message: "Values in steps must be defined",
       })
-      .strict()
-      .or(
-        z
-          .object({
-            type: z.literal("error").optional().default("error"),
-            error: failureEventErrorSchema,
-          })
-          .strict()
-      )
+    )
+    .optional()
+    .nullable(),
+  [ExecutionVersion.V1]: z
+    .record(
+      z
+        .object({
+          type: z.literal("data").optional().default("data"),
+          data: z.any().refine((v) => typeof v !== "undefined", {
+            message: "Data in steps must be defined",
+          }),
+        })
+        .strict()
+        .or(
+          z
+            .object({
+              type: z.literal("error").optional().default("error"),
+              error: failureEventErrorSchema,
+            })
+            .strict()
+        )
 
-      /**
-       * If the result isn't a distcint `data` or `error` object, then it's
-       * likely that the executor has set this directly to a value, for example
-       * in the case of `sleep` or `waitForEvent`.
-       *
-       * In this case, pull the entire value through as data.
-       */
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      .or(z.any().transform((v) => ({ type: "data" as const, data: v })))
-  )
-  .default({});
+        /**
+         * If the result isn't a distcint `data` or `error` object, then it's
+         * likely that the executor has set this directly to a value, for example
+         * in the case of `sleep` or `waitForEvent`.
+         *
+         * In this case, pull the entire value through as data.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        .or(z.any().transform((v) => ({ type: "data" as const, data: v })))
+    )
+    .default({}),
+} satisfies Record<ExecutionVersion, z.ZodSchema>;
 
-export type StepsResponse = z.infer<typeof stepsSchema>;
+export type StepsResponse = {
+  [V in ExecutionVersion]: z.infer<(typeof stepsSchemas)[V]>;
+}[ExecutionVersion];
 
 export const batchSchema = z.array(
   z.record(z.any()).transform((v) => v as EventPayload)

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -839,10 +839,11 @@ export class InngestCommHandler<
     const { version } = immediateFnData;
 
     const result = runAsPromise(async () => {
-      const anyFnData = await fetchAllFnData(
-        immediateFnData,
-        this.client["inngestApi"]
-      );
+      const anyFnData = await fetchAllFnData({
+        data: immediateFnData,
+        api: this.client["inngestApi"],
+        version,
+      });
       if (!anyFnData.ok) {
         throw new Error(anyFnData.error);
       }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

- Fixes `waitForEvent` dropping some data when resolving with an event
- Fixes steps fetched via the API not being parsed for v0 runs

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [x] Added unit/integration tests
- [x] Added changesets if applicable
