### PR TITLE
Fix wrong URL in inferred dev mode

### DIFF
--- a/.changeset/early-clocks-talk.md
+++ b/.changeset/early-clocks-talk.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix inferred dev mode resulting in contacting the production API when fetching large state

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
         version: "8.6.2"
         run_install: false

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -1,5 +1,6 @@
 import { type fetch } from "cross-fetch";
 import { type ExecutionVersion } from "../components/execution/InngestExecution";
+import { type Mode } from "../helpers/env";
 import { getErrorMessage } from "../helpers/errors";
 import { fetchWithAuthFallback } from "../helpers/net";
 import { hashSigningKey } from "../helpers/strings";
@@ -15,29 +16,35 @@ import {
 
 type FetchT = typeof fetch;
 
-interface InngestApiConstructorOpts {
-  baseUrl?: string;
-  signingKey: string;
-  signingKeyFallback: string | undefined;
-  fetch: FetchT;
+export namespace InngestApi {
+  export interface Options {
+    baseUrl?: string;
+    signingKey: string;
+    signingKeyFallback: string | undefined;
+    fetch: FetchT;
+    mode: Mode;
+  }
 }
 
 export class InngestApi {
-  public readonly baseUrl: string;
+  public readonly apiBaseUrl?: string;
   private signingKey: string;
   private signingKeyFallback: string | undefined;
   private readonly fetch: FetchT;
+  private mode: Mode;
 
   constructor({
-    baseUrl = "https://api.inngest.com",
+    baseUrl,
     signingKey,
     signingKeyFallback,
     fetch,
-  }: InngestApiConstructorOpts) {
-    this.baseUrl = baseUrl;
+    mode,
+  }: InngestApi.Options) {
+    this.apiBaseUrl = baseUrl;
     this.signingKey = signingKey;
     this.signingKeyFallback = signingKeyFallback;
     this.fetch = fetch;
+    this.mode = mode;
   }
 
   private get hashedKey(): string {

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -142,7 +142,7 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
    * settings, but should still check for the presence of an environment
    * variable if it is not set.
    */
-  private readonly mode: Mode;
+  private _mode: Mode;
 
   get apiBaseUrl(): string | undefined {
     return this._apiBaseUrl;
@@ -193,7 +193,7 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
 
     this.id = id;
 
-    this.mode = getMode({
+    this._mode = getMode({
       explicitMode:
         typeof isDev === "boolean" ? (isDev ? "dev" : "cloud") : undefined,
     });
@@ -219,10 +219,11 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
     this.fetch = getFetch(fetch);
 
     this.inngestApi = new InngestApi({
-      baseUrl: this.apiBaseUrl || defaultInngestApiBaseUrl,
+      baseUrl: this.apiBaseUrl,
       signingKey: processEnv(envKeys.InngestSigningKey) || "",
       signingKeyFallback: processEnv(envKeys.InngestSigningKeyFallback),
       fetch: this.fetch,
+      mode: this.mode,
     });
 
     this.logger = logger;
@@ -262,6 +263,15 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
     );
 
     return [...prefix, ...(await stack)];
+  }
+
+  private get mode(): Mode {
+    return this._mode;
+  }
+
+  private set mode(m) {
+    this._mode = m;
+    this.inngestApi["mode"] = m;
   }
 
   /**

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -202,13 +202,13 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
       baseUrl ||
       processEnv(envKeys.InngestApiBaseUrl) ||
       processEnv(envKeys.InngestBaseUrl) ||
-      this.mode.getExplicitUrl(defaultInngestApiBaseUrl);
+      this.mode.getUrlFromMode(defaultInngestApiBaseUrl);
 
     this._eventBaseUrl =
       baseUrl ||
       processEnv(envKeys.InngestEventApiBaseUrl) ||
       processEnv(envKeys.InngestBaseUrl) ||
-      this.mode.getExplicitUrl(defaultInngestEventBaseUrl);
+      this.mode.getUrlFromMode(defaultInngestEventBaseUrl);
 
     this.setEventKey(eventKey || processEnv(envKeys.InngestEventKey) || "");
 

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -202,13 +202,13 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
       baseUrl ||
       processEnv(envKeys.InngestApiBaseUrl) ||
       processEnv(envKeys.InngestBaseUrl) ||
-      this.mode.getUrlFromMode(defaultInngestApiBaseUrl);
+      this.mode.getExplicitUrl(defaultInngestApiBaseUrl);
 
     this._eventBaseUrl =
       baseUrl ||
       processEnv(envKeys.InngestEventApiBaseUrl) ||
       processEnv(envKeys.InngestBaseUrl) ||
-      this.mode.getUrlFromMode(defaultInngestEventBaseUrl);
+      this.mode.getExplicitUrl(defaultInngestEventBaseUrl);
 
     this.setEventKey(eventKey || processEnv(envKeys.InngestEventKey) || "");
 

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -763,6 +763,18 @@ export class InngestCommHandler<
     return handler;
   }
 
+  private get mode(): Mode | undefined {
+    return this._mode;
+  }
+
+  private set mode(m) {
+    this._mode = m;
+
+    if (m) {
+      this.client["mode"] = m;
+    }
+  }
+
   /**
    * Given a set of functions to check if an action is available from the
    * instance's handler, enact any action that is found.

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -152,10 +152,15 @@ export class Mode {
   }
 
   /**
-   * Considering only the mode, retrieve the URL that we are sure we should be
-   * using, not considering any environment variables or other influences.
+   * If we are explicitly in a particular mode, retrieve the URL that we are
+   * sure we should be using, not considering any environment variables or other
+   * influences.
    */
-  public getUrlFromMode(defaultCloudUrl: string): string | undefined {
+  public getExplicitUrl(defaultCloudUrl: string): string | undefined {
+    if (!this.isExplicit) {
+      return undefined;
+    }
+
     if (this.explicitDevUrl) {
       return this.explicitDevUrl.href;
     }

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -152,15 +152,10 @@ export class Mode {
   }
 
   /**
-   * If we are explicitly in a particular mode, retrieve the URL that we are
-   * sure we should be using, not considering any environment variables or other
-   * influences.
+   * Considering only the mode, retrieve the URL that we are sure we should be
+   * using, not considering any environment variables or other influences.
    */
-  public getExplicitUrl(defaultCloudUrl: string): string | undefined {
-    if (!this.isExplicit) {
-      return undefined;
-    }
-
+  public getUrlFromMode(defaultCloudUrl: string): string | undefined {
     if (this.explicitDevUrl) {
       return this.explicitDevUrl.href;
     }


### PR DESCRIPTION
## Summary
Fix a bug where the Cloud URLs were used when dev mode is inferred

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] Added unit/integration tests
- [x] Added changesets if applicable
