### PR TITLE
Fix missing errors when rejecting execution

### DIFF
--- a/.changeset/four-tips-eat.md
+++ b/.changeset/four-tips-eat.md
@@ -1,0 +1,5 @@
+---
+"@inngest/test": patch
+---
+
+Fix `error` sometimes being `undefined` when a step rejects mid-run

--- a/packages/test/src/InngestTestEngine.ts
+++ b/packages/test/src/InngestTestEngine.ts
@@ -223,8 +223,7 @@ export class InngestTestEngine {
     };
 
     const rejectionHandler = (
-      output: InngestTestEngine.ExecutionOutput<"function-rejected">,
-      error: unknown = output.result.error
+      output: InngestTestEngine.ExecutionOutput<"function-rejected">
     ) => {
       if (
         typeof output === "object" &&
@@ -232,6 +231,23 @@ export class InngestTestEngine {
         "ctx" in output &&
         "state" in output
       ) {
+        let error = output.result.error;
+        if (!error) {
+          if (
+            "step" in output.result &&
+            typeof output.result.step === "object" &&
+            output.result.step !== null &&
+            "error" in output.result.step &&
+            output.result.step.error
+          ) {
+            error = output.result.step.error;
+          } else {
+            error = new Error(
+              "Function rejected without a visible error; this is a bug"
+            );
+          }
+        }
+
         return {
           ctx: output.ctx,
           state: output.state,
@@ -257,9 +273,7 @@ export class InngestTestEngine {
           .error
       ) {
         return rejectionHandler(
-          output as InngestTestEngine.ExecutionOutput<"function-rejected">,
-          (output as InngestTestEngine.ExecutionOutput<"step-ran">).result.step
-            .error
+          output as InngestTestEngine.ExecutionOutput<"function-rejected">
         );
       }
     }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes `error` sometimes being `undefined` when a step rejects when using the `InngestTestEngine`, caused by not always looking for the correct value from the returned checkpoints.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Closes https://github.com/inngest/inngest-js/issues/732#issuecomment-2484136903
