### PR TITLE
Remove sending `hash` when registering; not used or required

### DIFF
--- a/.changeset/lazy-lies-film.md
+++ b/.changeset/lazy-lies-film.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove sending `hash` when syncing

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1058,8 +1058,6 @@ export class InngestCommHandler<
       v: "0.1",
     };
 
-    // Calculate the checksum of the body... without the checksum itself being included.
-    body.hash = sha256().update(canonicalize(body)).digest("hex");
     return body;
   }
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1088,11 +1088,6 @@ export interface RegisterRequest {
    * The functions available at this particular handler.
    */
   functions: FunctionConfig[];
-
-  /**
-   * The hash of the current commit used to track deploys
-   */
-  hash?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Removes `hash` from syncs to adhere to the spec.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

## Related

- #108 
