### PR TITLE
Fix event key hash assuming hex

### DIFF
--- a/.changeset/mighty-queens-rest.md
+++ b/.changeset/mighty-queens-rest.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix event key appearing invalid when securely introspected via the dashboard

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -105,7 +105,7 @@ export const stringifyUnknown = (input: unknown): string | undefined => {
 };
 
 export const hashEventKey = (eventKey: string): string => {
-  return sha256().update(eventKey, "hex").digest("hex");
+  return sha256().update(eventKey).digest("hex");
 };
 
 export const hashSigningKey = (signingKey: string | undefined): string => {


### PR DESCRIPTION
## Summary
Fix event key hasher assuming the event key is a hex string

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable