### PR TITLE
Add multiple concurrency limits and scopes

### DIFF
--- a/.changeset/itchy-geese-eat.md
+++ b/.changeset/itchy-geese-eat.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Update concurrency with new scopes and multiple keys

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -97,10 +97,8 @@ export interface FunctionOptions<Events extends Record<string, EventPayload>, Ev
     //
     // (undocumented)
     cancelOn?: Cancellation<Events, Event>[];
-    concurrency?: number | {
-        limit: number;
-        key?: string;
-    };
+    // Warning: (ae-forgotten-export) The symbol "ConcurrencyOption" needs to be exported by the entry point index.d.ts
+    concurrency?: number | ConcurrencyOption | [ConcurrencyOption, ConcurrencyOption];
     debounce?: {
         key?: string;
         period: TimeStr;
@@ -429,7 +427,7 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:353:3 - (ae-forgotten-export) The symbol "AnyInngest" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:359:3 - (ae-forgotten-export) The symbol "AnyInngestFunction" needs to be exported by the entry point index.d.ts
 // src/types.ts:76:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:708:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:739:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -654,6 +654,37 @@ export type TriggerOptions<T extends string> = StrictUnion<
     }
 >;
 
+export interface ConcurrencyOption {
+  /**
+   * The concurrency limit for this option, adding a limit on how many concurrent
+   * steps can execute at once.
+   */
+  limit: number;
+
+  /**
+   * An optional concurrency key, as an expression using the common expression language
+   * (CEL).  The result of this expression is used to create new concurrency groups, or
+   * sub-queues, for each function run.
+   *
+   * The event is passed into this expression as "event".
+   *
+   * Examples:
+   * - `event.data.user_id`:  this evaluates to the user_id in the event.data object.
+   * - `event.data.user_id + "-" + event.data.account_id`: creates a new group per user/account
+   * - `"ai"`:  references a custom string
+   */
+  key?: string;
+
+  /**
+   * An optional scope for the concurrency group.  By default, concurrency limits are
+   * scoped to functions - one function's concurrency limits do not impact other functions.
+   *
+   * Changing this "scope" allows concurrency limits to work across environments (eg. production
+   * vs branch environments) or across your account (global).
+   */
+  scope?: "fn" | "env" | "account"
+}
+
 /**
  * A set of options for configuring an Inngest function.
  *
@@ -685,7 +716,7 @@ export interface FunctionOptions<
    *
    * Specifying just a number means specifying only the concurrency limit.
    */
-  concurrency?: number | { limit: number; key?: string };
+  concurrency?: number | ConcurrencyOption | [ConcurrencyOption, ConcurrencyOption];
 
   /**
    * batchEvents specifies the batch configuration on when this function

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -682,7 +682,7 @@ export interface ConcurrencyOption {
    * Changing this "scope" allows concurrency limits to work across environments (eg. production
    * vs branch environments) or across your account (global).
    */
-  scope?: "fn" | "env" | "account"
+  scope?: "fn" | "env" | "account";
 }
 
 /**


### PR DESCRIPTION
## Summary

Allows users to specify multiple concurrency limits with optional scopes.  This is used to create global sub-groups across functions.

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable
