### PR TITLE
Add `absoluteId()` to get the absolute ID of an `InngestFunction`

### DIFF
--- a/.changeset/wise-rings-marry.md
+++ b/.changeset/wise-rings-marry.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `InngestFunction#absoluteId()` to get the absolute ID of an `InngestFunction`

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -91,6 +91,14 @@ export class InngestFunction<
   }
 
   /**
+   * The generated or given ID for this function, prefixed with the app ID. This
+   * is used for routing invokes and identifying the function across apps.
+   */
+  protected get absoluteId(): string {
+    return this.id(this.client.id);
+  }
+
+  /**
    * The name of this function as it will appear in the Inngest Cloud UI.
    */
   public get name(): string {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add `InngestFunction#absoluteId()` to fetch the full ID using the client.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Used internally
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
