### PR TITLE
Fix inline example to match v3

### DIFF
--- a/.changeset/yellow-buttons-fail.md
+++ b/.changeset/yellow-buttons-fail.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix inline example to match v3

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -81,11 +81,11 @@ export type EventsFromOpts<TOpts extends ClientOptions> =
  * To provide event typing, see {@link EventSchemas}.
  *
  * ```ts
- * const inngest = new Inngest({ name: "My App" });
+ * const inngest = new Inngest({ id: "my-app" });
  *
  * // or to provide event typing too
  * const inngest = new Inngest({
- *   name: "My App",
+ *   id: "my-app",
  *   schemas: new EventSchemas().fromRecord<{
  *     "app/user.created": {
  *       data: { userId: string };


### PR DESCRIPTION
## Summary
The inline documentation was still using v2 semantics. 

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

~~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~~
~~- [ ] Added unit/integration tests~~
~~- [ ] Added changesets if applicable~~

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
n/a
