### PR TITLE
Remove `@inngest/eslint-plugin` alpha warnings; it's in use

### DIFF
--- a/.changeset/witty-teachers-rhyme.md
+++ b/.changeset/witty-teachers-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@inngest/eslint-plugin": patch
+---
+
+Remove `@inngest/eslint-plugin` alpha warnings

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,8 +1,5 @@
 # `@inngest/eslint-plugin`
 
-> [!WARNING]
-> This package is currently in alpha and is undocumented. Use with caution.
-
 An ESLint plugin and config for [`inngest`](/packages/inngest/).
 
 ## Getting started
@@ -22,7 +19,7 @@ Add the plugin to your ESLint configuration file with the recommended config.
 }
 ```
 
-You can also manually configure each rule instead of using the `plugin:@inngest/recommend` config.
+You can also manually configure each rule instead of using the `plugin:@inngest/recommended` config.
 
 ```json
 {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Removes the warning in the `@inngest/eslint-plugin` package README that states it's in alpha; it's being used and is working.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
