### PR TITLE
Bump `actions/*-artifact` to `v4`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Package as tarball
         run: pnpm run local:pack
       - name: Archive package tarball
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: inngestpkg
           path: packages/inngest/inngest.tgz
@@ -232,7 +232,7 @@ jobs:
       - uses: ./.github/actions/setup-and-build
 
       - name: Download pre-built SDK
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: inngestpkg
           path: packages/inngest


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Bumps `actions/upload-artifact` and `actions/download-artifact` from `v3` to `v4` following `v3`'s deprecation.

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO CI
- [ ] ~Added unit/integration tests~ N/A KTLO CI
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
