### PR TITLE
Trigger patch release of @inngest/middleware-encryption to add missing dist folder

### DIFF
--- a/.changeset/silent-dancers-thank.md
+++ b/.changeset/silent-dancers-thank.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-encryption": patch
+---
+
+Fix packages sometimes not shipping dist files if released with multiple packages


### PR DESCRIPTION
## Summary
`"Some packages were not being built properly before shipping if multiple packages were shipped at the same time."` - inngest/inngest-js/issues/444

That has since been fixed by inngest/inngest-js/issues/444, but `@inngest/middleware-encryption` still needs to be re-released so dist files are published.




## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [ ] ~~Added unit/integration tests~~
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Related to inngest/inngest-js/issues/444
- Fixes inngest/inngest-js/issues/450
