### PR TITLE
Fix missing `EventPayload.id`

### DIFF
--- a/.changeset/flat-dogs-wash.md
+++ b/.changeset/flat-dogs-wash.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `EventPayload.id` missing from typing when attempting to send events with `inngest.send()` or `step.sendEvent()`

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -43,6 +43,7 @@ export type EventNameFromTrigger<Events extends Record<string, EventPayload>, T 
 // @public
 export interface EventPayload {
     data?: any;
+    id?: string;
     name: string;
     ts?: number;
     user?: any;
@@ -471,7 +472,7 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:357:3 - (ae-forgotten-export) The symbol "AnyInngest" needs to be exported by the entry point index.d.ts
 // src/types.ts:80:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:754:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:766:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -410,6 +410,12 @@ describe("send", () => {
     describe("no custom types", () => {
       const inngest = createClient({ id: "test", eventKey: testEventKey });
 
+      test.todo("disallows sending invalid fields");
+
+      test.todo(
+        "disallows sending invalid fields when sending multiple events"
+      );
+
       test("allows sending a single event with an object", () => {
         const _fn = () => inngest.send({ name: "anything", data: "foo" });
       });
@@ -504,6 +510,8 @@ describe("send", () => {
         // @ts-expect-error Empty data
         const _fn = () => inngest.send({ name: "foo", data: {} });
       });
+
+      test.todo("disallows sending invalid fields for a known event");
 
       test("allows sending known data-empty event with no data", () => {
         const _fn = () => inngest.send({ name: "baz" });

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -422,6 +422,11 @@ describe("send", () => {
             { name: "anythingelse" },
           ]);
       });
+
+      test("allows setting an ID for an event", () => {
+        const _fn = () =>
+          inngest.send({ name: "anything", data: "foo", id: "test" });
+      });
     });
 
     describe("multiple custom types", () => {
@@ -518,6 +523,11 @@ describe("send", () => {
             { name: "foo", data: { foo: "" } },
             { name: "bar", data: { bar: "" } },
           ]);
+      });
+
+      test("allows setting an ID for a known event", () => {
+        const _fn = () =>
+          inngest.send({ name: "foo", data: { foo: "" }, id: "test" });
       });
     });
   });

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -401,7 +401,7 @@ export const createStepTools = <
         user: opts.user,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         v: opts.v,
-      } satisfies Omit<Required<EventPayload>, "name" | "ts"> &
+      } satisfies Omit<Required<EventPayload>, "name" | "ts" | "id"> &
         Partial<Pick<EventPayload, "name" | "ts">>;
 
       return {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -304,7 +304,10 @@ export type AnyHandler = Handler<any, any, any, any>;
  */
 export interface EventPayload {
   /**
-   * A unique identifier for the event
+   * A unique identifier for the type of event. We recommend using lowercase dot
+   * notation for names, prepending `prefixes/` with a slash for organization.
+   *
+   * e.g. `cloudwatch/alarms/triggered`, `cart/session.created`
    */
   name: string;
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -304,11 +304,11 @@ export type AnyHandler = Handler<any, any, any, any>;
  */
 export interface EventPayload {
   /**
-   * A unique id used to idempotently ingest a given event payload once (i.e.
-   * deduplication).
+   * A unique id used to idempotently process a given event payload.
    *
    * Set this when sending events to ensure that the event is only processed
-   * once; if an event with the same ID is sent again, it will be ignored.
+   * once; if an event with the same ID is sent again, it will not invoke
+   * functions.
    */
   id?: string;
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -304,6 +304,15 @@ export type AnyHandler = Handler<any, any, any, any>;
  */
 export interface EventPayload {
   /**
+   * A unique id used to idempotently ingest a given event payload once (i.e.
+   * deduplication).
+   *
+   * Set this when sending events to ensure that the event is only processed
+   * once; if an event with the same ID is sent again, it will be ignored.
+   */
+  id?: string;
+
+  /**
    * A unique identifier for the type of event. We recommend using lowercase dot
    * notation for names, prepending `prefixes/` with a slash for organization.
    *


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes #423, where `id` is missing in types when attempting to send an event using `inngest.send()` or `step.sendEvent()`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- Fixes #423 
