### PR TITLE
Fix `data` not being required during invocation with a schema+reference

### DIFF
--- a/.changeset/nervous-fishes-appear.md
+++ b/.changeset/nervous-fishes-appear.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `data` not being required during invocation with a schema+reference

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -359,8 +359,9 @@ export namespace InngestFunctionReference {
     };
     export type HelperGenericArgs<TFnInput, TFnOutput> = HelperArgs<TFnInput, TFnOutput> | InngestFunction.Any;
     // Warning: (ae-forgotten-export) The symbol "PayloadFromAnyInngestFunction" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ResolveSchema" needs to be exported by the entry point index.d.ts
-    export type HelperReturn<TArgs> = TArgs extends InngestFunction.Any ? InngestFunctionReference<PayloadFromAnyInngestFunction<TArgs>, GetFunctionOutput<TArgs>> : TArgs extends HelperArgs<infer TFnInput, infer TFnOutput> ? InngestFunctionReference<MinimalEventPayload<ResolveSchema<TFnInput, TFnInput, any>>, ResolveSchema<TFnOutput, TFnOutput, unknown>> : never;
+    export type HelperReturn<TArgs> = TArgs extends InngestFunction.Any ? InngestFunctionReference<PayloadFromAnyInngestFunction<TArgs>, GetFunctionOutput<TArgs>> : TArgs extends HelperArgs<infer TFnInput, infer TFnOutput> ? InngestFunctionReference<IsAny<ResolveSchema<TFnInput, TFnInput, any>> extends true ? MinimalEventPayload : Simplify<MinimalEventPayload<ResolveSchema<TFnInput, TFnInput, any>> & Required<Pick<MinimalEventPayload<ResolveSchema<TFnInput, TFnInput, any>>, "data">>>, ResolveSchema<TFnOutput, TFnOutput, unknown>> : never;
 }
 
 // @public

--- a/packages/inngest/src/components/InngestFunctionReference.ts
+++ b/packages/inngest/src/components/InngestFunctionReference.ts
@@ -1,3 +1,5 @@
+import { type Simplify } from "type-fest";
+import { type IsAny } from "../helpers/types";
 import {
   type ResolveSchema,
   type ValidSchemaInput,
@@ -155,7 +157,21 @@ export namespace InngestFunctionReference {
     : TArgs extends HelperArgs<infer TFnInput, infer TFnOutput>
       ? InngestFunctionReference<
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          MinimalEventPayload<ResolveSchema<TFnInput, TFnInput, any>>,
+          IsAny<ResolveSchema<TFnInput, TFnInput, any>> extends true
+            ? MinimalEventPayload
+            : Simplify<
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                MinimalEventPayload<ResolveSchema<TFnInput, TFnInput, any>> &
+                  Required<
+                    Pick<
+                      MinimalEventPayload<
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        ResolveSchema<TFnInput, TFnInput, any>
+                      >,
+                      "data"
+                    >
+                  >
+              >,
           ResolveSchema<TFnOutput, TFnOutput, unknown>
         >
       : never;

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -734,6 +734,19 @@ describe("invoke", () => {
         });
     });
 
+    test("disallows missing payload with a reference function and schema", () => {
+      const _test = () =>
+        // @ts-expect-error No `data` provided
+        invoke("id", {
+          function: referenceFunction({
+            functionId: "fn",
+            schemas: {
+              data: z.object({ wowza: z.string() }),
+            },
+          }),
+        });
+    });
+
     test("disallows incorrect payload with a reference function and schema", () => {
       const _test = () =>
         invoke("id", {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

When using `referenceFunction()` to invoke, `data` was never required, even if the referenced function had a `data` schema.

This call should (and does following this PR) throw a TS error as it is lacking `data`:

```ts
invoke("id", {
  function: referenceFunction({
    functionId: "fn",
    schemas: {
      data: z.object({ wowza: z.string() }),
    },
  }),
});
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
