### PR TITLE
Fix `Jsonify` removing `unknown` types

### DIFF
--- a/packages/inngest/src/helpers/jsonify.test.ts
+++ b/packages/inngest/src/helpers/jsonify.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { type Jsonify } from "@local/helpers/jsonify";
+import { type IsUnknown } from "@local/helpers/types";
+import { assertType, type IsAny, type IsEqual } from "type-plus";
+
+describe("Jsonify", () => {
+  test("allows `any`", () => {
+    type Actual = Jsonify<any>;
+    assertType<IsAny<Actual>>(true);
+  });
+
+  test("allows `unknown`", () => {
+    type Actual = Jsonify<unknown>;
+    assertType<IsUnknown<Actual>>(true);
+  });
+
+  test("allows number literals", () => {
+    type Actual = Jsonify<1>;
+    type Expected = 1;
+    assertType<IsEqual<Actual, Expected>>(true);
+  });
+
+  test("allows string literals", () => {
+    type Actual = Jsonify<"foo">;
+    type Expected = "foo";
+    assertType<IsEqual<Actual, Expected>>(true);
+  });
+
+  describe("object", () => {
+    test("allows `any`", () => {
+      type Actual = Jsonify<{ foo: any }>;
+      type Expected = { foo: any };
+      assertType<IsEqual<Actual, Expected>>(true);
+    });
+
+    test("allows `unknown`", () => {
+      type Actual = Jsonify<{ foo: unknown }>;
+      type Expected = { foo: unknown };
+      assertType<IsEqual<Actual, Expected>>(true);
+    });
+
+    test("allows number literals", () => {
+      type Actual = Jsonify<{ foo: 1 }>;
+      type Expected = { foo: 1 };
+      assertType<IsEqual<Actual, Expected>>(true);
+    });
+
+    test("allows string literals", () => {
+      type Actual = Jsonify<{ foo: "bar" }>;
+      type Expected = { foo: "bar" };
+      assertType<IsEqual<Actual, Expected>>(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`Jsonify` is used to represent a step output going through serialization as it passes to and from an Inngest Server in JSON. This used to be part of the `type-fest` package, but we removed that when introducing support for TypeScript 5.4 in #500, as our version support range for TS exceeded what was provided by the `type-fest` package.

As part of that, we've pulled `Jsonify` into our code. There are some issues (in the related section) we can now fix much more easily.

The issue that motivated this change (#509) would also have been solved by allowing a developer to provide types that describe how the output of a step is transformed. This is available, but is a rare ask and needs time to implement.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Docs only outline that this is a helper, not specific behaviour
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #509 (marking this as a fix, but again, note that middleware typing can also solve different strains of this issue)
- Fixes #456
- Does not fix #98, but is an example of fixing `Jsonify` issues that can also resolve this
