### PR TITLE
Add ability to use `z.discriminatedUnion` and `z.union` in schemas

### DIFF
--- a/.changeset/olive-ladybugs-cover.md
+++ b/.changeset/olive-ladybugs-cover.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add ability to use `z.discriminatedUnion` and `z.union` in schemas

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -305,8 +305,8 @@ export type IsStringLiteral<T extends string> = string extends T ? false : true;
 // @public
 export type LiteralZodEventSchema = z_2.ZodObject<{
     name: z_2.ZodLiteral<string>;
-    data?: z_2.AnyZodObject | z_2.ZodAny;
-    user?: z_2.AnyZodObject | z_2.ZodAny;
+    data?: z_2.ValidZodValue;
+    user?: z_2.ValidZodValue;
 }>;
 
 // @public
@@ -461,8 +461,8 @@ export type UnionKeys<T> = T extends T ? keyof T : never;
 
 // @public
 export type ZodEventSchemas = Record<string, {
-    data?: z_2.AnyZodObject | z_2.ZodAny;
-    user?: z_2.AnyZodObject | z_2.ZodAny;
+    data?: z_2.ValidZodValue;
+    user?: z_2.ValidZodValue;
 }>;
 
 // Warnings were encountered during analysis:

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -459,6 +459,63 @@ describe("EventSchemas", () => {
           >
         >(true);
       });
+
+      test("can use a discriminated union", () => {
+        const schemas = new EventSchemas().fromZod({
+          "test.event": {
+            data: z.discriminatedUnion("shared", [
+              z.object({
+                shared: z.literal("foo"),
+                foo: z.string(),
+              }),
+              z.object({
+                shared: z.literal("bar"),
+                bar: z.number(),
+              }),
+            ]),
+          },
+        });
+
+        assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          shared: "foo" as const,
+          foo: "",
+        });
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          shared: "bar" as const,
+          bar: 0,
+        });
+      });
+
+      test("can use a union with valid values", () => {
+        const schemas = new EventSchemas().fromZod({
+          "test.event": {
+            data: z.union([
+              z.object({
+                foo: z.string(),
+              }),
+              z.object({
+                bar: z.number(),
+              }),
+            ]),
+          },
+        });
+
+        assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          foo: "",
+        });
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          bar: 0,
+        });
+      });
+
+      test("cannot use a union with invalid values", () => {
+        new EventSchemas().fromZod({
+          // @ts-expect-error - data must be object|any
+          "test.event": { data: z.union([z.string(), z.number()]) },
+        });
+      });
     });
 
     describe("literal array", () => {
@@ -592,6 +649,68 @@ describe("EventSchemas", () => {
             string | undefined
           >
         >(true);
+      });
+
+      test("can use a discriminated union", () => {
+        const schemas = new EventSchemas().fromZod([
+          z.object({
+            name: z.literal("test.event"),
+            data: z.discriminatedUnion("shared", [
+              z.object({
+                shared: z.literal("foo"),
+                foo: z.string(),
+              }),
+              z.object({
+                shared: z.literal("bar"),
+                bar: z.number(),
+              }),
+            ]),
+          }),
+        ]);
+
+        assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          shared: "foo" as const,
+          foo: "",
+        });
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          shared: "bar" as const,
+          bar: 0,
+        });
+      });
+
+      test("can use a union with valid values", () => {
+        const schemas = new EventSchemas().fromZod([
+          z.object({
+            name: z.literal("test.event"),
+            data: z.union([
+              z.object({
+                foo: z.string(),
+              }),
+              z.object({
+                bar: z.number(),
+              }),
+            ]),
+          }),
+        ]);
+
+        assertType<Schemas<typeof schemas>["test.event"]["name"]>("test.event");
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          foo: "",
+        });
+        assertType<Schemas<typeof schemas>["test.event"]["data"]>({
+          bar: 0,
+        });
+      });
+
+      test("cannot use a union with invalid values", () => {
+        new EventSchemas().fromZod([
+          // @ts-expect-error - data must be object|any
+          z.object({
+            name: z.literal("test.event"),
+            data: z.union([z.string(), z.number()]),
+          }),
+        ]);
       });
     });
   });

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -68,8 +68,8 @@ type PreventClashingNames<T> = CheckNever<{
  */
 export type LiteralZodEventSchema = z.ZodObject<{
   name: z.ZodLiteral<string>;
-  data?: z.AnyZodObject | z.ZodAny;
-  user?: z.AnyZodObject | z.ZodAny;
+  data?: z.ValidZodValue;
+  user?: z.ValidZodValue;
 }>;
 
 /**
@@ -88,8 +88,8 @@ export type LiteralZodEventSchemas = LiteralZodEventSchema[];
 export type ZodEventSchemas = Record<
   string,
   {
-    data?: z.AnyZodObject | z.ZodAny;
-    user?: z.AnyZodObject | z.ZodAny;
+    data?: z.ValidZodValue;
+    user?: z.ValidZodValue;
   }
 >;
 

--- a/packages/inngest/src/helpers/validators/zod.ts
+++ b/packages/inngest/src/helpers/validators/zod.ts
@@ -29,10 +29,39 @@ export type ZodObject<TShape = { [k: string]: ZodTypeAny }> = {
   };
 };
 
+export type ZodDiscriminatedUnion = {
+  _def: {
+    typeName: "ZodDiscriminatedUnion";
+  };
+};
+
+export type ZodUnion<
+  TOptions extends (AnyZodObject | ZodDiscriminatedUnion | ZodAny)[] = (
+    | AnyZodObject
+    | ZodDiscriminatedUnion
+    | ZodAny
+  )[],
+> = {
+  options: TOptions;
+  _def: {
+    typeName: "ZodUnion";
+  };
+};
+
 export type AnyZodObject = ZodObject<any>;
 
 export type ZodAny = {
   _any: true;
 };
+
+export type ValidZodValue =
+  // Allow `z.object()`
+  | AnyZodObject
+  // Allow `z.discriminatedUnion()`, a union of objects with a common key
+  | ZodDiscriminatedUnion
+  // Allow `z.any()`
+  | ZodAny
+  // Allow `z.union()`, only in cases where it's a union of other valid zod values
+  | ZodUnion;
 
 export type infer<T extends ZodTypeAny> = T["_output"];


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add the ability to use [`z.discriminatedUnion()`](https://zod.dev/?id=discriminated-unions) and [`z.union()`](https://zod.dev/?id=unions) (as long as it's only a union of valid types).

Note that `z.discriminatedUnion()` will likely be deprecated in lieu of `z.switch()`, though this API is not yet available. See colinhacks/zod#2106.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #396
- colinhacks/zod#2106
