### PR TITLE
Widens the `AiAdapter` types to allow for easy overrides

### DIFF
--- a/.changeset/stale-falcons-dress.md
+++ b/.changeset/stale-falcons-dress.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Widen the `AiAdapter` types to allow for easy overrides

--- a/packages/inngest/src/components/ai/adapter.ts
+++ b/packages/inngest/src/components/ai/adapter.ts
@@ -21,6 +21,12 @@ export interface AiAdapter {
   format: AiAdapter.Format;
 
   /**
+   * The constructor options for the adapter.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any;
+
+  /**
    * The input and output types for this AI I/O format.
    *
    * This is not accessible externally, and is only used internally to define
@@ -79,6 +85,17 @@ export interface AiAdapter {
  * types.
  */
 export namespace AiAdapter {
+  export interface Any extends Omit<AiAdapter, "format"> {
+    /**
+     * The I/O format for the adapter.
+     *
+     * Allows any value, such that this type can be easily used with any
+     * adapter.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    format: any;
+  }
+
   /**
    * A helper used to infer the input type of an adapter.
    */

--- a/packages/inngest/src/components/ai/models/anthropic.ts
+++ b/packages/inngest/src/components/ai/models/anthropic.ts
@@ -92,5 +92,7 @@ export namespace Anthropic {
   /**
    * An Anthropic model using the Anthropic format for I/O.
    */
-  export type AiModel = AnthropicAiAdapter & { options: AiModelOptions };
+  export interface AiModel extends AnthropicAiAdapter {
+    options: AiModelOptions;
+  }
 }

--- a/packages/inngest/src/components/ai/models/openai.ts
+++ b/packages/inngest/src/components/ai/models/openai.ts
@@ -77,5 +77,7 @@ export namespace OpenAi {
   /**
    * An OpenAI model using the OpenAI format for I/O.
    */
-  export type AiModel = OpenAiAiAdapter & { options: AiModelOptions };
+  export interface AiModel extends OpenAiAiAdapter {
+    options: AiModelOptions;
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Widens typing for `AiAdapter` types for use with `@inngest/agent-kit`, to allow for some easier checking of subtypes with `extends`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Internal
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Testing with inngest/agent-kit#17
