### PR TITLE
Add maximum recursion depth for object path finding

### DIFF
--- a/.changeset/sharp-suns-poke.md
+++ b/.changeset/sharp-suns-poke.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add maximum recursion depth for object path typing for `step.waitForEvent()`'s `match` and `cancelOn`

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -4,6 +4,7 @@ import { type Jsonify } from "../helpers/jsonify";
 import { timeStr } from "../helpers/strings";
 import {
   type ExclusiveKeys,
+  type IsStringLiteral,
   type ObjectPaths,
   type ParametersExceptFirst,
   type SendEventPayload,
@@ -548,8 +549,12 @@ type WaitForEventOpts<
      *
      * {@link https://www.inngest.com/docs/functions/expressions}
      */
-    match?: ObjectPaths<Events[TriggeringEvent]> &
-      ObjectPaths<Events[IncomingEvent]>;
+    match?: IsStringLiteral<keyof Events & string> extends true
+      ? IsStringLiteral<IncomingEvent & string> extends true
+        ? ObjectPaths<Events[TriggeringEvent]> &
+            ObjectPaths<Events[IncomingEvent]>
+        : string
+      : string;
 
     /**
      * If provided, the step function will wait for the incoming event to match

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -120,6 +120,24 @@ type AnyIsEqual<T1, T2> = T1 extends T2
   : never;
 
 /**
+ * The maximum recursion depth for object paths when traversing an object. For
+ * example, a depth of `2` would find `data.foo`, `data.foo.bar`, but not
+ * `data.foo.bar.baz`.
+ *
+ * Current (TS 5.4) versions of TypeScript have a high base recursion depth of
+ * 1000, though the repeated mapping of object paths is intensive; just getting
+ * to that depth incurs a significant performance cost, resulting in TypeScript
+ * appearing to hang instead of reaching its limit.
+ *
+ * We combat a facet of this issue by limiting the recurson depth here, though
+ * the sheer number of events can also stress the compiler.
+ *
+ * In the future, we will remove this field in favour of a more efficient CEL
+ * implementation.
+ */
+type MaxObjectPathsDepth = 8;
+
+/**
  * A helper for concatenating an existing path `K` with new paths from the
  * value `V`, making sure to skip those we've already seen in
  * `TraversedTypes`.
@@ -127,27 +145,48 @@ type AnyIsEqual<T1, T2> = T1 extends T2
  * Purposefully skips some primitive objects to avoid building unsupported or
  * recursive paths.
  */
-type PathImpl<K extends string | number, V, TraversedTypes> = V extends
-  | Primitive
-  | Date
+type PathImpl<
+  K extends string | number,
+  V,
+  TraversedTypes,
+  TDepthTracker extends number[],
+> = V extends Primitive | Date
   ? `${K}`
   : true extends AnyIsEqual<TraversedTypes, V>
     ? `${K}`
-    : `${K}` | `${K}.${PathInternal<V, TraversedTypes | V>}`;
+    :
+        | `${K}`
+        | `${K}.${PathInternal<V, TraversedTypes | V, [...TDepthTracker, 0]>}`;
 
 /**
  * Start iterating over a given object `T` and return all string paths used to
  * access properties within that object as if you were in code.
  */
-type PathInternal<T, TraversedTypes = T> = T extends ReadonlyArray<infer V>
-  ? IsTuple<T> extends true
-    ? {
-        [K in TupleKeys<T>]-?: PathImpl<K & string, T[K], TraversedTypes>;
-      }[TupleKeys<T>]
-    : PathImpl<number, V, TraversedTypes>
-  : {
-      [K in keyof T]-?: PathImpl<K & string, T[K], TraversedTypes>;
-    }[keyof T];
+type PathInternal<
+  T,
+  TraversedTypes = T,
+  TDepthTracker extends number[] = [],
+> = TDepthTracker["length"] extends MaxObjectPathsDepth
+  ? never
+  : T extends ReadonlyArray<infer V>
+    ? IsTuple<T> extends true
+      ? {
+          [K in TupleKeys<T>]-?: PathImpl<
+            K & string,
+            T[K],
+            TraversedTypes,
+            TDepthTracker
+          >;
+        }[TupleKeys<T>]
+      : PathImpl<number, V, TraversedTypes, TDepthTracker>
+    : {
+        [K in keyof T]-?: PathImpl<
+          K & string,
+          T[K],
+          TraversedTypes,
+          TDepthTracker
+        >;
+      }[keyof T];
 
 /**
  * Given an object, recursively return all string paths used to access


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Calculating object paths for typing is computationally expensive. We use this technique for `step.waitForEvent()`'s `match` option and some parts of function configuration, such as `cancelOn`.

Depending on the sheer size of some events, these comparisons can generate tens of thousands of valid strings, resulting in a lot of recursion and processing by the language server. In unlucky cases, the compiler appears to hang indefinitely as it recurses, taking an unreasonable amount of time to hit the built-in depth of 1,000.

This change ensures we never try to go as deep, limiting our recursion to `8`. This means that, when validating the `match` property, we will find and allow...
```
"data.foo.bar.baz.qux.quux.corge.grault.garply"
```
...but not...
```
"data.foo.bar.baz.qux.quux.corge.grault.garply.waldo"
```
Use of the latter can still be specified using the `if` property:
```
"event.data.foo.bar.baz.qux.quux.corge.grault.garply.waldo == async.data.foo.bar.baz.qux.quux.corge.grault.garply.waldo"
```

Note that these changes only address one facet of the complexity of calculating the object paths here; sheer volume of events can still overwhelm the compiler. In the future, we will remove this field and typing in favour of CEL expressions with better DX.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~Added unit/integration tests~ N/A Existing tests cover
- [x] Added changesets if applicable
