### PR TITLE
fix: required type annotation typescript error

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -122,6 +122,11 @@
       "import": "./hono.js",
       "types": "./hono.d.ts"
     },
+    "./types": {
+      "require": "./types.js",
+      "import": "./types.js",
+      "types": "./types.d.ts"
+    },
     "./api/*": "./api/*.js",
     "./components/*": "./components/*.js",
     "./deno/*": "./deno/*.js",


### PR DESCRIPTION


## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->
This commit addresses `The inferred type of 'inngest' cannot be named without a reference to '../../../node_modules/inngest/types'. This is likely not portable. A type annotation is necessary. ts (2742)` error described in #695. Version 3.22.7 hasn't fixed the issue.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

Fixes: #695
