### PR TITLE
Set explicit return types for `"inngest/fastify"`

### DIFF
--- a/.changeset/brave-camels-appear.md
+++ b/.changeset/brave-camels-appear.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Set explicit return types for `"inngest/fastify"` for JSR publishing

--- a/packages/inngest/src/fastify.ts
+++ b/packages/inngest/src/fastify.ts
@@ -50,6 +50,7 @@
  */
 
 import {
+  type FastifyInstance,
   type FastifyPluginCallback,
   type FastifyReply,
   type FastifyRequest,
@@ -105,7 +106,12 @@ type InngestPluginOptions = {
  *
  * @public
  */
-export const serve = (options: ServeHandlerOptions) => {
+export const serve = (
+  options: ServeHandlerOptions
+): ((
+  req: FastifyRequest<{ Querystring: Record<string, string | undefined> }>,
+  reply: FastifyReply
+) => Promise<unknown>) => {
   const handler = new InngestCommHandler({
     frameworkName,
     ...options,
@@ -173,7 +179,11 @@ export const serve = (options: ServeHandlerOptions) => {
  *
  * @public
  */
-const fastifyPlugin = ((fastify, options, done) => {
+const fastifyPlugin: (
+  fastify: FastifyInstance,
+  options: InngestPluginOptions,
+  done: (err?: Error | undefined) => void
+) => void = ((fastify, options, done): void => {
   if (!options?.client) {
     throw new Error(
       "Inngest `client` is required when serving with Fastify plugin"


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Address "slow types" for `"inngest/fastify"` handler.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
