### PR TITLE
Wait until messages have been flushed before setting `CLOSED`

### DIFF
--- a/.changeset/young-cherries-laugh.md
+++ b/.changeset/young-cherries-laugh.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Connect now sets the connection state to `CLOSING` while handling and flushing any pending messages instead of immediately going to `CLOSED`

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -202,8 +202,6 @@ class WebSocketWorkerConnection implements WorkerConnection {
       this.currentConnection = undefined;
     }
 
-    this.state = ConnectionState.CLOSED;
-
     this.debug("Connection closed");
 
     this.debug("Waiting for in-flight requests to complete");
@@ -219,6 +217,7 @@ class WebSocketWorkerConnection implements WorkerConnection {
       await this.messageBuffer.flush(this._hashedFallbackKey);
     }
 
+    this.state = ConnectionState.CLOSED;
     this.resolveClosingPromise?.();
 
     this.debug("Fully closed");


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Wait until messages have been flushed before setting `connection.state` to `CLOSED`.

This means that the state is correctly `CLOSING` while performing a warm shutdown.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A In progress cc @djfarrelly 
- [ ] ~Added unit/integration tests~ N/A 
- [x] Added changesets if applicable
