### PR TITLE
Return `206` with `op: "StepNotFound"` when no step found to run

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1039,16 +1039,12 @@ export class InngestCommHandler<
           },
           "step-not-found": (result) => {
             return {
-              status: 500,
+              status: 206,
               headers: {
                 "Content-Type": "application/json",
                 [headerKeys.NoRetry]: "false",
               },
-              body: stringify({
-                error: `Could not find step "${
-                  result.step.displayName || result.step.id
-                }" to run; timed out`,
-              }),
+              body: stringify([result.step]),
               version,
             };
           },


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

If a step is intended to be run and was not found due to non-determinism or a changed function, still return a `206` with the `"StepNotFound"` opcode.

This complements inngest/inngest#1715 to ensure we recover from these situations gracefully.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- inngest/inngest#1715
