### PR TITLE
With Hono, try using the `env` adapter to access env vars

### DIFF
--- a/.changeset/lucky-readers-deny.md
+++ b/.changeset/lucky-readers-deny.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Merge given env vars with `process.env` to support partial env shims like Hono in AWS Lambda

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,18 @@ jobs:
         with:
           node-version: ${{ matrix.nodeVersion }}
       # Uses npm as pnpm doesn't support Node < 16
-      - run: node --version && npm --version && npm run test
+      # If we're on Node <18, restrict some framework tests that do not support
+      # Node on this version.
+      - run: |
+          node --version
+          npm --version
+          npm run test --testPathIgnorePatterns "<rootDir>/src/hono.test.ts"
+        if: ${{ matrix.nodeVersion < 18 }}
+      - run: |
+          node --version
+          npm --version
+          npm run test
+        if: ${{ matrix.nodeVersion >= 18 }}
 
   inngest_types:
     name: "inngest: Type tests"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,7 @@ jobs:
       - run: |
           node --version
           npm --version
-          npm run test --testPathIgnorePatterns "<rootDir>/src/hono.test.ts"
+          npm run test -- --testPathIgnorePatterns "<rootDir>/src/hono.test.ts"
         if: ${{ matrix.nodeVersion < 18 }}
       - run: |
           node --version

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -664,7 +664,13 @@ export class InngestCommHandler<
         ),
       ]);
 
-      this.env = env ?? allProcessEnv();
+      // Always make sure to merge whatever env we've been given with
+      // `process.env`; some platforms may not provide all the necessary
+      // environment variables or may use two sources.
+      this.env = {
+        ...allProcessEnv(),
+        ...env,
+      };
 
       const getInngestHeaders = (): Record<string, string> =>
         inngestHeaders({

--- a/packages/inngest/src/hono.ts
+++ b/packages/inngest/src/hono.ts
@@ -18,6 +18,7 @@
  */
 
 import { type Context } from "hono";
+import { env } from "hono/adapter";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
@@ -107,7 +108,7 @@ export const serve = (
         headers: (key) => c.req.header(key),
         method: () => c.req.method,
         body: () => c.req.json(),
-        env: () => c.env as Env,
+        env: () => env(c) as Env,
       };
     },
   });


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

In Hono, try to use the [Adapter Helper](https://hono.dev/docs/helpers/adapter) to correctly access environment variables instead of relying on `c.env` being the correct value.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
