### PR TITLE
Make `data.error` parsing for `inngest/function.failed` more resilient

### DIFF
--- a/.changeset/blue-owls-drive.md
+++ b/.changeset/blue-owls-drive.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Make `data.error` parsing for `inngest/function.failed` more resilient

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -576,8 +576,8 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:320:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:339:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
-// src/types.ts:84:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:839:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:86:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
+// src/types.ts:841:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -576,8 +576,8 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:320:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:339:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
-// src/types.ts:78:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:833:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:84:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
+// src/types.ts:839:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -52,13 +52,19 @@ export type GetEvents<T extends Inngest.Any> = T extends Inngest<infer U>
   ? EventsFromOpts<U>
   : never;
 
-export const failureEventErrorSchema = z.object({
-  name: z.string(),
-  message: z.string(),
-  stack: z.string().optional(),
-  cause: z.string().optional(),
-  status: z.number().optional(),
-});
+export const failureEventErrorSchema = z
+  .object({
+    name: z.string().optional().default("Error"),
+    error: z.string().optional(),
+    message: z.string().optional(),
+    stack: z.string().optional(),
+  })
+  .transform(({ error, ...val }) => {
+    return {
+      ...val,
+      message: error?.trim() || val.message || "Unknown error",
+    };
+  });
 
 export type MiddlewareStack = [
   InngestMiddleware<MiddlewareOptions>,

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -54,15 +54,17 @@ export type GetEvents<T extends Inngest.Any> = T extends Inngest<infer U>
 
 export const failureEventErrorSchema = z
   .object({
-    name: z.string().trim().optional().default("Error"),
+    name: z.string().trim().optional(),
     error: z.string().trim().optional(),
     message: z.string().trim().optional(),
     stack: z.string().trim().optional(),
   })
-  .transform(({ error, ...val }) => {
+  .catch({})
+  .transform((val) => {
     return {
-      ...val,
-      message: error || val.message || "Unknown error",
+      name: val.name || "Error",
+      message: val.message || val.error || "Unknown error",
+      stack: val.stack,
     };
   });
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -54,15 +54,15 @@ export type GetEvents<T extends Inngest.Any> = T extends Inngest<infer U>
 
 export const failureEventErrorSchema = z
   .object({
-    name: z.string().optional().default("Error"),
-    error: z.string().optional(),
-    message: z.string().optional(),
-    stack: z.string().optional(),
+    name: z.string().trim().optional().default("Error"),
+    error: z.string().trim().optional(),
+    message: z.string().trim().optional(),
+    stack: z.string().trim().optional(),
   })
   .transform(({ error, ...val }) => {
     return {
       ...val,
-      message: error?.trim() || val.message || "Unknown error",
+      message: error || val.message || "Unknown error",
     };
   });
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Complements inngest/inngest#1077 by also making SDK error parsing more resilient, allowing replay of these events with an updated SDK.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- inngest/inngest#1077 
