### PR TITLE
Update no-nested-steps.ts

### DIFF
--- a/.changeset/heavy-files-try.md
+++ b/.changeset/heavy-files-try.md
@@ -1,0 +1,5 @@
+---
+"@inngest/eslint-plugin": patch
+---
+
+Fix `no-nested-steps` not catching nested steps other than `step.run()`

--- a/packages/eslint-plugin/src/rules/no-nested-steps.test.ts
+++ b/packages/eslint-plugin/src/rules/no-nested-steps.test.ts
@@ -10,11 +10,36 @@ ruleTester.run("my-rule", noNestedSteps, {
     `const a = await step.run("a", () => "a");
      const b = await step.run("b", () => "b");`,
     `await step.run("a", () => "a").then((a) => step.run("b", () => a + "b"));`,
+    `await step.run("a", () => someOtherCall());`,
   ],
   invalid: [
     {
       code: `await step.run("a", async () => {
           await step.run("b", async () => {
+               // ...
+          });
+      });`,
+      errors: [{ messageId: "no-nested-steps" }],
+    },
+    {
+      code: `await step.run("a", async () => {
+          step.sendEvent("b", () => {
+               // ...
+          });
+      });`,
+      errors: [{ messageId: "no-nested-steps" }],
+    },
+    {
+      code: `await step.run("a", async () => {
+          step.invoke("b", () => {
+               // ...
+          });
+      });`,
+      errors: [{ messageId: "no-nested-steps" }],
+    },
+    {
+      code: `await step.run("a", async () => {
+          step.anything("b", () => {
                // ...
           });
       });`,

--- a/packages/eslint-plugin/src/rules/no-nested-steps.ts
+++ b/packages/eslint-plugin/src/rules/no-nested-steps.ts
@@ -5,50 +5,42 @@ export const noNestedSteps: TSESLint.RuleModule<"no-nested-steps"> = {
     type: "problem",
     docs: {
       description:
-        "disallow use of any `step.*` within a `step.run()` function",
+        "disallow use of any `step.*` within another `step.*` function",
       recommended: "recommended",
     },
     schema: [], // no options
     messages: {
       "no-nested-steps":
-        "Use of `step.*` within a `step.run()` function is not allowed",
+        "Use of `step.*` within another `step.*` function is not allowed",
     },
   },
   defaultOptions: [],
-  create(context) {
-    let stepRunDepth = 0;
+  create(context: TSESLint.RuleContext<"no-nested-steps", []>) {
+    let stepDepth = 0;
 
     return {
-      CallExpression(node) {
+      CallExpression(node: TSESLint.TSESTree.CallExpression) {
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           node.callee.object.type === AST_NODE_TYPES.Identifier &&
           node.callee.object.name === "step"
         ) {
-          if (
-            node.callee.property.type === AST_NODE_TYPES.Identifier &&
-            node.callee.property.name === "run"
-          ) {
-            stepRunDepth += 1;
-          }
-
-          if (stepRunDepth > 1) {
+          if (stepDepth > 0) {
             context.report({
               node,
               messageId: "no-nested-steps",
             });
           }
+          stepDepth++;
         }
       },
-      "CallExpression:exit"(node) {
+      "CallExpression:exit"(node: TSESLint.TSESTree.CallExpression) {
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           node.callee.object.type === AST_NODE_TYPES.Identifier &&
-          node.callee.object.name === "step" &&
-          node.callee.property.type === AST_NODE_TYPES.Identifier &&
-          node.callee.property.name === "run"
+          node.callee.object.name === "step"
         ) {
-          stepRunDepth -= 1;
+          stepDepth--;
         }
       },
     };

--- a/packages/eslint-plugin/src/rules/no-nested-steps.ts
+++ b/packages/eslint-plugin/src/rules/no-nested-steps.ts
@@ -19,7 +19,7 @@ export const noNestedSteps: TSESLint.RuleModule<"no-nested-steps"> = {
     let stepDepth = 0;
 
     return {
-      CallExpression(node: TSESLint.TSESTree.CallExpression) {
+      CallExpression(node) {
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           node.callee.object.type === AST_NODE_TYPES.Identifier &&
@@ -34,7 +34,7 @@ export const noNestedSteps: TSESLint.RuleModule<"no-nested-steps"> = {
           stepDepth++;
         }
       },
-      "CallExpression:exit"(node: TSESLint.TSESTree.CallExpression) {
+      "CallExpression:exit"(node) {
         if (
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           node.callee.object.type === AST_NODE_TYPES.Identifier &&


### PR DESCRIPTION
Today we had an interesting and expensive learning experience- we had pushed step.sendEvent inside step.run. As part of the retrospective I noticed the eslint plugin seemed to only be picking up step.run inside step.run, not step.invoke or step.sendEvent etc.

UPDATED: eslint-plugin/src/rules/no-nested-steps.ts

- Updated rule to disallow use of any `step.*` within another `step.*` function
- Added check to report error if `step.*` is used within another `step.*` function
- issue with counting the depth of nested `step.run()` calls

## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable