### PR TITLE
Set dummy value for event key for local development

### DIFF
--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -3,6 +3,7 @@ import {
   defaultDevServerHost,
   defaultInngestBaseUrl,
   defaultInngestEventBaseUrl,
+  dummyEventKey,
   envKeys,
   logPrefix,
 } from "../helpers/consts";
@@ -165,7 +166,7 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
 
     this.setEventKey(eventKey || processEnv(envKeys.InngestEventKey) || "");
 
-    if (!this.eventKey) {
+    if (!this.eventKeySet()) {
       console.warn(
         prettyError({
           type: "warn",
@@ -289,12 +290,16 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
      */
     eventKey: string
   ): void {
-    this.eventKey = eventKey;
+    this.eventKey = eventKey || dummyEventKey;
 
     this.sendEventUrl = new URL(
       `e/${this.eventKey}`,
       this.baseUrl || defaultInngestEventBaseUrl
     );
+  }
+
+  private eventKeySet(): boolean {
+    return Boolean(this.eventKey) && this.eventKey !== dummyEventKey;
   }
 
   /**
@@ -418,7 +423,7 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
           url = devServerUrl(defaultDevServerHost, `e/${this.eventKey}`).href;
         }
       }
-    } else if (!this.eventKey) {
+    } else if (!this.eventKeySet()) {
       throw new Error(
         prettyError({
           whatHappened: "Failed to send event",

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -147,3 +147,5 @@ export enum internalEvents {
 export const logPrefix = chalk.magenta.bold("[Inngest]");
 
 export const debugPrefix = "inngest";
+
+export const dummyEventKey = "NO_EVENT_KEY_SET";


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

This fixes a bug whereby events are attempted to send to `/e` instead of `/e/123`, resulting in failed requests following #357.

We should maintain that the API should always expect a key, so we'll make the change here to set a dummy key just as users had to pre-#357.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #357
