### PR TITLE
Optimize V1 execution memoization

### DIFF
--- a/.changeset/new-actors-breathe.md
+++ b/.changeset/new-actors-breathe.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Optimize function memoization

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -716,6 +716,11 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
     let warnOfParallelIndexing = false;
 
     /**
+     * Counts the number of times we've extended this tick.
+     */
+    let tickExtensionCount = 0;
+
+    /**
      * Given a colliding step ID, maybe warn the user about parallel indexing.
      */
     const maybeWarnOfParallelIndexing = (collisionId: string) => {
@@ -758,7 +763,15 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         return;
       }
 
-      foundStepsReportPromise = resolveAfterPending()
+      let extensionPromise: Promise<void>;
+      if (++tickExtensionCount >= 10) {
+        tickExtensionCount = 0;
+        extensionPromise = new Promise((resolve) => setTimeout(resolve));
+      } else {
+        extensionPromise = resolveAfterPending();
+      }
+
+      foundStepsReportPromise = extensionPromise
         /**
          * Ensure that we wait for this promise to resolve before continuing.
          *

--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -35,12 +35,12 @@ export const createFrozenPromise = (): Promise<unknown> => {
  * Returns a Promise that resolves after the current event loop's microtasks
  * have finished, but before the next event loop tick.
  */
-export const resolveAfterPending = (count = 1000): Promise<void> => {
+export const resolveAfterPending = (count = 10): Promise<void> => {
   /**
    * This uses a brute force implementation that will continue to enqueue
-   * microtasks 1000 times before resolving. This is to ensure that the
-   * microtask queue is drained, even if the microtask queue is being
-   * manipulated by other code.
+   * microtasks 10 times before resolving. This is to ensure that the microtask
+   * queue is drained, even if the microtask queue is being manipulated by other
+   * code.
    *
    * While this still doesn't guarantee that the microtask queue is drained,
    * it's our best bet for giving other non-controlled promises a chance to

--- a/packages/inngest/test/benchmark/execution/util.ts
+++ b/packages/inngest/test/benchmark/execution/util.ts
@@ -49,7 +49,7 @@ export const createExecutionWithMemoizedSteps = ({
     const execution = client
       .createFunction({ id: "test" }, { event: "test" }, async ({ step }) => {
         for (let i = 0; i < stepCount; i++) {
-          await step.run(userStepId, () => userStepOutput);
+          await step.run(i === 0 ? userStepId : `${userStepId}${STEP_INDEXING_SUFFIX}${i}`, () => userStepOutput);
         }
       })
       ["createExecution"]({


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

A pass to improve performance when using the `V1` request version.

- Using `Map` for busy hashmaps instead of regular `{}` objects
- Removal of some pure `.reduce()` calls that were recreating objects every cycle
- Optimized automatic step indexing to kill the ugly loop
  - This was done originally to handle the case where a user had manually specified `a:2`, but then also repeated `a`, ensuring we fill out previous step names as well as future ones. Still ugly though.
- Reduce the number of microtasks we extend the tick from `1000` to `10`
- After 10 passes of prolonging the event loop, let it tick to allow other code to run at a healthy rate

Below are some benchmarks when memoizing steps before and after this PR.

### Before

```
cpu: 12th Gen Intel(R) Core(TM) i5-12600K
runtime: node v22.12.0 (x64-linux)

benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• execution
------------------------------------------------------------ -----------------------------
memoized-steps/0      30'010 ns/iter  (17'526 ns … 4'664 µs) 23'602 ns 95'624 ns  1'996 µs
memoized-steps/1         276 µs/iter     (219 µs … 1'210 µs)    255 µs    874 µs  1'089 µs
memoized-steps/10      1'339 µs/iter   (1'075 µs … 2'305 µs)  1'527 µs  2'055 µs  2'305 µs
memoized-steps/100    12'121 µs/iter (11'260 µs … 13'742 µs) 12'391 µs 13'742 µs 13'742 µs
memoized-steps/500    69'044 µs/iter (68'171 µs … 69'947 µs) 69'848 µs 69'947 µs 69'947 µs
memoized-steps/1000      194 ms/iter       (190 ms … 199 ms)    199 ms    199 ms    199 ms
memoized-steps/2000    1'102 ms/iter   (1'097 ms … 1'108 ms)  1'108 ms  1'108 ms  1'108 ms
memoized-steps/5000    7'551 ms/iter   (7'502 ms … 7'600 ms)  7'600 ms  7'600 ms  7'600 ms
memoized-steps/10000  31'382 ms/iter (31'286 ms … 31'479 ms) 31'479 ms 31'479 ms 31'479 ms
```

### After
```
cpu: 12th Gen Intel(R) Core(TM) i5-12600K
runtime: node v22.12.0 (x64-linux)

benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• execution
------------------------------------------------------------ -----------------------------
memoized-steps/0      31'314 ns/iter  (17'160 ns … 5'075 µs) 24'245 ns    113 µs  2'034 µs
memoized-steps/1      45'477 ns/iter  (28'080 ns … 3'152 µs) 35'171 ns    142 µs  1'852 µs
memoized-steps/10        129 µs/iter  (91'879 ns … 2'115 µs)    108 µs  1'329 µs  1'815 µs
memoized-steps/100     1'065 µs/iter     (772 µs … 4'579 µs)    984 µs  2'601 µs  4'579 µs
memoized-steps/500     5'099 µs/iter   (4'204 µs … 6'188 µs)  5'598 µs  6'063 µs  6'188 µs
memoized-steps/1000   10'592 µs/iter  (9'550 µs … 13'829 µs) 10'941 µs 13'829 µs 13'829 µs
memoized-steps/2000   21'314 µs/iter (19'379 µs … 26'899 µs) 21'849 µs 26'899 µs 26'899 µs
memoized-steps/5000   58'380 µs/iter (56'946 µs … 60'416 µs) 58'798 µs 60'416 µs 60'416 µs
memoized-steps/10000     148 ms/iter       (145 ms … 152 ms)    150 ms    152 ms    152 ms
```
<details>
<summary>(In V2) After + batching removal</summary>

This benchmark further removes step batching needed to support `Promise.race()`. With the introduction of V2 and `group.race()`, we no longer need this support and return to much better timings.

```
cpu: 12th Gen Intel(R) Core(TM) i5-12600K
runtime: node v22.12.0 (x64-linux)

benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• execution
------------------------------------------------------------ -----------------------------
memoized-steps/0      30'224 ns/iter  (17'360 ns … 3'624 µs) 23'375 ns    120 µs  2'042 µs
memoized-steps/1      37'376 ns/iter  (22'688 ns … 3'035 µs) 27'611 ns    125 µs  2'198 µs
memoized-steps/10        101 µs/iter  (67'167 ns … 3'203 µs) 76'863 ns  1'570 µs  2'482 µs
memoized-steps/100       791 µs/iter     (558 µs … 3'164 µs)    707 µs  2'469 µs  3'164 µs
memoized-steps/500     4'184 µs/iter   (3'072 µs … 8'180 µs)  5'013 µs  5'932 µs  8'180 µs
memoized-steps/1000    8'403 µs/iter  (6'513 µs … 10'702 µs)  8'765 µs 10'702 µs 10'702 µs
memoized-steps/2000   16'182 µs/iter (14'539 µs … 18'223 µs) 16'717 µs 18'223 µs 18'223 µs
memoized-steps/5000   40'352 µs/iter (38'202 µs … 46'049 µs) 40'588 µs 46'049 µs 46'049 µs
memoized-steps/10000  80'490 µs/iter (78'923 µs … 82'810 µs) 80'808 µs 82'810 µs 82'810 µs
```
</details>

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Perf
- [ ] ~Added unit/integration tests~ N/A Existing benchmarks
- [x] Added changesets if applicable

## Related

- Previous optimizations: #561 
