### PR TITLE
Ensure `@inngest/ai` bumps JSR versions

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "tsc",
     "postversion": "pnpm run build",
-    "release": "node ../../scripts/release/publish.js && pnpm dlx jsr publish --allow-slow-types --allow-dirty"
+    "release": "node ../../scripts/release/publish.js && pnpm dlx jsr publish --allow-slow-types --allow-dirty",
+    "release:version": "node ../../scripts/release/jsrVersion.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Bumps JSR versions when `@inngest/ai`'s version is bumped.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A CI
- [x] Added changesets if applicable

## Related

- Blocking #806 
