### PR TITLE
Add support for global `Netlify.env` objects

### DIFF
--- a/.changeset/famous-gorillas-run.md
+++ b/.changeset/famous-gorillas-run.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add support for global `Netlify.env` objects when accessing environment variables

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -244,7 +244,17 @@ export const processEnv = (key: string): EnvValue => {
   return allProcessEnv()[key];
 };
 
+/**
+ * The Deno environment, which is not always available.
+ */
 declare const Deno: {
+  env: { toObject: () => Env };
+};
+
+/**
+ * The Netlify environment, which is not always available.
+ */
+declare const Netlify: {
   env: { toObject: () => Env };
 };
 
@@ -257,6 +267,7 @@ declare const Deno: {
  * where it may not be defined, such as Deno or the browser.
  */
 export const allProcessEnv = (): Env => {
+  // Node, or Node-like environments
   try {
     // eslint-disable-next-line @inngest/internal/process-warn
     if (process.env) {
@@ -267,8 +278,20 @@ export const allProcessEnv = (): Env => {
     // noop
   }
 
+  // Deno
   try {
     const env = Deno.env.toObject();
+
+    if (env) {
+      return env;
+    }
+  } catch (_err) {
+    // noop
+  }
+
+  // Netlify
+  try {
+    const env = Netlify.env.toObject();
 
     if (env) {
       return env;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Netlify, though it uses Deno under the hood, rename `Deno.env` to `Netlify.env`. This PR adds support for this new global and ensures we use it to access environment variables.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
