### PR TITLE
Support Remix env vars on Cloudflare Pages via `context.env`

### DIFF
--- a/.changeset/eight-masks-grab.md
+++ b/.changeset/eight-masks-grab.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Support Remix env vars on Cloudflare Pages via `context.env`

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1249,7 +1249,7 @@ export type Handler<
 export type HandlerResponse<Output = any, StreamOutput = any> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body: () => MaybePromise<any>;
-  env?: () => MaybePromise<Env>;
+  env?: () => MaybePromise<Env | undefined>;
   headers: (key: string) => MaybePromise<string | null | undefined>;
 
   /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes an issue where the `"inngest/remix"` serve handler cannot access environment variables when used on Cloudflare Pages.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable
