### PR TITLE
Fix event API errors not being parsed and returned

### DIFF
--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -141,13 +141,16 @@ describe("send", () => {
       error,
     }: Partial<SendEventResponse> = {}) => {
       return jest.fn((url: string, opts: { body: string }) => {
-        const json = {
-          status,
-          ids:
-            ids ??
-            (JSON.parse(opts.body) as EventPayload[]).map(() => "test-id"),
-          error,
-        };
+        const json = error
+          ? {
+              error,
+            }
+          : {
+              status,
+              ids:
+                ids ??
+                (JSON.parse(opts.body) as EventPayload[]).map(() => "test-id"),
+            };
 
         return Promise.resolve({
           status,

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -493,12 +493,12 @@ export const sendEventResponseSchema = z.object({
   /**
    * Event IDs
    */
-  ids: z.array(z.string()),
+  ids: z.array(z.string()).default([]),
 
   /**
    * HTTP Status Code. Will be undefined if no request was sent.
    */
-  status: z.number(),
+  status: z.number().default(0),
 
   /**
    * Error message. Will be undefined if no error occurred.


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

When the event API responds with an error, we attempt to parse that error and include it in the `Error` returned to the user.

The tests for this, however, mocked the incorrect response from Inngest, resulting in the illusion of this functioning. The mock has been changed and the fix implemented by slightly changing the parsing of the response.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [ ] Added changesets if applicable
