### PR TITLE
Set sentry transaction name according to inngest function

### DIFF
--- a/.changeset/shy-goats-heal.md
+++ b/.changeset/shy-goats-heal.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-sentry": patch
+---
+
+Set sentry transaction name according to Inngest function

--- a/packages/middleware-sentry/src/middleware.ts
+++ b/packages/middleware-sentry/src/middleware.ts
@@ -166,6 +166,7 @@ export const sentryMiddleware = (
 
                       Sentry.withActiveSpan(reqSpan, (scope) => {
                         scope.setTags(sharedTags);
+                        scope.setTransactionName(`inngest:${fn.name}`);
                         scope.captureException(result.error);
                       });
                     } else {


### PR DESCRIPTION
## Summary
Set transaction name in sentry according to inngest function name so that it's immediately obvious in sentry's UI which function had the error:

<img width="529" alt="Screenshot 2024-08-05 at 11 53 08 AM" src="https://github.com/user-attachments/assets/626d8f1e-7edb-4959-8ccf-e57f2aa3ab5c">

I tried calling `setTransactionName` next to `scope.setTags(sharedTags);` on line 84 but the transaction name was not appropriately set when I threw an error in my function.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
