### PR TITLE
Handle `chalk` being `undefined`

### DIFF
--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -164,7 +164,8 @@ export enum internalEvents {
   ScheduledTimer = "inngest/scheduled.timer",
 }
 
-export const logPrefix: string = chalk.magenta.bold("[Inngest]");
+export const logPrefix: string =
+  chalk?.magenta.bold("[Inngest]") || "[Inngest]";
 
 export const debugPrefix = "inngest";
 

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -405,17 +405,19 @@ export const prettyError = ({
   stack,
   code,
 }: PrettyError): string => {
-  const { icon, colorFn } = (
+  const { icon, colorFn = (s: string) => s } = (
     {
-      error: { icon: "❌", colorFn: chalk.red },
-      warn: { icon: "⚠️", colorFn: chalk.yellow },
+      error: { icon: "❌", colorFn: chalk?.red },
+      warn: { icon: "⚠️", colorFn: chalk?.yellow },
     } satisfies Record<
       NonNullable<PrettyError["type"]>,
-      { icon: string; colorFn: (s: string) => string }
+      { icon: string; colorFn?: (s: string) => string }
     >
   )[type];
 
-  let header = `${icon}  ${chalk.bold.underline(whatHappened.trim())}`;
+  let header = `${icon}  ${
+    chalk?.bold.underline(whatHappened.trim()) || whatHappened.trim()
+  }`;
   if (stack) {
     header +=
       "\n" +


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`chalk` is sometimes `undefined` in some environments, see #563.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Can't reproduce
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #563
