### PR TITLE
Allow for use of `exactOptionalPropertyTypes: true`

### DIFF
--- a/.changeset/proud-apes-attend.md
+++ b/.changeset/proud-apes-attend.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow for use of `exactOptionalPropertyTypes: true` when serving

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -298,7 +298,7 @@ export namespace InngestFunction {
 
   export interface Like {
     name: string;
-    description?: string;
+    description?: string | undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes #836, allowing for use of `exactOptionalPropertyTypes: true` for type comparisons when serving.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A We need some config-specific tests for this
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #836 
