### PR TITLE
Make INNGEST_ALLOW_IN_BAND_SYNC opt out

### DIFF
--- a/.changeset/shy-boats-explode.md
+++ b/.changeset/shy-boats-explode.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Make INNGEST_ALLOW_IN_BAND_SYNC opt out

--- a/packages/inngest/scripts/integrationTestRunner.ts
+++ b/packages/inngest/scripts/integrationTestRunner.ts
@@ -15,6 +15,7 @@ async function checkServerReady(
   apiUrl: string,
   timeout: number
 ): Promise<void> {
+  let error;
   const startTime = Date.now();
   while (Date.now() - startTime < timeout) {
     try {
@@ -24,11 +25,12 @@ async function checkServerReady(
         return;
       }
       throw new Error(`Server not ready: ${response.status}`);
-    } catch (error) {
-      console.log("Server not ready:", error);
+    } catch (e) {
+      error = e;
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
   }
+  console.log("Server not ready:", error);
   throw new Error(`Server did not start within ${timeout / 1000} seconds.`);
 }
 

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1239,7 +1239,7 @@ export class InngestCommHandler<
             parseAsBoolean(this.env[envKeys.InngestAllowInBandSync])
           )
             .then((allowInBandSync) => {
-              if (!allowInBandSync) {
+              if (allowInBandSync !== undefined && !allowInBandSync) {
                 return syncKind.OutOfBand;
               }
 

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -867,7 +867,7 @@ export const testFramework = (
             sdkMode: serverKind;
             requestedSyncKind: syncKind | undefined;
             validSignature: boolean | undefined;
-            allowInBandSync: boolean;
+            allowInBandSync: boolean | undefined;
             actionOverrides?: Partial<HandlerResponse>;
           }
         ) => {
@@ -893,9 +893,13 @@ export const testFramework = (
               : validSignature === false
                 ? "an invalid"
                 : "no"
-          } signature ${
-            allowInBandSync ? "" : "(in-band syncs disallowed in env var) "
-          }should ${
+          } signature (in-band syncs ${
+            allowInBandSync === false
+              ? "disallowed in"
+              : allowInBandSync === true
+                ? "allowed in"
+                : "undefined as"
+          } env var) should ${
             typeof expectedResponse === "number" ? "return" : "perform"
           } ${expectedResponse}`;
 
@@ -918,9 +922,13 @@ export const testFramework = (
                 [envKeys.InngestSigningKey]: signingKey,
                 [envKeys.InngestDevMode]:
                   sdkMode === serverKind.Dev ? "true" : "false",
-                [envKeys.InngestAllowInBandSync]: allowInBandSync
-                  ? "true"
-                  : "false",
+                ...(typeof allowInBandSync !== "undefined"
+                  ? {
+                      [envKeys.InngestAllowInBandSync]: allowInBandSync
+                        ? "true"
+                        : "false",
+                    }
+                  : {}),
               },
               actionOverrides
             );
@@ -974,12 +982,14 @@ export const testFramework = (
           Object.values(serverKind).forEach((serverMode) => {
             Object.values(serverKind).forEach((sdkMode) => {
               [undefined, false, true].forEach((validSignature) => {
-                expectResponse(syncKind.OutOfBand, {
-                  serverMode,
-                  sdkMode,
-                  requestedSyncKind: undefined,
-                  validSignature,
-                  allowInBandSync: true,
+                [undefined, true].forEach((allowInBandSync) => {
+                  expectResponse(syncKind.OutOfBand, {
+                    serverMode,
+                    sdkMode,
+                    requestedSyncKind: undefined,
+                    validSignature,
+                    allowInBandSync,
+                  });
                 });
               });
             });
@@ -991,12 +1001,14 @@ export const testFramework = (
           Object.values(serverKind).forEach((serverMode) => {
             Object.values(serverKind).forEach((sdkMode) => {
               [undefined, false, true].forEach((validSignature) => {
-                expectResponse(syncKind.OutOfBand, {
-                  serverMode,
-                  sdkMode,
-                  requestedSyncKind: syncKind.OutOfBand,
-                  validSignature,
-                  allowInBandSync: true,
+                [undefined, true].forEach((allowInBandSync) => {
+                  expectResponse(syncKind.OutOfBand, {
+                    serverMode,
+                    sdkMode,
+                    requestedSyncKind: syncKind.OutOfBand,
+                    validSignature,
+                    allowInBandSync,
+                  });
                 });
               });
             });
@@ -1008,12 +1020,14 @@ export const testFramework = (
           describe("with valid signature", () => {
             Object.values(serverKind).forEach((serverMode) => {
               Object.values(serverKind).forEach((sdkMode) => {
-                expectResponse(syncKind.InBand, {
-                  serverMode,
-                  sdkMode,
-                  requestedSyncKind: syncKind.InBand,
-                  validSignature: true,
-                  allowInBandSync: true,
+                [undefined, true].forEach((allowInBandSync) => {
+                  expectResponse(syncKind.InBand, {
+                    serverMode,
+                    sdkMode,
+                    requestedSyncKind: syncKind.InBand,
+                    validSignature: true,
+                    allowInBandSync,
+                  });
                 });
               });
             });
@@ -1022,14 +1036,17 @@ export const testFramework = (
           describe("with invalid signature", () => {
             Object.values(serverKind).forEach((serverMode) => {
               Object.values(serverKind).forEach((sdkMode) => {
-                const res = sdkMode === serverKind.Dev ? syncKind.InBand : 401;
+                [undefined, true].forEach((allowInBandSync) => {
+                  const res =
+                    sdkMode === serverKind.Dev ? syncKind.InBand : 401;
 
-                expectResponse(res, {
-                  serverMode,
-                  sdkMode,
-                  requestedSyncKind: syncKind.InBand,
-                  validSignature: false,
-                  allowInBandSync: true,
+                  expectResponse(res, {
+                    serverMode,
+                    sdkMode,
+                    requestedSyncKind: syncKind.InBand,
+                    validSignature: false,
+                    allowInBandSync,
+                  });
                 });
               });
             });
@@ -1038,14 +1055,17 @@ export const testFramework = (
           describe("with no signature", () => {
             Object.values(serverKind).forEach((serverMode) => {
               Object.values(serverKind).forEach((sdkMode) => {
-                const res = sdkMode === serverKind.Dev ? syncKind.InBand : 401;
+                [undefined, true].forEach((allowInBandSync) => {
+                  const res =
+                    sdkMode === serverKind.Dev ? syncKind.InBand : 401;
 
-                expectResponse(res, {
-                  serverMode,
-                  sdkMode,
-                  requestedSyncKind: syncKind.InBand,
-                  validSignature: undefined,
-                  allowInBandSync: true,
+                  expectResponse(res, {
+                    serverMode,
+                    sdkMode,
+                    requestedSyncKind: syncKind.InBand,
+                    validSignature: undefined,
+                    allowInBandSync,
+                  });
                 });
               });
             });
@@ -1054,13 +1074,15 @@ export const testFramework = (
           describe("#789 with no body", () => {
             Object.values(serverKind).forEach((serverMode) => {
               Object.values(serverKind).forEach((sdkMode) => {
-                expectResponse(500, {
-                  actionOverrides: { body: () => undefined },
-                  serverMode,
-                  sdkMode,
-                  requestedSyncKind: syncKind.InBand,
-                  validSignature: true,
-                  allowInBandSync: true,
+                [undefined, true].forEach((allowInBandSync) => {
+                  expectResponse(500, {
+                    actionOverrides: { body: () => undefined },
+                    serverMode,
+                    sdkMode,
+                    requestedSyncKind: syncKind.InBand,
+                    validSignature: true,
+                    allowInBandSync,
+                  });
                 });
               });
             });


### PR DESCRIPTION
## Summary
Make `INNGEST_ALLOW_IN_BAND_SYNC` opt out. This means that the SDK will perform an in-band sync if the Inngest server tells it to, except when `INNGEST_ALLOW_IN_BAND_SYNC` is explicitly set to a falsy value.