### PR TITLE
Ensure workspace linking is defined globally otherwise it's inconsistent

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=true
+link-workspace-packages=false

--- a/packages/middleware-encryption/.npmrc
+++ b/packages/middleware-encryption/.npmrc
@@ -1,1 +1,0 @@
-link-workspace-packages=false


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Sets the [link-workspace-packages](https://pnpm.io/npmrc#link-workspace-packages) setting to `false`, meaning internal linking between packages is not attempted.

This is done to prevent an `inngest` peer dependency from using the unbuilt local package, as the build process for `inngest` is non-trivial and the location of the built files changes.

We move it here (from within the `packages/middleware-encryption` directory) so that this always takes effect when running `pnpm install`. Otherwise, the global `pnpm-lock.yaml` file will change depending on where you run `pnpm install` in the project, which is not good.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable
