### PR TITLE
Allow a single-element `concurrency` option in function definitions

### DIFF
--- a/.changeset/rotten-frogs-jog.md
+++ b/.changeset/rotten-frogs-jog.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix not allowing a single-element `concurrency` option in function definitions

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -128,7 +128,8 @@ export interface FunctionOptions<Events extends Record<string, EventPayload>, Ev
     // (undocumented)
     cancelOn?: Cancellation<Events, Event>[];
     // Warning: (ae-forgotten-export) The symbol "ConcurrencyOption" needs to be exported by the entry point index.d.ts
-    concurrency?: number | ConcurrencyOption | [ConcurrencyOption, ConcurrencyOption];
+    // Warning: (ae-forgotten-export) The symbol "RecursiveTuple" needs to be exported by the entry point index.d.ts
+    concurrency?: number | ConcurrencyOption | RecursiveTuple<ConcurrencyOption, 2>;
     debounce?: {
         key?: string;
         period: TimeStr;
@@ -566,8 +567,8 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:320:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:339:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
-// src/types.ts:77:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:819:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:78:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
+// src/types.ts:821:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/helpers/types.test.ts
+++ b/packages/inngest/src/helpers/types.test.ts
@@ -1,0 +1,35 @@
+import { type RecursiveTuple } from "@local/helpers/types";
+import { IsEqual, assertType } from "type-plus";
+
+describe("RecursiveTuple", () => {
+  test("should create a tuple of length 1", () => {
+    type Expected = [string];
+    type Actual = RecursiveTuple<string, 1>;
+    assertType<IsEqual<Expected, Actual>>(true);
+  });
+
+  test("should create a tuple of length 2", () => {
+    type Expected = [string] | [string, string];
+    type Actual = RecursiveTuple<string, 2>;
+    assertType<IsEqual<Expected, Actual>>(true);
+  });
+
+  test("should create a tuple of length 3", () => {
+    type Expected = [string] | [string, string] | [string, string, string];
+    type Actual = RecursiveTuple<string, 3>;
+    assertType<IsEqual<Expected, Actual>>(true);
+  });
+
+  test("should create a tuple with mixed primitives", () => {
+    type Expected = [string | number] | [string | number, string | number];
+    type Actual = RecursiveTuple<string | number, 2>;
+    assertType<IsEqual<Expected, Actual>>(true);
+  });
+
+  test("should expand type aliases of primitives", () => {
+    type T0 = string;
+    type Expected = [string] | [string, string];
+    type Actual = RecursiveTuple<T0, 2>;
+    assertType<IsEqual<Expected, Actual>>(true);
+  });
+});

--- a/packages/inngest/src/helpers/types.test.ts
+++ b/packages/inngest/src/helpers/types.test.ts
@@ -1,5 +1,5 @@
 import { type RecursiveTuple } from "@local/helpers/types";
-import { IsEqual, assertType } from "type-plus";
+import { assertType, type IsEqual } from "type-plus";
 
 describe("RecursiveTuple", () => {
   test("should create a tuple of length 1", () => {

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -251,3 +251,17 @@ export type IsEmptyObject<T> = {} extends T
     ? true
     : false
   : false;
+
+/**
+ * Create a tuple that can be of length 1 to `TLength`, where each element is
+ * of type `TElement`.
+ */
+export type RecursiveTuple<
+  TElement,
+  TLength extends number,
+  TAccumulator extends TElement[] = [TElement],
+> = TAccumulator["length"] extends TLength
+  ? TAccumulator
+  :
+      | RecursiveTuple<TElement, TLength, [TElement, ...TAccumulator]>
+      | TAccumulator;

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -18,6 +18,7 @@ import { type internalEvents } from "./helpers/consts";
 import {
   type IsStringLiteral,
   type ObjectPaths,
+  type RecursiveTuple,
   type StrictUnion,
 } from "./helpers/types";
 import { type Logger } from "./middleware/logger";
@@ -791,12 +792,13 @@ export interface FunctionOptions<
    * can occur across all runs of the function.  A value of 0 (or undefined) means
    * use the maximum available concurrency.
    *
-   * Specifying just a number means specifying only the concurrency limit.
+   * Specifying just a number means specifying only the concurrency limit. A
+   * maximum of two concurrency options can be specified.
    */
   concurrency?:
     | number
     | ConcurrencyOption
-    | [ConcurrencyOption, ConcurrencyOption];
+    | RecursiveTuple<ConcurrencyOption, 2>;
 
   /**
    * batchEvents specifies the batch configuration on when this function


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes `concurrency: [ConcurrencyOption]` not being allowed.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable
