### PR TITLE
Fix bad wildcard export for ESM/CJS compatibility

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -108,7 +108,7 @@
       "types": "./deno/fresh.d.ts"
     },
     "./api/*": "./api/*.js",
-    "./components": "./components/*.js",
+    "./components/*": "./components/*.js",
     "./deno/*": "./deno/*.js",
     "./helpers/*": "./helpers/*.js",
     "./middleware/*": "./middleware/*.js"


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes a bad `exports` entry that should be a wildcard.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [ ] ~~Added unit/integration tests~~ N/A
- [ ] Added changesets if applicable
