### PR TITLE
Fix/named fn params

### DIFF
--- a/.changeset/tall-nails-think.md
+++ b/.changeset/tall-nails-think.md
@@ -1,0 +1,10 @@
+---
+"inngest": patch
+---
+
+Fix named functions returning `never[]` for their parameters when passed to `step.run()`
+
+```ts
+// This now works
+step.run("", function named() {});
+```

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -173,6 +173,10 @@ describe("run", () => {
     });
   });
 
+  test("types allow named function", () => {
+    void step.run("", function named() {});
+  });
+
   test("types returned from run are the result of (de)serialization", () => {
     const input = {
       str: "",
@@ -429,17 +433,33 @@ describe("ai", () => {
       // @ts-expect-error Invalid data
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       void step.ai.wrap("", (flag: boolean, value: number) => {});
+
+      // @ts-expect-error Invalid data
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      void step.ai.wrap("", function (flag: boolean, value: number) {});
     });
 
     test("disallow step inputs when function does not expect them", () => {
       // @ts-expect-error Invalid data
       void step.ai.wrap("", () => {}, true);
+
+      // @ts-expect-error Invalid data
+      void step.ai.wrap("", function () {}, true);
     });
 
     test("disallow step inputs that don't match what function expects", () => {
       // @ts-expect-error Invalid data
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       void step.ai.wrap("", (flag: boolean, value: number) => {}, 10, true);
+
+      void step.ai.wrap(
+        "",
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        function (flag: boolean, value: number) {},
+        // @ts-expect-error Invalid data
+        10,
+        true
+      );
     });
 
     test("optional input", async () => {
@@ -448,6 +468,17 @@ describe("ai", () => {
           "",
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           (flag: boolean, value?: number) => {
+            // valid - enough arguments given - missing arg is optional
+          },
+          true
+        )
+      ).resolves.toMatchObject({});
+
+      await expect(
+        step.run(
+          "",
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          function (flag: boolean, value?: number) {
             // valid - enough arguments given - missing arg is optional
           },
           true

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -186,7 +186,8 @@ export const createStepTools = <TClient extends Inngest.Any>(
     type?: string
   ) => {
     return createTool<
-      <TFn extends (...args: Parameters<TFn>) => unknown>(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <TFn extends (...args: any[]) => unknown>(
         idOrOptions: StepOptionsOrId,
 
         /**
@@ -236,6 +237,7 @@ export const createStepTools = <TClient extends Inngest.Any>(
         };
       },
       {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         fn: (_, fn, ...input) => fn(...input),
       }
     );


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Broadens the types of `step.run()` to better recognize `Function` as callable, therefore making the generic and allowing `Parameters<TFn>` to extract correctly.

```ts
// This should now work
step.run("", function named() {});
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
