### PR TITLE
INN-2152 Slim down "pretty errors" before sending to Inngest

### DIFF
--- a/.changeset/cold-hairs-carry.md
+++ b/.changeset/cold-hairs-carry.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Inngest errors now appear more succintly in UIs, free of ANSI codes and verbose information

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -125,6 +125,7 @@
     "json-stringify-safe": "^5.0.1",
     "ms": "^2.1.3",
     "serialize-error-cjs": "^0.1.3",
+    "strip-ansi": "^5.2.0",
     "type-fest": "^3.13.1",
     "zod": "~3.22.3"
   },

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -5,6 +5,7 @@ import { logPrefix } from "../../helpers/consts";
 import {
   ErrCode,
   deserializeError,
+  minifyPrettyError,
   prettyError,
   serializeError,
 } from "../../helpers/errors";
@@ -446,7 +447,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         retriable = error.retryAfter;
       }
 
-      const serializedError = serializeError(error);
+      const serializedError = minifyPrettyError(serializeError(error));
 
       return { type: "function-rejected", error: serializedError, retriable };
     }

--- a/packages/inngest/src/helpers/errors.test.ts
+++ b/packages/inngest/src/helpers/errors.test.ts
@@ -1,4 +1,11 @@
-import { isSerializedError, serializeError } from "@local/helpers/errors";
+import {
+  ErrCode,
+  fixEventKeyMissingSteps,
+  isSerializedError,
+  minifyPrettyError,
+  prettyError,
+  serializeError,
+} from "@local/helpers/errors";
 
 interface ErrorTests {
   name: string;
@@ -101,5 +108,60 @@ describe("serializeError", () => {
     name: "Existing serialized error",
     error: serializeError(new Error("test")),
     tests: { message: "test" },
+  });
+});
+
+describe("minifyPrettyError", () => {
+  describe("should minify a pretty error", () => {
+    const originalErr = serializeError(
+      new Error(
+        prettyError({
+          whatHappened: "Failed to send event",
+          consequences: "Your event or events were not sent to Inngest.",
+          why: "We couldn't find an event key to use to send events to Inngest.",
+          toFixNow: fixEventKeyMissingSteps,
+        })
+      )
+    );
+
+    const err = minifyPrettyError(originalErr);
+
+    const expected = "Failed to send event";
+
+    test("sets message", () => {
+      expect(err.message).toBe(expected);
+    });
+
+    test("sets stack", () => {
+      expect(err.stack).toMatch(`Error: ${expected}\n`);
+      expect(err.stack).toMatch(originalErr.stack);
+    });
+  });
+
+  describe("should prepend code", () => {
+    const originalErr = serializeError(
+      new Error(
+        prettyError({
+          whatHappened: "Failed to send event",
+          consequences: "Your event or events were not sent to Inngest.",
+          why: "We couldn't find an event key to use to send events to Inngest.",
+          toFixNow: fixEventKeyMissingSteps,
+          code: ErrCode.NESTING_STEPS,
+        })
+      )
+    );
+
+    const err = minifyPrettyError(originalErr);
+
+    const expected = `${ErrCode.NESTING_STEPS} - Failed to send event`;
+
+    test("sets message", () => {
+      expect(err.message).toBe(expected);
+    });
+
+    test("sets stack", () => {
+      expect(err.stack).toMatch(`Error: ${expected}\n`);
+      expect(err.stack).toMatch(originalErr.stack);
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       serialize-error-cjs:
         specifier: ^0.1.3
         version: 0.1.3
+      strip-ansi:
+        specifier: ^5.2.0
+        version: 5.2.0
       type-fest:
         specifier: ^3.13.1
         version: 3.13.1
@@ -2103,6 +2106,11 @@ packages:
     dependencies:
       type-fest: 0.21.3
     dev: true
+
+  /ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
+    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -6301,6 +6309,13 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
     dev: true
+
+  /strip-ansi@5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
+    dependencies:
+      ansi-regex: 4.1.1
+    dev: false
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Slims down "pretty errors," whose name is already subjective, before sending them to Inngest, by stripping ANSI codes and removing immediate debugging information.

| ![Before](https://github.com/inngest/inngest-js/assets/1736957/5cc6e965-4806-483e-9ae5-c0c38ff5d960) | ![image](https://github.com/inngest/inngest-js/assets/1736957/8e7f22bf-6f7c-4c80-b8ab-9b0f231a4326) |
| - | - |
| Before | After |

The UI could access the code being sent (e.g. `AUTOMATIC_PARALLEL_INDEXING`), but it's probably nicer to send this code inside serialized errors in the future, allowing the UI to provide hints and links to documentation, inclusive of short links such as `https://innge.st/ERR_CODE_HERE`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Improvement
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-2152
