### PR TITLE
Fix release builds running wrong npm script

### DIFF
--- a/.changeset/proud-scissors-begin.md
+++ b/.changeset/proud-scissors-begin.md
@@ -1,0 +1,5 @@
+---
+"@inngest/eslint-plugin": patch
+---
+
+Version bump to resolve release issues

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "release:all": "pnpm run release:build && pnpm run release:publish && pnpm run release:tag",
+    "release:all": "pnpm run build && pnpm run release:publish && pnpm run release:tag",
     "build": "pnpm run --if-present --recursive build",
     "release:publish": "pnpm run --if-present --recursive release",
     "release:tag": "node scripts/release/tag.js",


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

A follow-up to #444 - we run the wrong script when releasing 🙄

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #444
