### PR TITLE
Make DefaultEncryptionService use libsodium

### DIFF
--- a/packages/middleware-encryption/package.json
+++ b/packages/middleware-encryption/package.json
@@ -31,11 +31,11 @@
   "author": "Jack Williams <jack@inngest.com>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/crypto-js": "^4.2.1",
+    "@types/libsodium-wrappers": "^0.7.14",
     "typescript": "~5.4.0"
   },
   "dependencies": {
-    "crypto-js": "^4.2.0"
+    "libsodium-wrappers": "^0.7.13"
   },
   "peerDependencies": {
     "inngest": "^3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,16 +229,16 @@ importers:
 
   packages/middleware-encryption:
     dependencies:
-      crypto-js:
-        specifier: ^4.2.0
-        version: 4.2.0
       inngest:
         specifier: ^3.0.0
         version: 3.7.0(typescript@5.4.2)
+      libsodium-wrappers:
+        specifier: ^0.7.13
+        version: 0.7.13
     devDependencies:
-      '@types/crypto-js':
-        specifier: ^4.2.1
-        version: 4.2.1
+      '@types/libsodium-wrappers':
+        specifier: ^0.7.14
+        version: 0.7.14
       typescript:
         specifier: ~5.4.0
         version: 5.4.2
@@ -2784,10 +2784,6 @@ packages:
       '@types/node': 18.16.16
     dev: true
 
-  /@types/crypto-js@4.2.1:
-    resolution: {integrity: sha512-FSPGd9+OcSok3RsM0UZ/9fcvMOXJ1ENE/ZbLfOPlBWj7BgXtEAM8VYfTtT760GiLbQIMoVozwVuisjvsVwqYWw==}
-    dev: true
-
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
     dependencies:
@@ -2902,6 +2898,10 @@ packages:
       '@types/keygrip': 1.0.5
       '@types/koa-compose': 3.2.8
       '@types/node': 18.16.16
+    dev: true
+
+  /@types/libsodium-wrappers@0.7.14:
+    resolution: {integrity: sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==}
     dev: true
 
   /@types/mdast@4.0.3:
@@ -4220,10 +4220,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  /crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    dev: false
 
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
@@ -7166,6 +7162,16 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  /libsodium-wrappers@0.7.13:
+    resolution: {integrity: sha512-kasvDsEi/r1fMzKouIDv7B8I6vNmknXwGiYodErGuESoFTohGSKZplFtVxZqHaoQ217AynyIFgnOVRitpHs0Qw==}
+    dependencies:
+      libsodium: 0.7.13
+    dev: false
+
+  /libsodium@0.7.13:
+    resolution: {integrity: sha512-mK8ju0fnrKXXfleL53vtp9xiPq5hKM0zbDQtcxQIsSmxNgSxqCj6R7Hl9PkrNe2j29T4yoDaF7DJLK9/i5iWUw==}
+    dev: false
 
   /light-my-request@5.10.0:
     resolution: {integrity: sha512-ZU2D9GmAcOUculTTdH9/zryej6n8TzT+fNGdNtm6SDp5MMMpHrJJkvAdE3c6d8d2chE9i+a//dS9CWZtisknqA==}


### PR DESCRIPTION
## Summary
Change `DefaultEncryptionService` in `@inngest/middleware-encryption` to use libsodium. This is a breaking change.

Standardizing our SDKs' encryption middlewares on libsodium allows for easy interoperability. For example, our TypeScript SDK could send an encrypted event to our Python SDK.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
