### PR TITLE
Catch execution result handler failures, such as parsing issues

### DIFF
--- a/.changeset/flat-crabs-drive.md
+++ b/.changeset/flat-crabs-drive.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fixed an issue where an error log wasn't shown if execution result parsing failed, such as in the case of serialization failures

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -416,8 +416,8 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/InngestCommHandler.ts:831:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:831:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:836:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:836:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:264:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:277:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:283:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -753,7 +753,12 @@ export class InngestCommHandler<
           stepOutput.type
         ] as ExecutionResultHandler<ActionResponse>;
 
-        return await handler(stepOutput);
+        try {
+          return await handler(stepOutput);
+        } catch (err) {
+          this.log("error", "Error handling execution result", err);
+          throw err;
+        }
       }
 
       if (method === "GET") {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Log an error to the console if handling an execution result fails. This can happen if something simple like serialization fails when packaging up the user's response.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable
