### PR TITLE
Fix peer deps force bumping during releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

We use non-local peer dependencies due to a restriction with the build process of `inngest`.

This contributes to changesets bumping peer dependencies for packages that want to reference `inngest` from their wide constraint (e.g. `^3.0.0`) to a narrower one (e.g. `^3.7.1`).

I believe we can avoid this using an experimental flag added in changesets/changesets#383.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

## Related

- changesets/changesets#383
- changesets/changesets#524
