### PR TITLE
Add internal events to default `EventSchemas`

### DIFF
--- a/.changeset/cool-foxes-bow.md
+++ b/.changeset/cool-foxes-bow.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix internal `inngest/*` events not being present when using `new EventSchemas()`

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -51,8 +51,8 @@ export interface EventPayload {
 
 // @public
 export class EventSchemas<S extends Record<string, EventPayload> = {
-    [internalEvents_2.FunctionFailed]: FailureEventPayload;
-    [internalEvents_2.FunctionFinished]: FinishedEventPayload;
+    [internalEvents.FunctionFailed]: FailureEventPayload;
+    [internalEvents.FunctionFinished]: FinishedEventPayload;
 }> {
     fromGenerated<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
     // Warning: (ae-forgotten-export) The symbol "PreventClashingNames" needs to be exported by the entry point index.d.ts
@@ -466,7 +466,6 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/EventSchemas.ts:220:5 - (ae-forgotten-export) The symbol "internalEvents_2" needs to be exported by the entry point index.d.ts
 // src/components/EventSchemas.ts:221:5 - (ae-forgotten-export) The symbol "FinishedEventPayload" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:845:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:845:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -9,7 +9,7 @@ import { IsEqual } from 'type-fest';
 import { Jsonify } from 'type-fest';
 import { Simplify } from 'type-fest';
 import { SimplifyDeep } from 'type-fest/source/merge-deep';
-import { z as z_2 } from 'zod';
+import { z } from 'zod';
 
 // @public
 export interface ClientOptions {
@@ -50,7 +50,10 @@ export interface EventPayload {
 }
 
 // @public
-export class EventSchemas<S extends Record<string, EventPayload>> {
+export class EventSchemas<S extends Record<string, EventPayload> = {
+    [internalEvents_2.FunctionFailed]: FailureEventPayload;
+    [internalEvents_2.FunctionFinished]: FinishedEventPayload;
+}> {
     fromGenerated<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
     // Warning: (ae-forgotten-export) The symbol "PreventClashingNames" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ClashingNameError" needs to be exported by the entry point index.d.ts
@@ -84,7 +87,7 @@ export type FailureEventPayload<P extends EventPayload = EventPayload> = {
     data: {
         function_id: string;
         run_id: string;
-        error: z_2.output<typeof failureEventErrorSchema>;
+        error: z.output<typeof failureEventErrorSchema>;
         event: P;
     };
 };
@@ -286,6 +289,8 @@ export class InngestMiddleware<TOpts extends MiddlewareOptions> {
 export enum internalEvents {
     FunctionFailed = "inngest/function.failed",
     // (undocumented)
+    FunctionFinished = "inngest/function.finished",
+    // (undocumented)
     FunctionInvoked = "inngest/function.invoked"
 }
 
@@ -294,13 +299,13 @@ export enum internalEvents {
 // @internal
 export type IsStringLiteral<T extends string> = string extends T ? false : true;
 
-// Warning: (ae-forgotten-export) The symbol "z" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "z_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type LiteralZodEventSchema = z.ZodObject<{
-    name: z.ZodLiteral<string>;
-    data?: z.AnyZodObject | z.ZodAny;
-    user?: z.AnyZodObject | z.ZodAny;
+export type LiteralZodEventSchema = z_2.ZodObject<{
+    name: z_2.ZodLiteral<string>;
+    data?: z_2.AnyZodObject | z_2.ZodAny;
+    user?: z_2.AnyZodObject | z_2.ZodAny;
 }>;
 
 // @public
@@ -455,12 +460,14 @@ export type UnionKeys<T> = T extends T ? keyof T : never;
 
 // @public
 export type ZodEventSchemas = Record<string, {
-    data?: z.AnyZodObject | z.ZodAny;
-    user?: z.AnyZodObject | z.ZodAny;
+    data?: z_2.AnyZodObject | z_2.ZodAny;
+    user?: z_2.AnyZodObject | z_2.ZodAny;
 }>;
 
 // Warnings were encountered during analysis:
 //
+// src/components/EventSchemas.ts:220:5 - (ae-forgotten-export) The symbol "internalEvents_2" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:221:5 - (ae-forgotten-export) The symbol "FinishedEventPayload" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:845:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:845:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:268:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
@@ -471,7 +478,7 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:357:3 - (ae-forgotten-export) The symbol "AnyInngest" needs to be exported by the entry point index.d.ts
 // src/types.ts:80:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:754:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:770:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -12,12 +12,18 @@ type Schemas<T extends EventSchemas<any>> = GetEvents<
 >;
 
 describe("EventSchemas", () => {
-  test("creates generic types by default", () => {
+  test("adds internal types by default", () => {
     const schemas = new EventSchemas();
 
-    assertType<IsEqual<Schemas<typeof schemas>, Record<string, EventPayload>>>(
-      true
-    );
+    type Expected =
+      | `${internalEvents.FunctionFailed}`
+      | `${internalEvents.FunctionFinished}`;
+
+    type Actual = Schemas<typeof schemas>[keyof Schemas<
+      typeof schemas
+    >]["name"];
+
+    assertType<IsEqual<Expected, Actual>>(true);
   });
 
   describe("fromRecord", () => {

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -1,7 +1,12 @@
 import { type Simplify } from "type-fest";
+import { type internalEvents } from "../helpers/consts";
 import { type IsEmptyObject, type IsStringLiteral } from "../helpers/types";
 import type * as z from "../helpers/validators/zod";
-import { type EventPayload } from "../types";
+import {
+  type EventPayload,
+  type FailureEventPayload,
+  type FinishedEventPayload,
+} from "../types";
 
 /**
  * Declares the shape of an event schema we expect from the user. This may be
@@ -210,7 +215,12 @@ export type Combine<
  *
  * @public
  */
-export class EventSchemas<S extends Record<string, EventPayload>> {
+export class EventSchemas<
+  S extends Record<string, EventPayload> = {
+    [internalEvents.FunctionFailed]: FailureEventPayload;
+    [internalEvents.FunctionFinished]: FinishedEventPayload;
+  },
+> {
   /**
    * Use generated Inngest types to type events.
    */

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -7,11 +7,7 @@ import {
   type GetStepTools,
 } from "@local";
 import { type createStepTools } from "@local/components/InngestStepTools";
-import {
-  envKeys,
-  headerKeys,
-  type internalEvents,
-} from "@local/helpers/consts";
+import { envKeys, headerKeys, internalEvents } from "@local/helpers/consts";
 import { type IsAny } from "@local/helpers/types";
 import { type Logger } from "@local/middleware/logger";
 import { type SendEventResponse } from "@local/types";
@@ -519,6 +515,12 @@ describe("send", () => {
             { name: "bar", data: { bar: "" } },
           ]);
       });
+
+      test("disallows sending an internal event", () => {
+        const _fn = () =>
+          // @ts-expect-error Internal event
+          inngest.send({ name: internalEvents.FunctionFinished });
+      });
     });
   });
 });
@@ -769,7 +771,12 @@ describe("helper types", () => {
     type T0 = GetFunctionInput<typeof inngest>;
 
     test("returns event typing", () => {
-      type Expected = `${internalEvents.FunctionInvoked}` | "foo" | "bar";
+      type Expected =
+        | `${internalEvents.FunctionFailed}`
+        | `${internalEvents.FunctionFinished}`
+        | `${internalEvents.FunctionInvoked}`
+        | "foo"
+        | "bar";
       type Actual = T0["event"]["name"];
       assertType<IsEqual<Expected, Actual>>(true);
     });

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -142,6 +142,7 @@ export enum internalEvents {
    */
   FunctionFailed = "inngest/function.failed",
   FunctionInvoked = "inngest/function.invoked",
+  FunctionFinished = "inngest/function.finished",
 }
 
 export const logPrefix = chalk.magenta.bold("[Inngest]");

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -27,9 +27,16 @@ export type PartialK<T, K extends PropertyKey = PropertyKey> = Partial<
 export type SendEventPayload<Events extends Record<string, EventPayload>> =
   SingleOrArray<
     {
-      [K in keyof Events]: PartialK<Omit<Events[K], "v">, "ts">;
-    }[keyof Events]
+      [K in keyof WithoutInternal<Events>]: PartialK<
+        Omit<WithoutInternal<Events>[K], "v">,
+        "ts"
+      >;
+    }[keyof WithoutInternal<Events>]
   >;
+
+export type WithoutInternal<T extends Record<string, EventPayload>> = {
+  [K in keyof T as K extends `inngest/${string}` ? never : K]: T[K];
+};
 
 /**
  * A list of simple, JSON-compatible, primitive types that contain no other

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -99,6 +99,22 @@ export type FailureEventArgs<P extends EventPayload = EventPayload> = {
   error: Error;
 };
 
+export type FinishedEventPayload = {
+  name: `${internalEvents.FunctionFinished}`;
+  data: {
+    function_id: string;
+    run_id: string;
+    correlation_id?: string;
+  } & (
+    | {
+        error: z.output<typeof failureEventErrorSchema>;
+      }
+    | {
+        result: unknown;
+      }
+  );
+};
+
 /**
  * Unique codes for the different types of operation that can be sent to Inngest
  * from SDK step functions.


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds internal `inngest/function.failed` and `inngest/function.completed` events to the list of default events when using `new EventSchemas()`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix - already stated that we do this
- [x] Added unit/integration tests
- [x] Added changesets if applicable
