### PR TITLE
Remove circular `ctx` type in middleware; TS <5.1 finds this hard

### DIFF
--- a/.changeset/chatty-monkeys-float.md
+++ b/.changeset/chatty-monkeys-float.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix circular `ctx` type in middleware for TS <5.1

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -418,7 +418,10 @@ type InitialRunInfo = Readonly<
        * A partial context object that will be passed to the function. Does not
        * necessarily contain all the data that will be passed to the function.
        */
-      ctx: Pick<MiddlewareRunArgs["ctx"], "event" | "runId">;
+      ctx: Readonly<{
+        event: EventPayload;
+        runId: string;
+      }>;
     }
   >
 >;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes a circular `ctx` reference affecting middleware when using mapped arguments with TS <5.1.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] Added unit/integration tests
- [x] Added changesets if applicable
