### PR TITLE
Do not swallow JSON parsing error when syncing

### DIFF
--- a/.changeset/hungry-islands-fly.md
+++ b/.changeset/hungry-islands-fly.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Do not swallow JSON parsing errors when syncing

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1141,6 +1141,7 @@ export class InngestCommHandler<
       data = await res.json();
     } catch (err) {
       this.log("warn", "Couldn't unpack register response:", err);
+      throw err;
     }
     const { status, error, skipped, modified } = registerResSchema.parse(data);
 

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -606,7 +606,7 @@ export const testFramework = (
 
       describe("env detection and headers", () => {
         test("uses env headers from client", async () => {
-          nock("https://api.inngest.com").post("/fn/register").reply(200);
+          nock("https://api.inngest.com").post("/fn/register").reply(200, {});
 
           const ret = await run(
             [


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes an issue where failing to parse the JSON response of Inngest when syncing results does nothing but log a warning.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A 
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- https://inngest.slack.com/archives/C06K5S9S3K6/p1712709050317129
