### PR TITLE
Optimize memoization

### DIFF
--- a/.changeset/silver-impalas-happen.md
+++ b/.changeset/silver-impalas-happen.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Optimize memoization of steps, providing a performance improvement of up 48x for very high step counts

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -631,6 +631,20 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     let foundStepsToReport: FoundStep[] = [];
 
     /**
+     * A map of the subset of found steps to report that have not yet been
+     * handled. Used for fast access to steps that need to be handled in order.
+     */
+    let unhandledFoundStepsToReport: Record<string, FoundStep> = {};
+
+    /**
+     * An ordered list of step IDs that have yet to be handled in this
+     * execution. Used to ensure that we handle steps in the order they were
+     * found and based on the `stepCompletionOrder` in this execution's state.
+     */
+    const remainingStepCompletionOrder: string[] =
+      this.state.stepCompletionOrder.slice();
+
+    /**
      * A promise that's used to ensure that step reporting cannot be run more than
      * once in a given asynchronous time span.
      */
@@ -710,14 +724,18 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         .then(() => {
           foundStepsReportPromise = undefined;
 
-          for (let i = 0; i < this.state.stepCompletionOrder.length; i++) {
-            const handled = foundStepsToReport
-              .find((step) => {
-                return step.hashedId === this.state.stepCompletionOrder[i];
-              })
-              ?.handle();
+          for (let i = 0; i < remainingStepCompletionOrder.length; i++) {
+            const nextStepId = remainingStepCompletionOrder[i];
+            if (!nextStepId) {
+              // Strange - removed this empty index
+              remainingStepCompletionOrder.splice(i, 1);
+              continue;
+            }
 
+            const handled = unhandledFoundStepsToReport[nextStepId]?.handle();
             if (handled) {
+              remainingStepCompletionOrder.splice(i, 1);
+              delete unhandledFoundStepsToReport[nextStepId];
               return void reportNextTick();
             }
           }
@@ -726,6 +744,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
           // found and report it.
           const steps = [...foundStepsToReport] as [FoundStep, ...FoundStep[]];
           foundStepsToReport = [];
+          unhandledFoundStepsToReport = {};
 
           return void this.state.setCheckpoint({
             type: "steps-found",
@@ -739,6 +758,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
      */
     const pushStepToReport = (step: FoundStep) => {
       foundStepsToReport.push(step);
+      unhandledFoundStepsToReport[step.hashedId] = step;
       reportNextTick();
     };
 

--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -33,7 +33,7 @@ export const createFrozenPromise = (): Promise<unknown> => {
  * Returns a Promise that resolves after the current event loop's microtasks
  * have finished, but before the next event loop tick.
  */
-export const resolveAfterPending = (): Promise<void> => {
+export const resolveAfterPending = (count = 1000): Promise<void> => {
   /**
    * This uses a brute force implementation that will continue to enqueue
    * microtasks 1000 times before resolving. This is to ensure that the
@@ -50,7 +50,7 @@ export const resolveAfterPending = (): Promise<void> => {
 
     const iterate = () => {
       shimQueueMicrotask(() => {
-        if (i++ > 1000) {
+        if (i++ > count) {
           return resolve();
         }
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Memoization of large numbers of steps can take a long time in a single request. This is at its worst when steps reach higher limits and are all synchronous with no parallelism.

This particular loop causes a nasty performance hitch, resulting in functions with large synchronous step counts to take an incredibly long time to memoize before execution starts. With this change, we see a 2x improvement in performance for low step counts, a 4x improvement for high step counts, and a 48x improvement for exceedingly high step counts of 10k.

Our preservation of [`Promise.race()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race) functionality is what causes the remainder of the latency; we allow the JS event loop to find many steps and process them as a batches to ensure that we can order their resolution appropriately, thereby preserving the output of `Promise.race()` calls.

Ceasing to support `Promise.race()` would mean removal of this technique, resulting in a huge performance increase as we no longer need to batch found steps. This can be discussed outside of this PR, but should be noted as the remaining delay after these improvements.

### Benchmarks

These are performed with the scrappy benchmarking added in #559.

<details>
<summary>Before</summary>

```
benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• execution
------------------------------------------------------------ -----------------------------
memoized-steps/0       8'743 ns/iter   (6'075 ns … 2'320 µs)  7'683 ns 23'873 ns    145 µs
memoized-steps/1         165 µs/iter     (134 µs … 1'930 µs)    157 µs    343 µs  1'600 µs
memoized-steps/10        937 µs/iter     (767 µs … 2'935 µs)    927 µs  2'356 µs  2'935 µs
memoized-steps/100    10'330 µs/iter  (9'120 µs … 11'984 µs) 11'063 µs 11'984 µs 11'984 µs
memoized-steps/500       144 ms/iter       (138 ms … 152 ms)    146 ms    152 ms    152 ms
memoized-steps/1000      797 ms/iter       (781 ms … 813 ms)    811 ms    813 ms    813 ms
memoized-steps/2000    5'337 ms/iter   (5'260 ms … 5'465 ms)  5'452 ms  5'465 ms  5'465 ms
memoized-steps/5000   78'726 ms/iter (75'928 ms … 84'101 ms) 81'857 ms 84'101 ms 84'101 ms
memoized-steps/10000      724 s/iter         (705 s … 746 s)     738 s     746 s     746 s
```
</details>
<details>
<summary>After</summary>

```
benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• execution
------------------------------------------------------------ -----------------------------
memoized-steps/0       9'925 ns/iter   (6'533 ns … 2'539 µs)  8'695 ns 27'181 ns    123 µs
memoized-steps/1         178 µs/iter     (139 µs … 2'092 µs)    172 µs    364 µs  2'018 µs
memoized-steps/10        930 µs/iter     (780 µs … 2'993 µs)    906 µs  2'613 µs  2'993 µs
memoized-steps/100     9'595 µs/iter  (8'443 µs … 11'699 µs) 10'347 µs 11'699 µs 11'699 µs
memoized-steps/500    71'044 µs/iter (67'939 µs … 72'297 µs) 71'996 µs 72'297 µs 72'297 µs
memoized-steps/1000      198 ms/iter       (191 ms … 206 ms)    205 ms    206 ms    206 ms
memoized-steps/2000      605 ms/iter       (582 ms … 668 ms)    610 ms    668 ms    668 ms
memoized-steps/5000    3'452 ms/iter   (3'300 ms … 3'621 ms)  3'589 ms  3'621 ms  3'621 ms
memoized-steps/10000  15'414 ms/iter (14'917 ms … 15'666 ms) 15'575 ms 15'666 ms 15'666 ms
```
</details>

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Perf fix
- [ ] ~Added unit/integration tests~ N/A Adding benchmarks in #559
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Benchmarking in #559 used
