### PR TITLE
Fix event key hash when not set

### DIFF
--- a/.changeset/cold-eggs-smash.md
+++ b/.changeset/cold-eggs-smash.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix event key hash exists when event key is not set

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -7,6 +7,7 @@ import {
   debugPrefix,
   defaultInngestApiBaseUrl,
   defaultInngestEventBaseUrl,
+  dummyEventKey,
   envKeys,
   headerKeys,
   logPrefix,
@@ -523,7 +524,7 @@ export class InngestCommHandler<
   }
 
   private get hashedEventKey(): string | undefined {
-    if (!this.client["eventKey"]) {
+    if (!this.client["eventKey"] || this.client["eventKey"] === dummyEventKey) {
       return undefined;
     }
     return hashEventKey(this.client["eventKey"]);


### PR DESCRIPTION
## Summary
Fix event key hash not `undefined` when event key is not set. We were incorrectly hashing the default `EVENT_KEY_NOT_SET` value

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
