### PR TITLE
Forward `X-Inngest-Server-Kind` headers for registration failures

### DIFF
--- a/.changeset/light-buttons-deliver.md
+++ b/.changeset/light-buttons-deliver.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Forward `X-Inngest-Server-Kind` headers to assist in preventing some issues with registration handshakes

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -161,6 +161,10 @@ export enum headerKeys {
     // (undocumented)
     Framework = "x-inngest-framework",
     // (undocumented)
+    InngestExpectedServerKind = "x-inngest-expected-server-kind",
+    // (undocumented)
+    InngestServerKind = "x-inngest-server-kind",
+    // (undocumented)
     NoRetry = "x-inngest-no-retry",
     // (undocumented)
     Platform = "x-inngest-platform",
@@ -449,8 +453,8 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/InngestCommHandler.ts:837:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:837:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:845:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:845:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:268:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:281:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:287:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -518,14 +518,22 @@ export class InngestCommHandler<
         };
       }, {} as HandlerResponseWithErrors);
 
-      this.env =
-        (await actions.env?.("starting to handle request")) ?? allProcessEnv();
+      const [env, expectedServerKind] = await Promise.all([
+        actions.env?.("starting to handle request"),
+        actions.headers(
+          "checking expected server kind",
+          headerKeys.InngestServerKind
+        ),
+      ]);
+
+      this.env = env ?? allProcessEnv();
 
       const getInngestHeaders = (): Record<string, string> =>
         inngestHeaders({
           env: this.env,
           framework: this.frameworkName,
           client: this.client,
+          expectedServerKind: expectedServerKind || undefined,
           extras: {
             "Server-Timing": timer.getHeader(),
           },

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -121,6 +121,8 @@ export enum headerKeys {
   NoRetry = "x-inngest-no-retry",
   RequestVersion = "x-inngest-req-version",
   RetryAfter = "retry-after",
+  InngestServerKind = "x-inngest-server-kind",
+  InngestExpectedServerKind = "x-inngest-expected-server-kind",
 }
 
 export const defaultInngestApiBaseUrl = "https://api.inngest.com/";

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -148,3 +148,8 @@ export const logPrefix = chalk.magenta.bold("[Inngest]");
 export const debugPrefix = "inngest";
 
 export const dummyEventKey = "NO_EVENT_KEY_SET";
+
+export enum serverKind {
+  Dev = "dev",
+  Cloud = "cloud",
+}

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -217,6 +217,13 @@ export const inngestHeaders = (opts?: {
   client?: Inngest;
 
   /**
+   * The Inngest server we expect to be communicating with, used to ensure that
+   * various parts of a handshake are all happening the same type of
+   * participant.
+   */
+  expectedServerKind?: string;
+
+  /**
    * Any additional headers to include in the returned headers.
    */
   extras?: Record<string, string>;
@@ -230,6 +237,10 @@ export const inngestHeaders = (opts?: {
 
   if (opts?.framework) {
     headers[headerKeys.Framework] = opts.framework;
+  }
+
+  if (opts?.expectedServerKind) {
+    headers[headerKeys.InngestExpectedServerKind] = opts.expectedServerKind;
   }
 
   const env = {

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -218,7 +218,7 @@ export const inngestHeaders = (opts?: {
 
   /**
    * The Inngest server we expect to be communicating with, used to ensure that
-   * various parts of a handshake are all happening the same type of
+   * various parts of a handshake are all happening with the same type of
    * participant.
    */
   expectedServerKind?: string;

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -4,7 +4,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import { Inngest } from "@local";
 import { type ServeHandlerOptions } from "@local/components/InngestCommHandler";
-import { envKeys, headerKeys, queryKeys } from "@local/helpers/consts";
+import {
+  envKeys,
+  headerKeys,
+  queryKeys,
+  serverKind,
+} from "@local/helpers/consts";
 import { type Env } from "@local/helpers/env";
 import { slugify } from "@local/helpers/strings";
 import { type FunctionTrigger } from "@local/types";
@@ -240,7 +245,12 @@ export const testFramework = (
       test("shows introspection data", async () => {
         const ret = await run(
           [{ client: inngest, functions: [] }],
-          [{ method: "GET" }]
+          [
+            {
+              method: "GET",
+              headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+            },
+          ]
         );
 
         const body = JSON.parse(ret.body);
@@ -249,6 +259,7 @@ export const testFramework = (
           status: 200,
           headers: expect.objectContaining({
             [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+            [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
             [headerKeys.Framework]: expect.stringMatching(
               handler.frameworkName
             ),
@@ -282,7 +293,13 @@ export const testFramework = (
 
           const ret = await run(
             [{ client: inngest, functions: [] }],
-            [{ method: "PUT", url: "/api/inngest" }]
+            [
+              {
+                method: "PUT",
+                url: "/api/inngest",
+                headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+              },
+            ]
           );
 
           const retBody = JSON.parse(ret.body);
@@ -291,6 +308,7 @@ export const testFramework = (
             status: 200,
             headers: expect.objectContaining({
               [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+              [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
               [headerKeys.Framework]: expect.stringMatching(
                 handler.frameworkName
               ),
@@ -313,7 +331,12 @@ export const testFramework = (
 
           const ret = await run(
             [{ client: inngest, functions: [] }],
-            [{ method: "PUT" }],
+            [
+              {
+                method: "PUT",
+                headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+              },
+            ],
             {
               [envKeys.IsNetlify]: "true",
             }
@@ -322,6 +345,7 @@ export const testFramework = (
           expect(ret).toMatchObject({
             headers: expect.objectContaining({
               [headerKeys.Platform]: "netlify",
+              [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
             }),
           });
         });
@@ -343,7 +367,13 @@ export const testFramework = (
 
           const ret = await run(
             [{ client: inngest, functions: [] }],
-            [{ method: "PUT", url: customUrl }]
+            [
+              {
+                method: "PUT",
+                url: customUrl,
+                headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+              },
+            ]
           );
 
           const retBody = JSON.parse(ret.body);
@@ -352,6 +382,7 @@ export const testFramework = (
             status: 200,
             headers: expect.objectContaining({
               [headerKeys.SdkVersion]: expect.stringContaining("inngest-js:v"),
+              [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
               [headerKeys.Framework]: expect.stringMatching(
                 handler.frameworkName
               ),
@@ -465,13 +496,19 @@ export const testFramework = (
                 functions: [],
               },
             ],
-            [{ method: "PUT" }]
+            [
+              {
+                method: "PUT",
+                headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+              },
+            ]
           );
 
           expect(ret).toMatchObject({
             status: 200,
             headers: expect.objectContaining({
               [headerKeys.Environment]: expect.stringMatching("FOO"),
+              [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
             }),
           });
         });


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Forwards `X-Inngest-Server-Kind` headers as `X-Inngest-Expected-Server-Kind` for communications with Inngest servers.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Internal change
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- inngest/inngest#868
