### PR TITLE
Fix `next` JSR export

### DIFF
--- a/packages/inngest/src/next.ts
+++ b/packages/inngest/src/next.ts
@@ -21,7 +21,7 @@
  */
 
 import { type NextApiRequest, type NextApiResponse } from "next";
-import { type NextRequest } from "next/server";
+import { type NextRequest } from "next/server.js";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes an annoying release bug, with JSR failing for `inngest`.
See https://github.com/inngest/inngest-js/actions/runs/11741974959/job/32711752350

We don't usually require extensions for libraries because we expect packages to also have ESM exports declared in their `package.json`, but `next` does not do this, so we must explicitly use the extension still.

Annoyingly, a dry run publish with `jsr` doesn't reveal this. 🙄

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A CI fix
- [ ] ~Added unit/integration tests~ N/A CI fix
- [x] Added changesets if applicable
