### PR TITLE
Change "No request version" log from warn to debug; previous executor v

### DIFF
--- a/.changeset/tasty-hornets-matter.md
+++ b/.changeset/tasty-hornets-matter.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Change `No request version` log from warn to debug

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -82,7 +82,7 @@ const fnDataVersionSchema = z.object({
     .optional()
     .transform<ExecutionVersion>((v) => {
       if (typeof v === "undefined") {
-        console.warn(
+        console.debug(
           `No request version specified by executor; defaulting to v${PREFERRED_EXECUTION_VERSION}`
         );
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Ensure the `No request version` log is a debug log instead of a warning. This does indicate that something might be off with the executor being used, though it won't harm any functionality or performance.

![image](https://github.com/inngest/inngest-js/assets/1736957/f11177f4-060e-4834-aad6-ebc1c6f09065)

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable
