### PR TITLE
name -> id for clientoptions in readme

### DIFF
--- a/packages/inngest/README.md
+++ b/packages/inngest/README.md
@@ -62,12 +62,12 @@ Write serverless functions and background jobs right in your own code:
 ```ts
 import { Inngest } from "inngest";
 
-const inngest = new Inngest({ name: "My App" });
+const inngest = new Inngest({ id: "My App" });
 
 // This function will be invoked by Inngest via HTTP any time
 // the "app/user.signup" event is sent to to Inngest
 export default inngest.createFunction(
-  { name: "User onboarding communication" },
+  { id: "User onboarding communication" },
   { event: "app/user.signup" },
   async ({ event, step }) => {
     await step.run("Send welcome email", async () => {
@@ -95,7 +95,7 @@ import { serve } from "inngest/next";
 import myFunction from "../userOnboardingCOmmunication"; // see above function
 
 // You can create this in a single file and import where it's needed
-const inngest = new Inngest({ name: "My App" });
+const inngest = new Inngest({ id: "My App" });
 
 // Securely serve your Inngest functions for remote invocation:
 export default serve(inngest, [myFunction]);
@@ -106,7 +106,7 @@ export default serve(inngest, [myFunction]);
 ```ts
 // Send events
 import { Inngest } from "inngest";
-const inngest = new Inngest({ name: "My App" });
+const inngest = new Inngest({ id: "My App" });
 
 // This will run the function above automatically, in the background
 inngest.send("app/user.signup", {


### PR DESCRIPTION
## Summary
I pulled latest and tried the example code in the readme's getting started:

```
const inngest = new Inngest({ name: "My App" });
```
and got:

```
src/index.ts:147:31 - error TS2345: Argument of type '{ name: string; }' is not assignable to parameter of type 'ClientOptions'.
  Object literal may only specify known properties, and 'name' does not exist in type 'ClientOptions'.

147 const inngest = new Inngest({ name: "My App" });
```

Guessing the readme has drifted from the code and it should be `id` and not `name`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
