### PR TITLE
Fix OpenAI `tools` types

### DIFF
--- a/.changeset/clever-jobs-hammer.md
+++ b/.changeset/clever-jobs-hammer.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix OpenAI `tools` types - not properly scoped

--- a/packages/inngest/src/components/ai/adapters/openai.ts
+++ b/packages/inngest/src/components/ai/adapters/openai.ts
@@ -270,40 +270,47 @@ export interface OpenAiAiAdapter extends AiAdapter {
        */
       tools?: {
         /**
-         * The name of the function to be called. Must be a-z, A-Z, 0-9, or
-         * contain underscores and dashes, with a maximum length of 64.
+         * The type of the tool.
          */
-        name: string;
+        type: "function";
 
-        /**
-         * A description of what the function does, used by the model to choose
-         * when and how to call the function.
-         */
-        description?: string;
+        function: {
+          /**
+           * The name of the function to be called. Must be a-z, A-Z, 0-9, or
+           * contain underscores and dashes, with a maximum length of 64.
+           */
+          name: string;
 
-        /**
-         * The parameters the functions accepts, described as a JSON Schema
-         * object. See the
-         * [guide](https://platform.openai.com/docs/guides/function-calling) for
-         * examples, and the [JSON Schema
-         * reference](https://json-schema.org/understanding-json-schema/) for
-         * documentation about the format.
-         *
-         * Omitting `parameters` defines a function with an empty parameter
-         * list.
-         */
-        parameters?: Record<string, unknown>;
+          /**
+           * A description of what the function does, used by the model to choose
+           * when and how to call the function.
+           */
+          description?: string;
 
-        /**
-         * Whether to enable strict schema adherence when generating the
-         * function call. If set to true, the model will follow the exact schema
-         * defined in the `parameters field`. Only a subset of JSON Schema is
-         * supported when `strict` is `true`. Learn more about Structured
-         * Outputs in the function calling guide.
-         *
-         * @default false
-         */
-        strict?: boolean;
+          /**
+           * The parameters the functions accepts, described as a JSON Schema
+           * object. See the
+           * [guide](https://platform.openai.com/docs/guides/function-calling) for
+           * examples, and the [JSON Schema
+           * reference](https://json-schema.org/understanding-json-schema/) for
+           * documentation about the format.
+           *
+           * Omitting `parameters` defines a function with an empty parameter
+           * list.
+           */
+          parameters?: Record<string, unknown>;
+
+          /**
+           * Whether to enable strict schema adherence when generating the
+           * function call. If set to true, the model will follow the exact schema
+           * defined in the `parameters field`. Only a subset of JSON Schema is
+           * supported when `strict` is `true`. Learn more about Structured
+           * Outputs in the function calling guide.
+           *
+           * @default false
+           */
+          strict?: boolean;
+        };
       }[];
 
       /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes the incorrect OpenAI `tools` type.

https://platform.openai.com/docs/api-reference/chat

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Typing
- [x] Added changesets if applicable
