### PR TITLE
Fix path matching types getting lost in recursive types

### DIFF
--- a/.changeset/wicked-peaches-visit.md
+++ b/.changeset/wicked-peaches-visit.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix path matching types getting lost in certain recursive event types

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { IsEqual } from 'type-fest';
 import { Jsonify } from 'type-fest';
 import { Simplify } from 'type-fest';
 import { z as z_2 } from 'zod';

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -125,7 +125,7 @@
     "json-stringify-safe": "^5.0.1",
     "ms": "^2.1.3",
     "serialize-error-cjs": "^0.1.3",
-    "type-fest": "^3.5.1",
+    "type-fest": "^3.13.1",
     "zod": "~3.21.4"
   },
   "devDependencies": {

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -1,4 +1,4 @@
-import { type Simplify } from "type-fest";
+import { type IsEqual, type Simplify } from "type-fest";
 import { type EventPayload } from "../types";
 
 /**
@@ -43,16 +43,6 @@ export type Primitive =
   | boolean
   | symbol
   | bigint;
-
-/**
- * Given T1 and T2, use a distributive conditional to check whether they are
- * directly equal and not just extensions.
- */
-type IsEqual<T1, T2> = T1 extends T2
-  ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2
-    ? true
-    : false
-  : false;
 
 /**
  * Returns `true` if `T` is a tuple, else `false`.

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -35,24 +35,77 @@ export type SendEventPayload<Events extends Record<string, EventPayload>> =
  * A list of simple, JSON-compatible, primitive types that contain no other
  * values.
  */
-export type Primitive = string | number | boolean | undefined | null;
+export type Primitive =
+  | null
+  | undefined
+  | string
+  | number
+  | boolean
+  | symbol
+  | bigint;
 
 /**
- * Given a key and a value, create a string that would be used to access that
- * property in code.
+ * Given T1 and T2, use a distributive conditional to check whether they are
+ * directly equal and not just extensions.
  */
-type StringPath<K extends string | number, V> = V extends Primitive
+type IsEqual<T1, T2> = T1 extends T2
+  ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2
+    ? true
+    : false
+  : false;
+
+/**
+ * Returns `true` if `T` is a tuple, else `false`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type IsTuple<T extends ReadonlyArray<any>> = number extends T["length"]
+  ? false
+  : true;
+
+/**
+ * Given a tuple `T`, return the keys of that tuple, excluding any shared or
+ * generic keys like `number` and standard array methods.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TupleKeys<T extends ReadonlyArray<any>> = Exclude<keyof T, keyof any[]>;
+
+/**
+ * Returns `true` if `T1` matches anything in the union `T2`, else` never`.
+ */
+type AnyIsEqual<T1, T2> = T1 extends T2
+  ? IsEqual<T1, T2> extends true
+    ? true
+    : never
+  : never;
+
+/**
+ * A helper for concatenating an existing path `K` with new paths from the
+ * value `V`, making sure to skip those we've already seen in
+ * `TraversedTypes`.
+ *
+ * Purposefully skips some primitive objects to avoid building unsupported or
+ * recursive paths.
+ */
+type PathImpl<K extends string | number, V, TraversedTypes> = V extends
+  | Primitive
+  | Date
   ? `${K}`
-  : `${K}` | `${K}.${Path<V>}`;
+  : true extends AnyIsEqual<TraversedTypes, V>
+  ? `${K}`
+  : `${K}` | `${K}.${PathInternal<V, TraversedTypes | V>}`;
 
 /**
- * Given an object or array, recursively return all string paths used to access
- * properties within those objects.
+ * Start iterating over a given object `T` and return all string paths used to
+ * access properties within that object as if you were in code.
  */
-type Path<T> = T extends Array<infer V>
-  ? StringPath<number, V>
+type PathInternal<T, TraversedTypes = T> = T extends ReadonlyArray<infer V>
+  ? IsTuple<T> extends true
+    ? {
+        [K in TupleKeys<T>]-?: PathImpl<K & string, T[K], TraversedTypes>;
+      }[TupleKeys<T>]
+    : PathImpl<number, V, TraversedTypes>
   : {
-      [K in keyof T]-?: StringPath<K & string, T[K]>;
+      [K in keyof T]-?: PathImpl<K & string, T[K], TraversedTypes>;
     }[keyof T];
 
 /**
@@ -63,7 +116,7 @@ type Path<T> = T extends Array<infer V>
  * paths of known objects.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ObjectPaths<T extends Record<string, any>> = Path<T>;
+export type ObjectPaths<T> = T extends any ? PathInternal<T> : never;
 
 /**
  * Returns all keys from objects in the union `T`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
       type-fest:
-        specifier: ^3.5.1
-        version: 3.5.1
+        specifier: ^3.13.1
+        version: 3.13.1
       zod:
         specifier: ~3.21.4
         version: 3.21.4
@@ -6640,8 +6640,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /type-fest@3.5.1:
-    resolution: {integrity: sha512-70T99cpILFk2fzwuljwWxmazSphFrdOe3gRHbp6bqs71pxFBbJwFqnmkLO2lQL6aLHxHmYAnP/sL+AJWpT70jA==}
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
     dev: false
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes a "_Type instantiation is excessively deep and possibly infinite_" bug when attempting to generate paths for events with recursive types, such as a common `JsonValue` type.

```ts
type JsonObject = { [Key in string]?: JsonValue };
type JsonArray = Array<JsonValue>;
type JsonValue =
  | string
  | number
  | boolean
  | JsonObject
  | JsonArray
  | null;
```

We refactor the way paths are generated a little here, most notably ensuring we skip known deep/recursive types and don't needlessly iterate those we've seen before.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
