### PR TITLE
Make `@inngest/test` -> `inngest` a regular dependency

### DIFF
--- a/packages/middleware-encryption/package.json
+++ b/packages/middleware-encryption/package.json
@@ -64,7 +64,7 @@
     "cross-fetch": "^4.0.0",
     "eslint": "^8.30.0",
     "fetch-mock-jest": "^1.5.1",
-    "inngest": "^3.21.0",
+    "inngest": "3.21.0",
     "jest": "^29.3.1",
     "ts-jest": "^29.1.0",
     "typescript": "~5.5.2",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -39,11 +39,9 @@
   "author": "Inngest Inc. <hello@inngest.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "inngest": "^3.22.12",
     "tinyspy": "^3.0.2",
     "ulid": "^2.3.0"
-  },
-  "peerDependencies": {
-    "inngest": "^3.22.12"
   },
   "devDependencies": {
     "prettier": "^3.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,7 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1(node-fetch@2.7.0)
       inngest:
-        specifier: ^3.21.0
+        specifier: 3.21.0
         version: 3.21.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.5.2)
       jest:
         specifier: ^29.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,7 +304,7 @@ importers:
     dependencies:
       inngest:
         specifier: ^3.22.12
-        version: 3.22.13(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.6.2)
+        version: 3.23.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.6.2)
       tinyspy:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3026,8 +3026,8 @@ packages:
       typescript:
         optional: true
 
-  inngest@3.22.13:
-    resolution: {integrity: sha512-IBF0wgw3hfYyl59RX6xilKYQFbI+8kOLi78jIoi1zRheVoUAW4MMZEPOFpQVn3at1XtZehwSffctqZ4TjijtCQ==}
+  inngest@3.23.0:
+    resolution: {integrity: sha512-Pkq1yJ+4ihQNTh4BcNq+4Fo5iCcLP1H5dj6jdhOHO8SuuwiqHkWyDgIZBAbsryq92+3YI7PuSz+4Qewf+trwog==}
     engines: {node: '>=14'}
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
@@ -8183,7 +8183,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.22.13(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.6.2):
+  inngest@3.23.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.6.2):
     dependencies:
       '@types/debug': 4.1.12
       canonicalize: 1.0.8


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes broken JSR publishing for `@inngest/test`.

JSR doesn't support peer dependencies, though a non-optional peer dependency is identical to a regular dependency in any modern package manager.

Moving `inngest` to be a regular dependency of `@inngest/test` to resolve the JSR publishing issue.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Release CI
- [x] Added changesets if applicable
