### PR TITLE
Run `onSendEvent` middleware hooks for `step.invoke()` payloads

### DIFF
--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -399,26 +399,23 @@ export const createStepTools = <
     >(({ id, name }, invokeOpts) => {
       // Create a discriminated union to operate on based on the input types
       // available for this tool.
-      const payloadSchema = z.object({
-        data: z.record(z.any()).optional(),
-        user: z.record(z.any()).optional(),
-        v: z.string().optional(),
+      const optsSchema = invokePayloadSchema.extend({
         timeout: z.union([z.number(), z.string(), z.date()]).optional(),
       });
 
-      const parsedFnOpts = payloadSchema
+      const parsedFnOpts = optsSchema
         .extend({
           _type: z.literal("fullId").optional().default("fullId"),
           function: z.string().min(1),
         })
         .or(
-          payloadSchema.extend({
+          optsSchema.extend({
             _type: z.literal("fnInstance").optional().default("fnInstance"),
             function: z.instanceof(InngestFunction),
           })
         )
         .or(
-          payloadSchema.extend({
+          optsSchema.extend({
             _type: z.literal("refInstance").optional().default("refInstance"),
             function: z.instanceof(InngestFunctionReference),
           })
@@ -473,6 +470,16 @@ export const createStepTools = <
 
   return tools;
 };
+
+/**
+ * The event payload portion of the options for `step.invoke()`. This does not
+ * include non-payload options like `timeout` or the function to invoke.
+ */
+export const invokePayloadSchema = z.object({
+  data: z.record(z.any()).optional(),
+  user: z.record(z.any()).optional(),
+  v: z.string().optional(),
+});
 
 type InvocationTargetOpts<TFunction extends InvokeTargetFunctionDefinition> = {
   function: TFunction;

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -1,7 +1,7 @@
 import { sha1 } from "hash.js";
-import { internalEvents } from "inngest/helpers/consts";
 import { type Simplify } from "type-fest";
 import { z } from "zod";
+import { internalEvents } from "../../helpers/consts";
 import {
   ErrCode,
   deserializeError,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

The `onSendEvent.transformInput()` middleware hook is used to intercept events being sent and change either the shape or number of events being sent. When invoking a function via `step.invoke()`, an _internal_ `inngest/function.invoked` event is sent, though the `onSendEvent.transformInput()` hook is **not** currently run.

For middleware like `@inngest/middleware-encryption`, this poses a challenge, as it can no longer encrypt fields when using `step.invoke()` instead of `step.sendEvent()`.

This PR ensures that the hook is also used for events being sent via `step.invoke()`, such that middleware can now appropriately affect the payloads.

Some notes on design decisions here:

- The `onSendEvent` hook will be run for each individual `step.invoke()`. This is the same functionality as calling `step.sendEvent()` multiple times. While the `transformInput()` hook supports batched `payloads`, this makes it difficult to determine which payloads have been affected if a user has omitted some from the returned array.
- Unlike `step.sendEvent()` or `inngest.send()`, we do not allow a developer to omit the event to be sent by `step.invoke()` 

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable
