### PR TITLE
Fix `"inngest/hono"` serve handler not parsing environment variables

### DIFF
--- a/examples/framework-hono/package.json
+++ b/examples/framework-hono/package.json
@@ -4,7 +4,8 @@
     "deploy": "wrangler deploy --minify src/index.ts"
   },
   "dependencies": {
-    "hono": "^4.2.7"
+    "hono": "^4.2.7",
+    "inngest": "^3.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240403.0",

--- a/packages/inngest/src/hono.ts
+++ b/packages/inngest/src/hono.ts
@@ -36,7 +36,47 @@ export const serve = (options: ServeHandlerOptions) => {
         transformResponse: ({ headers, status, body }) => {
           return c.body(body, { headers, status });
         },
-        url: () => new URL(c.req.url, c.req.header("host")),
+        url: () => {
+          try {
+            // If this is an absolute URL, use it right now.
+            return new URL(c.req.url);
+          } catch {
+            // no-op
+          }
+
+          // We now know that `c.req.url` is a relative URL, so let's try
+          // to build a base URL to pair it with.
+          const host = options.serveHost || c.req.header("host");
+          if (!host) {
+            throw new Error(
+              "No host header found in request and no `serveHost` given either."
+            );
+          }
+
+          let baseUrl = host;
+          // Only set the scheme if we don't already have one, as a user may
+          // have specified the protocol in `serveHost` as a way to force it
+          // in their environment, e.g. for testing.
+          if (!baseUrl.includes("://")) {
+            let scheme: "http" | "https" = "https";
+            try {
+              // If we're in dev, assume `http` instead. Not that we directly
+              // access the environment instead of using any helpers here to
+              // ensure compatibility with tools with Webpack which will replace
+              // this with a literal.
+              // eslint-disable-next-line @inngest/internal/process-warn
+              if (process.env.NODE_ENV !== "production") {
+                scheme = "http";
+              }
+            } catch (err) {
+              // no-op
+            }
+
+            baseUrl = `${scheme}://${baseUrl}`;
+          }
+
+          return new URL(c.req.url, baseUrl);
+        },
         queryString: (key) => c.req.query(key),
         headers: (key) => c.req.header(key),
         method: () => c.req.method,

--- a/packages/inngest/src/hono.ts
+++ b/packages/inngest/src/hono.ts
@@ -3,6 +3,7 @@ import {
   InngestCommHandler,
   type ServeHandlerOptions,
 } from "./components/InngestCommHandler";
+import { type Env } from "./helpers/env";
 import { type SupportedFrameworkName } from "./types";
 
 export const frameworkName: SupportedFrameworkName = "hono";
@@ -40,6 +41,7 @@ export const serve = (options: ServeHandlerOptions) => {
         headers: (key) => c.req.header(key),
         method: () => c.req.method,
         body: () => c.req.json(),
+        env: () => c.env as Env,
       };
     },
   });


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

The `"inngest/hono"` serve handler was not fetching environment variables, which are not reliably accessible via globals in common environments such as Cloudflare Workers.

In addition, `url` handling was a little wonky and didn't seem to handle many variants. The hope was that Hono handled that to ensure that `c.req.url` is always/never absolute, but this doesn't seem to be the case.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Supersedes #557 as we should no longer be required to manually set signing and event keys
- Fixes #560's URL issues
- Fixes _some_ of the isues in #556, though there are still some unknowns for the C++ errors there
