### PR TITLE
Disable and warn on step tool usage after execution

### DIFF
--- a/packages/inngest/CHANGELOG.md
+++ b/packages/inngest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # inngest
 
+## 3.27.5
+
+### Patch Changes
+
+- [#773](https://github.com/inngest/inngest-js/pull/773) [`fb745ef`](https://github.com/inngest/inngest-js/commit/fb745ef749d851031c494f602ff8611a6b1dab14) Thanks [@amh4r](https://github.com/amh4r)! - Fix Nuxt and H3 uses https in dev
+
 ## 3.27.4
 
 ### Patch Changes

--- a/packages/inngest/jsr.json
+++ b/packages/inngest/jsr.json
@@ -2,7 +2,7 @@
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@inngest/sdk",
   "description": "Official SDK for Inngest.com. Inngest is the reliability layer for modern applications. Inngest combines durable execution, events, and queues into a zero-infra platform with built-in observability.",
-  "version": "3.27.4",
+  "version": "3.27.5",
   "include": [
     "./src/**/*.ts"
   ],

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inngest",
-  "version": "3.27.4",
+  "version": "3.27.5",
   "description": "Official SDK for Inngest.com. Inngest is the reliability layer for modern applications. Inngest combines durable execution, events, and queues into a zero-infra platform with built-in observability.",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/inngest/src/h3.ts
+++ b/packages/inngest/src/h3.ts
@@ -89,13 +89,17 @@ export const serve = (
         body: () => readBody(event),
         headers: (key) => getHeader(event, key),
         method: () => event.method,
-        url: () =>
-          new URL(
+        url: () => {
+          let scheme = "https";
+          if ((processEnv("NODE_ENV") ?? "dev").startsWith("dev")) {
+            scheme = "http";
+          }
+
+          return new URL(
             String(event.path),
-            `${
-              processEnv("NODE_ENV") === "development" ? "http" : "https"
-            }://${String(getHeader(event, "host"))}`
-          ),
+            `${scheme}://${String(getHeader(event, "host"))}`
+          );
+        },
         queryString: (key) => {
           const param = getQuery(event)[key];
           if (param) {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

If a `step.**()` tool is called after a particular execution has finished, this means that some userland code is holding on to the reference and attempting to call it, which will always result in a hanging `Promise` being returned and very confusing results with the Executor.

This PR adds a small warning if this is detected.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Internal
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Would have helped debug inngest/agent-kit#23
