### PR TITLE
Fix typing for `"inngest/lambda"` handler being incorrect Proxy type

### DIFF
--- a/.changeset/tame-wolves-swim.md
+++ b/.changeset/tame-wolves-swim.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix typing for `"inngest/lambda"` handler being incorrect Proxy type

--- a/packages/inngest/src/lambda.ts
+++ b/packages/inngest/src/lambda.ts
@@ -26,7 +26,6 @@
 
 import {
   type APIGatewayEvent,
-  type APIGatewayProxyEvent,
   type APIGatewayProxyEventV2,
   type APIGatewayProxyResult,
   type Context,
@@ -73,14 +72,14 @@ export const frameworkName: SupportedFrameworkName = "aws-lambda";
 export const serve = (
   options: ServeHandlerOptions
 ): ((
-  event: Either<APIGatewayProxyEvent, APIGatewayProxyEventV2>,
+  event: Either<APIGatewayEvent, APIGatewayProxyEventV2>,
   _context: Context
 ) => Promise<APIGatewayProxyResult>) => {
   const handler = new InngestCommHandler({
     frameworkName,
     ...options,
     handler: (
-      event: Either<APIGatewayProxyEvent, APIGatewayProxyEventV2>,
+      event: Either<APIGatewayEvent, APIGatewayProxyEventV2>,
       _context: Context
     ) => {
       /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fix incorrect type being used for `"inngest/lambda"` handler following #587.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Caused by #587
