### PR TITLE
fix(ai): `model` and `max_tokens` should be optional on `MessageCreateParamsBase` for `step.ai` APIs

### DIFF
--- a/.changeset/sweet-oranges-complain.md
+++ b/.changeset/sweet-oranges-complain.md
@@ -1,0 +1,5 @@
+---
+"@inngest/ai": patch
+---
+
+fix(ai): `model` and `max_tokens` should be optional on `MessageCreateParamsBase` for `step.ai` APIs

--- a/packages/ai/src/adapters/anthropic.ts
+++ b/packages/ai/src/adapters/anthropic.ts
@@ -404,7 +404,7 @@ export namespace AnthropicAiAdapter {
      * Different models have different maximum values for this parameter. See
      * [models](https://docs.anthropic.com/en/docs/models-overview) for details.
      */
-    max_tokens: number;
+    max_tokens?: number;
 
     /**
      * Input messages.
@@ -501,7 +501,7 @@ export namespace AnthropicAiAdapter {
      * [models](https://docs.anthropic.com/en/docs/models-overview) for additional
      * details and options.
      */
-    model: Model;
+    model?: Model;
 
     /**
      * An object describing metadata about the request.


### PR DESCRIPTION
Similar to OpenIA, having these 2 params mandatory breaks the API with `anthropic()` from `@inngest/ai`

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/6c3222c6-ddea-4825-ae2a-56d1d0060c26" />
