### PR TITLE
Fix requiring enum value when using an internal event as a trigger

### DIFF
--- a/.changeset/hungry-mice-appear.md
+++ b/.changeset/hungry-mice-appear.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix requiring enum value when using an internal event as a trigger

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -62,8 +62,8 @@ export interface EventPayload<TData = any> extends MinimalEventPayload<TData> {
 
 // @public
 export class EventSchemas<S extends Record<string, EventPayload> = {
-    [internalEvents.FunctionFailed]: FailureEventPayload;
-    [internalEvents.FunctionFinished]: FinishedEventPayload;
+    [FnFailedEventName]: FailureEventPayload;
+    [FnFinishedEventName]: FinishedEventPayload;
 }> {
     fromGenerated<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
     // Warning: (ae-forgotten-export) The symbol "PreventClashingNames" needs to be exported by the entry point index.d.ts
@@ -567,6 +567,8 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
+// src/components/EventSchemas.ts:223:5 - (ae-forgotten-export) The symbol "FnFailedEventName" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:224:5 - (ae-forgotten-export) The symbol "FnFinishedEventName" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:903:5 - (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:905:9 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:905:36 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -1,5 +1,8 @@
 import { type Simplify } from "type-fest";
-import { type internalEvents } from "../helpers/consts";
+import {
+  type FnFailedEventName,
+  type FnFinishedEventName,
+} from "../helpers/consts";
 import { type IsEmptyObject, type IsStringLiteral } from "../helpers/types";
 import type * as z from "../helpers/validators/zod";
 import {
@@ -217,8 +220,8 @@ export type Combine<
  */
 export class EventSchemas<
   S extends Record<string, EventPayload> = {
-    [internalEvents.FunctionFailed]: FailureEventPayload;
-    [internalEvents.FunctionFinished]: FinishedEventPayload;
+    [FnFailedEventName]: FailureEventPayload;
+    [FnFinishedEventName]: FinishedEventPayload;
   },
 > {
   /**

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -145,6 +145,14 @@ export enum internalEvents {
   FunctionFinished = "inngest/function.finished",
 }
 
+/**
+ * Accessing enum values as literals in some TypeScript types can be difficult,
+ * so we also manually create the string values here.
+ */
+export const FnFailedEventName = `${internalEvents.FunctionFailed}`;
+export const FnInvokedEventName = `${internalEvents.FunctionInvoked}`;
+export const FnFinishedEventName = `${internalEvents.FunctionFinished}`;
+
 export const logPrefix = chalk.magenta.bold("[Inngest]");
 
 export const debugPrefix = "inngest";


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

No longer require an enum value like `internalEvents.FunctionFailed` if wanting to use an internal event as a trigger.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #454
