### PR TITLE
Fix broken `debug` extension

### DIFF
--- a/.changeset/brown-turtles-vanish.md
+++ b/.changeset/brown-turtles-vanish.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix exception being thrown from `debug` when used with Nitro running on Cloudflare Pages

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -73,7 +73,7 @@ export class InngestExecution {
   protected debug: Debugger;
 
   constructor(protected options: InngestExecutionOptions) {
-    this.debug = Debug(debugPrefix).extend(this.options.runId);
+    this.debug = Debug(`${debugPrefix}:${this.options.runId}`);
   }
 }
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

[debug](https://www.npmjs.com/package/debug) is a really old library, and its browser detection is old, too. For newer pairings of framework and runtime such as Nitro + Cloudflare Pages, their code for detecting which code should be delivered doesn't catch the markers these leave behind.

One silly symptom of this is that `Debug()` returns an anonymous function with no extra properties instead of a `Debugger` instance if the wrong code is consumed following a bad detection. This results in the following `.extend()` call failing.

We fix that here by just not calling `.extend()`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Will add a Nitro example in another PR
- [x] Added changesets if applicable
