### PR TITLE
Use `@inngest/ai@^0.0.5`

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -200,7 +200,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.3",
-    "@inngest/ai": "0.0.4",
+    "@inngest/ai": "0.0.5",
     "@jpwilliams/waitgroup": "^2.1.1",
     "@types/debug": "^4.1.12",
     "canonicalize": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       '@inngest/ai':
-        specifier: 0.0.4
-        version: 0.0.4
+        specifier: 0.0.5
+        version: 0.0.5
       '@jpwilliams/waitgroup':
         specifier: ^2.1.1
         version: 2.1.1
@@ -1111,8 +1111,8 @@ packages:
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
 
-  '@inngest/ai@0.0.4':
-    resolution: {integrity: sha512-LZcKfMB8QWBFwO+ZvwYmpX/mxI4OhTfL1YNhQPiOX7Fb1PGOOw8cjvLB/y8bQf3XOqzjpjIk8FpsgzuIFMkpBQ==}
+  '@inngest/ai@0.0.5':
+    resolution: {integrity: sha512-lMD6XiptAGNxzwf5JOHcvN9ug3nzb4VBn8SXloSImKPUdKbD7klXsTCLahb9GCeKyDeMdnHZnTgiZjYrebXgIg==}
 
   '@inngest/test@0.1.3':
     resolution: {integrity: sha512-3iwhqXs4Z8reWMmbOMObZ9nIfIDzTwpkDPf6L86746hs/rkOy+OZpagKosQZLc0JxxiSFzQhrgCBDtrYJoMIBg==}
@@ -6037,7 +6037,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.1': {}
 
-  '@inngest/ai@0.0.4':
+  '@inngest/ai@0.0.5':
     dependencies:
       '@types/node': 22.10.5
       typescript: 5.8.2


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Upgrade `@inngest/ai` to `0.0.5`.

Following this, we shouldn't need the web of upgrades when updating `@inngest/ai` and @inngest/agent-kit`, due to #871.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO upgrade
- [ ] ~Added unit/integration tests~ N/A KTLO upgrade
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #871
