### PR TITLE
Simplify step returns such that `JsonifyObject<>` is hidden entirely

### DIFF
--- a/.changeset/brave-moose-swim.md
+++ b/.changeset/brave-moose-swim.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove `JsonifyObject<>` wrapper from step output - it's now clearer to see the actual type of a step's result

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -7,6 +7,7 @@
 import { IsEqual } from 'type-fest';
 import { Jsonify } from 'type-fest';
 import { Simplify } from 'type-fest';
+import { SimplifyDeep } from 'type-fest/source/merge-deep';
 import { z as z_2 } from 'zod';
 
 // @public

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -1,4 +1,5 @@
 import { type Jsonify } from "type-fest";
+import { type SimplifyDeep } from "type-fest/source/merge-deep";
 import { timeStr } from "../helpers/strings";
 import {
   type ExclusiveKeys,
@@ -271,12 +272,14 @@ export const createStepTools = <
          * TODO Middleware can affect this. If run input middleware has returned
          * new step data, do not Jsonify.
          */
-        Jsonify<
-          T extends () => Promise<infer U>
-            ? Awaited<U extends void ? null : U>
-            : ReturnType<T> extends void
-            ? null
-            : ReturnType<T>
+        SimplifyDeep<
+          Jsonify<
+            T extends () => Promise<infer U>
+              ? Awaited<U extends void ? null : U>
+              : ReturnType<T> extends void
+              ? null
+              : ReturnType<T>
+          >
         >
       >
     >(


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Step results are serialized and deserialized while being pushed to/from Inngest, so step returns are typed as JSON to make this clear.

These returns still came back wrapped in `JsonifyObject<>`, though, meaning they didn't actually show the resulting changes unless the user started to attempt to use them. This small change ensures we display the resulting type correctly, free of any wrappers.

| ![image](https://github.com/inngest/inngest-js/assets/1736957/cc1027a3-d246-43e1-b6c9-7adad2dea485) | ![image](https://github.com/inngest/inngest-js/assets/1736957/1c639a86-cd2f-49a1-96cd-2018c7ba52de) |
| - | - |
| Before | After |


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable