### PR TITLE
Fix Nuxt and H3 use https when no NODE_ENV

### DIFF
--- a/.changeset/angry-houses-move.md
+++ b/.changeset/angry-houses-move.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix Nuxt and H3 uses https in dev

--- a/packages/inngest/src/h3.ts
+++ b/packages/inngest/src/h3.ts
@@ -89,13 +89,17 @@ export const serve = (
         body: () => readBody(event),
         headers: (key) => getHeader(event, key),
         method: () => event.method,
-        url: () =>
-          new URL(
+        url: () => {
+          let scheme = "https";
+          if ((processEnv("NODE_ENV") ?? "dev").startsWith("dev")) {
+            scheme = "http";
+          }
+
+          return new URL(
             String(event.path),
-            `${
-              processEnv("NODE_ENV") === "development" ? "http" : "https"
-            }://${String(getHeader(event, "host"))}`
-          ),
+            `${scheme}://${String(getHeader(event, "host"))}`
+          );
+        },
         queryString: (key) => {
           const param = getQuery(event)[key];
           if (param) {


### PR DESCRIPTION
## Summary
Fix the SDK reporting its scheme as `https` when the `NODE_ENV` env var isn't set.