### PR TITLE
Allow wildcard event typing with `.fromRecord()`

### DIFF
--- a/.changeset/rotten-carrots-search.md
+++ b/.changeset/rotten-carrots-search.md
@@ -1,0 +1,45 @@
+---
+"inngest": patch
+---
+
+Allow wildcard event typing with `.fromRecord()`
+
+The following schema is now valid:
+
+```ts
+export const schemas = new EventSchemas().fromRecord<{
+  "app/blog.post.*":
+    | {
+        name: "app/blog.post.created";
+        data: {
+          postId: string;
+          authorId: string;
+          createdAt: string;
+        };
+      }
+    | {
+        name: "app/blog.post.published";
+        data: {
+          postId: string;
+          authorId: string;
+          publishedAt: string;
+        };
+      };
+}>();
+```
+
+When creating a function, this allows you to appropriately type narrow the event to pull out the correct data:
+
+```ts
+inngest.createFunction(
+  { id: "my-fn" },
+  { event: "app/blog.post.*" },
+  async ({ event }) => {
+    if (event.name === "app/blog.post.created") {
+      console.log("Blog post created at:", event.data.createdAt);
+    } else if (event.name === "app/blog.post.published") {
+      console.log("Blog post published at:", event.data.publishedAt);
+    }
+  }
+);
+```

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -80,7 +80,9 @@ type PreventClashingNames<T> = CheckNever<{
   [K in keyof T]: T[K] extends { name: infer N }
     ? N extends K
       ? T[K]
-      : ClashingNameError
+      : K extends `${string}*${string}`
+        ? T[K] // TODO In this case, every obj should contain a name
+        : ClashingNameError
     : T[K];
 }>;
 
@@ -180,23 +182,34 @@ export type ZodToStandardSchema<T extends ZodEventSchemas> = {
 
 /**
  * A helper type to convert input schemas into the format expected by the
- * `EventSchemas` class, which ensures that each event contains all pieces
- * of information required.
+ * `EventSchemas` class, which ensures that each event contains all pieces of
+ * information required.
  *
  * It purposefully uses slightly more complex (read: verbose) mapped types to
  * flatten the output and preserve comments.
  *
  * @public
  */
-export type StandardEventSchemaToPayload<T> = Simplify<{
-  [K in keyof T & string]: {
-    [K2 in keyof (Omit<EventPayload, keyof T[K]> & T[K] & { name: K })]: (Omit<
-      EventPayload,
-      keyof T[K]
-    > &
-      T[K] & { name: K })[K2];
-  };
-}>;
+export type StandardEventSchemaToPayload<T> = {
+  [K in keyof T & string]: AddName<
+    Simplify<Omit<EventPayload, keyof T[K]> & T[K]>,
+    K
+  >;
+};
+
+/**
+ * A helper type to add a given name to each object in a type if it doesn't
+ * exist as a string literal.
+ *
+ * Use in this way ensures simpler types can enforce preserving comments.
+ */
+export type AddName<TObj, TDefaultName extends string> = TObj extends {
+  name: string;
+}
+  ? IsStringLiteral<TObj["name"]> extends true
+    ? TObj
+    : Simplify<TObj & { name: TDefaultName }>
+  : Simplify<TObj & { name: TDefaultName }>;
 
 /**
  * A helper type to combine two event schemas together, ensuring the result is

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -41,6 +41,7 @@
 export * from "@inngest/ai";
 export {
   EventSchemas,
+  type AddName,
   type AssertInternalEventPayloads,
   type Combine,
   type LiteralZodEventSchema,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds the ability to provide better wildcard event typing in `.fromRecord()` by changing how name is assigned and overwritten when forming `EventSchemas`.

The following schema is now valid:

```ts
export const schemas = new EventSchemas().fromRecord<{
  "app/blog.post.*":
    | {
        name: "app/blog.post.created";
        data: {
          postId: string;
          authorId: string;
          createdAt: string;
        };
      }
    | {
        name: "app/blog.post.published";
        data: {
          postId: string;
          authorId: string;
          publishedAt: string;
        };
      };
}>();
```

When creating a function, this allows you to appropriately type narrow the event to pull out the correct data:

```ts
inngest.createFunction(
  { id: "my-fn" },
  { event: "app/blog.post.*" },
  async ({ event }) => {
    if (event.name === "app/blog.post.created") {
      console.log("Blog post created at:", event.data.createdAt);
    } else if (event.name === "app/blog.post.published") {
      console.log("Blog post published at:", event.data.publishedAt);
    }
  }
);
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Previous method documented in inngest/website#1055
