### PR TITLE
Check request server kind during sync

### DIFF
--- a/.changeset/cuddly-books-speak.md
+++ b/.changeset/cuddly-books-speak.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Check request server kind during sync

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -11,7 +11,6 @@ import {
   logPrefix,
   probe as probeEnum,
   queryKeys,
-  serverKind,
 } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import { enumFromValue } from "../helpers/enum";

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -11,6 +11,7 @@ import {
   logPrefix,
   probe as probeEnum,
   queryKeys,
+  serverKind,
 } from "../helpers/consts";
 import { devServerAvailable, devServerUrl } from "../helpers/devserver";
 import { enumFromValue } from "../helpers/enum";
@@ -1186,6 +1187,23 @@ export class InngestCommHandler<
         );
         if (deployId === "undefined") {
           deployId = undefined;
+        }
+
+        const requestServerKind = await actions.headers(
+          `reading ${headerKeys.InngestServerKind} header`,
+          headerKeys.InngestServerKind
+        );
+        if (requestServerKind && requestServerKind !== this._mode?.type) {
+          return {
+            status: 400,
+            body: stringify({
+              message: `Server kind mismatch; expected "${this._mode?.type}" but got "${requestServerKind}"`,
+            }),
+            headers: {
+              "Content-Type": "application/json",
+            },
+            version: undefined,
+          };
         }
 
         const { status, message, modified } = await this.register(

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -662,7 +662,7 @@ export const testFramework = (
             [
               {
                 method: "PUT",
-                headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+                headers: { [headerKeys.InngestServerKind]: serverKind.Cloud },
               },
             ]
           );
@@ -671,7 +671,7 @@ export const testFramework = (
             status: 200,
             headers: expect.objectContaining({
               [headerKeys.Environment]: expect.stringMatching("FOO"),
-              [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
+              [headerKeys.InngestExpectedServerKind]: serverKind.Cloud,
             }),
           });
         });

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -675,6 +675,33 @@ export const testFramework = (
             }),
           });
         });
+
+        test("throws 400 if in different mode to server", async () => {
+          nock("https://api.inngest.com").post("/fn/register").reply(200, {});
+
+          const ret = await run(
+            [
+              {
+                client: new Inngest({ id: "Test", isDev: false }),
+                functions: [],
+              },
+            ],
+            [
+              {
+                method: "PUT",
+                headers: { [headerKeys.InngestServerKind]: serverKind.Dev },
+              },
+            ]
+          );
+
+          expect(ret).toMatchObject({
+            status: 400,
+            body: expect.stringContaining("Server kind mismatch"),
+            headers: expect.objectContaining({
+              [headerKeys.InngestExpectedServerKind]: serverKind.Dev,
+            }),
+          });
+        });
       });
 
       test("register with overwritten host and path when specified", async () => {


### PR DESCRIPTION
## Summary
Check request server kind during sync. If the request has a server kind and it doesn't match the SDK's mode, then reject.

This is necessary because users are currently able to sync a "dev mode" SDK to Cloud

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable