### PR TITLE
Make `InngestFunction` properties `protected`

### DIFF
--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -51,10 +51,10 @@ export class InngestFunction<
   static failureSuffix = "-failure";
 
   public readonly opts: TFnOpts;
-  private readonly fn: THandler;
-  private readonly onFailureFn?: TFailureHandler;
+  protected readonly fn: THandler;
+  protected readonly onFailureFn?: TFailureHandler;
   protected readonly client: TClient;
-  private readonly middleware: Promise<MiddlewareRegisterReturn[]>;
+  protected readonly middleware: Promise<MiddlewareRegisterReturn[]>;
 
   /**
    * A stateless Inngest function, wrapping up function configuration and any


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

This helps fight against version mismatches complaining about typing, as the `protected` properties are silently inherited across versions.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] ~Added unit/integration tests~ N/A
- [ ] Added changesets if applicable
