### PR TITLE
Add timeouts to function configuration

### DIFF
--- a/.changeset/proud-pets-stare.md
+++ b/.changeset/proud-pets-stare.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add timeouts as function config

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -501,17 +501,19 @@ export namespace InngestFunction {
       start?: TimeStr;
 
       /**
-       * Finish represents the time between a function starting and the function finishing.
-       * If a function takes longer than this time to finish, the function is marked as cancelled.
+       * Finish represents the time between a function starting and the function
+       * finishing. If a function takes longer than this time to finish, the
+       * function is marked as cancelled.
        *
-       * The start time is taken from the time that the first successful function request begins,
-       * and does not include the time spent in the queue before the function starts.
+       * The start time is taken from the time that the first successful
+       * function request begins, and does not include the time spent in the
+       * queue before the function starts.
        *
-       * Note that if the final request to a function begins before this timeout, and completes
-       * after this timeout, the function will succeed.
+       * Note that if the final request to a function begins before this
+       * timeout, and completes after this timeout, the function will succeed.
        */
       finish?: TimeStr;
-    },
+    };
 
     cancelOn?: Cancellation<GetEvents<TClient, true>>[];
 

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -123,6 +123,7 @@ export class InngestFunction<
       throttle,
       concurrency,
       debounce,
+      timeouts,
       priority,
     } = this.opts;
 
@@ -165,6 +166,7 @@ export class InngestFunction<
       concurrency,
       debounce,
       priority,
+      timeouts,
     };
 
     if (cancelOn) {
@@ -479,6 +481,37 @@ export namespace InngestFunction {
        */
       run?: string;
     };
+
+    /**
+     * Configure timeouts for the function.  If any of the timeouts are hit, the
+     * function run will be cancelled.
+     */
+    timeouts?: {
+      /**
+       * Start represents the timeout for starting a function.  If the time
+       * between scheduling and starting a function exceeds this value, the
+       * function will be cancelled.
+       *
+       * This is, essentially, the amount of time that a function sits in the
+       * queue before starting.
+       *
+       * A function may exceed this duration because of concurrency limits,
+       * throttling, etc.
+       */
+      start?: TimeStr;
+
+      /**
+       * Finish represents the time between a function starting and the function finishing.
+       * If a function takes longer than this time to finish, the function is marked as cancelled.
+       *
+       * The start time is taken from the time that the first successful function request begins,
+       * and does not include the time spent in the queue before the function starts.
+       *
+       * Note that if the final request to a function begins before this timeout, and completes
+       * after this timeout, the function will succeed.
+       */
+      finish?: TimeStr;
+    },
 
     cancelOn?: Cancellation<GetEvents<TClient, true>>[];
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1169,6 +1169,12 @@ export const functionConfigSchema = z.strictObject({
         .optional(),
     })
     .optional(),
+  timeouts: z
+    .strictObject({
+      start: z.string().transform((x) => x as TimeStr),
+      finish: z.string().transform((x) => x as TimeStr),
+    })
+    .optional(),
   priority: z
     .strictObject({
       run: z.string().optional(),

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1171,8 +1171,14 @@ export const functionConfigSchema = z.strictObject({
     .optional(),
   timeouts: z
     .strictObject({
-      start: z.string().transform((x) => x as TimeStr),
-      finish: z.string().transform((x) => x as TimeStr),
+      start: z
+        .string()
+        .transform((x) => x as TimeStr)
+        .optional(),
+      finish: z
+        .string()
+        .transform((x) => x as TimeStr)
+        .optional(),
     })
     .optional(),
   priority: z


### PR DESCRIPTION
This adds to parameters:

- `timeouts.start`
- `timeouts.finish`

If either of these timeouts are hit, the function run will be cancelled.

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable
