### PR TITLE
Upgrade `tsx` in the `framework-fastify` example to be Node 18 compat

### DIFF
--- a/examples/framework-fastify/package.json
+++ b/examples/framework-fastify/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.5.2",
-    "tsx": "^3.12.7",
+    "tsx": "^4.7.3",
     "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Small bump of `tsx` in `examples/framework-fastify` to ensure it works with Node 18.19.0.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- privatenumber/tsx#421
