### PR TITLE
Allow passing `error` when transforming outputs in middleware

### DIFF
--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -499,7 +499,9 @@ type MiddlewareSendEventOutput = (
 type MiddlewareRunOutput = (ctx: {
   result: Readonly<Pick<OutgoingOp, "error" | "data">>;
   step?: Readonly<Omit<OutgoingOp, "id">>;
-}) => MaybePromise<{ result?: Partial<Pick<OutgoingOp, "data">> } | void>;
+}) => MaybePromise<{
+  result?: Partial<Pick<OutgoingOp, "data" | "error">>;
+} | void>;
 
 type MiddlewareRunFinished = (ctx: {
   result: Readonly<Pick<OutgoingOp, "error" | "data">>;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Allows passing an `error` when using `onFunctionRun.transformOutput` in middleware.

Runtime code already supports this, allowing for common actions such as recreating (or creating new) errors based on data returned from executions. For example:

```ts
new InngestMiddleware({
  name: "My Middleware",
  init() {
    return {
      onFunctionRun({ fn }) {
        return {
          transformOutput({ result }) {
            if (result.error && result.error instanceof ForbiddenError) {
              return {
                result: {
                  error: new NonRetriableError(result.error.message),
                },
              };
            }
          },
        };
      },
    };
  },
});
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable
