### PR TITLE
Use `StepError`s for unhandled error catching

### DIFF
--- a/.changeset/wild-tables-pump.md
+++ b/.changeset/wild-tables-pump.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Improve UI when showing an unhandled `StepError`

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -390,9 +390,6 @@ export const createStepTools = <
      *
      * A string ID can also be passed to reference functions outside of the
      * current app.
-     *
-     * If a function isn't found or otherwise errors, the step will fail and
-     * throw a `NonRetriableError`.
      */
     invoke: createTool<
       <TFunction extends InvokeTargetFunctionDefinition>(

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -456,12 +456,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
      * we should return a `NonRetriableError` to stop execution.
      */
     if (typeof output.error !== "undefined") {
-      const serializedError = serializeError(output.error);
-      output.data = serializedError;
-
-      if (output.error === this.state.recentlyRejectedStepError) {
-        output.data = serializeError(output.error);
-      }
+      output.data = serializeError(output.error);
     }
 
     const transformedOutput = await this.state.hooks?.transformOutput?.({

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -460,9 +460,6 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
       output.data = serializedError;
 
       if (output.error === this.state.recentlyRejectedStepError) {
-        output.error = new NonRetriableError(serializedError.message, {
-          cause: output.error,
-        });
         output.data = serializeError(output.error);
       }
     }
@@ -479,7 +476,9 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
        * Ensure we give middleware the chance to decide on retriable behaviour
        * by looking at the error returned from output transformation.
        */
-      let retriable: boolean | string = !(error instanceof NonRetriableError);
+      let retriable: boolean | string = !(
+        error instanceof NonRetriableError || error instanceof StepError
+      );
       if (retriable && error instanceof RetryAfterError) {
         retriable = error.retryAfter;
       }

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -760,24 +760,6 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
 
             if (typeof stepState.data !== "undefined") {
               resolve(stepState.data);
-            } else if (opId.op === StepOpCode.InvokeFunction) {
-              const errCheck = z
-                .object({ message: z.string() })
-                .safeParse(stepState.error);
-
-              const errMessage = [
-                "Invoking function failed",
-                errCheck.success ? errCheck.data.message : "",
-              ]
-                .map((s) => s.trim())
-                .filter(Boolean)
-                .join("; ");
-
-              const err = new NonRetriableError(errMessage, {
-                cause: stepState.error,
-              });
-
-              reject(err);
             } else {
               this.state.recentlyRejectedStepError = new StepError(
                 opId.id,

--- a/packages/inngest/src/test/functions/step-invoke-not-found/index.test.ts
+++ b/packages/inngest/src/test/functions/step-invoke-not-found/index.test.ts
@@ -33,7 +33,7 @@ describe("run", () => {
     expect(item).toBeDefined();
 
     const output = await item?.getOutput();
-    expect(output?.name).toEqual("NonRetriableError");
+    expect(output?.name).toEqual("Error");
     expect(output?.message).toContain("Invoking function failed");
   }, 20000);
 });

--- a/packages/inngest/src/test/functions/step-invoke-not-found/index.test.ts
+++ b/packages/inngest/src/test/functions/step-invoke-not-found/index.test.ts
@@ -34,6 +34,6 @@ describe("run", () => {
 
     const output = await item?.getOutput();
     expect(output?.name).toEqual("Error");
-    expect(output?.message).toContain("Invoking function failed");
+    expect(output?.message).toContain("could not find function");
   }, 20000);
 });


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Aligns with the [spec](https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md) for throwing errors when memoizing data. This previous solution was for the initial release of `step.invoke()` pre-per-step errors.

Functionally there is no change, though the UI will no longer show `NonRetriableError` prefixes and will prefer user error data.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [x] Added unit/integration tests
- [x] Added changesets if applicable
