### PR TITLE
Fix Sentry/Express tracing issues when using `app.use()`

### DIFF
--- a/.changeset/fresh-waves-live.md
+++ b/.changeset/fresh-waves-live.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix an issue where Sentry's wrapping of `inngest/express` caused Sentry to throw a runtime error during instantiation

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -468,8 +468,8 @@ export type ZodEventSchemas = Record<string, {
 // Warnings were encountered during analysis:
 //
 // src/components/EventSchemas.ts:221:5 - (ae-forgotten-export) The symbol "FinishedEventPayload" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:845:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:845:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:869:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:869:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:268:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:281:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:287:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/src/deno/fresh.ts
+++ b/packages/inngest/src/deno/fresh.ts
@@ -32,7 +32,9 @@ export const serve = (options: ServeHandlerOptions) => {
 
   const fn = handler.createHandler();
 
-  return (req: Request) => fn(req, Deno.env.toObject());
+  return function handleRequest(req: Request) {
+    return fn(req, Deno.env.toObject());
+  };
 };
 
 declare const Deno: { env: { toObject: () => { [index: string]: string } } };

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -235,6 +235,27 @@ export const testFramework = (
       test("serve should be a function", () => {
         expect(handler.serve).toEqual(expect.any(Function));
       });
+
+      test("serve should return a function with a name", () => {
+        const actual = handler.serve({ client: inngest, functions: [] });
+
+        expect(actual.name).toEqual(expect.any(String));
+        expect(actual.name).toBeTruthy();
+      });
+
+      /**
+       * Some platforms check (at runtime) the length of the function being used
+       * to handle an endpoint. If this is a variadic function, it will fail
+       * that check.
+       *
+       * Therefore, we expect the arguments accepted to be the same length as
+       * the `handler` function passed internally.
+       */
+      test("serve should return a function with a non-variadic length", () => {
+        const actual = handler.serve({ client: inngest, functions: [] });
+
+        expect(actual.length).toBeGreaterThan(0);
+      });
     });
 
     if (opts?.handlerTests) {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Express performs some runtime checks to assess functions being used to handle middleware. When used with Express Sentry middleware (which wraps other endpoints, like Inngest's), our internal use of variadic arguments can produce a function signature that looks like it can't adequately handle a request.

This should be resolved by using the signature of the function passed when creating the serve handler, ensuring we keep the function signature looking healthy.

Thanks for the repro of this issue, @spastorelli! Looks fixed using this PR (`inngest@pr-440`).

- Original repro: https://replit.com/@spsgitbook/InngestWithSentryRepro#index.js
- Fixed repro: https://replit.com/@jpwilliams1/InngestWithSentryRepro#index.js
`npm install inngest@pr-440`

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- Fixes #436
- getsentry/sentry-javascript#3284
