### PR TITLE
Ensure we add max_tokens as an anthropic option

### DIFF
--- a/.changeset/late-pans-beg.md
+++ b/.changeset/late-pans-beg.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add max_tokens as a param for anthropic model providers

--- a/packages/inngest/src/components/ai/models/anthropic.ts
+++ b/packages/inngest/src/components/ai/models/anthropic.ts
@@ -38,8 +38,10 @@ export const anthropic: AiAdapter.ModelCreator<
     format: "anthropic",
     onCall(_, body) {
       body.model ||= options.model;
+      body.max_tokens ||= options.max_tokens;
     },
     headers,
+    options,
   } as Anthropic.AiModel;
 };
 
@@ -61,6 +63,11 @@ export namespace Anthropic {
      * table for details on which models work with the Anthropic API.
      */
     model: Model;
+
+    /**
+     * The maximum number of tokens to generate before stopping.
+     */
+    max_tokens: number;
 
     /**
      * The Anthropic API key to use for authenticating your request. By default
@@ -85,5 +92,5 @@ export namespace Anthropic {
   /**
    * An Anthropic model using the Anthropic format for I/O.
    */
-  export type AiModel = AnthropicAiAdapter;
+  export type AiModel = AnthropicAiAdapter & { options: AiModelOptions };
 }

--- a/packages/inngest/src/components/ai/models/openai.ts
+++ b/packages/inngest/src/components/ai/models/openai.ts
@@ -30,6 +30,7 @@ export const openai: AiAdapter.ModelCreator<
     onCall(_, body) {
       body.model ||= options.model;
     },
+    options,
   } as OpenAi.AiModel;
 };
 
@@ -74,5 +75,5 @@ export namespace OpenAi {
   /**
    * An OpenAI model using the OpenAI format for I/O.
    */
-  export type AiModel = OpenAiAiAdapter;
+  export type AiModel = OpenAiAiAdapter & { options: AiModelOptions };
 }


### PR DESCRIPTION
This adds `max_tokens` as an anthropic model option.  It also exposes model options in the model itself, allowing eg. AgentKit to access the model directly via these options.

