### PR TITLE
Fix `"inngest/next"` types not inferring from `defineProperties`

### DIFF
--- a/.changeset/dirty-mangos-exist.md
+++ b/.changeset/dirty-mangos-exist.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `"inngest/next"` types not inferring from `defineProperties`


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes #340, ensuring the return type of `"inngest/next"`'s `serve()` is correctly inferred.

Fuller integration tests for the app router will come in #341.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A #341
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #340
