### PR TITLE
Don't return a `Response` in `inngest/next` if in serverless

### DIFF
--- a/.changeset/silly-dolphins-pump.md
+++ b/.changeset/silly-dolphins-pump.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix serverless use of `inngest/next` with `next@>=13.0.0 <13.5.0` failing to return a response, as well as `next@>=13.5.0` logging the same error


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Next.js versions `next@>=13.0.0 <13.5.0` will throw an error if a `Response` object is returned from a serverless endpoint. `next@>=13.5.0` will display the error but continue to function.

Next.js edge still requires that the `ReturnType` of the function is a `Response`, so we keep that type whilst ensuring it's not actually passed back in serverless endpoints.

There are so many edge cases here and this one breaks across minor versions. Separate exports (e.g. `inngest/next-13-edge`) might be appropriate in the future if the type/runtime guards continue to become stricter on the Next.js side.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [ ] ~~Added unit/integration tests~~ N/A Will observe logs disappearing in current integration tests which use `next@13.5.4`: https://github.com/inngest/inngest-js/actions/runs/7181668471/job/19556571083?pr=421
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #400 
