### PR TITLE
Add `Error.cause` (de)serialization

### DIFF
--- a/.changeset/orange-badgers-guess.md
+++ b/.changeset/orange-badgers-guess.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add de(serialization) of `Error.cause`, meaning nested errors can now be correctly used with `StepError`

--- a/packages/inngest/src/api/schema.ts
+++ b/packages/inngest/src/api/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ExecutionVersion } from "../components/execution/InngestExecution";
-import { failureEventErrorSchema, type EventPayload } from "../types";
+import { jsonErrorSchema, type EventPayload } from "../types";
 
 export const errorSchema = z.object({
   error: z.string(),
@@ -31,7 +31,7 @@ export const stepsSchemas = {
           z
             .object({
               type: z.literal("error").optional().default("error"),
-              error: failureEventErrorSchema,
+              error: jsonErrorSchema,
             })
             .strict()
         )

--- a/packages/inngest/src/components/StepError.ts
+++ b/packages/inngest/src/components/StepError.ts
@@ -1,4 +1,5 @@
-import { z } from "zod";
+import { deserializeError } from "../helpers/errors";
+import { jsonErrorSchema } from "../types";
 
 /**
  * An error that represents a step exhausting all retries and failing. This is
@@ -10,6 +11,8 @@ import { z } from "zod";
  * @public
  */
 export class StepError extends Error {
+  public cause?: unknown;
+
   constructor(
     /**
      * The ID of the step that failed.
@@ -17,17 +20,7 @@ export class StepError extends Error {
     public readonly stepId: string,
     err: unknown
   ) {
-    const parsedErr = z
-      .object({
-        name: z.string(),
-        message: z.string(),
-        stack: z.string().optional(),
-      })
-      .catch({
-        name: "Error",
-        message: "An unknown error occurred; could not parse error",
-      })
-      .parse(err);
+    const parsedErr = jsonErrorSchema.parse(err);
 
     super(parsedErr.message);
     this.name = parsedErr.name;
@@ -35,5 +28,10 @@ export class StepError extends Error {
 
     // Don't show the internal stack trace if we don't have one.
     this.stack = parsedErr.stack ?? undefined;
+
+    // Try setting the cause if we have one
+    this.cause = parsedErr.cause
+      ? deserializeError(parsedErr.cause)
+      : undefined;
   }
 }

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -17,7 +17,7 @@ import {
 import { type MaybePromise, type PartialK } from "../../helpers/types";
 import {
   StepOpCode,
-  failureEventErrorSchema,
+  jsonErrorSchema,
   type BaseContext,
   type Context,
   type EventPayload,
@@ -422,7 +422,7 @@ export class V0InngestExecution
 
     if (this.options.isFailureHandler) {
       const eventData = z
-        .object({ error: failureEventErrorSchema })
+        .object({ error: jsonErrorSchema })
         .parse(fnArg.event?.data);
 
       (fnArg as Partial<Pick<FailureEventArgs, "error">>) = {

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -19,7 +19,7 @@ import {
 import { type MaybePromise, type Simplify } from "../../helpers/types";
 import {
   StepOpCode,
-  failureEventErrorSchema,
+  jsonErrorSchema,
   type BaseContext,
   type Context,
   type EventPayload,
@@ -624,7 +624,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
      */
     if (this.options.isFailureHandler) {
       const eventData = z
-        .object({ error: failureEventErrorSchema })
+        .object({ error: jsonErrorSchema })
         .parse(fnArg.event?.data);
 
       (fnArg as Partial<Pick<FailureEventArgs, "error">>) = {

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -89,7 +89,8 @@ export const serializeError = (subject: unknown): SerializedError => {
         if (
           typeof target === "object" &&
           target !== null &&
-          "cause" in target
+          "cause" in target &&
+          target.cause
         ) {
           target = target.cause = serializeError(target.cause);
           continue;

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -113,6 +113,8 @@ export const serializeError = (subject: unknown): SerializedError => {
         ...serializeError(
           new Error(typeof subject === "string" ? subject : stringify(subject))
         ),
+        // Remove the stack; it's not relevant here
+        stack: "",
         [SERIALIZED_KEY]: SERIALIZED_VALUE,
       };
     } catch (err) {

--- a/packages/inngest/src/test/functions/handling-step-errors/index.test.ts
+++ b/packages/inngest/src/test/functions/handling-step-errors/index.test.ts
@@ -34,7 +34,15 @@ describe("run", () => {
 
     const output = await item?.getOutput();
     expect(output).toEqual({
-      error: { name: "Error", message: "Oh no!", stack: expect.any(String) },
+      error: {
+        name: "Error",
+        message: "Oh no!",
+        stack: expect.any(String),
+        cause: expect.objectContaining({
+          name: "Error",
+          message: "This is the cause",
+        }),
+      },
     });
   }, 10000);
 
@@ -46,7 +54,9 @@ describe("run", () => {
     expect(item).toBeDefined();
 
     const output = await item?.getOutput();
-    expect(output).toEqual({ data: expect.any(String) });
+    expect(output).toEqual({
+      data: `err was: "Oh no!" and the cause was: "This is the cause"`,
+    });
   }, 10000);
 
   test(`ran "c succeeds" step`, async () => {

--- a/packages/inngest/src/test/functions/handling-step-errors/index.ts
+++ b/packages/inngest/src/test/functions/handling-step-errors/index.ts
@@ -6,11 +6,13 @@ export default inngest.createFunction(
   async ({ step }) => {
     try {
       await step.run("a", () => {
-        throw new Error("Oh no!");
+        throw new Error("Oh no!", {
+          cause: new Error("This is the cause"),
+        });
       });
     } catch (err) {
       await step.run("b", () => {
-        return `err was: ${err.message}`;
+        return `err was: "${err.message}" and the cause was: "${err.cause.message}"`;
       });
     }
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -23,21 +23,33 @@ import {
 } from "./helpers/types";
 import { type Logger } from "./middleware/logger";
 
-export const failureEventErrorSchema = z
-  .object({
-    name: z.string().trim().optional(),
-    error: z.string().trim().optional(),
-    message: z.string().trim().optional(),
-    stack: z.string().trim().optional(),
+const baseJsonErrorSchema = z.object({
+  name: z.string().trim().optional(),
+  error: z.string().trim().optional(),
+  message: z.string().trim().optional(),
+  stack: z.string().trim().optional(),
+});
+
+export type JsonError = z.infer<typeof baseJsonErrorSchema> & {
+  name: string;
+  message: string;
+  cause?: JsonError;
+};
+
+export const jsonErrorSchema = baseJsonErrorSchema
+  .extend({
+    cause: z.lazy(() => jsonErrorSchema).optional(),
   })
+  .passthrough()
   .catch({})
   .transform((val) => {
     return {
+      ...val,
       name: val.name || "Error",
       message: val.message || val.error || "Unknown error",
       stack: val.stack,
     };
-  });
+  }) as z.ZodType<JsonError>;
 
 /**
  * The payload for an internal Inngest event that is sent when a function fails.
@@ -49,7 +61,7 @@ export type FailureEventPayload<P extends EventPayload = EventPayload> = {
   data: {
     function_id: string;
     run_id: string;
-    error: z.output<typeof failureEventErrorSchema>;
+    error: z.output<typeof jsonErrorSchema>;
     event: P;
   };
 };
@@ -85,7 +97,7 @@ export type FinishedEventPayload = {
     correlation_id?: string;
   } & (
     | {
-        error: z.output<typeof failureEventErrorSchema>;
+        error: z.output<typeof jsonErrorSchema>;
       }
     | {
         result: unknown;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes `Error.cause` not being serialized or available when reporting errors in steps or functions.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Docs already show `cause`
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- inngest/inngest#1643
