### PR TITLE
Fix create astro install commands

### DIFF
--- a/examples/framework-astro/README.md
+++ b/examples/framework-astro/README.md
@@ -7,15 +7,15 @@ This is an [Astro](https://astro.build/) project bootstrapped with [`create astr
 Use [`create astro`](https://docs.astro.build/en/install/auto/) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
-npm create astro@latest --template https://github.com/inngest/inngest-js/tree/main/examples/framework-astro inngest-astro
+npm create astro@latest -- --template inngest/inngest-js/examples/framework-astro inngest-astro
 ```
 
 ```bash
-yarn create astro@latest --template https://github.com/inngest/inngest-js/tree/main/examples/framework-astro inngest-astro
+yarn create astro --template inngest/inngest-js/examples/framework-astro inngest-astro
 ```
 
 ```bash
-pnpm create astro@latest --template https://github.com/inngest/inngest-js/tree/main/examples/framework-astro inngest-astro
+pnpm create astro@latest --template inngest/inngest-js/examples/framework-astro inngest-astro
 ```
 
 Open [http://localhost:3000](http://localhost:3000/api/inngest) with your browser to see the result.


### PR DESCRIPTION
## Summary
The previous install commands did not work, but `create-astro` supports subdirectories ([source code](https://github.com/withastro/astro/blob/37e1018b0d0d9459c5ad8b5049d4926ea461ea59/packages/create-astro/src/actions/verify.ts#L82)). 

This also adds the extra `--` prefix for `npm create`  that is necessary before the arguments.

New README for reference: https://github.com/inngest/inngest-js/blob/392cb447f78d9b2606d36a36db4a642083966265/examples/framework-astro/README.md

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [ ] ~~Added unit/integration tests~~
- [ ] ~~Added changesets if applicable~~

## Related
n/a
