### PR TITLE
Allow specifying an `env` when sending events via the client

### DIFF
--- a/.changeset/pretty-radios-work.md
+++ b/.changeset/pretty-radios-work.md
@@ -1,0 +1,9 @@
+---
+"inngest": minor
+---
+
+Allow specifying an `env` when sending events via the client
+
+```ts
+await inngest.send({ name: "my.event" }, { env: "my-custom-env" });
+```

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -260,7 +260,7 @@ describe("send", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    test("should send env:foo if explicitly set", async () => {
+    test("should send env:foo if explicitly set in client", async () => {
       const inngest = createClient({
         id: "test",
         eventKey: testEventKey,
@@ -268,6 +268,26 @@ describe("send", () => {
       });
 
       await expect(inngest.send(testEvent)).resolves.toMatchObject({
+        ids: Array(1).fill(expect.any(String)),
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/e/${testEventKey}`),
+        expect.objectContaining({
+          method: "POST",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          headers: expect.objectContaining({
+            [headerKeys.Environment]: "foo",
+          }),
+        })
+      );
+    });
+
+    test("should send env:foo if explicitly set in send call", async () => {
+      const inngest = createClient({ id: "test", eventKey: testEventKey });
+
+      await expect(
+        inngest.send(testEvent, { env: "foo" })
+      ).resolves.toMatchObject({
         ids: Array(1).fill(expect.any(String)),
       });
       expect(global.fetch).toHaveBeenCalledWith(
@@ -305,7 +325,7 @@ describe("send", () => {
       );
     });
 
-    test("should send explicit env:foo over env var if set in both", async () => {
+    test("should send explicit env:foo over env var if set in env and client", async () => {
       process.env[envKeys.InngestEnvironment] = "bar";
 
       const inngest = createClient({
@@ -338,6 +358,32 @@ describe("send", () => {
       });
 
       await expect(inngest.send(testEvent)).resolves.toMatchObject({
+        ids: Array(1).fill(expect.any(String)),
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/e/${testEventKey}`),
+        expect.objectContaining({
+          method: "POST",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          headers: expect.objectContaining({
+            [headerKeys.Environment]: "foo",
+          }),
+        })
+      );
+    });
+
+    test("should send explicit env:foo over env var and client if set in send call", async () => {
+      process.env[envKeys.InngestEnvironment] = "bar";
+
+      const inngest = createClient({
+        id: "test",
+        eventKey: testEventKey,
+        env: "baz",
+      });
+
+      await expect(
+        inngest.send(testEvent, { env: "foo" })
+      ).resolves.toMatchObject({
         ids: Array(1).fill(expect.any(String)),
       });
       expect(global.fetch).toHaveBeenCalledWith(

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -372,9 +372,23 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
    * ```
    */
   public async send<Payload extends SendEventPayload<GetEvents<this>>>(
-    payload: Payload
+    payload: Payload,
+    options?: {
+      /**
+       * The Inngest environment to send events to. Defaults to whichever
+       * environment this client's event key is associated with.
+       *
+       * It's likely you never need to change this unless you're trying to sync
+       * multiple systems together using branch names.
+       */
+      env?: string;
+    }
   ): Promise<SendEventOutput<TClientOpts>> {
-    return this._send({ payload });
+    const headers: Record<string, string> = {
+      ...(options?.env ? { [headerKeys.Environment]: options.env } : {}),
+    };
+
+    return this._send({ payload, headers });
   }
 
   /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Be able to specify an `env` to send a batch of events to, overwriting the env specified on the client already (which defaults to the env represented by the event key).

```ts
await inngest.send({
  name: "some.event",
}, {
  env: "my-other-env",
});
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable]

## Related

- Documented in inngest/website#861
