### PR TITLE
Relax middleware reqArgs type from unknown to any

### DIFF
--- a/.changeset/shiny-wolves-hide.md
+++ b/.changeset/shiny-wolves-hide.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Relax middleware reqArgs type from unknown to any

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -398,7 +398,6 @@ export namespace InngestFunction {
       burst?: number;
     };
 
-
     /**
      * Debounce delays functions for the `period` specified. If an event is sent,
      * the function will not run until at least `period` has elapsed.

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -4,7 +4,7 @@ import { Inngest } from "@local/components/Inngest";
 import { referenceFunction } from "@local/components/InngestFunctionReference";
 import { InngestMiddleware } from "@local/components/InngestMiddleware";
 import { ExecutionVersion } from "@local/components/execution/InngestExecution";
-import { type IsEqual, type IsUnknown } from "@local/helpers/types";
+import { type IsEqual, type IsAny } from "@local/helpers/types";
 import { StepOpCode } from "@local/types";
 import {
   assertType,
@@ -21,13 +21,13 @@ describe("stacking and inference", () => {
         init() {
           return {
             onFunctionRun({ reqArgs }) {
-              assertType<IsEqual<typeof reqArgs, readonly unknown[]>>(true);
-              assertType<IsUnknown<(typeof reqArgs)[number]>>(true);
+              assertType<IsEqual<typeof reqArgs, readonly any[]>>(true);
+              assertType<IsAny<(typeof reqArgs)[number]>>(true);
 
               return {
                 transformInput({ reqArgs }) {
-                  assertType<IsEqual<typeof reqArgs, readonly unknown[]>>(true);
-                  assertType<IsUnknown<(typeof reqArgs)[number]>>(true);
+                  assertType<IsEqual<typeof reqArgs, readonly any[]>>(true);
+                  assertType<IsAny<(typeof reqArgs)[number]>>(true);
                 },
               };
             },

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -401,7 +401,8 @@ type MiddlewareRunArgs = Readonly<{
    * The raw arguments given to serve handler being used to execute the
    * function.
    */
-  reqArgs: Readonly<unknown[]>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reqArgs: Readonly<any[]>;
 }>;
 
 /**

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -768,7 +768,9 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
          */
         console.warn(
           prettyError({
-            whatHappened: `We detected that you have nested \`step.*\` tooling in \`${opId.displayName ?? opId.id}\``, 
+            whatHappened: `We detected that you have nested \`step.*\` tooling in \`${
+              opId.displayName ?? opId.id
+            }\``,
             consequences: "Nesting `step.*` tooling is not supported.",
             type: "warn",
             reassurance:


### PR DESCRIPTION
## Summary

When I am trying to type my Inngest Hono middleware

```typescript
import type { Context, Env } from "hono";
import type { BlankInput } from "hono/types";
import { InngestMiddleware } from "inngest";

export const honoMiddleware = new InngestMiddleware({
  name: "Hono Middleware",
  init() {
    return {
      onFunctionRun({
        reqArgs: [c],
      }: {
        reqArgs: Readonly<
          Context<
            Env,
            "/api/inngest",
            BlankInput
          >[]
        >;
      }) {
        return {
          transformInput() {
            return {
              ctx: {
                c,
              },
            };
          },
        };
      },
    };
  },
});
```

I currently get the error

```
Type '() => { onFunctionRun({ reqArgs, }: { reqArgs: readonly Context<Env, "/api/inngest", BlankInput>[]; }): { transformInput(): { ctx: { c: Context<Env, "/api/inngest", BlankInput>; }; }; }; }' is not assignable to type 'MiddlewareRegisterFn'.
  Type '{ onFunctionRun({ reqArgs, }: { reqArgs: readonly Context<Env, "/api/inngest", BlankInput>[]; }): { transformInput(): { ctx: { c: Context<Env, "/api/inngest", BlankInput>; }; }; }; }' is not assignable to type 'MaybePromise<MiddlewareRegisterReturn>'.
    Type '{ onFunctionRun({ reqArgs, }: { reqArgs: readonly Context<Env, "/api/inngest", BlankInput>[]; }): { transformInput(): { ctx: { c: Context<Env, "/api/inngest", BlankInput>; }; }; }; }' is not assignable to type 'MiddlewareRegisterReturn'.
      Types of property 'onFunctionRun' are incompatible.
        Type '({ reqArgs, }: { reqArgs: readonly Context<Env, "/api/inngest", BlankInput>[]; }) => { transformInput(): { ctx: { c: Context<Env, "/api/inngest", BlankInput>; }; }; }' is not assignable to type '(ctx: Readonly<{ readonly steps: Readonly<{ id: string; data?: any; error?: any; }>[]; readonly fn: Any; readonly reqArgs: readonly unknown[]; ctx: Pick<Record<string, unknown> & Readonly<BaseContext<Any, string>>, "event" | "runId">; }>) => MaybePromise<...>'.
          Types of parameters '__0' and 'ctx' are incompatible.
            Type 'Readonly<{ readonly steps: Readonly<{ id: string; data?: any; error?: any; }>[]; readonly fn: Any; readonly reqArgs: readonly unknown[]; ctx: Pick<Record<string, unknown> & Readonly<BaseContext<Any, string>>, "event" | "runId">; }>' is not assignable to type '{ reqArgs: readonly Context<Env, "/api/inngest", BlankInput>[]; }'.
              Types of property 'reqArgs' are incompatible.
                Type 'readonly unknown[]' is not assignable to type 'readonly Context<Env, "/api/inngest", BlankInput>[]'.
                  Type 'unknown' is not assignable to type 'Context<Env, "/api/inngest", BlankInput>'.
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [X] Added changesets if applicable

## Related

Also fixed lint errors that popped up
