### PR TITLE
Add step name or ID when there’s a NESTING_STEPS error

### DIFF
--- a/.changeset/three-shoes-shave.md
+++ b/.changeset/three-shoes-shave.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add step name or ID when there’s a NESTING_STEPS error

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -749,6 +749,9 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     }): Promise<unknown> => {
       await beforeExecHooksPromise;
 
+      const stepOptions = getStepOptions(args[0]);
+      const opId = matchOp(stepOptions, ...args.slice(1));
+
       if (this.state.executingStep) {
         /**
          * If a step is found after asynchronous actions during another step's
@@ -765,7 +768,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
          */
         console.warn(
           prettyError({
-            whatHappened: "We detected that you have nested `step.*` tooling.",
+            whatHappened: `We detected that you have nested \`step.*\` tooling in \`${opId.displayName ?? opId.id}\``, 
             consequences: "Nesting `step.*` tooling is not supported.",
             type: "warn",
             reassurance:
@@ -777,9 +780,6 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
           })
         );
       }
-
-      const stepOptions = getStepOptions(args[0]);
-      const opId = matchOp(stepOptions, ...args.slice(1));
 
       if (this.state.steps[opId.id]) {
         const originalId = opId.id;


### PR DESCRIPTION
## Summary
When there's a NESTING_STEPS error, debugging it is tricky because the stack traces can't necessarily determine the correct faulty file. 


## Checklist
~~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A, this is augmenting an existing error
~~- [ ] Added unit/integration tests~~ N/A, I don't think it's worth it
~~- [ ] Added changesets if applicable~~ N/A, I don't think it's worth it. 

## Related
- INN-2958
- #546