### PR TITLE
Enforce importing using extensions

### DIFF
--- a/.changeset/quick-deers-tell.md
+++ b/.changeset/quick-deers-tell.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix imports requiring internal extensions when being consumed by true ESM

--- a/.changeset/ten-gorillas-build.md
+++ b/.changeset/ten-gorillas-build.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `"inngest/nitro"` serve handler

--- a/examples/framework-nitro/.gitignore
+++ b/examples/framework-nitro/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.data
+.nitro
+.cache
+.output
+.env

--- a/examples/framework-nitro/.npmrc
+++ b/examples/framework-nitro/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/examples/framework-nitro/README.md
+++ b/examples/framework-nitro/README.md
@@ -1,0 +1,35 @@
+# Inngest Nitro Template
+
+This is a [Nitro](https://nitro.unjs.io/) project. It is a reference on how to send and receive events with Inngest in Nitro.
+
+## Getting Started
+
+Use [`create-next-app`](https://www.npmjs.com/package/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
+
+```bash
+npx create-next-app --example https://github.com/inngest/inngest-js/tree/main/examples/framework-nitro inngest-nitro
+```
+
+```bash
+yarn create next-app --example https://github.com/inngest/inngest-js/tree/main/examples/framework-nitro inngest-nitro
+```
+
+```bash
+pnpm create next-app --example https://github.com/inngest/inngest-js/tree/main/examples/framework-nitro inngest-nitro
+```
+
+### Run the app locally
+
+```sh
+npm install
+npm run dev
+```
+
+Open http://localhost:3000/api/inngest with your browser to see the result.
+
+- [Inngest functions](https://www.inngest.com/docs/functions) are available at `src/inngest/`.
+
+## Learn More
+
+- [Inngest Documentation](https://www.inngest.com/docs) - learn about the Inngest SDK, functions, and events
+- [Nitro Documentation](https://nitro.unjs.io/) - learn about Nitro features and API

--- a/examples/framework-nitro/inngest/client.ts
+++ b/examples/framework-nitro/inngest/client.ts
@@ -1,0 +1,4 @@
+import { Inngest } from "inngest";
+import { schemas } from "./types";
+
+export const inngest = new Inngest({ id: "my-nitro-app", schemas });

--- a/examples/framework-nitro/inngest/helloWorld.ts
+++ b/examples/framework-nitro/inngest/helloWorld.ts
@@ -1,0 +1,11 @@
+import { inngest } from "./client";
+
+export const helloWorld = inngest.createFunction(
+  { id: "hello-world" },
+  { event: "demo/event.sent" },
+  async ({ event, step }) => {
+    return {
+      message: `Hello ${event.name}!`,
+    };
+  }
+);

--- a/examples/framework-nitro/inngest/index.ts
+++ b/examples/framework-nitro/inngest/index.ts
@@ -1,0 +1,5 @@
+import { helloWorld } from "./helloWorld";
+
+export const functions = [helloWorld];
+
+export { inngest } from "./client";

--- a/examples/framework-nitro/inngest/types.ts
+++ b/examples/framework-nitro/inngest/types.ts
@@ -1,0 +1,10 @@
+import { EventSchemas } from "inngest";
+
+type DemoEventSent = {
+  name: "demo/event.sent";
+  data: {
+    message: string;
+  };
+};
+
+export const schemas = new EventSchemas().fromUnion<DemoEventSent>();

--- a/examples/framework-nitro/nitro.config.ts
+++ b/examples/framework-nitro/nitro.config.ts
@@ -1,0 +1,4 @@
+//https://nitro.unjs.io/config
+export default defineNitroConfig({
+  srcDir: "server"
+});

--- a/examples/framework-nitro/package.json
+++ b/examples/framework-nitro/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev",
+    "prepare": "nitro prepare",
+    "preview": "node .output/server/index.mjs"
+  },
+  "devDependencies": {
+    "nitropack": "latest"
+  },
+  "dependencies": {
+    "inngest": "^3.0.0"
+  }
+}

--- a/examples/framework-nitro/server/routes/api/inngest.ts
+++ b/examples/framework-nitro/server/routes/api/inngest.ts
@@ -1,0 +1,9 @@
+import { serve } from "inngest/h3";
+import { functions, inngest } from "~~/inngest";
+
+export default eventHandler(
+  serve({
+    client: inngest,
+    functions,
+  })
+);

--- a/examples/framework-nitro/server/routes/api/inngest.ts
+++ b/examples/framework-nitro/server/routes/api/inngest.ts
@@ -1,4 +1,4 @@
-import { serve } from "inngest/h3";
+import { serve } from "inngest/nitro";
 import { functions, inngest } from "~~/inngest";
 
 export default eventHandler(

--- a/examples/framework-nitro/server/routes/index.ts
+++ b/examples/framework-nitro/server/routes/index.ts
@@ -1,0 +1,3 @@
+export default eventHandler((event) => {
+  return "Start by editing <code>server/routes/index.ts</code>.";
+});

--- a/examples/framework-nitro/tsconfig.json
+++ b/examples/framework-nitro/tsconfig.json
@@ -1,0 +1,4 @@
+// https://nitro.unjs.io/guide/typescript
+{
+  "extends": "./.nitro/types/tsconfig.json"
+}

--- a/packages/inngest/.eslintrc.js
+++ b/packages/inngest/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
           "src/redwood.ts",
           "src/remix.ts",
           "src/sveltekit.ts",
+          "src/nitro.ts",
         ],
         includeInternal: true,
         includeTypes: true,

--- a/packages/inngest/.eslintrc.js
+++ b/packages/inngest/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
         includeTypes: true,
       },
     ],
+    "import/extensions": ["error", "always"],
   },
   overrides: [
     {
@@ -61,6 +62,12 @@ module.exports = {
       excludedFiles: ["*.d.ts", "*.test.ts", "src/test/**/*", "src/init.ts"],
       rules: {
         "@inngest/internal/process-warn": "warn",
+      },
+    },
+    {
+      files: ["src/**/*.test.ts"],
+      rules: {
+        "import/extensions": "off",
       },
     },
   ],

--- a/packages/inngest/jest.config.js
+++ b/packages/inngest/jest.config.js
@@ -5,8 +5,10 @@ module.exports = {
   testMatch: ["<rootDir>/src/**/*.test.ts", "!**/test/functions/**/*.test.ts"],
   roots: ["<rootDir>/src"],
   moduleNameMapper: {
+    "(\\..+)\\.js": "$1",
     inngest: "<rootDir>/src",
     "^@local$": "<rootDir>/src",
     "^@local/(.*)": "<rootDir>/src/$1",
+    "^@local/(.*)\\.js": "<rootDir>/src/$1",
   },
 };

--- a/packages/inngest/jsr.json
+++ b/packages/inngest/jsr.json
@@ -34,6 +34,7 @@
     "./sveltekit": "./src/sveltekit.ts",
     "./deno/fresh": "./src/deno/fresh.ts",
     "./hono": "./src/hono.ts",
+    "./nitro": "./src/nitro.ts",
     "./types": "./src/types.ts"
   }
 }

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -122,6 +122,11 @@
       "import": "./hono.js",
       "types": "./hono.d.ts"
     },
+    "./nitro": {
+      "require": "./nitro.js",
+      "import": "./nitro.js",
+      "types": "./nitro.d.ts"
+    },
     "./types": {
       "require": "./types.js",
       "import": "./types.js",

--- a/packages/inngest/scripts/checkDependencies.ts
+++ b/packages/inngest/scripts/checkDependencies.ts
@@ -284,4 +284,5 @@ checkDependencies("tsconfig.build.json", [
   "src/redwood.ts",
   "src/remix.ts",
   "src/sveltekit.ts",
+  "src/nitro.ts",
 ]);

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -1,15 +1,15 @@
 import { type fetch } from "cross-fetch";
-import { type ExecutionVersion } from "../components/execution/InngestExecution";
+import { type ExecutionVersion } from "../components/execution/InngestExecution.js";
 import {
   defaultDevServerHost,
   defaultInngestApiBaseUrl,
-} from "../helpers/consts";
-import { devServerAvailable } from "../helpers/devserver";
-import { type Mode } from "../helpers/env";
-import { getErrorMessage } from "../helpers/errors";
-import { fetchWithAuthFallback } from "../helpers/net";
-import { hashSigningKey } from "../helpers/strings";
-import { err, ok, type Result } from "../types";
+} from "../helpers/consts.js";
+import { devServerAvailable } from "../helpers/devserver.js";
+import { type Mode } from "../helpers/env.js";
+import { getErrorMessage } from "../helpers/errors.js";
+import { fetchWithAuthFallback } from "../helpers/net.js";
+import { hashSigningKey } from "../helpers/strings.js";
+import { err, ok, type Result } from "../types.js";
 import {
   batchSchema,
   errorSchema,
@@ -17,7 +17,7 @@ import {
   type BatchResponse,
   type ErrorResponse,
   type StepsResponse,
-} from "./schema";
+} from "./schema.js";
 
 type FetchT = typeof fetch;
 

--- a/packages/inngest/src/api/schema.ts
+++ b/packages/inngest/src/api/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { ExecutionVersion } from "../components/execution/InngestExecution";
-import { jsonErrorSchema, type EventPayload } from "../types";
+import { ExecutionVersion } from "../components/execution/InngestExecution.js";
+import { jsonErrorSchema, type EventPayload } from "../types.js";
 
 export const errorSchema = z.object({
   error: z.string(),

--- a/packages/inngest/src/astro.ts
+++ b/packages/inngest/src/astro.ts
@@ -16,8 +16,8 @@
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/bun.ts
+++ b/packages/inngest/src/bun.ts
@@ -27,9 +27,9 @@
 import {
   type InternalServeHandlerOptions,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { serve as serveEdge } from "./edge";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { serve as serveEdge } from "./edge.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/cloudflare.ts
+++ b/packages/inngest/src/cloudflare.ts
@@ -35,9 +35,9 @@
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type Either } from "./helpers/types";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type Either } from "./helpers/types.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -1,17 +1,17 @@
-import { type internalEvents } from "../helpers/consts";
+import { type internalEvents } from "../helpers/consts.js";
 import {
   type IsEmptyObject,
   type IsStringLiteral,
   type Simplify,
-} from "../helpers/types";
-import type * as z from "../helpers/validators/zod";
+} from "../helpers/types.js";
+import type * as z from "../helpers/validators/zod.js";
 import {
   type EventPayload,
   type FailureEventPayload,
   type FinishedEventPayload,
   type InvokedEventPayload,
   type ScheduledTimerEventPayload,
-} from "../types";
+} from "../types.js";
 
 /**
  * Declares the shape of an event schema we expect from the user. This may be

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -1,4 +1,4 @@
-import { InngestApi } from "../api/api";
+import { InngestApi } from "../api/api.js";
 import {
   defaultDevServerHost,
   defaultInngestApiBaseUrl,
@@ -7,8 +7,8 @@ import {
   envKeys,
   headerKeys,
   logPrefix,
-} from "../helpers/consts";
-import { devServerAvailable, devServerUrl } from "../helpers/devserver";
+} from "../helpers/consts.js";
+import { devServerAvailable, devServerUrl } from "../helpers/devserver.js";
 import {
   allProcessEnv,
   getFetch,
@@ -16,10 +16,10 @@ import {
   inngestHeaders,
   processEnv,
   type Mode,
-} from "../helpers/env";
-import { fixEventKeyMissingSteps, prettyError } from "../helpers/errors";
-import { type Jsonify } from "../helpers/jsonify";
-import { stringify } from "../helpers/strings";
+} from "../helpers/env.js";
+import { fixEventKeyMissingSteps, prettyError } from "../helpers/errors.js";
+import { type Jsonify } from "../helpers/jsonify.js";
+import { stringify } from "../helpers/strings.js";
 import {
   type AsArray,
   type IsNever,
@@ -27,8 +27,12 @@ import {
   type SimplifyDeep,
   type SingleOrArray,
   type WithoutInternal,
-} from "../helpers/types";
-import { DefaultLogger, ProxyLogger, type Logger } from "../middleware/logger";
+} from "../helpers/types.js";
+import {
+  DefaultLogger,
+  ProxyLogger,
+  type Logger,
+} from "../middleware/logger.js";
 import {
   sendEventResponseSchema,
   type ClientOptions,
@@ -40,10 +44,10 @@ import {
   type SendEventOutput,
   type SendEventResponse,
   type TriggersFromClient,
-} from "../types";
-import { type EventSchemas } from "./EventSchemas";
-import { InngestFunction } from "./InngestFunction";
-import { type InngestFunctionReference } from "./InngestFunctionReference";
+} from "../types.js";
+import { type EventSchemas } from "./EventSchemas.js";
+import { InngestFunction } from "./InngestFunction.js";
+import { type InngestFunctionReference } from "./InngestFunctionReference.js";
 import {
   InngestMiddleware,
   getHookStack,
@@ -52,7 +56,7 @@ import {
   type MiddlewareRegisterFn,
   type MiddlewareRegisterReturn,
   type SendEventHookStack,
-} from "./InngestMiddleware";
+} from "./InngestMiddleware.js";
 
 /**
  * Capturing the global type of fetch so that we can reliably access it below.

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { z } from "zod";
-import { ServerTiming } from "../helpers/ServerTiming";
+import { ServerTiming } from "../helpers/ServerTiming.js";
 import {
   debugPrefix,
   defaultInngestApiBaseUrl,
@@ -11,9 +11,9 @@ import {
   logPrefix,
   probe as probeEnum,
   queryKeys,
-} from "../helpers/consts";
-import { devServerAvailable, devServerUrl } from "../helpers/devserver";
-import { enumFromValue } from "../helpers/enum";
+} from "../helpers/consts.js";
+import { devServerAvailable, devServerUrl } from "../helpers/devserver.js";
+import { enumFromValue } from "../helpers/enum.js";
 import {
   Mode,
   allProcessEnv,
@@ -23,19 +23,19 @@ import {
   inngestHeaders,
   platformSupportsStreaming,
   type Env,
-} from "../helpers/env";
-import { rethrowError, serializeError } from "../helpers/errors";
+} from "../helpers/env.js";
+import { rethrowError, serializeError } from "../helpers/errors.js";
 import {
   fetchAllFnData,
   parseFnData,
   undefinedToNull,
   type FnData,
-} from "../helpers/functions";
-import { fetchWithAuthFallback, signDataWithKey } from "../helpers/net";
-import { runAsPromise } from "../helpers/promises";
-import { createStream } from "../helpers/stream";
-import { hashEventKey, hashSigningKey, stringify } from "../helpers/strings";
-import { type MaybePromise } from "../helpers/types";
+} from "../helpers/functions.js";
+import { fetchWithAuthFallback, signDataWithKey } from "../helpers/net.js";
+import { runAsPromise } from "../helpers/promises.js";
+import { createStream } from "../helpers/stream.js";
+import { hashEventKey, hashSigningKey, stringify } from "../helpers/strings.js";
+import { type MaybePromise } from "../helpers/types.js";
 import {
   functionConfigSchema,
   logLevels,
@@ -48,13 +48,13 @@ import {
   type RegisterRequest,
   type SupportedFrameworkName,
   type UnauthenticatedIntrospection,
-} from "../types";
-import { version } from "../version";
-import { type Inngest } from "./Inngest";
+} from "../types.js";
+import { version } from "../version.js";
+import { type Inngest } from "./Inngest.js";
 import {
   type CreateExecutionOptions,
   type InngestFunction,
-} from "./InngestFunction";
+} from "./InngestFunction.js";
 import {
   ExecutionVersion,
   PREFERRED_EXECUTION_VERSION,
@@ -62,7 +62,7 @@ import {
   type ExecutionResultHandler,
   type ExecutionResultHandlers,
   type InngestExecutionOptions,
-} from "./execution/InngestExecution";
+} from "./execution/InngestExecution.js";
 
 /**
  * A set of options that can be passed to a serve handler, intended to be used

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -428,7 +428,19 @@ export class InngestCommHandler<
       .parse(options.logLevel || this.env[envKeys.InngestLogLevel]);
 
     if (this.logLevel === "debug") {
-      debug.enable(`${debugPrefix}:*`);
+      /**
+       * `debug` is an old library; sometimes its runtime detection doesn't work
+       * for newer pairings of framework/runtime.
+       *
+       * One silly symptom of this is that `Debug()` returns an anonymous
+       * function with no extra properties instead of a `Debugger` instance if
+       * the wrong code is consumed following a bad detection. This results in
+       * the following `.enable()` call failing, so we just try carefully to
+       * enable it here.
+       */
+      if (debug.enable && typeof debug.enable === "function") {
+        debug.enable(`${debugPrefix}:*`);
+      }
     }
 
     const defaultStreamingOption: typeof this.streaming = false;

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -1,6 +1,6 @@
-import { internalEvents, queryKeys } from "../helpers/consts";
-import { timeStr } from "../helpers/strings";
-import { type RecursiveTuple, type StrictUnion } from "../helpers/types";
+import { internalEvents, queryKeys } from "../helpers/consts.js";
+import { timeStr } from "../helpers/strings.js";
+import { type RecursiveTuple, type StrictUnion } from "../helpers/types.js";
 import {
   type Cancellation,
   type ConcurrencyOption,
@@ -9,19 +9,19 @@ import {
   type TimeStr,
   type TimeStrBatch,
   type TriggersFromClient,
-} from "../types";
-import { type GetEvents, type Inngest } from "./Inngest";
+} from "../types.js";
+import { type GetEvents, type Inngest } from "./Inngest.js";
 import {
   type InngestMiddleware,
   type MiddlewareRegisterReturn,
-} from "./InngestMiddleware";
+} from "./InngestMiddleware.js";
 import {
   ExecutionVersion,
   type IInngestExecution,
   type InngestExecutionOptions,
-} from "./execution/InngestExecution";
-import { createV0InngestExecution } from "./execution/v0";
-import { createV1InngestExecution } from "./execution/v1";
+} from "./execution/InngestExecution.js";
+import { createV0InngestExecution } from "./execution/v0.js";
+import { createV1InngestExecution } from "./execution/v1.js";
 
 /**
  * A stateless Inngest function, wrapping up function configuration and any

--- a/packages/inngest/src/components/InngestFunctionReference.ts
+++ b/packages/inngest/src/components/InngestFunctionReference.ts
@@ -1,15 +1,15 @@
-import { type IsAny, type Simplify } from "../helpers/types";
+import { type IsAny, type Simplify } from "../helpers/types.js";
 import {
   type ResolveSchema,
   type ValidSchemaInput,
   type ValidSchemaOutput,
-} from "../helpers/validators";
+} from "../helpers/validators/index.js";
 import {
   type MinimalEventPayload,
   type PayloadForAnyInngestFunction,
-} from "../types";
-import { type GetFunctionOutput } from "./Inngest";
-import { type InngestFunction } from "./InngestFunction";
+} from "../types.js";
+import { type GetFunctionOutput } from "./Inngest.js";
+import { type InngestFunction } from "./InngestFunction.js";
 
 /**
  * A reference to an `InngestFunction` that can be used to represent both local

--- a/packages/inngest/src/components/InngestMiddleware.ts
+++ b/packages/inngest/src/components/InngestMiddleware.ts
@@ -1,11 +1,11 @@
-import { cacheFn, waterfall } from "../helpers/functions";
+import { cacheFn, waterfall } from "../helpers/functions.js";
 import {
   type Await,
   type MaybePromise,
   type ObjectAssign,
   type PartialK,
   type Simplify,
-} from "../helpers/types";
+} from "../helpers/types.js";
 import {
   type BaseContext,
   type EventPayload,
@@ -13,9 +13,9 @@ import {
   type OutgoingOp,
   type SendEventBaseOutput,
   type TriggersFromClient,
-} from "../types";
-import { type Inngest } from "./Inngest";
-import { type InngestFunction } from "./InngestFunction";
+} from "../types.js";
+import { type Inngest } from "./Inngest.js";
+import { type InngestFunction } from "./InngestFunction.js";
 
 /**
  * A middleware that can be registered with Inngest to hook into various

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
-import { logPrefix } from "../helpers/consts";
-import { type Jsonify } from "../helpers/jsonify";
-import { timeStr } from "../helpers/strings";
+import { logPrefix } from "../helpers/consts.js";
+import { type Jsonify } from "../helpers/jsonify.js";
+import { timeStr } from "../helpers/strings.js";
 import {
   type ExclusiveKeys,
   type ParametersExceptFirst,
   type SendEventPayload,
   type SimplifyDeep,
   type WithoutInternalStr,
-} from "../helpers/types";
+} from "../helpers/types.js";
 import {
   StepOpCode,
   type EventPayload,
@@ -21,16 +21,16 @@ import {
   type StepOptionsOrId,
   type TriggerEventFromFunction,
   type TriggersFromClient,
-} from "../types";
+} from "../types.js";
 import {
   type ClientOptionsFromInngest,
   type GetEvents,
   type GetFunctionOutput,
   type Inngest,
-} from "./Inngest";
-import { InngestFunction } from "./InngestFunction";
-import { InngestFunctionReference } from "./InngestFunctionReference";
-import { type InngestExecution } from "./execution/InngestExecution";
+} from "./Inngest.js";
+import { InngestFunction } from "./InngestFunction.js";
+import { InngestFunctionReference } from "./InngestFunctionReference.js";
+import { type InngestExecution } from "./execution/InngestExecution.js";
 
 export interface FoundStep extends HashedOp {
   hashedId: string;

--- a/packages/inngest/src/components/StepError.ts
+++ b/packages/inngest/src/components/StepError.ts
@@ -1,5 +1,5 @@
-import { deserializeError } from "../helpers/errors";
-import { jsonErrorSchema } from "../types";
+import { deserializeError } from "../helpers/errors.js";
+import { jsonErrorSchema } from "../types.js";
 
 /**
  * An error that represents a step exhausting all retries and failing. This is

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -1,11 +1,11 @@
 import Debug, { type Debugger } from "debug";
-import { type ServerTiming } from "../../helpers/ServerTiming";
-import { debugPrefix } from "../../helpers/consts";
-import { type MaybePromise, type Simplify } from "../../helpers/types";
-import { type Context, type IncomingOp, type OutgoingOp } from "../../types";
-import { type Inngest } from "../Inngest";
-import { type ActionResponse } from "../InngestCommHandler";
-import { type InngestFunction } from "../InngestFunction";
+import { type ServerTiming } from "../../helpers/ServerTiming.js";
+import { debugPrefix } from "../../helpers/consts.js";
+import { type MaybePromise, type Simplify } from "../../helpers/types.js";
+import { type Context, type IncomingOp, type OutgoingOp } from "../../types.js";
+import { type Inngest } from "../Inngest.js";
+import { type ActionResponse } from "../InngestCommHandler.js";
+import { type InngestFunction } from "../InngestFunction.js";
 
 /**
  * The possible results of an execution.

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -7,14 +7,14 @@ import {
   functionStoppedRunningErr,
   prettyError,
   serializeError,
-} from "../../helpers/errors";
-import { undefinedToNull } from "../../helpers/functions";
+} from "../../helpers/errors.js";
+import { undefinedToNull } from "../../helpers/functions.js";
 import {
   resolveAfterPending,
   resolveNextTick,
   runAsPromise,
-} from "../../helpers/promises";
-import { type MaybePromise, type PartialK } from "../../helpers/types";
+} from "../../helpers/promises.js";
+import { type MaybePromise, type PartialK } from "../../helpers/types.js";
 import {
   StepOpCode,
   jsonErrorSchema,
@@ -27,23 +27,23 @@ import {
   type IncomingOp,
   type OpStack,
   type OutgoingOp,
-} from "../../types";
-import { type Inngest } from "../Inngest";
-import { getHookStack, type RunHookStack } from "../InngestMiddleware";
+} from "../../types.js";
+import { type Inngest } from "../Inngest.js";
+import { getHookStack, type RunHookStack } from "../InngestMiddleware.js";
 import {
   createStepTools,
   getStepOptions,
   type StepHandler,
-} from "../InngestStepTools";
-import { NonRetriableError } from "../NonRetriableError";
-import { RetryAfterError } from "../RetryAfterError";
+} from "../InngestStepTools.js";
+import { NonRetriableError } from "../NonRetriableError.js";
+import { RetryAfterError } from "../RetryAfterError.js";
 import {
   InngestExecution,
   type ExecutionResult,
   type IInngestExecution,
   type InngestExecutionFactory,
   type InngestExecutionOptions,
-} from "./InngestExecution";
+} from "./InngestExecution.js";
 
 export const createV0InngestExecution: InngestExecutionFactory = (options) => {
   return new V0InngestExecution(options);

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -1,22 +1,22 @@
 import { sha1 } from "hash.js";
 import { z } from "zod";
-import { internalEvents } from "../../helpers/consts";
+import { internalEvents } from "../../helpers/consts.js";
 import {
   ErrCode,
   deserializeError,
   minifyPrettyError,
   prettyError,
   serializeError,
-} from "../../helpers/errors";
-import { undefinedToNull } from "../../helpers/functions";
+} from "../../helpers/errors.js";
+import { undefinedToNull } from "../../helpers/functions.js";
 import {
   createDeferredPromise,
   createDeferredPromiseWithStack,
   createTimeoutPromise,
   resolveAfterPending,
   runAsPromise,
-} from "../../helpers/promises";
-import { type MaybePromise, type Simplify } from "../../helpers/types";
+} from "../../helpers/promises.js";
+import { type MaybePromise, type Simplify } from "../../helpers/types.js";
 import {
   StepOpCode,
   jsonErrorSchema,
@@ -26,9 +26,9 @@ import {
   type FailureEventArgs,
   type Handler,
   type OutgoingOp,
-} from "../../types";
-import { type Inngest } from "../Inngest";
-import { getHookStack, type RunHookStack } from "../InngestMiddleware";
+} from "../../types.js";
+import { type Inngest } from "../Inngest.js";
+import { getHookStack, type RunHookStack } from "../InngestMiddleware.js";
 import {
   STEP_INDEXING_SUFFIX,
   createStepTools,
@@ -36,10 +36,10 @@ import {
   invokePayloadSchema,
   type FoundStep,
   type StepHandler,
-} from "../InngestStepTools";
-import { NonRetriableError } from "../NonRetriableError";
-import { RetryAfterError } from "../RetryAfterError";
-import { StepError } from "../StepError";
+} from "../InngestStepTools.js";
+import { NonRetriableError } from "../NonRetriableError.js";
+import { RetryAfterError } from "../RetryAfterError.js";
+import { StepError } from "../StepError.js";
 import {
   InngestExecution,
   type ExecutionResult,
@@ -47,7 +47,7 @@ import {
   type InngestExecutionFactory,
   type InngestExecutionOptions,
   type MemoizedOp,
-} from "./InngestExecution";
+} from "./InngestExecution.js";
 
 export const createV1InngestExecution: InngestExecutionFactory = (options) => {
   return new V1InngestExecution(options);

--- a/packages/inngest/src/deno/fresh.ts
+++ b/packages/inngest/src/deno/fresh.ts
@@ -20,8 +20,8 @@
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "../components/InngestCommHandler";
-import { type SupportedFrameworkName } from "../types";
+} from "../components/InngestCommHandler.js";
+import { type SupportedFrameworkName } from "../types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/digitalocean.ts
+++ b/packages/inngest/src/digitalocean.ts
@@ -29,8 +29,8 @@ import {
   InngestCommHandler,
   type ActionResponse,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 type HTTP = {
   headers: Record<string, string>;

--- a/packages/inngest/src/edge.ts
+++ b/packages/inngest/src/edge.ts
@@ -19,8 +19,8 @@
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/express.ts
+++ b/packages/inngest/src/express.ts
@@ -25,9 +25,9 @@ import { type Request, type Response } from "express";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type Either } from "./helpers/types";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type Either } from "./helpers/types.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/fastify.ts
+++ b/packages/inngest/src/fastify.ts
@@ -55,13 +55,13 @@ import {
   type FastifyReply,
   type FastifyRequest,
 } from "fastify";
-import { type Inngest } from "./components/Inngest";
+import { type Inngest } from "./components/Inngest.js";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type InngestFunction } from "./components/InngestFunction";
-import { type RegisterOptions, type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type InngestFunction } from "./components/InngestFunction.js";
+import { type RegisterOptions, type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/h3.ts
+++ b/packages/inngest/src/h3.ts
@@ -39,9 +39,9 @@ import {
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { processEnv } from "./helpers/env";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { processEnv } from "./helpers/env.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/helpers/ServerTiming.ts
+++ b/packages/inngest/src/helpers/ServerTiming.ts
@@ -1,4 +1,4 @@
-import { runAsPromise } from "./promises";
+import { runAsPromise } from "./promises.js";
 
 interface Timing {
   description: string;

--- a/packages/inngest/src/helpers/devserver.ts
+++ b/packages/inngest/src/helpers/devserver.ts
@@ -1,4 +1,4 @@
-import { defaultDevServerHost } from "./consts";
+import { defaultDevServerHost } from "./consts.js";
 
 /**
  * A simple type map that we can transparently use `fetch` later without having

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -3,11 +3,11 @@
 // along with prefixes, meaning we have to explicitly use the full `process.env.FOO`
 // string in order to read variables.
 
-import { type Inngest } from "../components/Inngest";
-import { type SupportedFrameworkName } from "../types";
-import { version } from "../version";
-import { defaultDevServerHost, envKeys, headerKeys } from "./consts";
-import { stringifyUnknown } from "./strings";
+import { type Inngest } from "../components/Inngest.js";
+import { type SupportedFrameworkName } from "../types.js";
+import { version } from "../version.js";
+import { defaultDevServerHost, envKeys, headerKeys } from "./consts.js";
+import { stringifyUnknown } from "./strings.js";
 
 /**
  * @public

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -8,9 +8,9 @@ import {
 } from "serialize-error-cjs";
 import stripAnsi from "strip-ansi";
 import { z } from "zod";
-import { type Inngest } from "../components/Inngest";
-import { NonRetriableError } from "../components/NonRetriableError";
-import { type ClientOptions, type OutgoingOp } from "../types";
+import { type Inngest } from "../components/Inngest.js";
+import { NonRetriableError } from "../components/NonRetriableError.js";
+import { type ClientOptions, type OutgoingOp } from "../types.js";
 
 const SERIALIZED_KEY = "__serialized";
 const SERIALIZED_VALUE = true;

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -1,14 +1,14 @@
 import { ZodError, z } from "zod";
-import { type InngestApi } from "../api/api";
-import { stepsSchemas } from "../api/schema";
-import { type InngestFunction } from "../components/InngestFunction";
+import { type InngestApi } from "../api/api.js";
+import { stepsSchemas } from "../api/schema.js";
+import { type InngestFunction } from "../components/InngestFunction.js";
 import {
   ExecutionVersion,
   PREFERRED_EXECUTION_VERSION,
-} from "../components/execution/InngestExecution";
-import { err, ok, type Result } from "../types";
-import { prettyError } from "./errors";
-import { type Await } from "./types";
+} from "../components/execution/InngestExecution.js";
+import { err, ok, type Result } from "../types.js";
+import { prettyError } from "./errors.js";
+import { type Await } from "./types.js";
 
 /**
  * Wraps a function with a cache. When the returned function is run, it will

--- a/packages/inngest/src/helpers/jsonify.ts
+++ b/packages/inngest/src/helpers/jsonify.ts
@@ -21,7 +21,7 @@ import {
   type IsUnknown,
   type KnownKeys,
   type Simplify,
-} from "./types";
+} from "./types.js";
 
 // Note: The return value has to be `any` and not `unknown` so it can match `void`.
 type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol;

--- a/packages/inngest/src/helpers/stream.ts
+++ b/packages/inngest/src/helpers/stream.ts
@@ -1,4 +1,4 @@
-import { stringify } from "./strings";
+import { stringify } from "./strings.js";
 
 /**
  * Creates a {@link ReadableStream} that sends a `value` every `interval`

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -1,7 +1,7 @@
 import { sha256 } from "hash.js";
 import { default as safeStringify } from "json-stringify-safe";
 import ms from "ms";
-import { type TimeStr } from "../types";
+import { type TimeStr } from "../types.js";
 
 /**
  * Safely `JSON.stringify()` an `input`, handling circular refernences and

--- a/packages/inngest/src/helpers/types.ts
+++ b/packages/inngest/src/helpers/types.ts
@@ -1,4 +1,4 @@
-import { type EventPayload } from "../types";
+import { type EventPayload } from "../types.js";
 
 /**
  * Returns the given generic as either itself or an array of itself.

--- a/packages/inngest/src/helpers/validators/index.ts
+++ b/packages/inngest/src/helpers/validators/index.ts
@@ -1,4 +1,4 @@
-import { type IsUnknown } from "../types";
+import { type IsUnknown } from "../types.js";
 import type * as z from "./zod";
 
 /**

--- a/packages/inngest/src/hono.ts
+++ b/packages/inngest/src/hono.ts
@@ -21,9 +21,9 @@ import { type Context } from "hono";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type Env } from "./helpers/env";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type Env } from "./helpers/env.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -46,8 +46,7 @@ export {
   type StandardEventSchemaToPayload,
   type StandardEventSchemas,
   type ZodEventSchemas,
-} from "./components/EventSchemas";
-export { Inngest } from "./components/Inngest";
+} from "./components/EventSchemas.js";
 export type {
   ClientOptionsFromInngest,
   EventsFromOpts,
@@ -56,22 +55,23 @@ export type {
   GetFunctionOutput,
   GetStepTools,
 } from "./components/Inngest";
-export { InngestCommHandler } from "./components/InngestCommHandler";
+export { Inngest } from "./components/Inngest.js";
 export type { ServeHandlerOptions } from "./components/InngestCommHandler";
+export { InngestCommHandler } from "./components/InngestCommHandler.js";
 export type { InngestFunction } from "./components/InngestFunction";
-export { referenceFunction } from "./components/InngestFunctionReference";
 export type { InngestFunctionReference } from "./components/InngestFunctionReference";
-export { InngestMiddleware } from "./components/InngestMiddleware";
+export { referenceFunction } from "./components/InngestFunctionReference.js";
 export type {
   MiddlewareOptions,
   MiddlewareRegisterFn,
   MiddlewareRegisterReturn,
 } from "./components/InngestMiddleware";
-export { NonRetriableError } from "./components/NonRetriableError";
-export { RetryAfterError } from "./components/RetryAfterError";
-export { StepError } from "./components/StepError";
-export { headerKeys, internalEvents, queryKeys } from "./helpers/consts";
-export { slugify } from "./helpers/strings";
+export { InngestMiddleware } from "./components/InngestMiddleware.js";
+export { NonRetriableError } from "./components/NonRetriableError.js";
+export { RetryAfterError } from "./components/RetryAfterError.js";
+export { StepError } from "./components/StepError.js";
+export { headerKeys, internalEvents, queryKeys } from "./helpers/consts.js";
+export { slugify } from "./helpers/strings.js";
 export type {
   IsStringLiteral,
   StrictUnion,
@@ -79,8 +79,8 @@ export type {
   UnionKeys,
   WithoutInternal,
 } from "./helpers/types";
-export { ProxyLogger } from "./middleware/logger";
 export type { LogArg } from "./middleware/logger";
+export { ProxyLogger } from "./middleware/logger.js";
 export type {
   BaseContext,
   ClientOptions,

--- a/packages/inngest/src/koa.ts
+++ b/packages/inngest/src/koa.ts
@@ -23,8 +23,8 @@ import type Koa from "koa";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/lambda.ts
+++ b/packages/inngest/src/lambda.ts
@@ -33,9 +33,9 @@ import {
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type Either } from "./helpers/types";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type Either } from "./helpers/types.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/next.ts
+++ b/packages/inngest/src/next.ts
@@ -25,10 +25,10 @@ import { type NextRequest } from "next/server.js";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { getResponse } from "./helpers/env";
-import { type Either } from "./helpers/types";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { getResponse } from "./helpers/env.js";
+import { type Either } from "./helpers/types.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/nitro.test.ts
+++ b/packages/inngest/src/nitro.test.ts
@@ -1,0 +1,9 @@
+import * as NitroHandler from "@local/nitro";
+import { createEvent } from "h3";
+import { testFramework } from "./test/helpers";
+
+testFramework("Nitro", NitroHandler, {
+  transformReq(req, res) {
+    return [createEvent(req, res)];
+  },
+});

--- a/packages/inngest/src/nitro.ts
+++ b/packages/inngest/src/nitro.ts
@@ -1,0 +1,37 @@
+/**
+ * An adapter for Nitro to serve and register any declared functions with
+ * Inngest, making them available to be triggered by events.
+ *
+ * @module
+ */
+
+import {
+  type InternalServeHandlerOptions,
+  type ServeHandlerOptions,
+} from "./components/InngestCommHandler.js";
+import { serve as serveH3 } from "./h3.js";
+import { type SupportedFrameworkName } from "./types.js";
+
+/**
+ * The name of the framework, used to identify the framework in Inngest
+ * dashboards and during testing.
+ */
+export const frameworkName: SupportedFrameworkName = "nitro";
+
+/**
+ * In Nitro, serve and register any declared functions with Inngest, making them
+ * available to be triggered by events.
+ *
+ * @public
+ */
+// Has explicit return type to avoid JSR-defined "slow types"
+export const serve = (
+  options: ServeHandlerOptions
+): ReturnType<typeof serveH3> => {
+  const optsOverrides: InternalServeHandlerOptions = {
+    ...options,
+    frameworkName,
+  };
+
+  return serveH3(optsOverrides);
+};

--- a/packages/inngest/src/nuxt.ts
+++ b/packages/inngest/src/nuxt.ts
@@ -8,9 +8,9 @@
 import {
   type InternalServeHandlerOptions,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { serve as serveH3 } from "./h3";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { serve as serveH3 } from "./h3.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/redwood.ts
+++ b/packages/inngest/src/redwood.ts
@@ -25,9 +25,9 @@ import {
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { processEnv } from "./helpers/env";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { processEnv } from "./helpers/env.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 export interface RedwoodResponse {
   statusCode: number;

--- a/packages/inngest/src/remix.ts
+++ b/packages/inngest/src/remix.ts
@@ -20,9 +20,9 @@ import {
   InngestCommHandler,
   type ActionResponse,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { type Env } from "./helpers/env";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { type Env } from "./helpers/env.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/sveltekit.ts
+++ b/packages/inngest/src/sveltekit.ts
@@ -25,9 +25,9 @@ import { type RequestEvent } from "@sveltejs/kit";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
-} from "./components/InngestCommHandler";
-import { processEnv } from "./helpers/env";
-import { type SupportedFrameworkName } from "./types";
+} from "./components/InngestCommHandler.js";
+import { processEnv } from "./helpers/env.js";
+import { type SupportedFrameworkName } from "./types.js";
 
 /**
  * The name of the framework, used to identify the framework in Inngest

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1248,7 +1248,8 @@ export type SupportedFrameworkName =
   | "sveltekit"
   | "fastify"
   | "koa"
-  | "hono";
+  | "hono"
+  | "nitro";
 
 /**
  * A set of options that can be passed to any step to configure it.

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1,18 +1,18 @@
 import { z } from "zod";
-import { type EventSchemas } from "./components/EventSchemas";
+import { type EventSchemas } from "./components/EventSchemas.js";
 import {
   type builtInMiddleware,
   type GetEvents,
   type Inngest,
-} from "./components/Inngest";
-import { type InngestFunction } from "./components/InngestFunction";
-import { type InngestFunctionReference } from "./components/InngestFunctionReference";
+} from "./components/Inngest.js";
+import { type InngestFunction } from "./components/InngestFunction.js";
+import { type InngestFunctionReference } from "./components/InngestFunctionReference.js";
 import {
   type ExtendSendEventWithMiddleware,
   type InngestMiddleware,
-} from "./components/InngestMiddleware";
-import { type createStepTools } from "./components/InngestStepTools";
-import { type internalEvents } from "./helpers/consts";
+} from "./components/InngestMiddleware.js";
+import { type createStepTools } from "./components/InngestStepTools.js";
+import { type internalEvents } from "./helpers/consts.js";
 import {
   type AsTuple,
   type IsEqual,
@@ -20,8 +20,8 @@ import {
   type Public,
   type Simplify,
   type WithoutInternal,
-} from "./helpers/types";
-import { type Logger } from "./middleware/logger";
+} from "./helpers/types.js";
+import { type Logger } from "./middleware/logger.js";
 
 const baseJsonErrorSchema = z.object({
   name: z.string().trim().optional(),


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Makes sure our CJS-only build supports truer ESM environments such as the default [Nitro](https://nitro.unjs.io/) setup; runtimes/bundlers will shim `require` to `import`, but file extensions can be non-negotiable.

This can result in errors importing internal dependencies of the library as those imports are shimmed:

```
[worker reload] Error [ERR_MODULE_NOT_FOUND]: Cannot find module '[...]/node_modules/.pnpm/inngest@3.22.5_encoding@0.1.13_h3@1.11.1_typescript@5.5.3/node_modules/inngest/helpers/ServerTiming' imported from [...]/apps/server/.nitro/dev/index.mjs
Did you mean to import "[...]/node_modules/.pnpm/inngest@3.22.5_encoding@0.1.13_h3@1.11.1_typescript@5.5.3/node_modules/inngest/helpers/ServerTiming.js"?
```

This change should be valid for both CJS and ESM builds. A previously-breaking Nitro example has been added to ensure we don't regress, as well as an ESLint rule that enforces all imports have the extensions needed.

As the shining bastion of our ESM future approaches, dual builds (building `dist` files for both CJS and ESM separately) will probably be more viable long-term. 

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR (Nitro framework docs)
- [x] Added unit/integration tests (Nitro example)
- [x] Added changesets if applicable

## Related

- inngest/website#960
