### PR TITLE
Remove `private` modifier from `createExecution` method on `InngestFunction`

### DIFF
--- a/.changeset/quiet-pumas-relax.md
+++ b/.changeset/quiet-pumas-relax.md
@@ -1,0 +1,7 @@
+---
+"inngest": patch
+---
+
+Expose `InngestFunction#createExecution()` as a `protected` method to allow custom unit testing.
+
+Note that this is an internal API and can change at any time; first-party testing tools will be adde at a later date.

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -12,8 +12,6 @@ import {
   NonRetriableError,
   type EventPayload,
 } from "@local";
-import { InngestFunction } from "@local/components/InngestFunction";
-import { STEP_INDEXING_SUFFIX } from "@local/components/InngestStepTools";
 import {
   ExecutionVersion,
   PREFERRED_EXECUTION_VERSION,
@@ -22,6 +20,8 @@ import {
   type InngestExecutionOptions,
 } from "@local/components/execution/InngestExecution";
 import { _internals } from "@local/components/execution/v1";
+import { InngestFunction } from "@local/components/InngestFunction";
+import { STEP_INDEXING_SUFFIX } from "@local/components/InngestStepTools";
 import { internalEvents } from "@local/helpers/consts";
 import {
   ErrCode,
@@ -408,11 +408,16 @@ describe("runFn", () => {
                 (ret.type === "step-ran" || ret.type === "steps-found")
               ) {
                 test("output hashes match expected shape", () => {
+                  // Horrible syntax for TS 4.7+ compatibility - lack of narrowing
                   const outgoingOps: OutgoingOp[] =
                     ret!.type === "step-ran"
-                      ? [ret!.step]
+                      ? [
+                          (ret as Extract<typeof ret, { type: "step-ran" }>)!
+                            .step,
+                        ]
                       : ret!.type === "steps-found"
-                        ? ret!.steps
+                        ? (ret as Extract<typeof ret, { type: "steps-found" }>)!
+                            .steps
                         : [];
 
                   outgoingOps.forEach((op) => {

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -209,7 +209,7 @@ export class InngestFunction<
     return config;
   }
 
-  createExecution(opts: CreateExecutionOptions): IInngestExecution {
+  protected createExecution(opts: CreateExecutionOptions): IInngestExecution {
     const options: InngestExecutionOptions = {
       client: this.client,
       fn: this,

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -209,7 +209,7 @@ export class InngestFunction<
     return config;
   }
 
-  private createExecution(opts: CreateExecutionOptions): IInngestExecution {
+  createExecution(opts: CreateExecutionOptions): IInngestExecution {
     const options: InngestExecutionOptions = {
       client: this.client,
       fn: this,

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -514,3 +514,12 @@ export type IsLiteral<T, Then = true, Else = false> = string extends T
 export type KnownKeys<T> = keyof {
   [K in keyof T as IsLiteral<K, K, never>]: T[K];
 };
+
+/**
+ * Given an object `T`, return the keys of that object that are public, ignoring
+ * `private` and `protected` keys.
+ *
+ * This shouldn't commonly be used or exposed in user-facing types, as it can
+ * skew extension checks.
+ */
+export type Public<T> = { [K in keyof T]: T[K] };

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import { type EventSchemas } from "./components/EventSchemas";
 import {
+  type builtInMiddleware,
   type GetEvents,
   type Inngest,
-  type builtInMiddleware,
 } from "./components/Inngest";
 import { type InngestFunction } from "./components/InngestFunction";
 import { type InngestFunctionReference } from "./components/InngestFunctionReference";
@@ -19,6 +19,7 @@ import {
   type IsNever,
   type IsStringLiteral,
   type ObjectPaths,
+  type Public,
   type Simplify,
   type WithoutInternal,
 } from "./helpers/types";
@@ -1161,8 +1162,8 @@ export type EventsFromFunction<T extends InngestFunction.Any> =
  * @public
  */
 export type InvokeTargetFunctionDefinition =
-  | InngestFunctionReference.Any
-  | InngestFunction.Any
+  | Public<InngestFunctionReference.Any>
+  | Public<InngestFunction.Any>
   | string;
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->
Removed `private` modifier from `createExecution` method on `InngestFunction` in order to allow calling created functions in the apps that use `inngest-js`.

---

When I was researching opportunities on testing my inngest functions, I found out that Inngest already has an option to call the create function that it uses internally for testing: `InngestFunction.createExecution`. It is used the the Inngest's own test files, e.g. [`InngestFunction.test.ts`](https://github.com/inngest/inngest-js/blob/baa9e5e63397943cd3c65896d7e908bf451e3c20/packages/inngest/src/components/InngestFunction.test.ts#L149)

It even seems to be working in my setup, if I ignore the type errors.

However, the `createExecution` method is not typed, resulting in very bad DX:
![CleanShot 2024-06-16 at 19 24 36@2x](https://github.com/inngest/inngest-js/assets/16190582/8b6edb55-6483-427c-853a-8687cc2fa664)

To add type definitions to this method, I removed the `private` modifier so that declarations for this method ship with the library, allowing developers to call/test created functions.


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A still too raw to add docs for testing
- [ ] ~~Added unit/integration tests~~
- [x] Added changesets if applicable

## Related
#468 
