### PR TITLE
Fix delayed environment variables not using event key

### DIFF
--- a/.changeset/gorgeous-cooks-talk.md
+++ b/.changeset/gorgeous-cooks-talk.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix delayed environment variables not using event key in `"inngest/cloudflare"`

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1155,7 +1155,7 @@ export class InngestCommHandler<
       this.client["inngestApi"].setSigningKey(this.signingKey);
     }
 
-    if (!this.client["eventKey"] && this.env[envKeys.InngestEventKey]) {
+    if (!this.client["eventKeySet"]() && this.env[envKeys.InngestEventKey]) {
       this.client.setEventKey(String(this.env[envKeys.InngestEventKey]));
     }
 

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -175,19 +175,25 @@ export const testFramework = (
     const [req, res] = createReqRes(mockReqOpts);
 
     let envToPass = { ...env };
+    let prevProcessEnv = undefined;
 
     /**
      * If we have `process` in this emulated environment, also mutate that to
      * account for common situations.
      */
     if (typeof process !== "undefined" && "env" in process) {
-      process.env = { ...process.env, ...envToPass };
+      prevProcessEnv = process.env;
+      process.env = { ...prevProcessEnv, ...envToPass };
       envToPass = { ...process.env };
     }
 
     const args = opts?.transformReq?.(req, res, envToPass) ?? [req, res];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ret = await (serveHandler as (...args: any[]) => any)(...args);
+
+    if (prevProcessEnv) {
+      process.env = prevProcessEnv;
+    }
 
     return (
       opts?.transformRes?.(args, ret) ?? {

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -271,7 +271,7 @@ export const testFramework = (
     describe("GET", () => {
       test("shows introspection data", async () => {
         const ret = await run(
-          [{ client: inngest, functions: [] }],
+          [{ client: createClient({ id: "test" }), functions: [] }],
           [
             {
               method: "GET",
@@ -296,8 +296,42 @@ export const testFramework = (
         expect(body).toMatchObject({
           message: "Inngest endpoint configured correctly.",
           functionsFound: 0,
+          hasEventKey: false,
+          hasSigningKey: false,
+        });
+      });
+
+      test("can pick up delayed event key from environment", async () => {
+        const ret = await run(
+          [{ client: createClient({ id: "test" }), functions: [] }],
+          [{ method: "GET" }],
+          { [envKeys.InngestEventKey]: "event-key-123" }
+        );
+
+        const body = JSON.parse(ret.body);
+
+        expect(body).toMatchObject({
+          message: "Inngest endpoint configured correctly.",
+          functionsFound: 0,
           hasEventKey: true,
           hasSigningKey: false,
+        });
+      });
+
+      test("can pick up delayed signing key from environment", async () => {
+        const ret = await run(
+          [{ client: createClient({ id: "test" }), functions: [] }],
+          [{ method: "GET" }],
+          { [envKeys.InngestSigningKey]: "signing-key-123" }
+        );
+
+        const body = JSON.parse(ret.body);
+
+        expect(body).toMatchObject({
+          message: "Inngest endpoint configured correctly.",
+          functionsFound: 0,
+          hasEventKey: false,
+          hasSigningKey: true,
         });
       });
     });


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes an issue where delayed access to environment variables was incorrectly missing setting the event key.

`Inngest.eventKey` will always be a populated string, falling back to a dummy value of `NO_EVENT_KEY_SET` if it's not specified during instantiation. We do this as API routing for ingestion (`https://inn.gs/e/:event_key`) sensibly relies on the event key being present, even in local dev.

In environments such as Cloudflare Workers where access to environment variables is delayed until the request handler is called, we'll should set the event key again if we only have a dummy and we now have a real one.

This code was erroneously checking that `eventKey` was truthy instead of calling the existing `eventKeySet()` method that considers dummy keys. 

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #481 
