### PR TITLE
Handle non-JSON sync response

### DIFF
--- a/.changeset/strange-hairs-fold.md
+++ b/.changeset/strange-hairs-fold.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+More gracefully handle non-JSON sync responses.


### PR DESCRIPTION
## Summary
More gracefully handle non-JSON sync responses. It's still a failure scenario but we don't want to throw an error

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
