### PR TITLE
Fix error when PUT is missing body

### DIFF
--- a/.changeset/bright-waves-sip.md
+++ b/.changeset/bright-waves-sip.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix crash when receiving a PUT without a body

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -763,6 +763,15 @@ export class InngestCommHandler<
         return { header, value };
       });
 
+      const contentLength = await actions
+        .headers("checking signature for request", headerKeys.ContentLength)
+        .then((value) => {
+          if (!value) {
+            return undefined;
+          }
+          return parseInt(value, 10);
+        });
+
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const [signature, method, body] = await Promise.all([
         actions
@@ -773,6 +782,11 @@ export class InngestCommHandler<
         methodP,
         methodP.then((method) => {
           if (method === "POST" || method === "PUT") {
+            if (!contentLength) {
+              // Return empty string because req.json() will throw an error.
+              return "";
+            }
+
             return actions.body(
               `checking body for request signing as method is ${method}`
             );

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -123,6 +123,7 @@ export enum envKeys {
  * @public
  */
 export enum headerKeys {
+  ContentLength = "content-length",
   Signature = "x-inngest-signature",
   SdkVersion = "x-inngest-sdk",
   Environment = "x-inngest-env",

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -263,7 +263,14 @@ export const testFramework = (
       ? getServeHandler(handlerOpts)
       : handlerOpts;
 
-    const host = "localhost:3000";
+    const headers: Record<string, string> = {
+      host: "localhost:3000",
+    };
+
+    if (reqOpts[0]?.body !== undefined) {
+      headers["content-type"] = "application/json";
+      headers["content-length"] = `${JSON.stringify(reqOpts[0].body).length}`;
+    }
 
     const mockReqOpts: httpMocks.RequestOptions = {
       hostname: "localhost",
@@ -272,7 +279,7 @@ export const testFramework = (
       ...reqOpts[0],
       headers: {
         ...reqOpts[0]?.headers,
-        host,
+        ...headers,
       },
     };
 


### PR DESCRIPTION
## Summary
Fix a server crash when calling `req.json()` on a `PUT` with an empty body.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
