### PR TITLE
Give all serve-related peer deps a larger range and make them optional

### DIFF
--- a/.changeset/healthy-needles-glow.md
+++ b/.changeset/healthy-needles-glow.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Give all `serve()`-related peer dependencies a wider range and make them optional, silencing warnings when installing `inngest`

--- a/.changeset/new-cups-kiss.md
+++ b/.changeset/new-cups-kiss.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-encryption": patch
+---
+
+Widen range of `inngest` peer dependency

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -241,15 +241,47 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": ">=1.27.3",
-    "@vercel/node": "^2.15.9",
-    "aws-lambda": "^1.0.7",
-    "express": "^4.19.2",
-    "fastify": "^4.21.0",
-    "h3": "^1.8.1",
-    "hono": "^4.2.7",
-    "koa": "^2.14.2",
+    "@vercel/node": ">=2.15.9",
+    "aws-lambda": ">=1.0.7",
+    "express": ">=4.19.2",
+    "fastify": ">=4.21.0",
+    "h3": ">=1.8.1",
+    "hono": ">=4.2.7",
+    "koa": ">=2.14.2",
     "next": ">=12.0.0",
     "typescript": ">=4.7.2"
+  },
+  "peerDependenciesMeta": {
+    "@sveltejs/kit": {
+      "optional": true
+    },
+    "@vercel/node": {
+      "optional": true
+    },
+    "aws-lambda": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    },
+    "fastify": {
+      "optional": true
+    },
+    "h3": {
+      "optional": true
+    },
+    "hono": {
+      "optional": true
+    },
+    "koa": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=14"

--- a/packages/middleware-encryption/package.json
+++ b/packages/middleware-encryption/package.json
@@ -40,6 +40,6 @@
     "crypto-js": "^4.2.0"
   },
   "peerDependencies": {
-    "inngest": "^3.0.0"
+    "inngest": ">=3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Widen the range of peer dependencies to assume support for later major versions until proven otherwise.

In addition, `serve()`-related peer dependencies are all marked as optional, ensuring modern package managers do not complain when it finds they are not installed; users will need at most one of these dependencies, so warning for all of them makes no sense.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #603 
