### PR TITLE
Add the encryption method used by default to the README

### DIFF
--- a/packages/middleware-encryption/README.md
+++ b/packages/middleware-encryption/README.md
@@ -8,7 +8,7 @@ This package provides an encryption middleware for Inngest, enabling secure hand
 ## Features
 
 - **Data Encryption:** Encrypts step and event data, with support for multiple encryption keys.
-- **Customizable Encryption Service:** Allows use of a custom encryption service or the default AES-based service.
+- **Customizable Encryption Service:** Allows use of a custom encryption service or defaults to using `AES-256-CBC`.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds the default encryption method used to the `README.md` of `@inngest/middleware-encryption` package.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Docs are here
- [ ] ~~Added unit/integration tests~~ N/A Docs
- [ ] Added changesets if applicable
