### PR TITLE
Loosen component typing for multi-package usage

### DIFF
--- a/.changeset/late-cups-smell.md
+++ b/.changeset/late-cups-smell.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+`serve()` and `connect()` now have looser typing for `client` and `functions`, resulting in easier use of multiple `inngest` packages in a single process

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -98,7 +98,9 @@ export type EventsFromOpts<TOpts extends ClientOptions> =
  *
  * @public
  */
-export class Inngest<TClientOpts extends ClientOptions = ClientOptions> {
+export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
+  implements Inngest.Like
+{
   /**
    * The ID of this instance, most commonly a reference to the application it
    * resides in.
@@ -757,10 +759,31 @@ export const builtInMiddleware = (<T extends InngestMiddleware.Stack>(
  */
 export namespace Inngest {
   /**
-   * Represents any `Inngest` instance, regardless of generics and
-   * inference.
+   * Represents any `Inngest` instance, regardless of generics and inference.
+   *
+   * Prefer use of `Inngest.Like` where possible to ensure compatibility with
+   * multiple versions.
    */
   export type Any = Inngest;
+
+  /**
+   * References any `Inngest` instance across library versions, useful for use
+   * in public APIs to ensure compatibility with multiple versions.
+   *
+   * Prefer use of `Inngest.Any` internally and `Inngest.Like` for public APIs.
+   */
+  export interface Like {
+    readonly id: string;
+    apiBaseUrl: string | undefined;
+    eventBaseUrl: string | undefined;
+    env: string | null;
+    buildId?: string | undefined;
+
+    setEnvVars(env?: Record<string, string | undefined>): this;
+    setEventKey(eventKey: string): void;
+    send(payload: unknown, options?: { env?: string }): Promise<unknown>;
+    createFunction: Inngest.CreateFunction<Inngest.Any>;
+  }
 
   export type CreateFunction<TClient extends Inngest.Any> = <
     TMiddleware extends InngestMiddleware.Stack,
@@ -843,7 +866,7 @@ export namespace Inngest {
  */
 export type GetStepTools<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TInngest extends Inngest<any>,
+  TInngest extends Inngest.Any,
   TTrigger extends keyof GetEvents<TInngest> &
     string = keyof GetEvents<TInngest> & string,
 > = GetFunctionInput<TInngest, TTrigger> extends { step: infer TStep }
@@ -989,5 +1012,5 @@ export type GetEvents<
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ClientOptionsFromInngest<TInngest extends Inngest<any>> =
+export type ClientOptionsFromInngest<TInngest extends Inngest.Any> =
   TInngest extends Inngest<infer U> ? U : ClientOptions;

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -778,11 +778,6 @@ export namespace Inngest {
     eventBaseUrl: string | undefined;
     env: string | null;
     buildId?: string | undefined;
-
-    setEnvVars(env?: Record<string, string | undefined>): this;
-    setEventKey(eventKey: string): void;
-    send(payload: unknown, options?: { env?: string }): Promise<unknown>;
-    createFunction: Inngest.CreateFunction<Inngest.Any>;
   }
 
   export type CreateFunction<TClient extends Inngest.Any> = <

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -79,7 +79,7 @@ export interface ServeHandlerOptions extends RegisterOptions {
   /**
    * The `Inngest` instance used to declare all functions.
    */
-  client: Inngest.Any;
+  client: Inngest.Like;
 
   /**
    * An array of the functions to serve and register with Inngest.
@@ -122,7 +122,7 @@ interface InngestCommHandlerOptions<
    * receiving events from the same service, as you can reuse a single
    * definition of Inngest.
    */
-  client: Inngest.Any;
+  client: Inngest.Like;
 
   /**
    * An array of the functions to serve and register with Inngest.
@@ -365,7 +365,7 @@ export class InngestCommHandler<
     }
 
     this.frameworkName = options.frameworkName;
-    this.client = options.client;
+    this.client = options.client as Inngest.Any;
     this.id = options.id || this.client.id;
 
     this.handler = options.handler as Handler;

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -127,7 +127,7 @@ interface InngestCommHandlerOptions<
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: readonly InngestFunction.Any[];
+  functions: readonly InngestFunction.Like[];
 
   /**
    * The `handler` is the function that will be called with your framework's
@@ -380,7 +380,7 @@ export class InngestCommHandler<
     );
 
     // Ensure we filter any undefined functions in case of missing imports.
-    this.rawFns = options.functions.filter(Boolean);
+    this.rawFns = options.functions.filter(Boolean) as InngestFunction.Any[];
 
     if (this.rawFns.length !== options.functions.length) {
       // TODO PrettyError

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -84,7 +84,7 @@ export interface ServeHandlerOptions extends RegisterOptions {
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: readonly InngestFunction.Any[];
+  functions: readonly InngestFunction.Like[];
 }
 
 export interface InternalServeHandlerOptions extends ServeHandlerOptions {

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -46,7 +46,8 @@ export class InngestFunction<
   TTriggers extends InngestFunction.Trigger<
     TriggersFromClient<TClient>
   >[] = InngestFunction.Trigger<TriggersFromClient<TClient>>[],
-> {
+> implements InngestFunction.Like
+{
   static stepId = "step";
   static failureSuffix = "-failure";
 
@@ -281,6 +282,13 @@ export namespace InngestFunction {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any
   >;
+
+  export interface Like {
+    opts: Options;
+    id(prefix?: string): string;
+    name: string;
+    description?: string;
+  }
 
   /**
    * A user-friendly method of specifying a trigger for an Inngest function.

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -284,8 +284,6 @@ export namespace InngestFunction {
   >;
 
   export interface Like {
-    opts: Options;
-    id(prefix?: string): string;
     name: string;
     description?: string;
   }

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -470,11 +470,11 @@ class WebSocketWorkerConnection implements WorkerConnection {
 }
 
 export const connect = async (
-  inngest: Inngest.Any,
+  inngest: Inngest.Like,
   options: ConnectHandlerOptions
   // eslint-disable-next-line @typescript-eslint/require-await
 ): Promise<WorkerConnection> => {
-  const conn = new WebSocketWorkerConnection(inngest, options);
+  const conn = new WebSocketWorkerConnection(inngest as Inngest.Any, options);
 
   await conn.connect();
 

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -1,4 +1,4 @@
-import { InngestCommHandler } from "inngest";
+import { InngestCommHandler, type InngestFunction } from "inngest";
 import { ulid } from "ulid";
 import { headerKeys, queryKeys } from "../../helpers/consts.js";
 import { allProcessEnv, getPlatformName } from "../../helpers/env.js";
@@ -112,7 +112,8 @@ class WebSocketWorkerConnection implements WorkerConnection {
     };
 
     const functions: Array<FunctionConfig> = this.options.functions.flatMap(
-      (f) => f["getConfig"](new URL("http://example.com")) // refactor; base URL shouldn't be optional here; we likely need to fetch a different kind of config
+      (f) =>
+        (f as InngestFunction.Any)["getConfig"](new URL("http://example.com")) // refactor; base URL shouldn't be optional here; we likely need to fetch a different kind of config
     );
 
     const data: connectionEstablishData = {

--- a/packages/inngest/src/components/connect/types.ts
+++ b/packages/inngest/src/components/connect/types.ts
@@ -5,7 +5,7 @@ export interface ConnectHandlerOptions extends RegisterOptions {
   /**
    * An array of the functions to serve and register with Inngest.
    */
-  functions: readonly InngestFunction.Any[];
+  functions: readonly InngestFunction.Like[];
 
   instanceId: string;
   maxConcurrency?: number;

--- a/packages/inngest/src/fastify.ts
+++ b/packages/inngest/src/fastify.ts
@@ -70,7 +70,7 @@ import { type RegisterOptions, type SupportedFrameworkName } from "./types.js";
 export const frameworkName: SupportedFrameworkName = "fastify";
 
 type InngestPluginOptions = {
-  client: Inngest.Any;
+  client: Inngest.Like;
   functions: InngestFunction.Any[];
   options?: RegisterOptions;
 };

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -463,7 +463,7 @@ export const fixEventKeyMissingSteps = [
   `Pass a key to the \`new Inngest()\` constructor using the \`${
     "eventKey" satisfies keyof ClientOptions
   }\` option`,
-  `Use \`inngest.${"setEventKey" satisfies keyof Inngest}()\` at runtime`,
+  `Use \`inngest.${"setEventKey" satisfies keyof Inngest.Like}()\` at runtime`,
 ];
 
 /**

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -463,7 +463,7 @@ export const fixEventKeyMissingSteps = [
   `Pass a key to the \`new Inngest()\` constructor using the \`${
     "eventKey" satisfies keyof ClientOptions
   }\` option`,
-  `Use \`inngest.${"setEventKey" satisfies keyof Inngest.Like}()\` at runtime`,
+  `Use \`inngest.${"setEventKey" satisfies keyof Inngest.Any}()\` at runtime`,
 ];
 
 /**

--- a/packages/inngest/src/helpers/functions.test.ts
+++ b/packages/inngest/src/helpers/functions.test.ts
@@ -1,8 +1,6 @@
-import { InngestFunction } from "@local/components/InngestFunction";
 import { ExecutionVersion } from "@local/components/execution/InngestExecution";
 import { parseFnData, type FnData } from "@local/helpers/functions";
 import { type EventPayload } from "@local/types";
-import { createClient } from "../test/helpers";
 
 const randomstr = (): string => {
   return (Math.random() + 1).toString(36).substring(2);
@@ -70,12 +68,6 @@ describe("#parseFnData", () => {
       isOk: false,
     },
   ];
-
-  const fn = new InngestFunction(
-    createClient({ id: "test-client" }),
-    { id: "test-fn", triggers: [{ event: "test-event" }] },
-    () => "test-return"
-  );
 
   specs.forEach((test) => {
     it(test.name, () => {

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -1,7 +1,6 @@
 import { ZodError, z } from "zod";
 import { type InngestApi } from "../api/api.js";
 import { stepsSchemas } from "../api/schema.js";
-import { type InngestFunction } from "../components/InngestFunction.js";
 import {
   ExecutionVersion,
   PREFERRED_EXECUTION_VERSION,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds `Inngest.Like` and `InngestFunction.Like` for lighter type comparisons when comparing types across two different versions of `inngest`.

This targets loosening types at two major boundaries:

- `serve()`, which receives an `Inngest` client and an array of `InngestFunction`s
  - This also includes the `fastifyPlugin` we provide
- `connect()`, which receives an array of `InngestFunction`s

These boundaries only accepted `Inngest.Any` and `InngestFunction.Any` types, which are bound to their local package version. This change switches to duck typing for these boundaries, meaning a client from one version can be safely used as the client for another.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A Existing
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Complements #819 for better multi-version handling
