### PR TITLE
Fix `@inngest/test` broken; package `dist/`

### DIFF
--- a/.changeset/purple-insects-do.md
+++ b/.changeset/purple-insects-do.md
@@ -1,0 +1,5 @@
+---
+"@inngest/test": patch
+---
+
+Fix `@inngest/test` not shipping `dist/` files

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -24,6 +24,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "inngest",
     "test",


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes `@inngest/test` publishing; `dist/` was not bundled.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Packaging fix
- [ ] ~Added unit/integration tests~ N/A Packaging fix
- [ ] ~Added changesets if applicable~ N/A Packaging fix

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #783 
