### PR TITLE
Add `@inngest/middleware-encryption` package

### DIFF
--- a/.changeset/good-rice-prove.md
+++ b/.changeset/good-rice-prove.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-encryption": minor
+---
+
+Release the first version of `@inngest/middleware-encryption`

--- a/packages/middleware-encryption/.gitignore
+++ b/packages/middleware-encryption/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/middleware-encryption/.npmrc
+++ b/packages/middleware-encryption/.npmrc
@@ -1,0 +1,1 @@
+link-workspace-packages=false

--- a/packages/middleware-encryption/LICENSE.md
+++ b/packages/middleware-encryption/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-encryption/README.md
+++ b/packages/middleware-encryption/README.md
@@ -1,5 +1,8 @@
 # @inngest/middleware-encryption
 
+> [!WARNING]
+> This package is currently in alpha. Use with caution.
+
 This package provides an encryption middleware for Inngest, enabling secure handling of sensitive data. It encrypts data being sent to and from Inngest, ensuring plaintext data never leaves your server.
 
 ## Features

--- a/packages/middleware-encryption/README.md
+++ b/packages/middleware-encryption/README.md
@@ -3,9 +3,9 @@
 This package provides an encryption middleware for Inngest, enabling secure handling of sensitive data. It encrypts data being sent to and from Inngest, ensuring plaintext data never leaves your server.
 
 ## Features
+
 - **Data Encryption:** Encrypts step and event data, with support for multiple encryption keys.
 - **Customizable Encryption Service:** Allows use of a custom encryption service or the default AES-based service.
-- **Event Data Encryption Option:** Option to encrypt events sent to Inngest, though this may impact certain Inngest dashboard features.
 
 ## Installation
 
@@ -19,6 +19,11 @@ npm install @inngest/middleware-encryption
 ## Usage
 
 To use the encryption middleware, import and initialize it with your encryption key(s). You can optionally provide a custom encryption service.
+
+By default, the following will be encrypted:
+
+- All step data
+- Event data placed inside `data.encrypted`
 
 ```ts
 import { encryptionMiddleware } from "@inngest/middleware-encryption";
@@ -34,6 +39,25 @@ const inngest = new Inngest({
   middleware: [mw],
 });
 ```
+
+
+
+## Customizing event encryption
+
+Only select pieces of event data are encrypted. By default, only the `data.encrypted` field.
+
+This can be customized using the `eventEncryptionField` setting
+
+- `string` - Encrypt fields matching this name
+- `string[]` - Encrypt fields matching these names
+- `(field: string) => boolean` - Provide a function to decide whether to encrypt a field
+- `false` - Disable all event encryption
+
+## Rotating encryption keys
+
+Provide an `Array<string>` when providing your `key` to support rotating encryption keys.
+
+The first key is always used to encrypt, but decryption will be attempted with all keys.
 
 ## Implementing your own encryption
 

--- a/packages/middleware-encryption/README.md
+++ b/packages/middleware-encryption/README.md
@@ -1,0 +1,85 @@
+# @inngest/middleware-encryption
+
+This package provides an encryption middleware for Inngest, enabling secure handling of sensitive data. It encrypts data being sent to and from Inngest, ensuring plaintext data never leaves your server.
+
+## Features
+- **Data Encryption:** Encrypts step and event data, with support for multiple encryption keys.
+- **Customizable Encryption Service:** Allows use of a custom encryption service or the default AES-based service.
+- **Event Data Encryption Option:** Option to encrypt events sent to Inngest, though this may impact certain Inngest dashboard features.
+
+## Installation
+
+```sh
+npm install @inngest/middleware-encryption
+```
+
+> [!NOTE]
+> Requires TypeScript SDK v3+
+
+## Usage
+
+To use the encryption middleware, import and initialize it with your encryption key(s). You can optionally provide a custom encryption service.
+
+```ts
+import { encryptionMiddleware } from "@inngest/middleware-encryption";
+
+// Initialize the middleware
+const mw = encryptionMiddleware({
+  key: "your-encryption-key",
+});
+
+// Use the middleware with Inngest
+const inngest = new Inngest({
+  id: "my-app",
+  middleware: [mw],
+});
+```
+
+## Implementing your own encryption
+
+To create a custom encryption service, you need to implement the abstract `EncryptionService` class provided by the package. Your custom service must implement two core methods: `encrypt` and `decrypt`.
+
+```ts
+export abstract class EncryptionService {
+  public abstract encrypt(value: unknown): string;
+  public abstract decrypt(value: string): unknown;
+}
+```
+
+For example, here's how you might define, instantiate, and use a custom encryption service:
+
+```ts
+import { EncryptionService } from "@inngest/middleware-encryption";
+
+class CustomEncryptionService implements EncryptionService {
+  constructor(/* custom parameters */) {
+    // Initialization code here
+  }
+
+  encrypt(value: unknown): string {
+    // Implement your custom encryption logic here
+    // Example: return CustomEncryptLib.encrypt(JSON.stringify(value), this.customKey);
+  }
+
+  decrypt(value: string): unknown {
+    // Implement your custom decryption logic here
+    // Example: return JSON.parse(CustomEncryptLib.decrypt(value, this.customKey));
+  }
+}
+```
+
+You can then pass it to the `encryptionMiddleware` function like so:
+
+```ts
+const customService = new CustomEncryptionService(/* custom parameters */);
+
+const mw = encryptionMiddleware({
+  encryptionService: customService,
+});
+
+// Use the middleware with Inngest
+const inngest = new Inngest({
+  id: "my-app",
+  middleware: [mw],
+});
+```

--- a/packages/middleware-encryption/package.json
+++ b/packages/middleware-encryption/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@inngest/middleware-encryption",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Inngest",
-  "main": "index.js",
+  "main": "dist/index.js",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/packages/middleware-encryption/package.json
+++ b/packages/middleware-encryption/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@inngest/middleware-encryption",
+  "version": "0.0.0",
+  "description": "Inngest",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc",
+    "postversion": "pnpm run build",
+    "release": "node ../../scripts/release/publish.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "inngest-middleware",
+    "inngest",
+    "middleware",
+    "encryption"
+  ],
+  "homepage": "https://github.com/inngest/inngest-js/tree/main/packages/middleware-encryption#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inngest/inngest-js.git",
+    "directory": "packages/middleware-encryption"
+  },
+  "author": "Jack Williams <jack@inngest.com>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/crypto-js": "^4.2.1",
+    "typescript": "~5.3.0"
+  },
+  "dependencies": {
+    "crypto-js": "^4.2.0"
+  },
+  "peerDependencies": {
+    "inngest": "^3.0.0"
+  }
+}

--- a/packages/middleware-encryption/package.json
+++ b/packages/middleware-encryption/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Inngest",
   "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",

--- a/packages/middleware-encryption/src/index.ts
+++ b/packages/middleware-encryption/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./middleware";

--- a/packages/middleware-encryption/src/middleware.ts
+++ b/packages/middleware-encryption/src/middleware.ts
@@ -1,0 +1,220 @@
+import AES from "crypto-js/aes";
+import CryptoJSUtf8 from "crypto-js/enc-utf8";
+import { InngestMiddleware, type MiddlewareRegisterReturn } from "inngest";
+
+/**
+ * A marker used to identify encrypted values without having to guess.
+ */
+const ENCRYPTION_MARKER = "__ENCRYPTED__";
+
+/**
+ * Options used to configure the encryption middleware.
+ */
+export interface EncryptionMiddlewareOptions {
+  /**
+   * The key or keys used to encrypt and decrypt data. If multiple keys are
+   * provided, the first key will be used to encrypt data and all keys will
+   * be tried when decrypting data.
+   */
+  key?: string | string[];
+
+  /**
+   * The encryption service used to encrypt and decrypt data. If not provided,
+   * a default encryption service will be used.
+   */
+  encryptionService?: EncryptionService;
+
+  /**
+   * Whether to encrypt events sent to Inngest. Defaults to `false`.
+   *
+   * Encrypting event data can impact the features available to you in terms
+   * of querying and filtering events in the Inngest dashboard, or using
+   * composability tooling such as `step.waitForEvent()`. Only enable this
+   * feature if you are absolutely sure that you need it.
+   */
+  encryptEvents?: boolean;
+}
+
+/**
+ * Encrypts and decrypts data sent to and from Inngest.
+ */
+export const encryptionMiddleware = (
+  /**
+   * Options used to configure the encryption middleware. If a custom
+   * `encryptionService` is not provided, the `key` option is required.
+   */
+  opts: EncryptionMiddlewareOptions
+) => {
+  const service =
+    opts.encryptionService || new DefaultEncryptionService(opts.key);
+
+  const encrypt = (value: unknown): EncryptedValue => {
+    return {
+      [ENCRYPTION_MARKER]: true,
+      data: service.encrypt(value),
+    };
+  };
+
+  const decrypt = (value: unknown): unknown => {
+    if (isEncryptedValue(value)) {
+      return service.decrypt(value.data);
+    }
+
+    return value;
+  };
+
+  return new InngestMiddleware({
+    name: "@inngest/middleware-encryption",
+    init: () => {
+      const registration: MiddlewareRegisterReturn = {
+        onFunctionRun: () => {
+          return {
+            transformInput: ({ ctx, steps }) => {
+              const inputTransformer: InputTransformer = {
+                steps: steps.map((step) => ({
+                  ...step,
+                  data: step.data && decrypt(step.data),
+                })),
+              };
+
+              if (opts.encryptEvents) {
+                inputTransformer.ctx = {
+                  event: ctx.event && {
+                    ...ctx.event,
+                    data: ctx.event.data && decrypt(ctx.event.data),
+                  },
+                  events:
+                    ctx.events &&
+                    ctx.events?.map((event) => ({
+                      ...event,
+                      data: event.data && decrypt(event.data),
+                    })),
+                } as {};
+              }
+
+              return inputTransformer;
+            },
+            transformOutput: (ctx) => {
+              if (!ctx.step) {
+                return;
+              }
+
+              return {
+                result: {
+                  data: ctx.result.data && encrypt(ctx.result.data),
+                },
+              };
+            },
+          };
+        },
+      };
+
+      if (opts.encryptEvents) {
+        registration.onSendEvent = () => {
+          return {
+            transformInput: ({ payloads }) => {
+              return {
+                payloads: payloads.map((payload) => ({
+                  ...payload,
+                  data: payload.data && encrypt(payload.data),
+                })),
+              };
+            },
+          };
+        };
+      }
+
+      return registration;
+    },
+  });
+};
+
+export interface EncryptedValue {
+  [ENCRYPTION_MARKER]: true;
+  data: string;
+}
+
+type InputTransformer = NonNullable<
+  Awaited<
+    ReturnType<
+      NonNullable<
+        Awaited<
+          ReturnType<NonNullable<MiddlewareRegisterReturn["onFunctionRun"]>>
+        >["transformInput"]
+      >
+    >
+  >
+>;
+
+const isEncryptedValue = (value: unknown): value is EncryptedValue => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ENCRYPTION_MARKER in value &&
+    value[ENCRYPTION_MARKER] === true &&
+    "data" in value &&
+    typeof value["data"] === "string"
+  );
+};
+
+/**
+ * A service that encrypts and decrypts data. You can implement this abstract
+ * class to provide your own encryption service, or use the default encryption
+ * service provided by this package.
+ */
+export abstract class EncryptionService {
+  public abstract encrypt(value: unknown): string;
+  public abstract decrypt(value: string): unknown;
+}
+
+/**
+ * The default encryption service used by the encryption middleware.
+ *
+ * This service uses AES encryption to encrypt and decrypt data. It supports
+ * multiple keys, so that you can rotate keys without breaking existing
+ * encrypted data.
+ */
+export class DefaultEncryptionService extends EncryptionService {
+  private readonly keys: [string, ...string[]];
+
+  constructor(key: string | string[] | undefined) {
+    super();
+
+    if (!key) {
+      throw new Error("Missing encryption key(s) in encryption middleware");
+    }
+
+    const keys = (Array.isArray(key) ? key : [key])
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (!keys.length) {
+      throw new Error("Missing encryption key(s) in encryption middleware");
+    }
+
+    this.keys = keys as [string, ...string[]];
+  }
+
+  encrypt(value: unknown): string {
+    return AES.encrypt(JSON.stringify(value), this.keys[0]).toString();
+  }
+
+  decrypt(value: string): unknown {
+    let err: unknown;
+
+    for (const key of this.keys) {
+      try {
+        const decrypted = AES.decrypt(value, key).toString(CryptoJSUtf8);
+        return JSON.parse(decrypted);
+      } catch (decryptionError) {
+        err = decryptionError;
+        continue;
+      }
+    }
+
+    throw (
+      err ||
+      new Error("Unable to decrypt value; no keys were able to decrypt it")
+    );
+  }
+}

--- a/packages/middleware-encryption/tsconfig.json
+++ b/packages/middleware-encryption/tsconfig.json
@@ -1,0 +1,103 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         version: 4.2.0
       inngest:
         specifier: ^3.0.0
-        version: 3.7.0
+        version: 3.7.0(typescript@5.3.2)
     devDependencies:
       '@types/crypto-js':
         specifier: ^4.2.1
@@ -5104,6 +5104,32 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  /inngest@3.7.0(typescript@5.3.2):
+    resolution: {integrity: sha512-LhtFC3S+Ak1ex94APD4IS6z7EuPrffw0CaIpHnEMNbzbpuVc4bF5aN/N4hS4VjNIx1TGxm6Um4ymHmFCSmtcSg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.7.2'
+    dependencies:
+      '@types/debug': 4.1.12
+      canonicalize: 1.0.8
+      chalk: 4.1.2
+      cross-fetch: 4.0.0
+      debug: 4.3.4
+      h3: 1.8.1
+      hash.js: 1.1.7
+      json-stringify-safe: 5.0.1
+      ms: 2.1.3
+      serialize-error-cjs: 0.1.3
+      strip-ansi: 5.2.0
+      type-fest: 3.13.1
+      type-plus: 5.6.0
+      typescript: 5.3.2
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /inquirer@9.2.10:
     resolution: {integrity: sha512-tVVNFIXU8qNHoULiazz612GFl+yqNfjMTbLuViNJE/d860Qxrd3NMrse8dm40VUQLOQeULvaQF8lpAhvysjeyA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,22 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
 
+  packages/middleware-encryption:
+    dependencies:
+      crypto-js:
+        specifier: ^4.2.0
+        version: 4.2.0
+      inngest:
+        specifier: ^3.0.0
+        version: 3.7.0
+    devDependencies:
+      '@types/crypto-js':
+        specifier: ^4.2.1
+        version: 4.2.1
+      typescript:
+        specifier: ~5.3.0
+        version: 5.3.2
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -2253,6 +2269,10 @@ packages:
       '@types/node': 18.16.16
     dev: true
 
+  /@types/crypto-js@4.2.1:
+    resolution: {integrity: sha512-FSPGd9+OcSok3RsM0UZ/9fcvMOXJ1ENE/ZbLfOPlBWj7BgXtEAM8VYfTtT760GiLbQIMoVozwVuisjvsVwqYWw==}
+    dev: true
+
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
     dependencies:
@@ -3447,6 +3467,10 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  /crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    dev: false
 
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add `@inngest/middleware-encryption` package to allow easy E2E encryption.

See the [README.md](https://github.com/inngest/inngest-js/blob/middleware-encryption/packages/middleware-encryption/README.md).

The package is already released (first release must always be done by hand); this PR merging makes no immediate changes, but ideally we use it to review `README.md`, license, and structure.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] ~~Added unit/integration tests~~ N/A Testing story needed for this
- [x] Added changesets if applicable

## Related

- Docs at inngest/website#591
