### PR TITLE
Support Next.js 15

### DIFF
--- a/.changeset/clever-pets-relax.md
+++ b/.changeset/clever-pets-relax.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Support Next.js 15 in serve handler typing

--- a/packages/inngest/src/next.ts
+++ b/packages/inngest/src/next.ts
@@ -49,7 +49,8 @@ export const frameworkName: SupportedFrameworkName = "nextjs";
  * environment used (edge vs serverless).
  */
 export type RequestHandler = (
-  ...args: [expectedReq: NextRequest, res: unknown]
+  expectedReq: NextRequest,
+  res: unknown
 ) => Promise<Response>;
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Ensures we support Next.js by being looser with second argument typing for `GET`, `POST`, and `PUT` endpoints.

```
$ pnpm build

> inngest15@0.1.0 build /home/nixos/scratch/inngest-nextjs15-bug
> next build

 ⚠ Configuration with next.config.ts is currently an experimental feature, use with caution.
  ▲ Next.js 15.0.0-canary.177

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types  ...Failed to compile.

src/app/api/inngest/route.ts
Type error: Route "src/app/api/inngest/route.ts" has an invalid "GET" export:
  Type "ServerResponse<IncomingMessage> & { send: Send<any>; json: Send<any>; ... 5 more ...; revalidate: (urlPath: string, opts?: { ...; } | undefined) => Promise<...>; }" is not a valid type for the function's second argument.
```

This is due to Next.js majors (and execution environments) all requiring different typing for that second argument, from `undefined`, to `NextApiResponse`, to `RouteContext`, which is _enforced_ by build-step type checking. Instead we set `unknown` and handle the difference manually at runtime.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #717 
