### PR TITLE
Add new `onFunctionRun.finished` middleware hook

### DIFF
--- a/.changeset/chilly-cooks-rescue.md
+++ b/.changeset/chilly-cooks-rescue.md
@@ -1,0 +1,20 @@
+---
+"inngest": minor
+---
+
+Add a new `onFunctionRun.finished` middleware hook, allowing you to hook into a run finishing successfully or failing
+
+```ts
+new InngestMiddleware({
+  name: "My Middleware",
+  init() {
+    return {
+      onFunctionRun() {
+        finished({ result }) {
+          // ...
+        },
+      },
+    };
+  },
+});
+```

--- a/.changeset/forty-mirrors-act.md
+++ b/.changeset/forty-mirrors-act.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `beforeExecution()` hook order when all state has been used running before `afterMemoization()`

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -77,6 +77,7 @@ const opts = (<T extends ClientOptions>(x: T): T => x)({
               beforeResponse: mockHook,
               transformInput: mockHook,
               transformOutput: mockHook,
+              finished: mockHook,
             };
           },
           onSendEvent: () => {

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -339,7 +339,8 @@ export type MiddlewareRegisterReturn = {
     /**
      * The `beforeResponse` hook is called after the output has been set and
      * before the response is sent back to Inngest. This is where you can
-     * perform any final actions before the response is sent back to Inngest.
+     * perform any final actions before the response is sent back to Inngest and
+     * is the final hook called.
      */
     beforeResponse?: BlankHook;
   }>;

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -322,6 +322,21 @@ export type MiddlewareRegisterReturn = {
     transformOutput?: MiddlewareRunOutput;
 
     /**
+     * The `finished` hook is called when the function has finished executing
+     * and has returned a final response that will end the run, either a
+     * successful or error response. In the case of an error response, further
+     * retries may be attempted and call this hook again.
+     *
+     * The output provided will be after `transformOutput` has been applied.
+     *
+     * This is not guaranteed to be called on every execution, and may be called
+     * multiple times if many parallel executions reach the end of the function;
+     * for a guaranteed single execution, create a function with an event
+     * trigger of `"inngest/function.finished"`.
+     */
+    finished?: MiddlewareRunFinished;
+
+    /**
      * The `beforeResponse` hook is called after the output has been set and
      * before the response is sent back to Inngest. This is where you can
      * perform any final actions before the response is sent back to Inngest.
@@ -484,6 +499,10 @@ type MiddlewareRunOutput = (ctx: {
   result: Readonly<Pick<OutgoingOp, "error" | "data">>;
   step?: Readonly<Omit<OutgoingOp, "id">>;
 }) => MaybePromise<{ result?: Partial<Pick<OutgoingOp, "data">> } | void>;
+
+type MiddlewareRunFinished = (ctx: {
+  result: Readonly<Pick<OutgoingOp, "error" | "data">>;
+}) => MaybePromise<void>;
 
 /**
  * @internal

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -157,9 +157,7 @@ export const getHookStack = async <
       [K in keyof TResult as Await<TResult[K]> extends Parameters<TResult[K]>[0]
         ? K
         : Await<TResult[K]> extends void | undefined
-          ? Parameters<TResult[K]>[0] extends void | undefined
-            ? K
-            : never
+          ? K
           : never]: void;
     }
   >

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -491,6 +491,8 @@ export class V0InngestExecution
     const { data, error } = { ...output, ...transformedOutput?.result };
 
     if (typeof error !== "undefined") {
+      await this.state.hooks?.finished?.({ result: { error } });
+
       /**
        * Ensure we give middleware the chance to decide on retriable behaviour
        * by looking at the error returned from output transformation.
@@ -504,6 +506,8 @@ export class V0InngestExecution
 
       return { type: "function-rejected", error: serializedError, retriable };
     }
+
+    await this.state.hooks?.finished?.({ result: { data } });
 
     return { type: "function-resolved", data: undefinedToNull(data) };
   }

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -490,9 +490,13 @@ export class V0InngestExecution
 
     const { data, error } = { ...output, ...transformedOutput?.result };
 
-    if (typeof error !== "undefined") {
-      await this.state.hooks?.finished?.({ result: { error } });
+    if (!step) {
+      await this.state.hooks?.finished?.({
+        result: { ...(typeof error !== "undefined" ? { error } : { data }) },
+      });
+    }
 
+    if (typeof error !== "undefined") {
       /**
        * Ensure we give middleware the chance to decide on retriable behaviour
        * by looking at the error returned from output transformation.
@@ -506,8 +510,6 @@ export class V0InngestExecution
 
       return { type: "function-rejected", error: serializedError, retriable };
     }
-
-    await this.state.hooks?.finished?.({ result: { data } });
 
     return { type: "function-resolved", data: undefinedToNull(data) };
   }

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -542,6 +542,8 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     const { data, error } = { ...output, ...transformedOutput?.result };
 
     if (typeof error !== "undefined") {
+      await this.state.hooks?.finished?.({ result: { error } });
+
       /**
        * Ensure we give middleware the chance to decide on retriable behaviour
        * by looking at the error returned from output transformation.
@@ -557,6 +559,8 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
 
       return { type: "function-rejected", error: serializedError, retriable };
     }
+
+    await this.state.hooks?.finished?.({ result: { data } });
 
     return { type: "function-resolved", data: undefinedToNull(data) };
   }

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -881,8 +881,8 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
        */
       if (!beforeExecHooksPromise && this.state.allStateUsed()) {
         await (beforeExecHooksPromise = (async () => {
-          await this.state.hooks?.beforeExecution?.();
           await this.state.hooks?.afterMemoization?.();
+          await this.state.hooks?.beforeExecution?.();
         })());
       }
 

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -59,8 +59,17 @@ export const waterfall = <TFns extends ((arg?: any) => any)[]>(
       const prev = await acc;
       const output = (await fn(prev)) as Promise<Await<TFns[number]>>;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return transform ? await transform(prev, output) : output;
+      if (transform) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return await transform(prev, output);
+      }
+
+      if (typeof output === "undefined") {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return prev;
+      }
+
+      return output;
     }, Promise.resolve(args[0]));
 
     return chain;

--- a/packages/inngest/test/composite_project/src/index.ts
+++ b/packages/inngest/test/composite_project/src/index.ts
@@ -16,7 +16,7 @@ export const inngest = new Inngest.Inngest({
 
             return {
               transformInput(ctx) {
-                console.log(ctx);
+                console.log("transformInput", ctx);
               },
               afterExecution() {
                 console.log("afterExecution");
@@ -34,7 +34,10 @@ export const inngest = new Inngest.Inngest({
                 console.log("beforeResponse");
               },
               transformOutput(ctx) {
-                console.log(ctx);
+                console.log("transformOutput", ctx);
+              },
+              finished() {
+                console.log("finished");
               },
             };
           },


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add a new `onFunctionRun.finished` hook that will:
- Conditionally run per execution based on if the function end was reached
- Provide the user with the result or error

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #330, which also explores adding more hooks to `onFunctionRun`
- Documented in inngest/website#860
