### PR TITLE
Remove inspect message

### DIFF
--- a/.changeset/tidy-islands-suffer.md
+++ b/.changeset/tidy-islands-suffer.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Removed inspect message

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -995,7 +995,6 @@ export class InngestCommHandler<
           authentication_succeeded: null,
           extra: {
             is_mode_explicit: this._mode.isExplicit,
-            message: "Inngest endpoint configured correctly.",
           },
           has_event_key: this.client["eventKeySet"](),
           has_signing_key: Boolean(this.signingKey),

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -990,7 +990,6 @@ export interface UnauthenticatedIntrospection {
   authentication_succeeded: false | null;
   extra: {
     is_mode_explicit: boolean;
-    message: string;
   };
   function_count: number;
   has_event_key: boolean;


### PR DESCRIPTION
## Summary
Remove the `Inngest endpoint configured correctly.` message in the inspect endpoint. This message caused user confusion since the SDK doesn't actually know if there are any configuration issues

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
