### PR TITLE
Handle missing request body

### DIFF
--- a/.changeset/silent-carrots-develop.md
+++ b/.changeset/silent-carrots-develop.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Better handle missing request body

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -797,6 +797,22 @@ export class InngestCommHandler<
         }),
       ]);
 
+      // This is when the request body is completely missing; it does not
+      // include an empty body. This commonly happens when the HTTP framework
+      // doesn't have body parsing middleware.
+      const isMissingBody = body === undefined;
+
+      if (isMissingBody) {
+        this.log(
+          "error",
+          "Missing body, possibly due to missing request body middleware"
+        );
+        return {
+          headers: getInngestHeaders(),
+          status: 500,
+        };
+      }
+
       const signatureValidation = this.validateSignature(signature, body);
 
       const headersToForwardP = Promise.all(headerPromises).then(

--- a/packages/inngest/src/deno/fresh.ts
+++ b/packages/inngest/src/deno/fresh.ts
@@ -70,8 +70,8 @@ export const serve = (
 
   const fn = handler.createHandler();
 
-  return function handleRequest(req: Request) {
-    return fn(req, Deno.env.toObject());
+  return function handleRequest(req: Request, ...other) {
+    return fn(req, Deno.env.toObject(), ...other);
   };
 };
 

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -5,6 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import { Inngest, InngestFunction } from "@local";
 import {
+  HandlerResponse,
   InngestCommHandler,
   type ServeHandlerOptions,
 } from "@local/components/InngestCommHandler";
@@ -260,7 +261,16 @@ export const testFramework = (
   const run = async (
     handlerOpts: Parameters<(typeof handler)["serve"]> | ServeHandler,
     reqOpts: Parameters<typeof httpMocks.createRequest>,
-    env: Env = {}
+    env: Env = {},
+
+    /**
+     * Forced action overrides, directly overwriting any fields returned by the
+     * handler.
+     *
+     * This is useful to produce specific scenarios where actions like body
+     * parsing may be missing from a framework.
+     */
+    actionOverrides?: Partial<HandlerResponse>
   ): Promise<HandlerStandardReturn> => {
     const serveHandler = Array.isArray(handlerOpts)
       ? getServeHandler(handlerOpts)
@@ -302,6 +312,10 @@ export const testFramework = (
     }
 
     const args = opts?.transformReq?.(req, res, envToPass) ?? [req, res];
+    if (actionOverrides) {
+      args.push({ actionOverrides });
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ret = await (serveHandler as (...args: any[]) => any)(...args);
 
@@ -847,12 +861,14 @@ export const testFramework = (
             requestedSyncKind,
             validSignature,
             allowInBandSync,
+            actionOverrides,
           }: {
             serverMode: serverKind;
             sdkMode: serverKind;
             requestedSyncKind: syncKind | undefined;
             validSignature: boolean | undefined;
             allowInBandSync: boolean;
+            actionOverrides?: Partial<HandlerResponse>;
           }
         ) => {
           const signingKey = "123";
@@ -895,7 +911,7 @@ export const testFramework = (
                     [headerKeys.InngestServerKind]: serverMode,
                     [headerKeys.InngestSyncKind]: requestedSyncKind,
                     [headerKeys.Signature]: signature,
-                  },
+                  }
                 },
               ],
               {
@@ -905,7 +921,8 @@ export const testFramework = (
                 [envKeys.InngestAllowInBandSync]: allowInBandSync
                   ? "true"
                   : "false",
-              }
+              },
+              actionOverrides
             );
 
             if (typeof expectedResponse === "number") {
@@ -1033,6 +1050,21 @@ export const testFramework = (
               });
             });
           });
+
+          describe("#789 with no body", () => {
+            Object.values(serverKind).forEach((serverMode) => {
+              Object.values(serverKind).forEach((sdkMode) => {
+                expectResponse(500, {
+                  actionOverrides: { body: () => undefined },
+                  serverMode,
+                  sdkMode,
+                  requestedSyncKind: syncKind.InBand,
+                  validSignature: true,
+                  allowInBandSync: true,
+                });
+              });
+            });
+          })
         });
       });
     });

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -911,7 +911,7 @@ export const testFramework = (
                     [headerKeys.InngestServerKind]: serverMode,
                     [headerKeys.InngestSyncKind]: requestedSyncKind,
                     [headerKeys.Signature]: signature,
-                  }
+                  },
                 },
               ],
               {
@@ -1064,12 +1064,33 @@ export const testFramework = (
                 });
               });
             });
-          })
+          });
         });
       });
     });
 
     describe("POST (run function)", () => {
+      describe("#789 missing body", () => {
+        test("returns 500", async () => {
+          const client = createClient({ id: "test" });
+
+          const fn = client.createFunction(
+            { name: "Test", id: "test" },
+            { event: "demo/event.sent" },
+            () => "fn"
+          );
+
+          const ret = await run(
+            [{ client, functions: [fn] }],
+            [{ method: "POST" }],
+            {},
+            { body: () => undefined }
+          );
+
+          expect(ret.status).toEqual(500);
+        });
+      });
+
       describe("signature validation", () => {
         const client = createClient({ id: "test" });
 


### PR DESCRIPTION
## Summary

Explicitly handle the missing request body case. This can happen when the app doesn't have request body parsing middleware (e.g. `express.json`).

Before these changes, the user would see an unhelpful "invalid signature" error:
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/ac563ff8-dc0e-450c-8125-76274086a2c8" />

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
