### PR TITLE
Remove `as string` casting of `unknown `error` when parsing API errors

### DIFF
--- a/.changeset/mighty-grapes-sell.md
+++ b/.changeset/mighty-grapes-sell.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix API failures being masked at runtime when fetching large step data or event batches fails

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -1,6 +1,7 @@
 import { type fetch } from "cross-fetch";
 import { type ExecutionVersion } from "../components/execution/InngestExecution";
 import { getFetch } from "../helpers/env";
+import { getErrorMessage } from "../helpers/errors";
 import { hashSigningKey } from "../helpers/strings";
 import { err, ok, type Result } from "../types";
 import {
@@ -65,7 +66,10 @@ export class InngestApi {
         }
       })
       .catch((error) => {
-        return err({ error: error as string, status: 500 });
+        return err({
+          error: getErrorMessage(error, "Unknown error retrieving step data"),
+          status: 500,
+        });
       });
   }
 
@@ -87,7 +91,10 @@ export class InngestApi {
         }
       })
       .catch((error) => {
-        return err({ error: error as string, status: 500 });
+        return err({
+          error: getErrorMessage(error, "Unknown error retrieving event batch"),
+          status: 500,
+        });
       });
   }
 }

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -342,6 +342,19 @@ const isError = (err: unknown): err is Error => {
 };
 
 /**
+ * Given an `unknown` object, retrieve the `message` property from it, or fall
+ * back to the `fallback` string if it doesn't exist or is empty.
+ */
+export const getErrorMessage = (err: unknown, fallback: string): string => {
+  const { message } = z
+    .object({ message: z.string().min(1) })
+    .catch({ message: fallback })
+    .parse(err);
+
+  return message;
+};
+
+/**
  * Given a {@link PrettyError}, return a nicely-formatted string ready to log
  * or throw.
  *


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes #482, removing an `as string` cast for an `unknown` `error` thrown from fetching data from the API.

An ESLint rule that requires an exemption when casting would be good.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #482
