### PR TITLE
Remove performance-sapping pure reduce

### DIFF
--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -520,13 +520,13 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     }
 
     if (inputMutations?.steps) {
-      this.state.stepState = inputMutations.steps.reduce(
-        (steps, step) => ({
-          ...steps,
-          [step.id]: step,
-        }),
-        {}
-      );
+      const stepState: Record<string, MemoizedOp> = {};
+
+      for (const step of inputMutations.steps) {
+        stepState[step.id] = step;
+      }
+
+      this.state.stepState = stepState;
     }
   }
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Resolves a contribution to poor memoization performance with larger step counts - the pure reduce here is constantly recreating the object, which at large step counts and slower CPUs can be devastatingly slow.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Perf
- [ ] ~Added unit/integration tests~ N/A Benchmarks exist
- [ ] Added changesets if applicable
