### PR TITLE
Add `inngest.setEnvVars(env)` to set env vars late on the client

### DIFF
--- a/.changeset/tidy-birds-sin.md
+++ b/.changeset/tidy-birds-sin.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `inngest.setEnvVars(env)` to set env vars late on the client

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -32,7 +32,7 @@ export namespace InngestApi {
 }
 
 export class InngestApi {
-  public readonly apiBaseUrl?: string;
+  public apiBaseUrl?: string;
   private signingKey: string;
   private signingKeyFallback: string | undefined;
   private readonly fetch: FetchT;

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -10,7 +10,12 @@ import {
   type GetStepTools,
 } from "@local";
 import { type createStepTools } from "@local/components/InngestStepTools";
-import { envKeys, headerKeys, internalEvents } from "@local/helpers/consts";
+import {
+  dummyEventKey,
+  envKeys,
+  headerKeys,
+  internalEvents,
+} from "@local/helpers/consts";
 import { type IsAny, type IsEqual, type IsNever } from "@local/helpers/types";
 import { type Logger } from "@local/middleware/logger";
 import { type SendEventResponse } from "@local/types";
@@ -1024,6 +1029,50 @@ describe("createFunction", () => {
         );
       });
     });
+  });
+});
+
+describe("setEnvVars", () => {
+  test("overwrites existing env vars", () => {
+    const inngest = createClient({ id: "test" });
+
+    expect(inngest["_mode"]).toMatchObject({
+      type: "dev",
+      isExplicit: false,
+    });
+    expect(inngest["mode"]["explicitDevUrl"]).toBeUndefined();
+    expect(inngest["_apiBaseUrl"]).toBeUndefined();
+    expect(inngest["_eventBaseUrl"]).toBeUndefined();
+    expect(inngest["eventKey"]).toBe(dummyEventKey);
+    expect(inngest["inngestApi"]["apiBaseUrl"]).toBeUndefined();
+    expect(inngest["inngestApi"]["mode"]).toMatchObject({
+      type: "dev",
+      isExplicit: false,
+    });
+    expect(inngest["inngestApi"]["mode"]["explicitDevUrl"]).toBeUndefined();
+
+    const devUrl = "http://example.com:5000/";
+    const devEventKey = "dev-event-key";
+
+    inngest.setEnvVars({
+      [envKeys.InngestDevMode]: devUrl,
+      [envKeys.InngestEventKey]: devEventKey,
+    });
+
+    expect(inngest["_mode"]).toMatchObject({
+      type: "dev",
+      isExplicit: true,
+    });
+    expect(inngest["_mode"]["explicitDevUrl"]?.href).toBe(devUrl);
+    expect(inngest["_apiBaseUrl"]).toBe(devUrl);
+    expect(inngest["_eventBaseUrl"]).toBe(devUrl);
+    expect(inngest["eventKey"]).toBe(devEventKey);
+    expect(inngest["inngestApi"]["apiBaseUrl"]).toBe(devUrl);
+    expect(inngest["inngestApi"]["mode"]).toMatchObject({
+      type: "dev",
+      isExplicit: true,
+    });
+    expect(inngest["inngestApi"]["mode"]["explicitDevUrl"]?.href).toBe(devUrl);
   });
 });
 

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -226,6 +226,11 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
     ]);
   }
 
+  /**
+   * Set the environment variables for this client. This is useful if you are
+   * passed environment variables at runtime instead of as globals and need to
+   * update the client with those values as requests come in.
+   */
   public setEnvVars(
     env: Record<string, string | undefined> = allProcessEnv()
   ): this {

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -10,6 +10,7 @@ import {
 } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import {
+  allProcessEnv,
   getFetch,
   getMode,
   inngestHeaders,
@@ -103,12 +104,18 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
   public readonly id: string;
 
   /**
+   * Stores the options so we can remember explicit settings the user has
+   * provided.
+   */
+  private readonly options: TClientOpts;
+
+  /**
    * Inngest event key, used to send events to Inngest Cloud.
    */
   private eventKey = "";
 
-  private readonly _apiBaseUrl: string | undefined;
-  private readonly _eventBaseUrl: string | undefined;
+  private _apiBaseUrl: string | undefined;
+  private _eventBaseUrl: string | undefined;
 
   private readonly inngestApi: InngestApi;
 
@@ -120,7 +127,7 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
     defaultInngestEventBaseUrl
   );
 
-  private readonly headers: Record<string, string>;
+  private headers!: Record<string, string>;
 
   private readonly fetch: FetchT;
 
@@ -142,7 +149,7 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
    * settings, but should still check for the presence of an environment
    * variable if it is not set.
    */
-  private _mode: Mode;
+  private _mode!: Mode;
 
   get apiBaseUrl(): string | undefined {
     return this._apiBaseUrl;
@@ -176,16 +183,17 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
    * });
    * ```
    */
-  constructor({
-    id,
-    eventKey,
-    baseUrl,
-    fetch,
-    env,
-    logger = new DefaultLogger(),
-    middleware,
-    isDev,
-  }: TClientOpts) {
+  constructor(options: TClientOpts) {
+    this.options = options;
+
+    const {
+      id,
+      fetch,
+      logger = new DefaultLogger(),
+      middleware,
+      isDev,
+    } = this.options;
+
     if (!id) {
       // TODO PrettyError
       throw new Error("An `id` must be passed to create an Inngest instance.");
@@ -198,24 +206,6 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
         typeof isDev === "boolean" ? (isDev ? "dev" : "cloud") : undefined,
     });
 
-    this._apiBaseUrl =
-      baseUrl ||
-      processEnv(envKeys.InngestApiBaseUrl) ||
-      processEnv(envKeys.InngestBaseUrl) ||
-      this.mode.getExplicitUrl(defaultInngestApiBaseUrl);
-
-    this._eventBaseUrl =
-      baseUrl ||
-      processEnv(envKeys.InngestEventApiBaseUrl) ||
-      processEnv(envKeys.InngestBaseUrl) ||
-      this.mode.getExplicitUrl(defaultInngestEventBaseUrl);
-
-    this.setEventKey(eventKey || processEnv(envKeys.InngestEventKey) || "");
-
-    this.headers = inngestHeaders({
-      inngestEnv: env,
-    });
-
     this.fetch = getFetch(fetch);
 
     this.inngestApi = new InngestApi({
@@ -226,12 +216,48 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
       mode: this.mode,
     });
 
+    this.loadModeEnvVars();
+
     this.logger = logger;
 
     this.middleware = this.initializeMiddleware([
       ...builtInMiddleware,
       ...(middleware || []),
     ]);
+  }
+
+  public setEnvVars(
+    env: Record<string, string | undefined> = allProcessEnv()
+  ): this {
+    this.mode = getMode({ env, client: this });
+
+    return this;
+  }
+
+  private loadModeEnvVars(): void {
+    this._apiBaseUrl =
+      this.options.baseUrl ||
+      this.mode["env"][envKeys.InngestApiBaseUrl] ||
+      this.mode["env"][envKeys.InngestBaseUrl] ||
+      this.mode.getExplicitUrl(defaultInngestApiBaseUrl);
+
+    this._eventBaseUrl =
+      this.options.baseUrl ||
+      this.mode["env"][envKeys.InngestEventApiBaseUrl] ||
+      this.mode["env"][envKeys.InngestBaseUrl] ||
+      this.mode.getExplicitUrl(defaultInngestEventBaseUrl);
+
+    this.setEventKey(
+      this.options.eventKey || this.mode["env"][envKeys.InngestEventKey] || ""
+    );
+
+    this.headers = inngestHeaders({
+      inngestEnv: this.options.env,
+      env: this.mode["env"],
+    });
+
+    this.inngestApi["mode"] = this.mode;
+    this.inngestApi["apiBaseUrl"] = this._apiBaseUrl;
   }
 
   /**
@@ -271,7 +297,7 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
 
   private set mode(m) {
     this._mode = m;
-    this.inngestApi["mode"] = m;
+    this.loadModeEnvVars();
   }
 
   /**

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -121,6 +121,11 @@ export interface ModeOptions {
    * If the mode was explicitly set as a dev URL, this is the URL that was set.
    */
   explicitDevUrl?: URL;
+
+  /**
+   * Environment variables to use when determining the mode.
+   */
+  env?: Env;
 }
 
 export class Mode {
@@ -133,7 +138,15 @@ export class Mode {
 
   public readonly explicitDevUrl?: URL;
 
-  constructor({ type, isExplicit, explicitDevUrl }: ModeOptions) {
+  private readonly env: Env;
+
+  constructor({
+    type,
+    isExplicit,
+    explicitDevUrl,
+    env = allProcessEnv(),
+  }: ModeOptions) {
+    this.env = env;
     this.type = type;
     this.isExplicit = isExplicit || Boolean(explicitDevUrl);
     this.explicitDevUrl = explicitDevUrl;

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -93,7 +93,7 @@ interface IsProdOptions {
   /**
    * The optional environment variables to use instead of `process.env`.
    */
-  env?: Record<string, unknown>;
+  env?: Record<string, EnvValue>;
 
   /**
    * The Inngest client that's being used when performing this check. This is
@@ -200,7 +200,7 @@ export const getMode = ({
   explicitMode,
 }: IsProdOptions = {}): Mode => {
   if (explicitMode) {
-    return new Mode({ type: explicitMode, isExplicit: true });
+    return new Mode({ type: explicitMode, isExplicit: true, env });
   }
 
   if (client?.["mode"].isExplicit) {
@@ -211,7 +211,7 @@ export const getMode = ({
     if (typeof env[envKeys.InngestDevMode] === "string") {
       try {
         const explicitDevUrl = new URL(env[envKeys.InngestDevMode]);
-        return new Mode({ type: "dev", isExplicit: true, explicitDevUrl });
+        return new Mode({ type: "dev", isExplicit: true, explicitDevUrl, env });
       } catch {
         // no-op
       }
@@ -219,7 +219,11 @@ export const getMode = ({
 
     const envIsDev = parseAsBoolean(env[envKeys.InngestDevMode]);
     if (typeof envIsDev === "boolean") {
-      return new Mode({ type: envIsDev ? "dev" : "cloud", isExplicit: true });
+      return new Mode({
+        type: envIsDev ? "dev" : "cloud",
+        isExplicit: true,
+        env,
+      });
     }
   }
 
@@ -227,7 +231,7 @@ export const getMode = ({
     return checkFns[checkKey](stringifyUnknown(env[key]), expected);
   });
 
-  return new Mode({ type: isProd ? "cloud" : "dev", isExplicit: false });
+  return new Mode({ type: isProd ? "cloud" : "dev", isExplicit: false, env });
 };
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

On some platforms, environment variables are sent as a function argument and are not available as a global. `serve()` handlers manage this transparently as they can silently retrieve the values they are passed, but `Inngest` clients can require manual intervention.

For these cases, we add `inngest.setEnvVars()`, allowing you to set environment variables at runtime and rest any URLs or configuration that was set during instantiation.

```ts
app.on("GET", "/api/send-some-event", async (c) => {
  inngest.setEnvVars(c.env);

  await inngest.send({ name: "test/event/after" });

  return c.json({ message: "Done!" });
});
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- Documented in inngest/website#873
