### PR TITLE
Fix `GetEvents<>` helper returning internal events by default

### DIFF
--- a/.changeset/great-shoes-study.md
+++ b/.changeset/great-shoes-study.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `GetEvents<>` helper returning internal events by default

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -163,13 +163,13 @@ export type FunctionTrigger<T = string> = {
 };
 
 // @public
-export type GetEvents<TInngest extends Inngest<any>> = EventsFromOpts<ClientOptionsFromInngest<TInngest>>;
+export type GetEvents<TInngest extends Inngest.Any, TWithInternal extends boolean = false> = TWithInternal extends true ? EventsFromOpts<ClientOptionsFromInngest<TInngest>> : WithoutInternal<EventsFromOpts<ClientOptionsFromInngest<TInngest>>>;
 
 // Warning: (ae-forgotten-export) The symbol "ExtendWithMiddleware" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "builtInMiddleware" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type GetFunctionInput<TInngest extends Inngest<any>, TTrigger extends keyof GetEvents<TInngest> & string = keyof GetEvents<TInngest> & string> = Parameters<Handler<ClientOptionsFromInngest<TInngest>, GetEvents<TInngest>, TTrigger, ExtendWithMiddleware<[
+export type GetFunctionInput<TInngest extends Inngest<any>, TTrigger extends keyof GetEvents<TInngest, true> & string = keyof GetEvents<TInngest, true> & string> = Parameters<Handler<ClientOptionsFromInngest<TInngest>, GetEvents<TInngest, true>, TTrigger, ExtendWithMiddleware<[
 typeof builtInMiddleware,
 NonNullable<ClientOptionsFromInngest<TInngest>["middleware"]>
 ]>>>[0];
@@ -559,6 +559,11 @@ export type TriggerOptions<T extends string> = StrictUnion<{
 // @public
 export type UnionKeys<T> = T extends T ? keyof T : never;
 
+// @public (undocumented)
+export type WithoutInternal<T extends Record<string, EventPayload>> = {
+    [K in keyof T as K extends `inngest/${string}` ? never : K]: T[K];
+};
+
 // @public
 export type ZodEventSchemas = Record<string, {
     data?: z_2.ValidZodValue;
@@ -576,8 +581,8 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:320:5 - (ae-forgotten-export) The symbol "MiddlewareRunOutput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:339:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
-// src/types.ts:86:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:841:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:56:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
+// src/types.ts:811:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -8,7 +8,8 @@ import { z } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Schemas<T extends EventSchemas<any>> = GetEvents<
-  Inngest<{ id: "test"; schemas: T }>
+  Inngest<{ id: "test"; schemas: T }>,
+  true
 >;
 
 describe("EventSchemas", () => {

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -3,6 +3,7 @@ import {
   Inngest,
   InngestMiddleware,
   type EventPayload,
+  type GetEvents,
   type GetFunctionInput,
   type GetStepTools,
 } from "@local";
@@ -784,6 +785,17 @@ describe("helper types", () => {
     T,
     K extends string | number | symbol,
   > = T extends Record<K, infer U> ? U : never;
+
+  describe("type GetEvents", () => {
+    test("can use GetEvents to send an event", () => {
+      type T0 = GetEvents<typeof inngest>;
+      type T1 = T0[keyof T0];
+
+      const _myEventSendingFn = (events: T1[]) => {
+        void inngest.send(events);
+      };
+    });
+  });
 
   describe("type GetFunctionInput", () => {
     type T0 = GetFunctionInput<typeof inngest>;

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -34,6 +34,9 @@ export type SendEventPayload<Events extends Record<string, EventPayload>> =
     }[keyof WithoutInternal<Events>]
   >;
 
+/**
+ * @public
+ */
 export type WithoutInternal<T extends Record<string, EventPayload>> = {
   [K in keyof T as K extends `inngest/${string}` ? never : K]: T[K];
 };

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -36,6 +36,7 @@ export type {
   StrictUnion,
   StrictUnionHelper,
   UnionKeys,
+  WithoutInternal,
 } from "./helpers/types";
 export { ProxyLogger } from "./middleware/logger";
 export type { LogArg } from "./middleware/logger";

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { type EventSchemas } from "./components/EventSchemas";
 import {
   type EventsFromOpts,
-  type Inngest,
   type builtInMiddleware,
 } from "./components/Inngest";
 import { type InngestFunction } from "./components/InngestFunction";
@@ -22,35 +21,6 @@ import {
   type StrictUnion,
 } from "./helpers/types";
 import { type Logger } from "./middleware/logger";
-
-/**
- * When passed an Inngest client, will return all event types for that client.
- *
- * It's recommended to use this instead of directly reusing your event types, as
- * Inngest will add extra properties and internal events such as `ts` and
- * `inngest/function.failed`.
- *
- * @example
- * ```ts
- * import { EventSchemas, Inngest, type GetEvents } from "inngest";
- *
- * export const inngest = new Inngest({
- *   id: "example-app",
- *   schemas: new EventSchemas().fromRecord<{
- *     "app/user.created": { data: { userId: string } };
- *   }>(),
- * });
- *
- * type Events = GetEvents<typeof inngest>;
- * type AppUserCreated = Events["app/user.created"];
- *
- * ```
- *
- * @public
- */
-export type GetEvents<T extends Inngest.Any> = T extends Inngest<infer U>
-  ? EventsFromOpts<U>
-  : never;
 
 export const failureEventErrorSchema = z
   .object({


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

As seen in #452, the `GetEvents<>` type helper returns user-defined _and_ internal functions such as `inngest/function.finished`. This was an unintentional change to the helper when adding internal events to the typing in #426.

The most common use for this helper is to create shims over `inngest.send()`. The inclusion of the internal events in this helper type means that the type cannot be passed to `inngest.send()` without wrapping it with `WithoutInternal<>`.

In this PR, we change `GetEvents<>` to now only return the user's events by default. If a user wishes to access internal events too, they can pass an extra generic parameter to do so:

```ts
type OnlyUserEvents = GetEvents<typeof inngest>; // compatible with `inngest.send()`
type AllEvents = GetEvents<typeof inngest, true>; // not compatible with `inngest.send()`
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Caused by #426
- Fixes #452 
- Added docs in inngest/website#671
