### PR TITLE
Pass serve handler arguments to middleware to access req-only data

### DIFF
--- a/.changeset/cuddly-moons-behave.md
+++ b/.changeset/cuddly-moons-behave.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Pass `reqArgs` to `onFunctionRun` middleware hook to be able to use request values within an Inngest function

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -242,10 +242,14 @@ export class InngestCommHandler<Input extends any[] = any[], Output = any, Strea
     // (undocumented)
     protected registerBody(url: URL): RegisterRequest;
     protected reqUrl(url: URL): URL;
-    // Warning: (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    protected runStep(functionId: string, stepId: string | null, data: unknown, timer: ServerTiming): {
+    protected runStep({ functionId, stepId, data, timer, reqArgs, }: {
+        functionId: string;
+        stepId: string | null;
+        data: unknown;
+        timer: ServerTiming;
+        reqArgs: unknown[];
+    }): {
         version: ExecutionVersion;
         result: Promise<ExecutionResult>;
     };
@@ -468,8 +472,9 @@ export type ZodEventSchemas = Record<string, {
 // Warnings were encountered during analysis:
 //
 // src/components/EventSchemas.ts:221:5 - (ae-forgotten-export) The symbol "FinishedEventPayload" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:869:8 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:869:35 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:886:5 - (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:888:9 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:888:36 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:268:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:281:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:287:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -163,6 +163,7 @@ describe("runFn", () => {
                 runId: "run",
                 stepState: {},
                 stepCompletionOrder: [],
+                reqArgs: [],
               },
             });
 
@@ -207,6 +208,7 @@ describe("runFn", () => {
                 stepState: {},
                 runId: "run",
                 stepCompletionOrder: [],
+                reqArgs: [],
               },
             });
 
@@ -250,6 +252,7 @@ describe("runFn", () => {
           requestedRunStep: opts?.runStep,
           timer,
           disableImmediateExecution: opts?.disableImmediateExecution,
+          reqArgs: [],
         },
       });
 

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -7,7 +7,7 @@ import { assertType, type IsEqual } from "type-plus";
 describe("stacking and inference", () => {
   describe("onFunctionRun", () => {
     test("has `reqArgs`", () => {
-      const mw = new InngestMiddleware({
+      new InngestMiddleware({
         name: "mw",
         init() {
           return {
@@ -25,10 +25,6 @@ describe("stacking and inference", () => {
           };
         },
       });
-
-      const inngest = new Inngest({ id: "test", middleware: [mw] });
-
-      inngest.createFunction({ id: "" }, { event: "" }, () => {});
     });
 
     describe("transformInput", () => {

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -1,10 +1,36 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Inngest } from "@local/components/Inngest";
 import { InngestMiddleware } from "@local/components/InngestMiddleware";
+import { type IsUnknown } from "type-fest";
 import { assertType, type IsEqual } from "type-plus";
 
 describe("stacking and inference", () => {
   describe("onFunctionRun", () => {
+    test("has `reqArgs`", () => {
+      const mw = new InngestMiddleware({
+        name: "mw",
+        init() {
+          return {
+            onFunctionRun({ reqArgs }) {
+              assertType<IsEqual<typeof reqArgs, readonly unknown[]>>(true);
+              assertType<IsUnknown<(typeof reqArgs)[number]>>(true);
+
+              return {
+                transformInput({ reqArgs }) {
+                  assertType<IsEqual<typeof reqArgs, readonly unknown[]>>(true);
+                  assertType<IsUnknown<(typeof reqArgs)[number]>>(true);
+                },
+              };
+            },
+          };
+        },
+      });
+
+      const inngest = new Inngest({ id: "test", middleware: [mw] });
+
+      inngest.createFunction({ id: "" }, { event: "" }, () => {});
+    });
+
     describe("transformInput", () => {
       describe("can add a value to input context", () => {
         const mw = new InngestMiddleware({

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -391,6 +391,12 @@ type MiddlewareRunArgs = Readonly<{
    * The function that is being executed.
    */
   fn: AnyInngestFunction;
+
+  /**
+   * The raw arguments given to serve handler being used to execute the
+   * function.
+   */
+  reqArgs: Readonly<unknown[]>;
 }>;
 
 /**

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -50,6 +50,7 @@ export const PREFERRED_EXECUTION_VERSION =
 export interface InngestExecutionOptions {
   client: AnyInngest;
   fn: AnyInngestFunction;
+  reqArgs: unknown[];
   runId: string;
   data: Omit<AnyContext, "step">;
   stepState: Record<string, MemoizedOp>;

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -258,6 +258,7 @@ export class V0InngestExecution
         ctx,
         fn: this.options.fn,
         steps: Object.values(this.options.stepState),
+        reqArgs: this.options.reqArgs,
       },
       {
         transformInput: (prev, output) => {
@@ -268,6 +269,7 @@ export class V0InngestExecution
               ...step,
               ...output?.steps?.[i],
             })),
+            reqArgs: prev.reqArgs,
           };
         },
         transformOutput: (prev, output) => {
@@ -445,6 +447,7 @@ export class V0InngestExecution
       ctx: { ...this.fnArg },
       steps: Object.values(this.options.stepState),
       fn: this.options.fn,
+      reqArgs: this.options.reqArgs,
     });
 
     if (inputMutations?.ctx) {

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -411,6 +411,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
       ctx: { ...this.fnArg },
       steps: Object.values(this.state.stepState),
       fn: this.options.fn,
+      reqArgs: this.options.reqArgs,
     });
 
     if (inputMutations?.ctx) {
@@ -836,6 +837,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         ctx,
         fn: this.options.fn,
         steps: Object.values(this.options.stepState),
+        reqArgs: this.options.reqArgs,
       },
       {
         transformInput: (prev, output) => {
@@ -846,6 +848,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
               ...step,
               ...output?.steps?.[i],
             })),
+            reqArgs: prev.reqArgs,
           };
         },
         transformOutput: (prev, output) => {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

In some cases, a user may want to access the incoming request objects in a way that doesn't affect how Inngest should handle the request. For example, in the case of utilizing Cloudflare AI on Cloudflare Workers, an `Ai` instance is created using the `env` object passed to the request.

Currently, arguments being passed to the request handler are used _only_ by the serve handler and aren't exposed to the function. Part of the reason for this is that the serve handler is currently entirely separate from creating functions, so typing request arguments would be difficult.

To resolve this in this PR, we instead pass these arguments to middleware, where we can then assess the request arguments and add properties to our function's input. #383 is used as the problem to solve here.

With this PR, #383 would be resolved using the following middleware:

```ts
import { Ai } from "@cloudflare/ai";
import { InngestMiddleware } from "inngest";

interface Env {
  // If you set another name in wrangler.toml as the value for 'binding',
  // replace "AI" with the variable name you defined.
  AI: any;
}

export const cloudflareMiddleware = new InngestMiddleware({
  name: "foo",
  init: () => {
    return {
      onFunctionRun: ({ reqArgs }) => {
        const [, env] = reqArgs as [Request, Env];
        const ai = new Ai(env.AI);

        return {
          transformInput: () => {
            return { ctx: { ai } };
          },
        };
      },
    };
  },
});
```

This would then be used like so:

```ts
import { inngest } from "./client";

export default inngest.createFunction(
  { id: "hello-world" },
  { event: "demo/event.sent" },
  async ({ ai }) => {
    // `ai` is typed and can be used directly or within a step
    const response = await ai.run("@cf/meta/llama-2-7b-chat-int8", {
      prompt: "What is the origin of the phrase Hello, World",
    });
  }
);
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #383
- inngest/website#623
