### PR TITLE
Allow access to userland promises when executing for `@inngest/test`

### DIFF
--- a/.changeset/young-spies-repeat.md
+++ b/.changeset/young-spies-repeat.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow access to userland promises when executing for `@inngest/test`

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -40,6 +40,11 @@ export interface FoundStep extends HashedOp {
   handled: boolean;
 
   /**
+   * The promise that has been returned to userland code for this step.
+   */
+  promise: Promise<unknown>;
+
+  /**
    * Returns a boolean representing whether or not the step was handled on this
    * invocation.
    */

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -43,6 +43,11 @@ export interface MemoizedOp extends IncomingOp {
    */
   rawArgs?: unknown[];
   fulfilled?: boolean;
+
+  /**
+   * The promise that has been returned to userland code.
+   */
+  promise?: Promise<unknown>;
   seen?: boolean;
 }
 

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -864,6 +864,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         hashedId,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         fn: opts?.fn ? () => opts.fn?.(...args) : undefined,
+        promise,
         fulfilled: Boolean(stepState),
         displayName: opId.displayName ?? opId.id,
         handled: false,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

For `@inngest/test` (#704), we need access to the internal promise that we send to userland code so that we can access its output for state assertions.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #704
