### PR TITLE
Remove verbose event keys warning

### DIFF
--- a/.changeset/warm-ghosts-refuse.md
+++ b/.changeset/warm-ghosts-refuse.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove verbose event keys warning

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -22,46 +22,6 @@ const testEvent: EventPayload = {
 
 const testEventKey = "foo-bar-baz-test";
 
-describe("instantiation", () => {
-  describe("event key warnings", () => {
-    let warnSpy: jest.SpyInstance;
-    const originalEnvEventKey = process.env[envKeys.InngestEventKey];
-
-    beforeEach(() => {
-      warnSpy = jest.spyOn(console, "warn");
-    });
-
-    afterEach(() => {
-      warnSpy.mockReset();
-      warnSpy.mockRestore();
-
-      if (originalEnvEventKey) {
-        process.env[envKeys.InngestEventKey] = originalEnvEventKey;
-      } else {
-        delete process.env[envKeys.InngestEventKey];
-      }
-    });
-
-    test("should log a warning if event key not specified", () => {
-      createClient({ id: "test" });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Could not find event key")
-      );
-    });
-
-    test("should not log a warning if event key is specified", () => {
-      createClient({ id: "test", eventKey: testEventKey });
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-
-    test("should not log a warning if event key is specified in env", () => {
-      process.env[envKeys.InngestEventKey] = testEventKey;
-      createClient({ id: "test" });
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-  });
-});
-
 describe("send", () => {
   describe("runtime", () => {
     const originalProcessEnv = process.env;

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -175,21 +175,6 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
 
     this.setEventKey(eventKey || processEnv(envKeys.InngestEventKey) || "");
 
-    if (!this.eventKeySet()) {
-      console.warn(
-        prettyError({
-          type: "warn",
-          whatHappened: "Could not find event key",
-          consequences:
-            "Sending events will throw in production unless an event key is added.",
-          toFixNow: fixEventKeyMissingSteps,
-          why: "We couldn't find an event key to use to send events to Inngest.",
-          otherwise:
-            "Create a new production event key at https://app.inngest.com/env/production/manage/keys.",
-        })
-      );
-    }
-
     this.headers = inngestHeaders({
       inngestEnv: env,
     });


### PR DESCRIPTION
### Summary

Event keys aren't required in dev.  This error can frustrate users in development (see Discord, Slack) and should be removed.

