### PR TITLE
Test against `typescript@~5.4.0` instead of `typescript@rc`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         tsVersion:
          - 'latest'
-         - 'rc'
+         - '~5.4.0'
          - '~5.3.0'
          - '~5.2.0'
          - '~5.1.0'


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Following #500 and the full release of [TypeScript 5.4](https://github.com/microsoft/TypeScript/releases/tag/v5.4.2), updates our type tests to use `typescript@~5.4.0` instead of `typescript@rc`, as the `rc` tag will change over time.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Chore
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- #500
