### PR TITLE
Separate Zod typing from library

### DIFF
--- a/.changeset/wicked-ties-laugh.md
+++ b/.changeset/wicked-ties-laugh.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Separate Zod typing from library, enabling minor-agnostic versioning support

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -6,7 +6,7 @@
 
 import { Jsonify } from 'type-fest';
 import { Simplify } from 'type-fest';
-import { z } from 'zod';
+import { z as z_2 } from 'zod';
 
 // @public
 export interface ClientOptions {
@@ -78,7 +78,7 @@ export type FailureEventPayload<P extends EventPayload = EventPayload> = {
     data: {
         function_id: string;
         run_id: string;
-        error: z.output<typeof failureEventErrorSchema>;
+        error: z_2.output<typeof failureEventErrorSchema>;
         event: P;
     };
 };
@@ -230,6 +230,8 @@ export enum internalEvents {
 // @internal
 export type IsStringLiteral<T extends string> = string extends T ? false : true;
 
+// Warning: (ae-forgotten-export) The symbol "z" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type LiteralZodEventSchema = z.ZodObject<{
     name: z.ZodLiteral<string>;

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -1,6 +1,6 @@
 import { type Simplify } from "type-fest";
-import { type z } from "zod";
 import { type IsEmptyObject, type IsStringLiteral } from "../helpers/types";
+import type * as z from "../helpers/validators/zod";
 import { type EventPayload } from "../types";
 
 /**
@@ -104,7 +104,7 @@ export type PickLiterals<T> = {
  *
  * @public
  */
-export type GetName<T> = T extends z.ZodObject<infer U extends z.ZodRawShape>
+export type GetName<T> = T extends z.ZodObject<infer U>
   ? U extends { name: z.ZodLiteral<infer S extends string> }
     ? S
     : never

--- a/packages/inngest/src/helpers/validators/zod.ts
+++ b/packages/inngest/src/helpers/validators/zod.ts
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Shim for Zod types to ensure hopeful compatibility between minor versions to
- * ensure that users can utilize the latest version of Zod without having to
- * wait for Inngest to update.
+ * Shim for Zod types to ensure hopeful compatibility between minor versions;
+ * let developers the latest version of Zod without having to have Inngest match
+ * the same version.
+ *
+ * Feels weird to be using internal properties like this, but types break across
+ * minors anyway, so at least with this we rely on fewer fields staying the
+ * same.
  */
 export type ZodLiteral<TValue = any> = {
   get value(): TValue;

--- a/packages/inngest/src/helpers/validators/zod.ts
+++ b/packages/inngest/src/helpers/validators/zod.ts
@@ -1,0 +1,33 @@
+/**
+ * Shim for Zod types to ensure hopeful compatibility between minor versions to
+ * ensure that users can utilize the latest version of Zod without having to
+ * wait for Inngest to update.
+ */
+export type ZodLiteral<TValue = any> = {
+  get value(): TValue;
+  _def: {
+    typeName: "ZodLiteral";
+  };
+};
+
+export type ZodTypeAny = {
+  _type: any;
+  _output: any;
+  _input: any;
+  _def: any;
+};
+
+export type ZodObject<TShape = { [k: string]: ZodTypeAny }> = {
+  get shape(): TShape;
+  _def: {
+    typeName: "ZodObject";
+  };
+};
+
+export type AnyZodObject = ZodObject<any>;
+
+export type ZodAny = {
+  _any: true;
+};
+
+export type infer<T extends ZodTypeAny> = T["_output"];

--- a/packages/inngest/src/helpers/validators/zod.ts
+++ b/packages/inngest/src/helpers/validators/zod.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Shim for Zod types to ensure hopeful compatibility between minor versions to
  * ensure that users can utilize the latest version of Zod without having to


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Separates Zod typing requirements from the Zod library itself, hopefully allowing us to support multiple client versions.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [ ] ~~Added unit/integration tests~~ N/A Exists already
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Alternative to #336 
