### PR TITLE
Add missing `finish_reason` to OpenAI output types

### DIFF
--- a/.changeset/lemon-sloths-wave.md
+++ b/.changeset/lemon-sloths-wave.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add missing `finish_reason` to OpenAI output types

--- a/packages/inngest/src/components/ai/adapters/openai.ts
+++ b/packages/inngest/src/components/ai/adapters/openai.ts
@@ -356,6 +356,16 @@ export interface OpenAiAiAdapter extends AiAdapter {
        */
       choices: {
         /**
+         * The reason the model stopped generating tokens. This will be `stop`
+         * if the model hit a natural stop point or a provided stop sequence,
+         * `length` if the maximum number of tokens specified in the request was
+         * reached, `content_filter` if content was omitted due to a flag from
+         * our content filters, `tool_calls` if the model called a tool, or
+         * `function_call` (deprecated) if the model called a function.
+         */
+        finish_reason: string;
+
+        /**
          * The index of the choice in the list of choices.
          */
         index: number;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds the missing `finish_reason: string` field to output types for OpenAI calls.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Helps inngest/agent-kit#17
