### PR TITLE
Ensure event payloads are typed as JSON

### DIFF
--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -824,7 +824,7 @@ describe("createFunction", () => {
         schemas: new EventSchemas().fromRecord<{
           foo: {
             name: "foo";
-            data: { title: string };
+            data: { title: string; date: Date };
           };
           bar: {
             name: "bar";
@@ -845,6 +845,17 @@ describe("createFunction", () => {
         inngest.createFunction("test", "unknown", ({ event }) => {
           assertType<unknown>(event);
         });
+      });
+
+      test("JSONifies known event data", () => {
+        inngest.createFunction(
+          { id: "test" },
+          { event: "foo" },
+          ({ event, events }) => {
+            assertType<string>(event.data.date);
+            assertType<string>(events[0].data.date);
+          }
+        );
       });
 
       test("allows name to be an object", () => {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -13,12 +13,14 @@ import {
 } from "./components/InngestMiddleware";
 import { type createStepTools } from "./components/InngestStepTools";
 import { type internalEvents } from "./helpers/consts";
+import { type Jsonify } from "./helpers/jsonify";
 import {
   type AsTuple,
   type IsEqual,
   type IsNever,
   type Public,
   type Simplify,
+  type SimplifyDeep,
   type WithoutInternal,
 } from "./helpers/types";
 import { type Logger } from "./middleware/logger";
@@ -349,8 +351,10 @@ export type BaseContext<
   /**
    * The event data present in the payload.
    */
-  event: GetContextEvents<TClient, TTriggers>;
-  events: AsTuple<GetContextEvents<TClient, TTriggers, true>>;
+  event: SimplifyDeep<Jsonify<GetContextEvents<TClient, TTriggers>>>;
+  events: AsTuple<
+    SimplifyDeep<Jsonify<GetContextEvents<TClient, TTriggers, true>>>
+  >;
 
   /**
    * The run ID for the current function execution


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

> [!WARNING]
> This is a breaking change for some builds.

This PR ensures that, similar to `step.run()` outputs, event data is also represented as being (de)serialized with JSON, stripping fields such as `Date`.

There are ongoing discussions on the appropriateness and typing application of middleware-based transformers (see #160), but for now we should make sure that they the typing correctly represents the runtime values.

Even though this is fixing a misrepresentation of an event's data, it could still break builds for users pushing `event.data` into other formats. Thus we cannot ship this until v4.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #160
