### PR TITLE
Set `inngest`'s ALS in global state to access it across versions

### DIFF
--- a/.changeset/shiny-pigs-smoke.md
+++ b/.changeset/shiny-pigs-smoke.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Set `inngest`'s ALS in global state to be able access it across versions and package boundaries

--- a/packages/inngest/src/components/execution/als.test.ts
+++ b/packages/inngest/src/components/execution/als.test.ts
@@ -7,6 +7,11 @@ describe("getAsyncLocalStorage", () => {
   afterEach(() => {
     jest.unmock("node:async_hooks");
     jest.resetModules();
+
+    // kill the global used for storing ALS state
+    delete (globalThis as Record<string | symbol | number, unknown>)[
+      Symbol.for("inngest:als")
+    ];
   });
 
   test("should return an `AsyncLocalStorageIsh`", async () => {
@@ -59,6 +64,11 @@ describe("getAsyncCtx", () => {
   afterEach(() => {
     jest.unmock("node:async_hooks");
     jest.resetModules();
+
+    // kill the global used for storing ALS state
+    delete (globalThis as Record<string | symbol | number, unknown>)[
+      Symbol.for("inngest:als")
+    ];
   });
 
   test("should return `undefined` outside of an Inngest async context", async () => {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Moves `inngest`'s [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html) usage to global state, ensuring we can access `inngest` context while using multiple versions and across boundaries.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A Included; multi-process tests not included - testing with `@inngest/agent-kit`
- [x] Added changesets if applicable
