### PR TITLE
Use withIsolationScope in Sentry middleware

### DIFF
--- a/.changeset/smooth-singers-do.md
+++ b/.changeset/smooth-singers-do.md
@@ -1,0 +1,5 @@
+---
+'@inngest/middleware-sentry': patch
+---
+
+Updated to use Sentry's withIsolationScope

--- a/packages/middleware-sentry/src/middleware.ts
+++ b/packages/middleware-sentry/src/middleware.ts
@@ -72,7 +72,7 @@ export const sentryMiddleware = (
     init({ client }) {
       return {
         onFunctionRun({ ctx, fn, steps }) {
-          return Sentry.withScope((scope) => {
+          return Sentry.withIsolationScope((scope) => {
             const sharedTags: Record<string, string | undefined> = {
               "inngest.client.id": client.id,
               "inngest.function.id": fn.id(client.id),


### PR DESCRIPTION
## Summary

Users reported leaking of the middleware's Inngest tags into other traces. It's recommended to use the isolation scope with a background job:

https://docs.sentry.io/platforms/javascript/guides/fastify/enriching-events/scopes/#using-withisolationscope

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A
- [ ] ~~Added unit/integration tests~~ N/A
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
https://discord.com/channels/842170679536517141/845000011040555018/1325823964072775721
