### PR TITLE
Fix `"inngest/cloudflare"` not supporting Cloudflare Workers

### DIFF
--- a/.changeset/orange-monkeys-confess.md
+++ b/.changeset/orange-monkeys-confess.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+`"inngest/cloudflare"` serve handler now supports both Cloudflare Pages Functions and Cloudflare Workers

--- a/packages/inngest/src/cloudflare.ts
+++ b/packages/inngest/src/cloudflare.ts
@@ -150,5 +150,22 @@ export const serve = (
     },
   });
 
-  return handler.createHandler();
+  const requestHandler = handler.createHandler();
+  type RequestHandler = typeof requestHandler;
+
+  /**
+   * When returning the handler, we haven't yet seen the input arguments for a
+   * request, so we can't yet know if it's a Cloudflare Pages Function or a
+   * Cloudflare Worker. We'll need to assert the shape of the input arguments
+   * at runtime.
+   *
+   * This means that we cover all bases needed for export when returning the
+   * handler, ensuring both `export const onRequest = serve(...)` and `export
+   * default serve(...)` are supported.
+   */
+  return Object.defineProperties(requestHandler, {
+    fetch: { value: requestHandler },
+  }) as RequestHandler & {
+    fetch: RequestHandler;
+  };
 };

--- a/packages/inngest/src/cloudflare.ts
+++ b/packages/inngest/src/cloudflare.ts
@@ -21,10 +21,12 @@
  * import { inngest } from "../../inngest/client";
  * import fnA from "../../inngest/fnA"; // Your own function
  *
- * export default serve({
- *   client: inngest,
- *   functions: [fnA],
- * });
+ * export default {
+ *   fetch: serve({
+ *     client: inngest,
+ *     functions: [fnA],
+ *   }),
+ * };
  * ```
  *
  * @module
@@ -107,10 +109,12 @@ const deriveHandlerArgs = (
  * import { inngest } from "../../inngest/client";
  * import fnA from "../../inngest/fnA"; // Your own function
  *
- * export default serve({
- *   client: inngest,
- *   functions: [fnA],
- * });
+ * export default {
+ *   fetch: serve({
+ *     client: inngest,
+ *     functions: [fnA],
+ *   }),
+ * };
  * ```
  *
  * @public
@@ -159,21 +163,5 @@ export const serve = (
     length: { value: 2 },
   });
 
-  type RequestHandler = typeof requestHandler;
-
-  /**
-   * When returning the handler, we haven't yet seen the input arguments for a
-   * request, so we can't yet know if it's a Cloudflare Pages Function or a
-   * Cloudflare Worker. We'll need to assert the shape of the input arguments
-   * at runtime.
-   *
-   * This means that we cover all bases needed for export when returning the
-   * handler, ensuring both `export const onRequest = serve(...)` and `export
-   * default serve(...)` are supported.
-   */
-  return Object.defineProperties(requestHandler, {
-    fetch: { value: requestHandler },
-  }) as RequestHandler & {
-    fetch: RequestHandler;
-  };
+  return requestHandler;
 };

--- a/packages/inngest/src/cloudflare.ts
+++ b/packages/inngest/src/cloudflare.ts
@@ -150,7 +150,15 @@ export const serve = (
     },
   });
 
-  const requestHandler = handler.createHandler();
+  /**
+   * Assign a non-variadic length to the handler to ensure early runtime guards
+   * aren't triggered when assessing whether exported functions are valid within
+   * the framework.
+   */
+  const requestHandler = Object.defineProperties(handler.createHandler(), {
+    length: { value: 2 },
+  });
+
   type RequestHandler = typeof requestHandler;
 
   /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes missing support for Cloudflare Workers in the `"inngest/cloudflare"` serve handler by lighting asserting the shape of handler input at runtime. In addition to Cloudflare Pages:

```ts
import { serve } from "inngest/cloudflare";
import { inngest } from "../../inngest/client";
import fnA from "../../inngest/fnA"; // Your own function

export const onRequest = serve({
  client: inngest,
  functions: [fnA],
});
```

We can now also serve using Cloudflare Workers:

```ts
import { serve } from "inngest/cloudflare";
import { inngest } from "../../inngest/client";
import fnA from "../../inngest/fnA"; // Your own function

export default {
  fetch: serve({
    client: inngest,
    functions: [fnA],
  }),
};
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] ~~Added unit/integration tests~~ N/A Covered
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Addresses code side of #617 
- Docs: inngest/website#817
