### PR TITLE
Fix `stringify()` failing to serialize `BigInt`; remove instead

### DIFF
--- a/.changeset/clever-dolphins-return.md
+++ b/.changeset/clever-dolphins-return.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix failing to parse `BigInt` during step/function result serialization; it is now correctly typed and returned as `never`

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -195,28 +195,52 @@ describe("run", () => {
       symbol: Symbol("foo"),
       map: new Map(),
       set: new Set(),
+      bigint: BigInt(123),
+      typedArray: new Int8Array(2),
+      promise: Promise.resolve(),
+      weakMap: new WeakMap([[{}, "test"]]),
+      weakSet: new WeakSet([{}]),
     };
 
     const output = step.run("step", () => input);
 
-    assertType<
-      Promise<{
+    type Expected = {
+      str: string;
+      num: number;
+      bool: boolean;
+      date: string;
+      obj: {
         str: string;
         num: number;
-        bool: boolean;
-        date: string;
-        obj: {
-          str: string;
-          num: number;
-        };
-        arr: (number | null | boolean)[];
-        infinity: number;
-        nan: number;
-        null: null;
-        map: Record<string, never>;
-        set: Record<string, never>;
-      }>
-    >(output);
+      };
+      arr: (number | null | boolean)[];
+      infinity: number;
+      nan: number;
+      null: null;
+      map: Record<string, never>;
+      set: Record<string, never>;
+      bigint: never;
+      typedArray: Record<string, number>;
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      promise: {};
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      weakMap: {};
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      weakSet: {};
+    };
+
+    assertType<Promise<Expected>>(output);
+
+    /**
+     * Used to ensure that stripped base properties are also adhered to.
+     */
+    type KeysMatchExactly<T, U> = keyof T extends keyof U
+      ? keyof U extends keyof T
+        ? true
+        : false
+      : false;
+
+    assertType<KeysMatchExactly<Expected, Awaited<typeof output>>>(true);
   });
 });
 

--- a/packages/inngest/src/helpers/strings.test.ts
+++ b/packages/inngest/src/helpers/strings.test.ts
@@ -1,4 +1,4 @@
-import { slugify, timeStr } from "@local/helpers/strings";
+import { slugify, stringify, timeStr } from "@local/helpers/strings";
 
 describe("slugify", () => {
   it("Generates a slug using hyphens", () => {
@@ -40,5 +40,11 @@ describe("timeStr", () => {
 
   test("converts a date to an ISO string", () => {
     expect(timeStr(new Date(0))).toEqual("1970-01-01T00:00:00.000Z");
+  });
+});
+
+describe("stringify", () => {
+  test("removes BigInt", () => {
+    expect(stringify({ a: BigInt(1), b: 2 })).toEqual(JSON.stringify({ b: 2 }));
   });
 });

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -1,7 +1,21 @@
 import { sha256 } from "hash.js";
+import { default as safeStringify } from "json-stringify-safe";
 import ms from "ms";
 import { type TimeStr } from "../types";
-export { default as stringify } from "json-stringify-safe";
+
+/**
+ * Safely `JSON.stringify()` an `input`, handling circular refernences and
+ * removing `BigInt` values.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const stringify = (input: any): string => {
+  return safeStringify(input, (key, value) => {
+    if (typeof value !== "bigint") {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return value;
+    }
+  });
+};
 
 /**
  * Returns a slugified string used to generate consistent IDs.


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

[`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)s are not natively parsed by JSON. Attempting to return a `BigInt` from a step or function will throw an error. This error was hard to see, which is fixed in #374.

Our types reflect that `BigInt` is unparseable and will type it as `never`, though these were obscured from the user a touch, which is fixed in #371.

For this reason, this PR ensures `BigInt`s are removed during parsing instead of throwing. We can investigate adding `BigInt` support across our SDKs past this fix; the `n` suffix seems an unwritten standard.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- #371
- #374
