### PR TITLE
Fix/bug nested name object

### DIFF
--- a/.changeset/cyan-camels-tap.md
+++ b/.changeset/cyan-camels-tap.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `{ name: string; }` objects being filtered out of `step.run()` responses when nullable or a union

--- a/packages/inngest/src/helpers/jsonify.test.ts
+++ b/packages/inngest/src/helpers/jsonify.test.ts
@@ -102,4 +102,41 @@ describe("Jsonify", () => {
       assertType<IsAny<Actual["foo"]["bar"]>>(true);
     });
   });
+
+  describe("#537", () => {
+    describe("nested { name: string; } object is preserved", () => {
+      test("when nullable", () => {
+        type Actual = Jsonify<{
+          profile: { name: string } | null;
+        }>;
+        type Expected = {
+          profile: { name: string } | null;
+        };
+
+        assertType<IsEqual<Actual, Expected>>(true);
+      });
+
+      test("when union with another object", () => {
+        type Actual = Jsonify<{
+          profile: { name: string } | { age: number };
+        }>;
+        type Expected = {
+          profile: { name: string } | { age: number };
+        };
+
+        assertType<IsEqual<Actual, Expected>>(true);
+      });
+
+      test("when union with another scalar", () => {
+        type Actual = Jsonify<{
+          profile: { name: string } | boolean;
+        }>;
+        type Expected = {
+          profile: { name: string } | boolean;
+        };
+
+        assertType<IsEqual<Actual, Expected>>(true);
+      });
+    });
+  });
 });

--- a/packages/inngest/src/helpers/jsonify.ts
+++ b/packages/inngest/src/helpers/jsonify.ts
@@ -151,8 +151,10 @@ type BaseKeyFilter<Type, Key extends keyof Type> = Key extends symbol
   To prevent a problem where an object with only a `name` property is incorrectly treated as assignable to a function, we first check if the property is a record.
   This check is necessary, because without it, if we don't verify whether the property is a record, an object with a type of `{name: any}` would return `never` due to its potential assignability to a function.
   See: https://github.com/sindresorhus/type-fest/issues/657
+
+  This has been modified again from the `type-fest` version again, as objects that were unions with other scalar values were being incorrectly treated as functions.
   */
-      Type[Key] extends Record<string, unknown>
+      { name: string } extends Type[Key]
       ? Key
       : [(...arguments_: any[]) => any] extends [Type[Key]]
         ? never


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes #537, in which nested `{ name: string; }` objects were being filtered out of `step.run()` returns when nullable or a union with other values.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #537
