### PR TITLE
Remove incorrect type showing internal events in `step.waitForEvent()`

### DIFF
--- a/.changeset/tiny-rockets-beam.md
+++ b/.changeset/tiny-rockets-beam.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove incorrect type showing internal events in `step.waitForEvent()`

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -9,6 +9,7 @@ import {
   type ParametersExceptFirst,
   type SendEventPayload,
   type SimplifyDeep,
+  type WithoutInternalStr,
 } from "../helpers/types";
 import {
   StepOpCode,
@@ -211,7 +212,7 @@ export const createStepTools = <
      * returning `null` instead of any event data.
      */
     waitForEvent: createTool<
-      <IncomingEvent extends TriggersFromClient<TClient>>(
+      <IncomingEvent extends WithoutInternalStr<TriggersFromClient<TClient>>>(
         idOrOptions: StepOptionsOrId,
         opts: WaitForEventOpts<
           GetEvents<TClient, true>,
@@ -219,8 +220,8 @@ export const createStepTools = <
           IncomingEvent
         >
       ) => Promise<
-        IncomingEvent extends TriggersFromClient<TClient>
-          ? GetEvents<TClient, true>[IncomingEvent] | null
+        IncomingEvent extends WithoutInternalStr<TriggersFromClient<TClient>>
+          ? GetEvents<TClient, false>[IncomingEvent] | null
           : IncomingEvent | null
       >
     >(

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -79,8 +79,12 @@ export type SendEventPayload<Events extends Record<string, EventPayload>> =
  * @public
  */
 export type WithoutInternal<T extends Record<string, EventPayload>> = {
-  [K in keyof T as K extends `inngest/${string}` ? never : K]: T[K];
+  [K in keyof T as WithoutInternalStr<K & string>]: T[K];
 };
+
+export type WithoutInternalStr<T extends string> = T extends `inngest/${string}`
+  ? never
+  : T;
 
 /**
  * A list of simple, JSON-compatible, primitive types that contain no other


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`step.waitForEvent()` cannot listen for internal `inngest/*` events. This PR corrects the typing for this tool to reflect that.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
