### PR TITLE
Replace `ulid` with `ulidx`

### DIFF
--- a/.changeset/beige-yaks-reply.md
+++ b/.changeset/beige-yaks-reply.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix event sending failing in some edge environments due to not finding `global.crypto` or `globalThis.crypto` when creating idempotency IDs

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -212,7 +212,7 @@
     "ms": "^2.1.3",
     "serialize-error-cjs": "^0.1.3",
     "strip-ansi": "^5.2.0",
-    "ulid": "^2.3.0",
+    "ulidx": "^2.4.1",
     "zod": "~3.22.3"
   },
   "devDependencies": {

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -1,4 +1,4 @@
-import { ulid } from "ulid";
+import { ulid } from "ulidx";
 import { InngestApi } from "../api/api.js";
 import {
   defaultDevServerHost,

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -1,6 +1,6 @@
 import { WaitGroup } from "@jpwilliams/waitgroup";
 import debug, { type Debugger } from "debug";
-import { ulid } from "ulid";
+import { ulid } from "ulidx";
 import { envKeys, headerKeys, queryKeys } from "../../helpers/consts.js";
 import { allProcessEnv, getPlatformName } from "../../helpers/env.js";
 import { parseFnData } from "../../helpers/functions.js";
@@ -29,7 +29,7 @@ import {
   parseStartResponse,
   parseWorkerReplyAck,
 } from "./messages.js";
-import { onShutdown, retrieveSystemAttributes, getHostname } from "./os.js";
+import { getHostname, onShutdown, retrieveSystemAttributes } from "./os.js";
 import {
   ConnectionState,
   DEFAULT_SHUTDOWN_SIGNALS,
@@ -38,11 +38,11 @@ import {
 } from "./types.js";
 import {
   AuthError,
-  expBackoff,
-  ReconnectError,
   ConnectionLimitError,
-  waitWithCancel,
+  expBackoff,
   parseTraceCtx,
+  ReconnectError,
+  waitWithCancel,
 } from "./util.js";
 
 const ResponseAcknowlegeDeadline = 5_000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,9 @@ importers:
       strip-ansi:
         specifier: ^5.2.0
         version: 5.2.0
-      ulid:
-        specifier: ^2.3.0
-        version: 2.3.0
+      ulidx:
+        specifier: ^2.4.1
+        version: 2.4.1
       zod:
         specifier: ~3.22.3
         version: 3.22.3
@@ -3786,6 +3786,9 @@ packages:
     resolution: {integrity: sha512-VFI2bpJaodz6P7x2uyLiX6RLYpZmOJqNmoCst/Yyd7hQlszyPwG/I9CQJ63nOtKSxpt5M7NH67V6nJL2BwCl7g==}
     engines: {node: ^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4}
 
+  layerr@3.0.0:
+    resolution: {integrity: sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -5066,6 +5069,10 @@ packages:
   ulid@2.3.0:
     resolution: {integrity: sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==}
     hasBin: true
+
+  ulidx@2.4.1:
+    resolution: {integrity: sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg==}
+    engines: {node: '>=16'}
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -9814,6 +9821,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  layerr@3.0.0: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -11171,6 +11180,10 @@ snapshots:
   ufo@1.3.0: {}
 
   ulid@2.3.0: {}
+
+  ulidx@2.4.1:
+    dependencies:
+      layerr: 3.0.0
 
   unbox-primitive@1.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

We use [`ulid`](https://www.npmjs.com/package/ulid) to generate some internal IDs, including when sending events in order to appropriately idempotently retry.

The `ulid` library, however, is dated. Most notably, when attempting to find a `crypto` module in order to securely generate random data, it checks for `window.crypto` (to support browsers), but not `global.crypto` or `globalThis.crypto` which are available in edge runtimes.

https://github.com/ulid/javascript/blob/b269f93944fe41a3c2798c3d883a33c7a2d4bf19/lib/index.ts#L118-L146

This creates an issue whereby edge runtimes do not find `crypto` in the global namespace, so fall back to attempting to import `node:crypto` and subsequently failing.

The `ulid` library does export a `factory()` that can be used to pass in a custom crypto module, meaning we could easily discover it ourselves. However, the [`ulidx`](https://www.npmjs.com/package/ulidx) effort also exists which handles these and other compatibility issues since `ulid` became unmaintained.

We'll switch to `ulidx` for now to resolve the issue, as this does a much more thorough job of discovering the `crypto` module:

https://github.com/perry-mitchell/ulidx/blob/5043c511406fb9b836ddf126583c80ffb90cbb73/source/ulid.ts#L70-L114

> [!NOTE]
> The creator of `ulidx` has been added as a collaborator to [ulid/javascript](https://github.com/ulid/javascript) repo with the intent to merge the efforts back into the `ulid` library. 🥳 

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Deploy env specific
- [x] Added changesets if applicable
- [x] Wait for fix confirmation for #863 

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #863 
- Hopefully `ulidx` is merged into `ulid` - ulid/javascript#113
