### PR TITLE
Add event id as sentry tag

### DIFF
--- a/.changeset/light-balloons-repeat.md
+++ b/.changeset/light-balloons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-sentry": patch
+---
+
+Add event ID as a Sentry tag

--- a/packages/middleware-sentry/src/middleware.ts
+++ b/packages/middleware-sentry/src/middleware.ts
@@ -73,10 +73,11 @@ export const sentryMiddleware = (
       return {
         onFunctionRun({ ctx, fn, steps }) {
           return Sentry.withScope((scope) => {
-            const sharedTags: Record<string, string> = {
+            const sharedTags: Record<string, string | undefined> = {
               "inngest.client.id": client.id,
               "inngest.function.id": fn.id(client.id),
               "inngest.function.name": fn.name,
+              "inngest.event.id": ctx.event.id,
               "inngest.event.name": ctx.event.name,
               "inngest.run.id": ctx.runId,
             };


### PR DESCRIPTION
## Summary
Add another sentry tag: the inngest event id.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
