### PR TITLE
Only throw lack of event key errors when we know we're in production

### DIFF
--- a/.changeset/metal-horses-invite.md
+++ b/.changeset/metal-horses-invite.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Stop "_Failed to send event_" errors occuring in local development when missing an event key

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -99,6 +99,9 @@ describe("send", () => {
     });
 
     test("should fail to send if event key not specified at instantiation", async () => {
+      // Will only throw this error in prod
+      process.env.CONTEXT = "production";
+
       const inngest = createClient({ id: "test" });
 
       await expect(() => inngest.send(testEvent)).rejects.toThrowError(


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Ensures that the `"Failed to send event"` error--produced when an event key has not been set on a client--will only throw in production environments and not local development.

This logic needed to change slightly anyway after the removal of `INNGEST_DEVSERVER_URL` in v3.

- If production detected, throw error if no event key
- If non-production detected, never throw an error (warning will still be shown upon instantiation)

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
