### PR TITLE
patch in support overloaded input types on create tool

### DIFF
--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -198,13 +198,34 @@ export const createStepTools = <TClient extends Inngest.Any>(
          * for next steps.
          */
         fn: TFn,
-
         /**
-         * Optional input to pass to the function. If this is specified, Inngest
-         * will keep track of the input for this step and be able to display it
-         * in the UI.
+         * Where there are multiple input type overloads, Parameters<TFn>
+         * will infer the type from the last overload. This breaks vercel's
+         * ai sdk generateObject for instance. Here patch in infer support
+         * for up to 4 overloads. I have not found a way to do this generically
+         * for n overloads.
          */
-        ...input: Parameters<TFn>
+        ...input: TFn extends {
+          (...args: infer A): unknown;
+          (...args: infer B): unknown;
+          (...args: infer C): unknown;
+          (...args: infer D): unknown;
+        }
+          ? A | B | C | D
+          : TFn extends {
+                (...args: infer A): unknown;
+                (...args: infer B): unknown;
+                (...args: infer C): unknown;
+              }
+            ? A | B | C
+            : TFn extends {
+                  (...args: infer A): unknown;
+                  (...args: infer B): unknown;
+                }
+              ? A | B
+              : TFn extends (...args: infer A) => unknown
+                ? A
+                : never
       ) => Promise<
         /**
          * TODO Middleware can affect this. If run input middleware has returned


### PR DESCRIPTION
## Summary
Previously for wrapped function calls like this with overloaded input types, typescript would throw errors because our generic input type were not seeing all the overloads:

```
    await step.ai.wrap("use vercel ai sdk", generateObject, {
      model: anthropicSdk("claude-3-5-sonnet-20241022"),
      schema: z.object({
        recipe: z.object({
          name: z.string(),
          ingredients: z.array(
            z.object({ name: z.string(), amount: z.string() })
          ),
          steps: z.array(z.string()),
        }),
      }),
      prompt: "Generate a lasagna recipe.",
    });
```
 
This patches in, somewhat dumbly, support for a few more additional overload types. This makes the above and *any* wrapped function call with up to 4 overloads work. I haven't found any generic way to support n input overloads. 


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
