### PR TITLE
Fix `hasEventKey` in `GET` request always returning `true`

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -767,7 +767,7 @@ export class InngestCommHandler<
 
         const introspection: IntrospectRequest = {
           message: "Inngest endpoint configured correctly.",
-          hasEventKey: Boolean(this.client["eventKey"]),
+          hasEventKey: this.client["eventKeySet"](),
           hasSigningKey: Boolean(this.signingKey),
           functionsFound: registerBody.functions.length,
         };


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes the `hasEventKey` property in `GET` requests to a serve handler always returning `true`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [ ] Added changesets if applicable
