### PR TITLE
Fix `@inngest/test` automatic spying not accounting for `step.**`

### DIFF
--- a/.changeset/famous-kiwis-itch.md
+++ b/.changeset/famous-kiwis-itch.md
@@ -1,0 +1,5 @@
+---
+"@inngest/test": patch
+---
+
+Fix `@inngest/test` automatic spying not accounting for `step.**`

--- a/packages/test/src/spy.ts
+++ b/packages/test/src/spy.ts
@@ -623,3 +623,18 @@ export function fn<T extends Procedure = Procedure>(
 
   return enhancedSpy as any;
 }
+
+export const mockAny = <T>(obj: T): T => {
+  if (typeof obj === "function") {
+    return fn(obj as (...args: any[]) => any) as T;
+  }
+
+  if (typeof obj === "object" && obj !== null) {
+    return Object.keys(obj).reduce((acc, key) => {
+      (acc as any)[key] = mockAny(obj[key as keyof typeof obj]);
+      return acc;
+    }, obj);
+  }
+
+  return obj;
+};

--- a/packages/test/src/util.ts
+++ b/packages/test/src/util.ts
@@ -1,7 +1,7 @@
 import { internalEvents } from "inngest";
 import type { Context, EventPayload } from "inngest/types";
 import { ulid } from "ulid";
-import { fn as mockFn } from "./spy.js";
+import { mockAny } from "./spy.js";
 
 /**
  * The default context transformation function that mocks all step tools. Use
@@ -9,22 +9,9 @@ import { fn as mockFn } from "./spy.js";
  * this functionality.
  */
 export const mockCtx = (ctx: Readonly<Context.Any>): Context.Any => {
-  const step = Object.keys(ctx.step).reduce(
-    (acc, key) => {
-      const tool = ctx.step[key as keyof typeof ctx.step];
-      const mock = mockFn(tool);
-
-      return {
-        ...acc,
-        [key]: mock,
-      };
-    },
-    {} as Context.Any["step"]
-  );
-
   return {
     ...ctx,
-    step,
+    step: mockAny(ctx.step),
   };
 };
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`@inngest/test` performs automatic mocking of the functions within the `step` object. This change ensure we also recursively apply those mocks such that `step.**()` is mocked, such as `step.ai.infer()`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Using in another PR
- [x] Added changesets if applicable
