### PR TITLE
Add `@inngest/middleware-remote-state`

### DIFF
--- a/packages/middleware-remote-state/.gitignore
+++ b/packages/middleware-remote-state/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/middleware-remote-state/LICENSE.md
+++ b/packages/middleware-remote-state/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-remote-state/package.json
+++ b/packages/middleware-remote-state/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@inngest/middleware-remote-state",
+  "version": "0.0.0",
+  "description": "...",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc",
+    "postversion": "pnpm run build",
+    "release:version": "node ../../scripts/release/jsrVersion.js",
+    "release": "node ../../scripts/release/publish.js && pnpm dlx jsr publish --allow-dirty"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "inngest-middleware",
+    "inngest",
+    "middleware",
+    "remote",
+    "state"
+  ],
+  "homepage": "https://github.com/inngest/inngest-js/tree/main/packages/middleware-remote-state#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inngest/inngest-js.git",
+    "directory": "packages/middleware-remote-state"
+  },
+  "author": "Jack Williams <jack@inngest.com>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "inngest": "^3.19.7",
+    "typescript": "~5.4.0"
+  },
+  "peerDependencies": {
+    "inngest": ">=3.0.0"
+  }
+}

--- a/packages/middleware-remote-state/src/index.ts
+++ b/packages/middleware-remote-state/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./middleware";

--- a/packages/middleware-remote-state/src/middleware.ts
+++ b/packages/middleware-remote-state/src/middleware.ts
@@ -1,0 +1,129 @@
+import {
+  InngestMiddleware,
+  type EventPayload,
+  type InngestFunction,
+  type MiddlewareOptions,
+} from "inngest";
+
+export interface RemoteStateMiddlewareOptions {
+  /**
+   * Options are just maybes
+   */
+  service: RemoteStateService;
+}
+
+export type MemoizedSteps = Readonly<StepResult>[];
+
+export interface StepResult {
+  // note that ID is missing, as it's not exposed by the middleware everywhere
+  data?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Like a dataloader, so people can batch-load keys.
+ *
+ * They should probably receive all step data?
+ * { [stepId]: { data: ... } | { error: ...}
+ *
+ * Then return a promise that resolves with the new data.
+ *
+ * Don't mutate - pure.
+ *
+ * Errors should be able to be handled by the middleware too.
+ * We don't support that yet!
+ *
+ * Event data?
+ *
+ * Conditional saving/loading? i.e. only save/load if some data is present?
+ */
+
+export const remoteStateMiddleware = ({
+  service,
+}: RemoteStateMiddlewareOptions): InngestMiddleware<MiddlewareOptions> => {
+  const mw = new InngestMiddleware({
+    name: "Inngest: Remote State Middleware",
+    init: () => {
+      return {
+        onFunctionRun: ({ steps, ctx: { event, runId }, fn }) => {
+          return {
+            transformInput: async () => {
+              const remoteSteps = await service.loadSteps({
+                event,
+                fn,
+                runId,
+                steps,
+              });
+
+              return {
+                steps: remoteSteps,
+              };
+            },
+            transformOutput: async ({ result, step }) => {
+              // Should we also save function-level results and errors?
+              if (!step || result.error) {
+                return;
+              }
+
+              const sanitizedStepResult = await service.saveStep({
+                event,
+                fn,
+                result,
+                runId,
+                // stepId: step.id,
+              });
+
+              return {
+                result: {
+                  ...result,
+                  ...sanitizedStepResult,
+                },
+              };
+            },
+            beforeResponse: async () => {},
+          };
+        },
+      };
+    },
+  });
+
+  return mw;
+};
+
+export namespace RemoteStateService {
+  export interface LoadStepsContext {
+    event: EventPayload;
+    fn: InngestFunction.Any;
+    runId: string;
+    steps: MemoizedSteps;
+  }
+
+  export interface SaveStepContext {
+    event: EventPayload;
+    fn: InngestFunction.Any;
+    result: StepResult;
+    runId: string;
+    // stepId: string; // Middleware doesn't expose this - should it?
+  }
+}
+
+export abstract class RemoteStateService {
+  /**
+   * Given a map of known step data, load any data needed and return the data
+   * that the SDK will use to memoize state.
+   */
+  public abstract loadSteps(
+    ctx: RemoteStateService.LoadStepsContext
+  ): Promise<MemoizedSteps>;
+
+  /**
+   * Given a step, maybe save it to a remote state store and then return the
+   * data that will be sent back to Inngest. This data will be received again by
+   * another request and used to load the step data.
+   */
+  public abstract saveStep(
+    ctx: RemoteStateService.SaveStepContext
+  ): Promise<StepResult>;
+}
+
+// e.g. export class S3RemoteStateService extends RemoteStateService {...}

--- a/packages/middleware-remote-state/src/s3.ts
+++ b/packages/middleware-remote-state/src/s3.ts
@@ -1,0 +1,113 @@
+import {
+  RemoteStateService,
+  type MemoizedSteps,
+  type StepResult,
+} from "./middleware";
+
+export namespace S3RemoteStateService {
+  export type BucketKeyGenerator = (
+    ctx: RemoteStateService.SaveStepContext
+  ) => {
+    bucket: string;
+    key: string;
+  };
+
+  export interface Options {
+    // naming lol
+    generateBucketAndKey: BucketKeyGenerator;
+  }
+}
+
+/**
+ * A marker used to identify values with remote state.
+ */
+const REMOTE_STATE_MARKER = "__REMOTE_STATE__";
+
+export interface RemoteStateValue {
+  [REMOTE_STATE_MARKER]: true;
+  bucket: string;
+  key: string;
+}
+
+const isRemoteState = (value: unknown): value is RemoteStateValue => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    REMOTE_STATE_MARKER in value &&
+    value[REMOTE_STATE_MARKER] === true &&
+    "bucket" in value &&
+    typeof value["bucket"] === "string" &&
+    "key" in value &&
+    typeof value["key"] === "string"
+  );
+};
+
+// faking it
+declare const s3: {
+  putObject: (bucket: string, key: string, data: string) => Promise<void>;
+  getObject: (bucket: string, key: string) => Promise<string>;
+};
+
+export class S3RemoteStateService extends RemoteStateService {
+  protected generateBucketAndKey: S3RemoteStateService.BucketKeyGenerator;
+
+  constructor(opts: S3RemoteStateService.Options) {
+    super();
+    this.generateBucketAndKey = opts.generateBucketAndKey;
+  }
+
+  public async saveStep(
+    ctx: RemoteStateService.SaveStepContext
+  ): Promise<StepResult> {
+    const { bucket, key } = this.generateBucketAndKey(ctx);
+    const data = JSON.stringify(ctx.result); // dangerous and greedy - do we need all of this? Circular references?
+
+    await s3.putObject(bucket, key, data);
+
+    return {
+      ...ctx.result,
+      data: {
+        [REMOTE_STATE_MARKER]: true,
+        bucket,
+        key,
+      } satisfies RemoteStateValue,
+    };
+  }
+
+  public async loadSteps(
+    ctx: RemoteStateService.LoadStepsContext
+  ): Promise<MemoizedSteps> {
+    /**
+     * This is lazy. There's also the option to batch load all of the data at
+     * once, as we have access to all of the keys we need to fetch here.
+     */
+    const steps = await Promise.all(
+      ctx.steps.map(async (step) => {
+        if (!isRemoteState(step.data)) {
+          return step;
+        }
+
+        const data = await s3.getObject(step.data.bucket, step.data.key);
+
+        return {
+          ...step,
+          data: JSON.parse(data),
+        };
+      })
+    );
+
+    return steps;
+  }
+}
+
+// test
+const foo = new S3RemoteStateService({
+  generateBucketAndKey: (ctx) => {
+    // just based on run ID, which is flawed af but whatever until we get
+    // the step ID exposed
+    return {
+      bucket: "my-bucket-whatever",
+      key: `run-${ctx.runId}`,
+    };
+  },
+});


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds `@inngest/middleware-remote-state`, giving consumers an easy way to push state to a remote store with a dataloader-like API.

We could also:

- Add async `encrypt` and `decrypt` functions to `@inngest/middleware-encryption` 
- Ensure all `encrypt` and `decrypt` calls are triggered and run in parallel
- Use `@inngest/middleware-encryption` in `@inngest/middleware-remote-state` to gather all keys, then provide usual dataloader-like API

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable
