### PR TITLE
Fix `@inngest/test` not capturing initial errors

### DIFF
--- a/packages/test/src/InngestTestEngine.ts
+++ b/packages/test/src/InngestTestEngine.ts
@@ -508,6 +508,8 @@ export class InngestTestEngine {
       Promise.resolve({}) as Promise<InngestTestEngine.MockState>
     );
 
+    InngestTestRun["updateState"](options, result);
+
     const run = new InngestTestRun({
       testEngine: this.clone(options),
     });

--- a/packages/test/src/InngestTestEngine.ts
+++ b/packages/test/src/InngestTestEngine.ts
@@ -91,6 +91,7 @@ export namespace InngestTestEngine {
 
   export interface MockedStep {
     id: string;
+    idIsHashed?: boolean;
     handler: () => any;
   }
 
@@ -251,11 +252,10 @@ export class InngestTestEngine {
       );
     } else if (output.result.type === "step-ran") {
       try {
+        // Any error halts execution until retries are modelled
         if (
-          (
-            (output as InngestTestEngine.ExecutionOutput<"step-ran">).result
-              .step.error as any
-          ).name === "NonRetriableError"
+          (output as InngestTestEngine.ExecutionOutput<"step-ran">).result.step
+            .error
         ) {
           return rejectionHandler(
             output as InngestTestEngine.ExecutionOutput<"function-rejected">,
@@ -407,7 +407,7 @@ export class InngestTestEngine {
     const steps = (options.steps || []).map((step) => {
       return {
         ...step,
-        id: _internals.hashId(step.id),
+        id: step.idIsHashed ? step.id : _internals.hashId(step.id),
       };
     });
 

--- a/packages/test/src/InngestTestEngine.ts
+++ b/packages/test/src/InngestTestEngine.ts
@@ -29,7 +29,7 @@ export namespace InngestTestEngine {
      * TODO Potentially later allow many functions such that we can invoke and
      * send events.
      */
-    function: InngestFunction.Any;
+    function: InngestFunction<any, any, any, any, any, any>;
 
     /**
      * The event payloads to send to the function. If none is given, an

--- a/packages/test/src/InngestTestEngine.ts
+++ b/packages/test/src/InngestTestEngine.ts
@@ -251,20 +251,16 @@ export class InngestTestEngine {
         output as InngestTestEngine.ExecutionOutput<"function-rejected">
       );
     } else if (output.result.type === "step-ran") {
-      try {
-        // Any error halts execution until retries are modelled
-        if (
+      // Any error halts execution until retries are modelled
+      if (
+        (output as InngestTestEngine.ExecutionOutput<"step-ran">).result.step
+          .error
+      ) {
+        return rejectionHandler(
+          output as InngestTestEngine.ExecutionOutput<"function-rejected">,
           (output as InngestTestEngine.ExecutionOutput<"step-ran">).result.step
             .error
-        ) {
-          return rejectionHandler(
-            output as InngestTestEngine.ExecutionOutput<"function-rejected">,
-            (output as InngestTestEngine.ExecutionOutput<"step-ran">).result
-              .step.error
-          );
-        }
-      } catch (err) {
-        // no-op
+        );
       }
     }
 

--- a/packages/test/src/InngestTestRun.ts
+++ b/packages/test/src/InngestTestRun.ts
@@ -167,10 +167,16 @@ export class InngestTestRun {
         "step-ran": () => {
           const result = exec.result as InngestTestRun.Checkpoint<"step-ran">;
 
+          // if this is an error, we should stop. Later we model retries.
+          if (result.step.error) {
+            return finish(exec);
+          }
+
           // add to our running state
           runningState.steps ??= [];
           runningState.steps.push({
-            id: result.step.name as string, // TODO we need the non-hashed ID here, or a way to map it
+            id: result.step.id,
+            idIsHashed: true,
             handler: () => {
               if (result.step.error) {
                 throw result.step.error;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes `@inngest/test` not capturing initial errors within a function as well as steps sometimes running twice.

For now this continues to not model retries, as per the README.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Using in `@inngest/middleware-validation`
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #731 
- Fixes #732
