### PR TITLE
Fix failure handler inheriting config

### DIFF
--- a/.changeset/forty-parents-learn.md
+++ b/.changeset/forty-parents-learn.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix failure handler inheriting config such as `priority` and `batchEvents` from their parent function

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -175,7 +175,6 @@ export class InngestFunction<
     const config: FunctionConfig[] = [fn];
 
     if (this.onFailureFn) {
-      const failureOpts = { ...opts };
       const id = `${fn.id}${InngestFunction.failureSuffix}`;
       const name = `${fn.name ?? fn.id} (failure)`;
 
@@ -183,7 +182,6 @@ export class InngestFunction<
       failureStepUrl.searchParams.set(queryKeys.FnId, id);
 
       config.push({
-        ...failureOpts,
         id,
         name,
         triggers: [


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Failure handlers incorrectly inherit config from their parent function.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [ ] Added changesets if applicable