### PR TITLE
Remove "Step already exists; automatically indexing" log

### DIFF
--- a/.changeset/forty-experts-visit.md
+++ b/.changeset/forty-experts-visit.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove "Step already exists; automatically indexing" log

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -708,10 +708,6 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
             break;
           }
         }
-
-        console.debug(
-          `${logPrefix} debug - Step "${originalId}" already exists; automatically indexing to "${opId.id}"`
-        );
       }
 
       const { promise, resolve, reject } = createDeferredPromise();


### PR DESCRIPTION
Despite being `debug` level, this log makes users concerned that they have a bug.  This causes support questions and a lack of trust.  This PR removes the log entirely.