### PR TITLE
fix: add missing concurrency options to function validation

### DIFF
--- a/.changeset/nine-cameras-argue.md
+++ b/.changeset/nine-cameras-argue.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix missing config fields such as `concurrency` when validating

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -191,7 +191,6 @@ export class InngestFunction<
     const config: FunctionConfig[] = [fn];
 
     if (this.onFailureFn) {
-      const failureOpts = { ...opts };
       const id = `${fn.id}${InngestFunction.failureSuffix}`;
       const name = `${fn.name ?? fn.id} (failure)`;
 
@@ -199,7 +198,6 @@ export class InngestFunction<
       failureStepUrl.searchParams.set(queryKeys.FnId, id);
 
       config.push({
-        ...failureOpts,
         id,
         name,
         triggers: [

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -115,7 +115,17 @@ export class InngestFunction<
     stepUrl.searchParams.set(queryKeys.FnId, fnId);
     stepUrl.searchParams.set(queryKeys.StepId, InngestFunction.stepId);
 
-    const { retries: attempts, cancelOn, ...opts } = this.opts;
+    const {
+      retries: attempts,
+      cancelOn,
+      idempotency,
+      batchEvents,
+      rateLimit,
+      throttle,
+      concurrency,
+      debounce,
+      priority,
+    } = this.opts;
 
     /**
      * Convert retries into the format required when defining function
@@ -124,13 +134,12 @@ export class InngestFunction<
     const retries = typeof attempts === "undefined" ? undefined : { attempts };
 
     const fn: FunctionConfig = {
-      ...opts,
       id: fnId,
       name: this.name,
       triggers: (this.opts.triggers ?? []).map((trigger) => {
         if ("event" in trigger) {
           return {
-            event: trigger.event,
+            event: trigger.event as string,
             expression: trigger.if,
           };
         }
@@ -150,6 +159,13 @@ export class InngestFunction<
           retries,
         },
       },
+      idempotency,
+      batchEvents,
+      rateLimit,
+      throttle,
+      concurrency,
+      debounce,
+      priority,
     };
 
     if (cancelOn) {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1086,6 +1086,14 @@ export const functionConfigSchema = z.strictObject({
       })
     )
     .optional(),
+  concurrency: z.union([
+    z.number(),
+    z.strictObject({
+      limit: z.number(),
+      key: z.string().optional(),
+      scope: z.union([z.literal("fn"), z.literal("env"), z.literal("account")]),
+    }),
+  ]),
 });
 
 /**


### PR DESCRIPTION
## Summary
After #625 we started getting these type of messages while having correct config:

> [NEXT] [Inngest] error - Config invalid for function "XXX" : Unrecognized key(s) in object: 'concurrency'

This should fix it.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

