### PR TITLE
Omit event ID in invoke type

### DIFF
--- a/.changeset/gold-apples-worry.md
+++ b/.changeset/gold-apples-worry.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Omit `id` when specifying an event for `step.invoke()`; idempotency IDs are not used here

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -485,7 +485,7 @@ type InvocationTargetOpts<TFunction extends InvokeTargetFunctionDefinition> = {
 
 type InvocationOpts<TFunction extends InvokeTargetFunctionDefinition> =
   InvocationTargetOpts<TFunction> &
-    TriggerEventFromFunction<TFunction> & {
+    Omit<TriggerEventFromFunction<TFunction>, "id"> & {
       /**
        * The step function will wait for the invocation to finish for a maximum
        * of this time, at which point the retured promise will be rejected


### PR DESCRIPTION
## Summary
Remove the event `id` option in `step.invoke` since it it's ignored

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
