### PR TITLE
Add generic function invocation event to all event schemas

### DIFF
--- a/.changeset/violet-phones-provide.md
+++ b/.changeset/violet-phones-provide.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add generic function invocation event to all event schemas

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -13,6 +13,13 @@ import { SimplifyDeep } from 'type-fest/source/merge-deep';
 import { z } from 'zod';
 
 // @public
+export type AssertInternalEventPayloads<T extends Record<internalEvents, EventPayload>> = {
+    [K in keyof T as `${K & string}`]: Simplify<Omit<T[K], "name"> & {
+        name: `${K & string}`;
+    }>;
+};
+
+// @public
 export interface ClientOptions {
     baseUrl?: string;
     env?: string;
@@ -61,11 +68,11 @@ export interface EventPayload<TData = any> extends MinimalEventPayload<TData> {
 }
 
 // @public
-export class EventSchemas<S extends Record<string, EventPayload> = {
-    [FnFailedEventName]: FailureEventPayload;
-    [FnFinishedEventName]: FinishedEventPayload;
-    [FnInvokedEventName]: InvokedEventPayload;
-}> {
+export class EventSchemas<S extends Record<string, EventPayload> = AssertInternalEventPayloads<{
+    [internalEvents.FunctionFailed]: FailureEventPayload;
+    [internalEvents.FunctionFinished]: FinishedEventPayload;
+    [internalEvents.FunctionInvoked]: InvokedEventPayload;
+}>> {
     fromGenerated<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
     // Warning: (ae-forgotten-export) The symbol "PreventClashingNames" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ClashingNameError" needs to be exported by the entry point index.d.ts
@@ -573,10 +580,7 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/EventSchemas.ts:225:5 - (ae-forgotten-export) The symbol "FnFailedEventName" needs to be exported by the entry point index.d.ts
-// src/components/EventSchemas.ts:226:5 - (ae-forgotten-export) The symbol "FnFinishedEventName" needs to be exported by the entry point index.d.ts
-// src/components/EventSchemas.ts:227:5 - (ae-forgotten-export) The symbol "FnInvokedEventName" needs to be exported by the entry point index.d.ts
-// src/components/EventSchemas.ts:227:5 - (ae-forgotten-export) The symbol "InvokedEventPayload" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:243:5 - (ae-forgotten-export) The symbol "InvokedEventPayload" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:903:5 - (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:905:9 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:905:36 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts

--- a/packages/inngest/etc/inngest.api.md
+++ b/packages/inngest/etc/inngest.api.md
@@ -64,6 +64,7 @@ export interface EventPayload<TData = any> extends MinimalEventPayload<TData> {
 export class EventSchemas<S extends Record<string, EventPayload> = {
     [FnFailedEventName]: FailureEventPayload;
     [FnFinishedEventName]: FinishedEventPayload;
+    [FnInvokedEventName]: InvokedEventPayload;
 }> {
     fromGenerated<T extends StandardEventSchemas>(): EventSchemas<Combine<S, T>>;
     // Warning: (ae-forgotten-export) The symbol "PreventClashingNames" needs to be exported by the entry point index.d.ts
@@ -572,8 +573,10 @@ export type ZodEventSchemas = Record<string, {
 
 // Warnings were encountered during analysis:
 //
-// src/components/EventSchemas.ts:223:5 - (ae-forgotten-export) The symbol "FnFailedEventName" needs to be exported by the entry point index.d.ts
-// src/components/EventSchemas.ts:224:5 - (ae-forgotten-export) The symbol "FnFinishedEventName" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:225:5 - (ae-forgotten-export) The symbol "FnFailedEventName" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:226:5 - (ae-forgotten-export) The symbol "FnFinishedEventName" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:227:5 - (ae-forgotten-export) The symbol "FnInvokedEventName" needs to be exported by the entry point index.d.ts
+// src/components/EventSchemas.ts:227:5 - (ae-forgotten-export) The symbol "InvokedEventPayload" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:903:5 - (ae-forgotten-export) The symbol "ServerTiming" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:905:9 - (ae-forgotten-export) The symbol "ExecutionVersion" needs to be exported by the entry point index.d.ts
 // src/components/InngestCommHandler.ts:905:36 - (ae-forgotten-export) The symbol "ExecutionResult" needs to be exported by the entry point index.d.ts
@@ -584,7 +587,7 @@ export type ZodEventSchemas = Record<string, {
 // src/components/InngestMiddleware.ts:339:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventInput" needs to be exported by the entry point index.d.ts
 // src/components/InngestMiddleware.ts:346:5 - (ae-forgotten-export) The symbol "MiddlewareSendEventOutput" needs to be exported by the entry point index.d.ts
 // src/types.ts:56:5 - (ae-forgotten-export) The symbol "failureEventErrorSchema" needs to be exported by the entry point index.d.ts
-// src/types.ts:811:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
+// src/types.ts:823:5 - (ae-forgotten-export) The symbol "TimeStrBatch" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -18,7 +18,8 @@ describe("EventSchemas", () => {
 
     type Expected =
       | `${internalEvents.FunctionFailed}`
-      | `${internalEvents.FunctionFinished}`;
+      | `${internalEvents.FunctionFinished}`
+      | `${internalEvents.FunctionInvoked}`;
 
     type Actual = Schemas<typeof schemas>[keyof Schemas<
       typeof schemas

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -2,6 +2,7 @@ import { type Simplify } from "type-fest";
 import {
   type FnFailedEventName,
   type FnFinishedEventName,
+  type FnInvokedEventName,
 } from "../helpers/consts";
 import { type IsEmptyObject, type IsStringLiteral } from "../helpers/types";
 import type * as z from "../helpers/validators/zod";
@@ -9,6 +10,7 @@ import {
   type EventPayload,
   type FailureEventPayload,
   type FinishedEventPayload,
+  type InvokedEventPayload,
 } from "../types";
 
 /**
@@ -222,6 +224,7 @@ export class EventSchemas<
   S extends Record<string, EventPayload> = {
     [FnFailedEventName]: FailureEventPayload;
     [FnFinishedEventName]: FinishedEventPayload;
+    [FnInvokedEventName]: InvokedEventPayload;
   },
 > {
   /**

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -1,9 +1,5 @@
 import { type Simplify } from "type-fest";
-import {
-  type FnFailedEventName,
-  type FnFinishedEventName,
-  type FnInvokedEventName,
-} from "../helpers/consts";
+import { type internalEvents } from "../helpers/consts";
 import { type IsEmptyObject, type IsStringLiteral } from "../helpers/types";
 import type * as z from "../helpers/validators/zod";
 import {
@@ -34,6 +30,26 @@ export type StandardEventSchema = {
  * @public
  */
 export type StandardEventSchemas = Record<string, StandardEventSchema>;
+
+/**
+ * Asserts that the given type `T` contains a mapping for all internal events.
+ *
+ * Usage of this ensures that we never forget about an internal event in schemas
+ * when adding new ones.
+ *
+ * It also ensures that the mapped name is not the enum type, as this would
+ * require a user to use the enum type to access the event schema to declare
+ * triggers, where we want to allow them to use the string literal.
+ *
+ * @public
+ */
+export type AssertInternalEventPayloads<
+  T extends Record<internalEvents, EventPayload>,
+> = {
+  [K in keyof T as `${K & string}`]: Simplify<
+    Omit<T[K], "name"> & { name: `${K & string}` }
+  >;
+};
 
 /**
  * A string error used to highlight to a user that they have a clashing name
@@ -221,11 +237,11 @@ export type Combine<
  * @public
  */
 export class EventSchemas<
-  S extends Record<string, EventPayload> = {
-    [FnFailedEventName]: FailureEventPayload;
-    [FnFinishedEventName]: FinishedEventPayload;
-    [FnInvokedEventName]: InvokedEventPayload;
-  },
+  S extends Record<string, EventPayload> = AssertInternalEventPayloads<{
+    [internalEvents.FunctionFailed]: FailureEventPayload;
+    [internalEvents.FunctionFinished]: FinishedEventPayload;
+    [internalEvents.FunctionInvoked]: InvokedEventPayload;
+  }>,
 > {
   /**
    * Use generated Inngest types to type events.

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -145,14 +145,6 @@ export enum internalEvents {
   FunctionFinished = "inngest/function.finished",
 }
 
-/**
- * Accessing enum values as literals in some TypeScript types can be difficult,
- * so we also manually create the string values here.
- */
-export const FnFailedEventName = `${internalEvents.FunctionFailed}`;
-export const FnInvokedEventName = `${internalEvents.FunctionInvoked}`;
-export const FnFinishedEventName = `${internalEvents.FunctionFinished}`;
-
 export const logPrefix = chalk.magenta.bold("[Inngest]");
 
 export const debugPrefix = "inngest";

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -1,5 +1,6 @@
 export {
   EventSchemas,
+  type AssertInternalEventPayloads,
   type Combine,
   type LiteralZodEventSchema,
   type StandardEventSchemaToPayload,

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -98,6 +98,18 @@ export type FinishedEventPayload = {
 };
 
 /**
+ * The payload for any generic function invocation event. In practice, the event
+ * data will be more specific to the function being invoked.
+ *
+ * @public
+ */
+export type InvokedEventPayload = Simplify<
+  Omit<EventPayload, "name"> & {
+    name: `${internalEvents.FunctionInvoked}`;
+  }
+>;
+
+/**
  * Unique codes for the different types of operation that can be sent to Inngest
  * from SDK step functions.
  */


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes an issue where `inngest/function.invoked` was missing from the list of internal events automatically returned when using `GetEvents<typeof inngest, true>`.

Also slightly refactors how these internal events are added, ensuring we can't forget them again.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
