### PR TITLE
Shift the invalid function config error to a warning

### DIFF
--- a/.changeset/giant-bugs-worry.md
+++ b/.changeset/giant-bugs-worry.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Change an error when function configuration is invalid to a warning instead

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1245,7 +1245,7 @@ export class InngestCommHandler<
         const errors = check.error.errors.map((err) => err.message).join("; ");
 
         this.log(
-          "error",
+          "warn",
           `Config invalid for function "${config.id}" : ${errors}`
         );
       }


### PR DESCRIPTION
We just log this in case someone has included extra properties.

## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Make the `Config invalid for function` error a warning instead; we still register the function in question and only really use this log to highlight extraneous keys.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related

- Helps with issues like #630 not appear so threatening
