### PR TITLE
Do not allow objectish `[]` event data; only actual objects

### DIFF
--- a/.changeset/cool-kiwis-cheer.md
+++ b/.changeset/cool-kiwis-cheer.md
@@ -1,0 +1,7 @@
+---
+"inngest": patch
+---
+
+Do not allow objectish `[]` for an event's `data` when providing schemas
+
+This helps solve an issue whereby types would be happy but sending an event fails at runtime.

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -144,6 +144,13 @@ describe("EventSchemas", () => {
       }>();
     });
 
+    test("cannot set objectish type for data", () => {
+      // @ts-expect-error Data must be object type or any
+      new EventSchemas().fromRecord<{
+        "test.event": { data: [] };
+      }>();
+    });
+
     test("can set event with matching 'name'", () => {
       const schemas = new EventSchemas().fromRecord<{
         "test.event": { name: "test.event"; data: { foo: string } };

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -23,9 +23,9 @@ import {
 export type StandardEventSchema = {
   name?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  user?: Record<string, any>;
+  user?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Disallows setting the `data` of an event to something that is not an `{}` object.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
