### PR TITLE
Add `timeout` to `step.invoke()` options

### DIFF
--- a/.changeset/shaggy-crabs-type.md
+++ b/.changeset/shaggy-crabs-type.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `timeout` to `step.invoke()` options

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -620,6 +620,54 @@ describe("invoke", () => {
         });
       });
     });
+
+    describe("timeouts", () => {
+      test("return correct timeout if string `timeout` given", async () => {
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            timeout: "1m",
+          })
+        ).resolves.toMatchObject({
+          opts: {
+            timeout: "1m",
+          },
+        });
+      });
+
+      test("return correct timeout if date `timeout` given", async () => {
+        const upcoming = new Date();
+        upcoming.setDate(upcoming.getDate() + 6);
+        upcoming.setHours(upcoming.getHours() + 1);
+
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            timeout: upcoming,
+          })
+        ).resolves.toMatchObject({
+          opts: {
+            timeout: expect.stringMatching(upcoming.toISOString()),
+          },
+        });
+      });
+
+      test("return correct timeout if `number` `timeout` given", async () => {
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            timeout: 60000,
+          })
+        ).resolves.toMatchObject({
+          opts: {
+            timeout: "1m",
+          },
+        });
+      });
+    });
   });
 
   describe("types", () => {

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -486,6 +486,9 @@ type InvocationOpts<TFunction extends InvokeTargetFunctionDefinition> =
        * of this time, at which point the retured promise will be rejected
        * instead of resolved with the output of the invoked function.
        *
+       * Note that the invoked function will continue to run even if this step
+       * times out.
+       *
        * The time to wait can be specified using a `number` of milliseconds, an
        * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`,
        * or a `Date` object.

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -396,13 +396,14 @@ export const createStepTools = <
         idOrOptions: StepOptionsOrId,
         opts: InvocationOpts<TFunction>
       ) => InvocationResult<GetFunctionOutput<TFunction>>
-    >(({ id, name }, opts) => {
+    >(({ id, name }, invokeOpts) => {
       // Create a discriminated union to operate on based on the input types
       // available for this tool.
       const payloadSchema = z.object({
         data: z.record(z.any()).optional(),
         user: z.record(z.any()).optional(),
         v: z.string().optional(),
+        timeout: z.union([z.number(), z.string(), z.date()]).optional(),
       });
 
       const parsedFnOpts = payloadSchema
@@ -422,7 +423,7 @@ export const createStepTools = <
             function: z.instanceof(InngestFunctionReference),
           })
         )
-        .safeParse(opts);
+        .safeParse(invokeOpts);
 
       if (!parsedFnOpts.success) {
         throw new Error(
@@ -430,24 +431,32 @@ export const createStepTools = <
         );
       }
 
-      const { _type, function: fn, data, user, v } = parsedFnOpts.data;
+      const { _type, function: fn, data, user, v, timeout } = parsedFnOpts.data;
       const payload = { data, user, v } satisfies MinimalEventPayload;
+      const opts: {
+        payload: MinimalEventPayload;
+        function_id: string;
+        timeout?: string;
+      } = {
+        payload,
+        function_id: "",
+        timeout: typeof timeout === "undefined" ? undefined : timeStr(timeout),
+      };
 
-      let functionId: string;
       switch (_type) {
         case "fnInstance":
-          functionId = fn.id(fn["client"].id);
+          opts.function_id = fn.id(fn["client"].id);
           break;
 
         case "fullId":
           console.warn(
             `${logPrefix} Invoking function with \`function: string\` is deprecated and will be removed in v4.0.0; use an imported function or \`referenceFunction()\` instead. See https://innge.st/ts-referencing-functions`
           );
-          functionId = fn;
+          opts.function_id = fn;
           break;
 
         case "refInstance":
-          functionId = [fn.opts.appId || client.id, fn.opts.functionId]
+          opts.function_id = [fn.opts.appId || client.id, fn.opts.functionId]
             .filter(Boolean)
             .join("-");
           break;
@@ -457,10 +466,7 @@ export const createStepTools = <
         id,
         op: StepOpCode.InvokeFunction,
         displayName: name ?? id,
-        opts: {
-          function_id: functionId,
-          payload,
-        },
+        opts,
       };
     }),
   };
@@ -473,7 +479,21 @@ type InvocationTargetOpts<TFunction extends InvokeTargetFunctionDefinition> = {
 };
 
 type InvocationOpts<TFunction extends InvokeTargetFunctionDefinition> =
-  InvocationTargetOpts<TFunction> & TriggerEventFromFunction<TFunction>;
+  InvocationTargetOpts<TFunction> &
+    TriggerEventFromFunction<TFunction> & {
+      /**
+       * The step function will wait for the invocation to finish for a maximum
+       * of this time, at which point the retured promise will be rejected
+       * instead of resolved with the output of the invoked function.
+       *
+       * The time to wait can be specified using a `number` of milliseconds, an
+       * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`,
+       * or a `Date` object.
+       *
+       * {@link https://npm.im/ms}
+       */
+      timeout?: number | string | Date;
+    };
 
 /**
  * A set of optional parameters given to a `waitForEvent` call to control how


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds a `timeout` option to `step.invoke()`, allowing users to specify a timeout other than the default when invoking a function as a step.

Uses the the same `timeout` as `step.waitForEvent()` and function config.

```ts
await step.invoke("Example", {
  function: myFn,
  timeout: "1h",
});
```

The Executor already supports this:

https://github.com/inngest/inngest/blob/658e7a6e003b1a3b4fb0f4349c3c7e635e09b9de/pkg/execution/state/driver_response.go#L159-L163

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- inngest/website#676