### PR TITLE
Fix `GetFunctionOutput` typing resulting in `{}`

### DIFF
--- a/.changeset/brown-ways-sort.md
+++ b/.changeset/brown-ways-sort.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `GetFunctionOutput` typing sometimes resulting in `{}`

--- a/.changeset/brown-ways-sort.md
+++ b/.changeset/brown-ways-sort.md
@@ -2,4 +2,4 @@
 "inngest": patch
 ---
 
-Fix `GetFunctionOutput` typing sometimes resulting in `{}`
+Fix `GetFunctionOutput` and `step.invoke()` typing sometimes resulting in `{}`

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -2,9 +2,11 @@ import {
   EventSchemas,
   Inngest,
   InngestMiddleware,
+  referenceFunction,
   type EventPayload,
   type GetEvents,
   type GetFunctionInput,
+  type GetFunctionOutput,
   type GetStepTools,
 } from "@local";
 import { type createStepTools } from "@local/components/InngestStepTools";
@@ -13,6 +15,7 @@ import { type IsAny } from "@local/helpers/types";
 import { type Logger } from "@local/middleware/logger";
 import { type SendEventResponse } from "@local/types";
 import { assertType, type IsEqual } from "type-plus";
+import { literal } from "zod";
 import { createClient } from "../test/helpers";
 
 const testEvent: EventPayload = {
@@ -940,6 +943,50 @@ describe("helper types", () => {
         Parameters<T0["step"]["sendEvent"]>[1],
         "name"
       >;
+      assertType<IsEqual<Expected, Actual>>(true);
+    });
+  });
+
+  describe("type GetFunctionOutput", () => {
+    test("returns output of an `InngestFunction`", () => {
+      const fn = inngest.createFunction(
+        { id: "test" },
+        { event: "foo" },
+        async () => {
+          return "foo";
+        }
+      );
+
+      type Expected = "foo";
+      type Actual = GetFunctionOutput<typeof fn>;
+      assertType<IsEqual<Expected, Actual>>(true);
+    });
+
+    test("returns output of an `InngestFunctionReference` to an `InngestFunction`", () => {
+      const fn = inngest.createFunction(
+        { id: "test" },
+        { event: "foo" },
+        async () => {
+          return "foo";
+        }
+      );
+
+      const ref = referenceFunction<typeof fn>({ functionId: "test" });
+
+      type Expected = "foo";
+      type Actual = GetFunctionOutput<typeof ref>;
+      assertType<IsEqual<Expected, Actual>>(true);
+    });
+
+    test("returns output of an `InngestFunctionReference` with `schemas`", () => {
+      const ref = referenceFunction({
+        functionId: "test",
+        schemas: { return: literal("foo") },
+      });
+
+      type Expected = "foo";
+      type Actual = GetFunctionOutput<typeof ref>;
+
       assertType<IsEqual<Expected, Actual>>(true);
     });
   });

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -948,12 +948,13 @@ describe("helper types", () => {
   });
 
   describe("type GetFunctionOutput", () => {
-    test("returns output of an `InngestFunction`", () => {
+    test("returns output of an async `InngestFunction`", () => {
       const fn = inngest.createFunction(
         { id: "test" },
         { event: "foo" },
+        // eslint-disable-next-line @typescript-eslint/require-await
         async () => {
-          return "foo";
+          return "foo" as const;
         }
       );
 
@@ -962,12 +963,43 @@ describe("helper types", () => {
       assertType<IsEqual<Expected, Actual>>(true);
     });
 
-    test("returns output of an `InngestFunctionReference` to an `InngestFunction`", () => {
+    test("returns output of a sync `InngestFunction`", () => {
       const fn = inngest.createFunction(
         { id: "test" },
         { event: "foo" },
+        () => {
+          return "foo" as const;
+        }
+      );
+
+      type Expected = "foo";
+      type Actual = GetFunctionOutput<typeof fn>;
+      assertType<IsEqual<Expected, Actual>>(true);
+    });
+
+    test("returns output of an `InngestFunctionReference` to an async `InngestFunction`", () => {
+      const fn = inngest.createFunction(
+        { id: "test" },
+        { event: "foo" },
+        // eslint-disable-next-line @typescript-eslint/require-await
         async () => {
-          return "foo";
+          return "foo" as const;
+        }
+      );
+
+      const ref = referenceFunction<typeof fn>({ functionId: "test" });
+
+      type Expected = "foo";
+      type Actual = GetFunctionOutput<typeof ref>;
+      assertType<IsEqual<Expected, Actual>>(true);
+    });
+
+    test("returns output of an `InngestFunctionReference` to a sync `InngestFunction`", () => {
+      const fn = inngest.createFunction(
+        { id: "test" },
+        { event: "foo" },
+        () => {
+          return "foo" as const;
         }
       );
 

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -818,9 +818,9 @@ export type GetFunctionOutputFromInngestFunction<
   TFunction extends InngestFunction.Any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 > = TFunction extends InngestFunction<any, any, any, any, infer IHandler>
-  ? IsNever<SimplifyDeep<Jsonify<ReturnType<IHandler>>>> extends true
+  ? IsNever<SimplifyDeep<Jsonify<Awaited<ReturnType<IHandler>>>>> extends true
     ? null
-    : SimplifyDeep<Jsonify<ReturnType<IHandler>>>
+    : SimplifyDeep<Jsonify<Awaited<ReturnType<IHandler>>>>
   : unknown;
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes #506, which suffers from the `GetFunctionOutput` helper type not awaiting function results.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #506
