### PR TITLE
Revert "Do not allow objectish `[]` event data; only actual objects"

### DIFF
--- a/.changeset/quiet-kids-build.md
+++ b/.changeset/quiet-kids-build.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Revert not allowing objectish (`[]`) values in `event.data`

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -144,13 +144,6 @@ describe("EventSchemas", () => {
       }>();
     });
 
-    test("cannot set objectish type for data", () => {
-      // @ts-expect-error Data must be object type or any
-      new EventSchemas().fromRecord<{
-        "test.event": { data: [] };
-      }>();
-    });
-
     test("can set event with matching 'name'", () => {
       const schemas = new EventSchemas().fromRecord<{
         "test.event": { name: "test.event"; data: { foo: string } };

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -23,9 +23,9 @@ import {
 export type StandardEventSchema = {
   name?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: Record<string, unknown>;
+  data?: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  user?: Record<string, unknown>;
+  user?: Record<string, any>;
 };
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Revert the fix for disallowing "objectish" event data.

While `{}` are only allowed at runtime, `Record<string, unknown>` is not valid for interfaces, which require index signatures. 🫠

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Reverts #655
- Closes #658 
- Closes #659 
