### PR TITLE
Fix wrong URL in getTargetUrl

### DIFF
--- a/.changeset/dirty-bats-pay.md
+++ b/.changeset/dirty-bats-pay.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix wrong URL when INNGEST_DEV=1

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -78,6 +78,10 @@ export class InngestApi {
   }
 
   private async getTargetUrl(path: string): Promise<URL> {
+    if (this.apiBaseUrl) {
+      return new URL(path, this.apiBaseUrl);
+    }
+
     let url = new URL(path, defaultInngestApiBaseUrl);
 
     if (this.mode.isDev && this.mode.isInferred && !this.apiBaseUrl) {


### PR DESCRIPTION
## Summary
Fix wrong URL in `getTargetUrl` when `this.apiBaseUrl` is set. This can happen when `INNGEST_DEV=1`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added changesets if applicable
