### PR TITLE
Fix/incorrect custom fetch wrapping

### DIFF
--- a/.changeset/hip-steaks-pay.md
+++ b/.changeset/hip-steaks-pay.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix serve handler's `fetch` implementation incorrectly being marked as custom if no custom `fetch` is given to `new Inngest()`

--- a/.changeset/sixty-walls-cough.md
+++ b/.changeset/sixty-walls-cough.md
@@ -1,0 +1,9 @@
+---
+"inngest": patch
+---
+
+Reduce incorrect occurences of the following log when a call with `fetch` fails
+
+```
+A request failed when using a custom fetch implementation; this may be a misconfiguration. Make sure that your fetch client is correctly bound to the global scope.
+```

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -1,6 +1,5 @@
 import { type fetch } from "cross-fetch";
 import { type ExecutionVersion } from "../components/execution/InngestExecution";
-import { getFetch } from "../helpers/env";
 import { getErrorMessage } from "../helpers/errors";
 import { fetchWithAuthFallback } from "../helpers/net";
 import { hashSigningKey } from "../helpers/strings";
@@ -20,7 +19,7 @@ interface InngestApiConstructorOpts {
   baseUrl?: string;
   signingKey: string;
   signingKeyFallback: string | undefined;
-  fetch?: FetchT;
+  fetch: FetchT;
 }
 
 export class InngestApi {
@@ -38,7 +37,7 @@ export class InngestApi {
     this.baseUrl = baseUrl;
     this.signingKey = signingKey;
     this.signingKeyFallback = signingKeyFallback;
-    this.fetch = getFetch(fetch);
+    this.fetch = fetch;
   }
 
   private get hashedKey(): string {

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -1,4 +1,4 @@
-import { EventSchemas } from "@local";
+import { EventSchemas, InngestCommHandler } from "@local";
 import { serve } from "@local/next";
 import { z } from "zod";
 import { createClient } from "../test/helpers";
@@ -63,5 +63,26 @@ describe("ServeHandler", () => {
 
       serve({ client: inngest, functions });
     });
+  });
+});
+
+describe("#597", () => {
+  test("does not mark `fetch` as custom if none given to `new Inngest()`", () => {
+    const inngest = createClient({ id: "test" });
+
+    const commHandler = new InngestCommHandler({
+      client: inngest,
+      frameworkName: "test-framework",
+      functions: [],
+      handler: () => ({
+        body: () => "body",
+        headers: () => undefined,
+        method: () => "GET",
+        url: () => new URL("https://www.inngest.com"),
+        transformResponse: (response) => response,
+      }),
+    });
+
+    expect(commHandler["fetch"]).toBe(inngest["fetch"]);
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -445,7 +445,7 @@ export class InngestCommHandler<
       })
       .parse(options.streaming || this.env[envKeys.InngestStreaming]);
 
-    this.fetch = getFetch(options.fetch || this.client["fetch"]);
+    this.fetch = options.fetch ? getFetch(options.fetch) : this.client["fetch"];
   }
 
   /**

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -472,7 +472,10 @@ export const getFetch = (givenFetch?: typeof fetch): typeof fetch => {
          * We also use this opportunity to log the causing error, as code higher
          * up the stack will likely abstract this.
          */
-        if (err instanceof Error && err.message?.startsWith("fetch failed")) {
+        if (
+          !(err instanceof Error) ||
+          !err.message?.startsWith("fetch failed")
+        ) {
           console.warn(
             "A request failed when using a custom fetch implementation; this may be a misconfiguration. Make sure that your fetch client is correctly bound to the global scope."
           );

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -465,9 +465,20 @@ export const getFetch = (givenFetch?: typeof fetch): typeof fetch => {
       try {
         return await givenFetch(...args);
       } catch (err) {
-        console.warn(
-          "A request failed when using a custom fetch implementation; this may be a misconfiguration. Make sure that your fetch client is correctly bound to the global scope."
-        );
+        /**
+         * Capture warnings that are not simple fetch failures and highlight
+         * them for the user.
+         *
+         * We also use this opportunity to log the causing error, as code higher
+         * up the stack will likely abstract this.
+         */
+        if (err instanceof Error && err.message?.startsWith("fetch failed")) {
+          console.warn(
+            "A request failed when using a custom fetch implementation; this may be a misconfiguration. Make sure that your fetch client is correctly bound to the global scope."
+          );
+          console.error(err);
+        }
+
         throw err;
       }
     };


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

A warning log for when a custom fetch implementation is suspected to be broken is a bit too spammy.

```
A request failed when using a custom fetch implementation; this may be a misconfiguration. Make sure that your fetch client is correctly bound to the global scope.
```

This log is intended to be shown when we suspect that the given fetch implementation is invalid and seems to not be functioning correctly, for example if it has lost its binding after being passed in an object.

At present, however, it is logged upon every failure, even if it is correctly handled by code further up the stack.

This PR ensures we only log if it's not an expected fetch failure like failing to reach a server, which still indicates that the implementation is functional.

It also fixes an issue where the fetch implementation used by the `InngestCommHandler` is wrapped and treated as custom if no custom implementation has been given to `new Inngest()`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [x] Added unit/integration tests
- [x] Added changesets if applicable