### PR TITLE
Make adapter types an easily-accessible value

### DIFF
--- a/.changeset/hot-knives-lie.md
+++ b/.changeset/hot-knives-lie.md
@@ -1,0 +1,5 @@
+---
+"@inngest/ai": patch
+---
+
+Broaden adapter typing for better cross-package compatibility

--- a/packages/ai/src/adapter.ts
+++ b/packages/ai/src/adapter.ts
@@ -2,13 +2,6 @@ import { type AnthropicAiAdapter } from "./adapters/anthropic.js";
 import { type OpenAiAiAdapter } from "./adapters/openai.js";
 
 /**
- * A symbol used internally to define the types for a model whilst keeping
- * generics clean. Must not be exported outside of this module.
- */
-export declare const types: unique symbol;
-export type types = typeof types;
-
-/**
  * An AI model, defining the I/O format and typing, and how to call the model.
  *
  * Models should extend this interface to define their own input and output
@@ -32,7 +25,7 @@ export interface AiAdapter {
    * This is not accessible externally, and is only used internally to define
    * the user-facing types for each model in a way that avoids using generics.
    */
-  [types]: {
+  "~types": {
     /**
      * The input typing for the format.
      */
@@ -74,7 +67,7 @@ export interface AiAdapter {
     /**
      * The input to pass to the model.
      */
-    body: this[types]["input"],
+    body: this["~types"]["input"],
   ) => void;
 }
 
@@ -99,12 +92,12 @@ export namespace AiAdapter {
   /**
    * A helper used to infer the input type of an adapter.
    */
-  export type Input<TAdapter extends AiAdapter> = TAdapter[types]["input"];
+  export type Input<TAdapter extends AiAdapter> = TAdapter["~types"]["input"];
 
   /**
    * A helper used to infer the output type of an adapter.
    */
-  export type Output<TAdapter extends AiAdapter> = TAdapter[types]["output"];
+  export type Output<TAdapter extends AiAdapter> = TAdapter["~types"]["output"];
 
   /**
    * Supported I/O formats for AI models.

--- a/packages/ai/src/adapters/anthropic.ts
+++ b/packages/ai/src/adapters/anthropic.ts
@@ -1,4 +1,4 @@
-import { type AiAdapter, type types } from "../adapter.js";
+import { type AiAdapter } from "../adapter.js";
 
 export interface AnthropicAiAdapter extends AiAdapter {
   /**
@@ -6,7 +6,7 @@ export interface AnthropicAiAdapter extends AiAdapter {
    */
   format: "anthropic";
 
-  [types]: {
+  "~types": {
     input: AnthropicAiAdapter.Input;
     output: AnthropicAiAdapter.Output;
   };

--- a/packages/ai/src/adapters/openai.ts
+++ b/packages/ai/src/adapters/openai.ts
@@ -1,4 +1,4 @@
-import { type AiAdapter, type types } from "../adapter.js";
+import { type AiAdapter } from "../adapter.js";
 
 /**
  * An OpenAI model using the OpenAI format for I/O.
@@ -9,7 +9,7 @@ export interface OpenAiAiAdapter extends AiAdapter {
    */
   format: "openai-chat";
 
-  [types]: {
+  "~types": {
     input: {
       /**
        * ID of the model to use. See the [model endpoint


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

We use an unexported `unique symbol` to store static types for AI adapters. This works well as it can store typing without verbose generics and hides the type when accessing the adapters e.g. `adatper.*`.

However, a process that includes multiple versions of `@inngest/ai` can then be problematic. This is often the case if `@inngest/ai` is a sub-dependency of your project, there are multiple sub-dependencies on `@inngest/ai`, or you have also installed your ownv version.

When this happens, the two `unique symbol`s are different and do not match when comparing types.

Instead, we just let the type be visible, with a `~` prefix so it at least goes to the bottom of autocomplete.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A KTLO
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Addressing build issues in inngest/agent-kit#87
