### PR TITLE
Export `[component].Any` types as helpers

### DIFF
--- a/.changeset/weak-olives-cross.md
+++ b/.changeset/weak-olives-cross.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add new `Inngest.Any` and `InngestFunction.Any` type helpers

--- a/packages/inngest/.eslintrc.js
+++ b/packages/inngest/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
       "error",
       { fixStyle: "inline-type-imports" },
     ],
+    "@typescript-eslint/no-namespace": "off",
     "import/consistent-type-specifier-style": ["error", "prefer-inline"],
     "import/no-duplicates": ["error", { "prefer-inline": true }],
     "import/no-extraneous-dependencies": [

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -148,10 +148,8 @@ typeof builtInMiddleware,
 NonNullable<ClientOptionsFromInngest<TInngest>["middleware"]>
 ]>>>[0];
 
-// Warning: (ae-forgotten-export) The symbol "AnyInngestFunction" needs to be exported by the entry point index.d.ts
-//
 // @public
-export type GetFunctionOutput<TFunction extends AnyInngestFunction | string> = TFunction extends InngestFunction<any, any, any, any, infer IHandler> ? IfNever<SimplifyDeep<Jsonify<Awaited<ReturnType<IHandler>>>>, null, SimplifyDeep<Jsonify<Awaited<ReturnType<IHandler>>>>> : unknown;
+export type GetFunctionOutput<TFunction extends InngestFunction.Any | string> = TFunction extends InngestFunction<any, any, any, any, infer IHandler> ? IfNever<SimplifyDeep<Jsonify<Awaited<ReturnType<IHandler>>>>, null, SimplifyDeep<Jsonify<Awaited<ReturnType<IHandler>>>>> : unknown;
 
 // @public
 export type GetStepTools<TInngest extends Inngest<any>, TTrigger extends keyof GetEvents<TInngest> & string = keyof GetEvents<TInngest> & string> = GetFunctionInput<TInngest, TTrigger> extends {
@@ -163,6 +161,11 @@ export type GetStepTools<TInngest extends Inngest<any>, TTrigger extends keyof G
 // @public
 export type Handler<TOpts extends ClientOptions, TEvents extends EventsFromOpts<TOpts>, TTrigger extends keyof TEvents & string, TOverrides extends Record<string, unknown> = Record<never, never>> = (
 ctx: Context<TOpts, TEvents, TTrigger, TOverrides>) => unknown;
+
+// @public
+export namespace Handler {
+    export type Any = Handler<any, any, any, any>;
+}
 
 // @public
 export enum headerKeys {
@@ -191,11 +194,10 @@ export enum headerKeys {
 // @public
 export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     constructor({ id, eventKey, baseUrl, fetch, env, logger, middleware, }: TOpts);
-    // Warning: (ae-forgotten-export) The symbol "AnyHandler" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ExclusiveKeys" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    createFunction<TMiddleware extends MiddlewareStack, TTrigger extends TriggerOptions<TTriggerName>, TTriggerName extends keyof EventsFromOpts<TOpts> & string = EventNameFromTrigger<EventsFromOpts<TOpts>, TTrigger>, THandler extends AnyHandler = Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, ExtendWithMiddleware<[
+    createFunction<TMiddleware extends MiddlewareStack, TTrigger extends TriggerOptions<TTriggerName>, TTriggerName extends keyof EventsFromOpts<TOpts> & string = EventNameFromTrigger<EventsFromOpts<TOpts>, TTrigger>, THandler extends Handler.Any = Handler<TOpts, EventsFromOpts<TOpts>, TTriggerName, ExtendWithMiddleware<[
     typeof builtInMiddleware,
     NonNullable<TOpts["middleware"]>,
     TMiddleware
@@ -213,6 +215,11 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     send<Payload extends SendEventPayload<EventsFromOpts<TOpts>>>(payload: Payload): Promise<SendEventOutput<TOpts>>;
     setEventKey(
     eventKey: string): void;
+}
+
+// @public
+export namespace Inngest {
+    export type Any = Inngest<any>;
 }
 
 // @public
@@ -268,7 +275,7 @@ export class InngestCommHandler<Input extends any[] = any[], Output = any, Strea
 // Warning: (ae-incompatible-release-tags) The symbol "InngestFunction" is marked as @public, but its signature references "FunctionTrigger" which is marked as @internal
 //
 // @public
-export class InngestFunction<TOpts extends ClientOptions = ClientOptions, Events extends EventsFromOpts<TOpts> = EventsFromOpts<TOpts>, Trigger extends FunctionTrigger<keyof Events & string> = FunctionTrigger<keyof Events & string>, Opts extends FunctionOptions<Events, EventNameFromTrigger<Events, Trigger>> = FunctionOptions<Events, EventNameFromTrigger<Events, Trigger>>, THandler extends AnyHandler = Handler<TOpts, Events, keyof Events & string>> {
+export class InngestFunction<TOpts extends ClientOptions = ClientOptions, Events extends EventsFromOpts<TOpts> = EventsFromOpts<TOpts>, Trigger extends FunctionTrigger<keyof Events & string> = FunctionTrigger<keyof Events & string>, Opts extends FunctionOptions<Events, EventNameFromTrigger<Events, Trigger>> = FunctionOptions<Events, EventNameFromTrigger<Events, Trigger>>, THandler extends Handler.Any = Handler<TOpts, Events, keyof Events & string>> {
     constructor(client: Inngest<TOpts>,
     opts: Opts, trigger: Trigger, fn: THandler);
     // (undocumented)
@@ -281,6 +288,11 @@ export class InngestFunction<TOpts extends ClientOptions = ClientOptions, Events
     static stepId: string;
     // (undocumented)
     readonly trigger: Trigger;
+}
+
+// @public
+export namespace InngestFunction {
+    export type Any = InngestFunction<any, any, any, any, any>;
 }
 
 // @public
@@ -331,8 +343,8 @@ export interface MiddlewareOptions {
 //
 // @public (undocumented)
 export type MiddlewareRegisterFn = (ctx: {
-    client: AnyInngest;
-    fn?: AnyInngestFunction;
+    client: Inngest.Any;
+    fn?: InngestFunction.Any;
 }) => MaybePromise<MiddlewareRegisterReturn>;
 
 // @public (undocumented)
@@ -413,8 +425,8 @@ export class RetryAfterError extends Error {
 
 // @public
 export interface ServeHandlerOptions extends RegisterOptions {
-    client: AnyInngest;
-    functions: readonly AnyInngestFunction[];
+    client: Inngest.Any;
+    functions: readonly InngestFunction.Any[];
 }
 
 // @public
@@ -472,18 +484,17 @@ export type ZodEventSchemas = Record<string, {
 // Warnings were encountered during analysis:
 //
 // src/components/EventSchemas.ts:221:5 - (ae-forgotten-export) The symbol "FinishedEventPayload" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:886:5 - (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:888:9 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
-// src/components/InngestCommHandler.ts:888:36 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:885:5 - (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:887:9 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
+// src/components/InngestCommHandler.ts:887:36 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:268:3 - (ae-forgotten-export) The symbol "InitialRunInfo" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:281:5 - (ae-forgotten-export) The symbol "MiddlewareRunInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:287:5 - (ae-forgotten-export) The symbol "BlankHook" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:320:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:339:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
-// src/components/InngestMiddleware.ts:357:3 - (ae-forgotten-export) The symbol "AnyInngest" needs to be exported by the entry point index.d.ts
-// src/types.ts:80:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:782:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:76:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
+// src/types.ts:799:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -659,7 +659,33 @@ export const builtInMiddleware = (<T extends MiddlewareStack>(m: T): T => m)([
   }),
 ]);
 
+/**
+ * A client used to interact with the Inngest API by sending or reacting to
+ * events.
+ *
+ * To provide event typing, see {@link EventSchemas}.
+ *
+ * ```ts
+ * const inngest = new Inngest({ name: "My App" });
+ *
+ * // or to provide event typing too
+ * const inngest = new Inngest({
+ *   name: "My App",
+ *   schemas: new EventSchemas().fromRecord<{
+ *     "app/user.created": {
+ *       data: { userId: string };
+ *     };
+ *   }>(),
+ * });
+ * ```
+ *
+ * @public
+ */
 export namespace Inngest {
+  /**
+   * Represents any `Inngest` instance, regardless of generics and
+   * inference.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type Any = Inngest<any>;
 }

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -22,7 +22,6 @@ import { type ExclusiveKeys, type SendEventPayload } from "../helpers/types";
 import { DefaultLogger, ProxyLogger, type Logger } from "../middleware/logger";
 import {
   sendEventResponseSchema,
-  type AnyHandler,
   type ClientOptions,
   type EventNameFromTrigger,
   type EventPayload,
@@ -36,7 +35,7 @@ import {
   type TriggerOptions,
 } from "../types";
 import { type EventSchemas } from "./EventSchemas";
-import { InngestFunction, type AnyInngestFunction } from "./InngestFunction";
+import { InngestFunction } from "./InngestFunction";
 import {
   InngestMiddleware,
   getHookStack,
@@ -62,9 +61,6 @@ export type EventsFromOpts<TOpts extends ClientOptions> =
   TOpts["schemas"] extends EventSchemas<infer U>
     ? U
     : Record<string, EventPayload>;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyInngest = Inngest<any>;
 
 /**
  * A client used to interact with the Inngest API by sending or reacting to
@@ -457,7 +453,7 @@ export class Inngest<TOpts extends ClientOptions = ClientOptions> {
     TTrigger extends TriggerOptions<TTriggerName>,
     TTriggerName extends keyof EventsFromOpts<TOpts> &
       string = EventNameFromTrigger<EventsFromOpts<TOpts>, TTrigger>,
-    THandler extends AnyHandler = Handler<
+    THandler extends Handler.Any = Handler<
       TOpts,
       EventsFromOpts<TOpts>,
       TTriggerName,
@@ -663,6 +659,11 @@ export const builtInMiddleware = (<T extends MiddlewareStack>(m: T): T => m)([
   }),
 ]);
 
+export namespace Inngest {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type Any = Inngest<any>;
+}
+
 /**
  * A helper type to extract the type of a set of event tooling from a given
  * Inngest instance and optionally a trigger.
@@ -733,7 +734,7 @@ export type GetFunctionInput<
  *
  * @public
  */
-export type GetFunctionOutput<TFunction extends AnyInngestFunction | string> =
+export type GetFunctionOutput<TFunction extends InngestFunction.Any | string> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TFunction extends InngestFunction<any, any, any, any, infer IHandler>
     ? IfNever<

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -45,9 +45,8 @@ import {
   type SupportedFrameworkName,
 } from "../types";
 import { version } from "../version";
-import { type AnyInngest } from "./Inngest";
+import { type Inngest } from "./Inngest";
 import {
-  type AnyInngestFunction,
   type CreateExecutionOptions,
   type InngestFunction,
 } from "./InngestFunction";
@@ -70,12 +69,12 @@ export interface ServeHandlerOptions extends RegisterOptions {
   /**
    * The `Inngest` instance used to declare all functions.
    */
-  client: AnyInngest;
+  client: Inngest.Any;
 
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: readonly AnyInngestFunction[];
+  functions: readonly InngestFunction.Any[];
 }
 
 export interface InternalServeHandlerOptions extends ServeHandlerOptions {
@@ -113,12 +112,12 @@ interface InngestCommHandlerOptions<
    * receiving events from the same service, as you can reuse a single
    * definition of Inngest.
    */
-  client: AnyInngest;
+  client: Inngest.Any;
 
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: readonly AnyInngestFunction[];
+  functions: readonly InngestFunction.Any[];
 
   /**
    * The `handler` is the function your framework requires to handle a
@@ -307,9 +306,9 @@ export class InngestCommHandler<
    * A private collection of just Inngest functions, as they have been passed
    * when instantiating the class.
    */
-  private readonly rawFns: AnyInngestFunction[];
+  private readonly rawFns: InngestFunction.Any[];
 
-  private readonly client: AnyInngest;
+  private readonly client: Inngest.Any;
 
   /**
    * A private collection of functions that are being served. This map is used

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -12,10 +12,7 @@ import {
   NonRetriableError,
   type EventPayload,
 } from "@local";
-import {
-  InngestFunction,
-  type AnyInngestFunction,
-} from "@local/components/InngestFunction";
+import { InngestFunction } from "@local/components/InngestFunction";
 import { STEP_INDEXING_SUFFIX } from "@local/components/InngestStepTools";
 import {
   ExecutionVersion,
@@ -228,7 +225,7 @@ describe("runFn", () => {
   describe("step functions", () => {
     const runFnWithStack = (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fn: AnyInngestFunction,
+      fn: InngestFunction.Any,
       stepState: InngestExecutionOptions["stepState"],
       opts?: {
         executionVersion?: ExecutionVersion;
@@ -272,7 +269,7 @@ describe("runFn", () => {
     const testFn = <
       T extends {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        fn: AnyInngestFunction;
+        fn: InngestFunction.Any;
         steps: Record<
           string,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -213,7 +213,20 @@ export class InngestFunction<
   }
 }
 
+/**
+ * A stateless Inngest function, wrapping up function configuration and any
+ * in-memory steps to run when triggered.
+ *
+ * This function can be "registered" to create a handler that Inngest can
+ * trigger remotely.
+ *
+ * @public
+ */
 export namespace InngestFunction {
+  /**
+   * Represents any `InngestFunction` instance, regardless of generics and
+   * inference.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type Any = InngestFunction<any, any, any, any, any>;
 }

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -1,7 +1,6 @@
 import { internalEvents, queryKeys } from "../helpers/consts";
 import { timeStr } from "../helpers/strings";
 import {
-  type AnyHandler,
   type ClientOptions,
   type EventNameFromTrigger,
   type FunctionConfig,
@@ -18,9 +17,6 @@ import {
 } from "./execution/InngestExecution";
 import { createV0InngestExecution } from "./execution/v0";
 import { createV1InngestExecution } from "./execution/v1";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyInngestFunction = InngestFunction<any, any, any, any, any>;
 
 /**
  * A stateless Inngest function, wrapping up function configuration and any
@@ -41,7 +37,7 @@ export class InngestFunction<
     Events,
     EventNameFromTrigger<Events, Trigger>
   > = FunctionOptions<Events, EventNameFromTrigger<Events, Trigger>>,
-  THandler extends AnyHandler = Handler<TOpts, Events, keyof Events & string>,
+  THandler extends Handler.Any = Handler<TOpts, Events, keyof Events & string>,
 > {
   static stepId = "step";
   static failureSuffix = "-failure";
@@ -215,6 +211,11 @@ export class InngestFunction<
     const { event } = this.trigger as { event?: string };
     return event;
   }
+}
+
+export namespace InngestFunction {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type Any = InngestFunction<any, any, any, any, any>;
 }
 
 export type CreateExecutionOptions = {

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -15,8 +15,8 @@ import {
   type OutgoingOp,
   type SendEventBaseOutput,
 } from "../types";
-import { type AnyInngest } from "./Inngest";
-import { type AnyInngestFunction } from "./InngestFunction";
+import { type Inngest } from "./Inngest";
+import { type InngestFunction } from "./InngestFunction";
 
 /**
  * A middleware that can be registered with Inngest to hook into various
@@ -354,13 +354,13 @@ export type MiddlewareRegisterFn = (ctx: {
   /**
    * The client this middleware is being registered on.
    */
-  client: AnyInngest;
+  client: Inngest.Any;
 
   /**
    * If defined, this middleware has been applied directly to an Inngest
    * function rather than on the client.
    */
-  fn?: AnyInngestFunction;
+  fn?: InngestFunction.Any;
 }) => MaybePromise<MiddlewareRegisterReturn>;
 
 /**
@@ -390,7 +390,7 @@ type MiddlewareRunArgs = Readonly<{
   /**
    * The function that is being executed.
    */
-  fn: AnyInngestFunction;
+  fn: InngestFunction.Any;
 
   /**
    * The raw arguments given to serve handler being used to execute the

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -23,7 +23,7 @@ import {
   type GetFunctionOutput,
   type Inngest,
 } from "./Inngest";
-import { type AnyInngestFunction } from "./InngestFunction";
+import { type InngestFunction } from "./InngestFunction";
 
 export interface FoundStep extends HashedOp {
   hashedId: string;
@@ -389,7 +389,7 @@ export const createStepTools = <
      * throw a `NonRetriableError`.
      */
     invoke: createTool<
-      <TFunction extends AnyInngestFunction | string>(
+      <TFunction extends InngestFunction.Any | string>(
         idOrOptions: StepOptionsOrId,
         opts: InvocationOpts<TFunction>
       ) => InvocationResult<GetFunctionOutput<TFunction>>
@@ -422,7 +422,7 @@ export const createStepTools = <
   return tools;
 };
 
-type InvocationOpts<TFunction extends AnyInngestFunction | string> = [
+type InvocationOpts<TFunction extends InngestFunction.Any | string> = [
   TriggerEventFromFunction<TFunction>,
 ] extends [never]
   ? { function: TFunction }

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -3,10 +3,10 @@ import { type Simplify } from "type-fest";
 import { type MaybePromise } from "type-plus";
 import { type ServerTiming } from "../../helpers/ServerTiming";
 import { debugPrefix } from "../../helpers/consts";
-import { type AnyContext, type IncomingOp, type OutgoingOp } from "../../types";
-import { type AnyInngest } from "../Inngest";
+import { type Context, type IncomingOp, type OutgoingOp } from "../../types";
+import { type Inngest } from "../Inngest";
 import { type ActionResponse } from "../InngestCommHandler";
-import { type AnyInngestFunction } from "../InngestFunction";
+import { type InngestFunction } from "../InngestFunction";
 
 /**
  * The possible results of an execution.
@@ -48,11 +48,11 @@ export const PREFERRED_EXECUTION_VERSION =
  * Options for creating a new {@link InngestExecution} instance.
  */
 export interface InngestExecutionOptions {
-  client: AnyInngest;
-  fn: AnyInngestFunction;
+  client: Inngest.Any;
+  fn: InngestFunction.Any;
   reqArgs: unknown[];
   runId: string;
-  data: Omit<AnyContext, "step">;
+  data: Omit<Context.Any, "step">;
   stepState: Record<string, MemoizedOp>;
   stepCompletionOrder: string[];
   requestedRunStep?: string;

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -19,12 +19,12 @@ import { type PartialK } from "../../helpers/types";
 import {
   StepOpCode,
   failureEventErrorSchema,
-  type AnyContext,
-  type AnyHandler,
   type BaseContext,
   type ClientOptions,
+  type Context,
   type EventPayload,
   type FailureEventArgs,
+  type Handler,
   type HashedOp,
   type IncomingOp,
   type OpStack,
@@ -56,8 +56,8 @@ export class V0InngestExecution
 {
   private state: V0ExecutionState;
   private execution: Promise<ExecutionResult> | undefined;
-  private userFnToRun: AnyHandler;
-  private fnArg: AnyContext;
+  private userFnToRun: Handler.Any;
+  private fnArg: Context.Any;
 
   constructor(options: InngestExecutionOptions) {
     super(options);
@@ -313,10 +313,10 @@ export class V0InngestExecution
     return state;
   }
 
-  private getUserFnToRun(): AnyHandler {
+  private getUserFnToRun(): Handler.Any {
     if (!this.options.isFailureHandler) {
       // TODO: Review; inferred types results in an `any` here!
-      return this.options.fn["fn"] as AnyHandler;
+      return this.options.fn["fn"] as Handler.Any;
     }
 
     if (!this.options.fn["onFailureFn"]) {
@@ -330,7 +330,7 @@ export class V0InngestExecution
     return this.options.fn["onFailureFn"];
   }
 
-  private createFnArg(): AnyContext {
+  private createFnArg(): Context.Any {
     // Start referencing everything
     this.state.tickOps = this.state.allFoundOps;
 
@@ -423,7 +423,7 @@ export class V0InngestExecution
     let fnArg = {
       ...(this.options.data as { event: EventPayload }),
       step,
-    } as AnyContext;
+    } as Context.Any;
 
     if (this.options.isFailureHandler) {
       const eventData = z

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -19,12 +19,12 @@ import { type MaybePromise } from "../../helpers/types";
 import {
   StepOpCode,
   failureEventErrorSchema,
-  type AnyContext,
-  type AnyHandler,
   type BaseContext,
   type ClientOptions,
+  type Context,
   type EventPayload,
   type FailureEventArgs,
+  type Handler,
   type OutgoingOp,
 } from "../../types";
 import { getHookStack, type RunHookStack } from "../InngestMiddleware";
@@ -52,11 +52,11 @@ export const createV1InngestExecution: InngestExecutionFactory = (options) => {
 
 class V1InngestExecution extends InngestExecution implements IInngestExecution {
   private state: V1ExecutionState;
-  private fnArg: AnyContext;
+  private fnArg: Context.Any;
   private checkpointHandlers: CheckpointHandlers;
   private timeoutDuration = 1000 * 10;
   private execution: Promise<ExecutionResult> | undefined;
-  private userFnToRun: AnyHandler;
+  private userFnToRun: Handler.Any;
 
   /**
    * If we're supposed to run a particular step via `requestedRunStep`, this
@@ -506,13 +506,13 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     return state;
   }
 
-  private createFnArg(): AnyContext {
+  private createFnArg(): Context.Any {
     const step = this.createStepTools();
 
     let fnArg = {
       ...(this.options.data as { event: EventPayload }),
       step,
-    } as AnyContext;
+    } as Context.Any;
 
     /**
      * Handle use of the `onFailure` option by deserializing the error.
@@ -785,10 +785,10 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     return createStepTools(this.options.client, stepHandler);
   }
 
-  private getUserFnToRun(): AnyHandler {
+  private getUserFnToRun(): Handler.Any {
     if (!this.options.isFailureHandler) {
       // TODO: Review; inferred types results in an `any` here!
-      return this.options.fn["fn"] as AnyHandler;
+      return this.options.fn["fn"] as Handler.Any;
     }
 
     if (!this.options.fn["onFailureFn"]) {

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -1,7 +1,7 @@
-import { type InngestFunction } from "inngest/components/InngestFunction";
 import { ZodError, z } from "zod";
 import { type InngestApi } from "../api/api";
 import { stepsSchemas } from "../api/schema";
+import { type InngestFunction } from "../components/InngestFunction";
 import {
   ExecutionVersion,
   PREFERRED_EXECUTION_VERSION,

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -1,7 +1,7 @@
+import { type InngestFunction } from "inngest/components/InngestFunction";
 import { ZodError, z } from "zod";
 import { type InngestApi } from "../api/api";
 import { stepsSchemas } from "../api/schema";
-import { type AnyInngestFunction } from "../components/InngestFunction";
 import {
   ExecutionVersion,
   PREFERRED_EXECUTION_VERSION,
@@ -94,7 +94,7 @@ const fnDataVersionSchema = z.object({
     }),
 });
 
-export const parseFnData = (fn: AnyInngestFunction, data: unknown) => {
+export const parseFnData = (fn: InngestFunction.Any, data: unknown) => {
   let version: ExecutionVersion;
 
   try {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -282,7 +282,15 @@ export type Context<
   TOverrides extends Record<string, unknown> = Record<never, never>,
 > = Omit<BaseContext<TOpts, TTrigger>, keyof TOverrides> & TOverrides;
 
+/**
+ * Builds a context object for an Inngest handler, optionally overriding some
+ * keys.
+ */
 export namespace Context {
+  /**
+   * Represents any {@link Context} object, regardless of generics and
+   * inference.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type Any = Context<any, any, any>;
 }
@@ -306,7 +314,16 @@ export type Handler<
   ctx: Context<TOpts, TEvents, TTrigger, TOverrides>
 ) => unknown;
 
+/**
+ * The shape of a Inngest function, taking in event, step, ctx, and step
+ * tooling.
+ *
+ * @public
+ */
 export namespace Handler {
+  /**
+   * Represents any `Handler`, regardless of generics and inference.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type Any = Handler<any, any, any, any>;
 }

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -2,15 +2,11 @@ import { type Simplify } from "type-fest";
 import { z } from "zod";
 import { type EventSchemas } from "./components/EventSchemas";
 import {
-  type AnyInngest,
   type EventsFromOpts,
   type Inngest,
   type builtInMiddleware,
 } from "./components/Inngest";
-import {
-  type AnyInngestFunction,
-  type InngestFunction,
-} from "./components/InngestFunction";
+import { type InngestFunction } from "./components/InngestFunction";
 import {
   type ExtendSendEventWithMiddleware,
   type InngestMiddleware,
@@ -50,7 +46,7 @@ import { type Logger } from "./middleware/logger";
  *
  * @public
  */
-export type GetEvents<T extends AnyInngest> = T extends Inngest<infer U>
+export type GetEvents<T extends Inngest.Any> = T extends Inngest<infer U>
   ? EventsFromOpts<U>
   : never;
 
@@ -286,8 +282,10 @@ export type Context<
   TOverrides extends Record<string, unknown> = Record<never, never>,
 > = Omit<BaseContext<TOpts, TTrigger>, keyof TOverrides> & TOverrides;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyContext = Context<any, any, any>;
+export namespace Context {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type Any = Context<any, any, any>;
+}
 
 /**
  * The shape of a Inngest function, taking in event, step, ctx, and step
@@ -308,8 +306,10 @@ export type Handler<
   ctx: Context<TOpts, TEvents, TTrigger, TOverrides>
 ) => unknown;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyHandler = Handler<any, any, any, any>;
+export namespace Handler {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type Any = Handler<any, any, any, any>;
+}
 
 /**
  * The shape of a single event's payload. It should be extended to enforce
@@ -1180,15 +1180,15 @@ export interface StepOptions {
  */
 export type StepOptionsOrId = StepOptions["id"] | StepOptions;
 
-export type EventsFromFunction<T extends AnyInngestFunction> =
+export type EventsFromFunction<T extends InngestFunction.Any> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends InngestFunction<any, infer TEvents, any, any, any>
     ? TEvents
     : never;
 
 export type TriggerEventFromFunction<
-  TFunction extends AnyInngestFunction | string,
-  TEvents = TFunction extends AnyInngestFunction
+  TFunction extends InngestFunction.Any | string,
+  TEvents = TFunction extends InngestFunction.Any
     ? EventsFromFunction<TFunction>
     : never,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds `[component].Any` types such as `Inngest.Any` and `InngestFunction.Any` to allow easier typing for collections or factories of pieces of the SDK.

- `Inngest.Any`
- `InngestFunction.Any`
- `Context.Any`
- `Handler.Any`

```ts
import { type InngestFunction } from "inngest";

const functionsToServe: InngestFunction.Any[] = [];
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- inngest/website#627