### PR TITLE
Automatically set all AI models exports in step tooling

### DIFF
--- a/.changeset/yellow-ties-greet.md
+++ b/.changeset/yellow-ties-greet.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Automatically set all AI models exports in step tooling based on `@inngest/ai` version

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -200,7 +200,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.3",
-    "@inngest/ai": "0.1.2",
+    "@inngest/ai": "^0.1.3",
     "@jpwilliams/waitgroup": "^2.1.1",
     "@types/debug": "^4.1.12",
     "canonicalize": "^1.0.8",

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -1,5 +1,4 @@
-import { type AiAdapter } from "@inngest/ai";
-import * as models from "@inngest/ai/dist/models";
+import { models, type AiAdapter } from "@inngest/ai";
 import { z } from "zod";
 import { logPrefix } from "../helpers/consts.js";
 import { type Jsonify } from "../helpers/jsonify.js";

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -1,4 +1,5 @@
-import { gemini, openai, type AiAdapter } from "@inngest/ai";
+import { type AiAdapter } from "@inngest/ai";
+import * as models from "@inngest/ai/dist/models";
 import { z } from "zod";
 import { logPrefix } from "../helpers/consts.js";
 import { type Jsonify } from "../helpers/jsonify.js";
@@ -412,22 +413,7 @@ export const createStepTools = <TClient extends Inngest.Any>(
       /**
        * Models for AI inference and other AI-related tasks.
        */
-      models: {
-        /**
-         * Create an OpenAI model using the OpenAI chat format.
-         *
-         * By default it targets the `https://api.openai.com/v1/` base URL.
-         */
-        openai,
-
-        /**
-         * Create a Gemini model using the OpenAI chat format.
-         *
-         * By default it targets the `https://generativelanguage.googleapis.com/v1beta/`
-         * base URL.
-         */
-        gemini,
-      },
+      models,
     },
 
     /**

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -412,7 +412,9 @@ export const createStepTools = <TClient extends Inngest.Any>(
       /**
        * Models for AI inference and other AI-related tasks.
        */
-      models,
+      models: {
+        ...models,
+      },
     },
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       '@inngest/ai':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: ^0.1.3
+        version: 0.1.3
       '@jpwilliams/waitgroup':
         specifier: ^2.1.1
         version: 2.1.1
@@ -1111,8 +1111,8 @@ packages:
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
 
-  '@inngest/ai@0.1.2':
-    resolution: {integrity: sha512-79Ez/2142GU5Fo44fMxo8rW6PaeVvIFnYqePdEeGTiymTGMMmcsAtrMTfnvq4AnMorFnrtTh6rr6P9xlSdhPJA==}
+  '@inngest/ai@0.1.3':
+    resolution: {integrity: sha512-J8R/pff6Nsm16e5V9UvcNO/wfaaNVS54/wN7cE8CREb1OOFzlCd3Y4TyGb0wyw3y+iTayOLa/KJEYziaGMPIbA==}
 
   '@inngest/test@0.1.3':
     resolution: {integrity: sha512-3iwhqXs4Z8reWMmbOMObZ9nIfIDzTwpkDPf6L86746hs/rkOy+OZpagKosQZLc0JxxiSFzQhrgCBDtrYJoMIBg==}
@@ -4587,6 +4587,7 @@ packages:
 
   serialize-error-cjs@0.1.3:
     resolution: {integrity: sha512-GXwbHkufrNZ87O7DUEvWhR8eBnOqiXtHsOXakkJliG7eLDmjh6gDlbJbMZFFbUx0J5sXKgwq4NFCs41dF5MhiA==}
+    deprecated: Rolling release, please update to 0.2.0
 
   serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
@@ -6037,7 +6038,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.1': {}
 
-  '@inngest/ai@0.1.2':
+  '@inngest/ai@0.1.3':
     dependencies:
       '@types/node': 22.10.5
       typescript: 5.8.2


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Automatically exports all `@inngest/ai` models within `inngest` as `step.ai.models.*`, instead of needing to manually update them.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A Covered
- [x] Added changesets if applicable
