### PR TITLE
Fix missing path when using INNGEST_DEV URL

### DIFF
--- a/.changeset/polite-carrots-reply.md
+++ b/.changeset/polite-carrots-reply.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix attempting to register without a path when using a URL from `INNGEST_DEV`

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1313,7 +1313,10 @@ export class InngestCommHandler<
         registerURL = devServerUrl(host, "/fn/register");
       }
     } else if (this._mode?.explicitDevUrl) {
-      registerURL = new URL(this._mode.explicitDevUrl);
+      registerURL = devServerUrl(
+        this._mode.explicitDevUrl.href,
+        "/fn/register"
+      );
     }
 
     if (deployId) {


### PR DESCRIPTION
## Summary
Fix missing path when setting a URL with `INNGEST_DEV`

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
