### PR TITLE
Make `app` optional in `useInngestSubscription()`

### DIFF
--- a/.changeset/fifty-pandas-report.md
+++ b/.changeset/fifty-pandas-report.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Loosen `react` peer dependency

--- a/.changeset/long-chicken-obey.md
+++ b/.changeset/long-chicken-obey.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+`app` is now optional when using `useInngestSubscription()`

--- a/examples/realtime-next/app/page.tsx
+++ b/examples/realtime-next/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useInngestApp } from "@/hooks/useInngestApp";
 import { useInngestSubscription } from "@inngest/realtime/hooks";
 import Image from "next/image";
 import { useState } from "react";
@@ -12,7 +11,6 @@ export default function Home() {
   const [tab, setTab] = useState<"fresh" | "latest">("fresh");
 
   const { data, error, freshData, state, latestData } = useInngestSubscription({
-    app: useInngestApp(),
     refreshToken: invoke,
     bufferInterval,
     enabled,

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -42,7 +42,7 @@
   "author": "Inngest Inc. <hello@inngest.com>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "react": "^18.0.0",
+    "react": ">=18.0.0"
     "inngest": "^3.32.7"
   },
   "devDependencies": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -43,7 +43,6 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "react": ">=18.0.0"
-    "inngest": "^3.32.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",
@@ -54,7 +53,6 @@
     "eslint": "^9.18.0",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^15.14.0",
-    "inngest": "^3.32.7",
     "jest": "^29.3.1",
     "react": "^19.0.0",
     "ts-jest": "^29.1.0",
@@ -65,6 +63,7 @@
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
     "debug": "^4.3.4",
+    "inngest": "^3.32.7",
     "zod": "^3.24.2"
   }
 }

--- a/packages/realtime/src/hooks.ts
+++ b/packages/realtime/src/hooks.ts
@@ -1,4 +1,4 @@
-import { type Inngest } from "inngest";
+import { Inngest } from "inngest";
 import { useEffect, useRef, useState } from "react";
 import { subscribe } from "./subscribe";
 import { type Realtime } from "./types";
@@ -23,14 +23,14 @@ export interface InngestSubscription<TToken extends Realtime.Subscribe.Token> {
 export function useInngestSubscription<
   const TToken extends Realtime.Subscribe.Token | null | undefined,
 >({
-  app,
+  app = new Inngest({ id: "useInngestSubscription" }),
   token: tokenInput,
   refreshToken,
   key,
   enabled = true,
   bufferInterval = 0,
 }: {
-  app: Inngest.Any;
+  app?: Inngest.Any;
   token?: TToken;
   refreshToken?: () => Promise<TToken>;
   key?: string;

--- a/packages/realtime/src/hooks.ts
+++ b/packages/realtime/src/hooks.ts
@@ -42,11 +42,11 @@ export function useInngestSubscription<
   const [freshData, setFreshData] = useState<Realtime.Message[]>([]);
   const [error, setError] = useState<Error | null>(null);
   const [state, setState] = useState<InngestSubscriptionState>(
-    InngestSubscriptionState.Closed
+    InngestSubscriptionState.Closed,
   );
 
   const subscriptionRef = useRef<Realtime.Subscribe.StreamSubscription | null>(
-    null
+    null,
   );
   const messageBuffer = useRef<Realtime.Message[]>([]);
   const bufferIntervalRef = useRef<number>(bufferInterval);
@@ -72,7 +72,6 @@ export function useInngestSubscription<
         setState(InngestSubscriptionState.Error);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Subscription management
@@ -136,7 +135,6 @@ export function useInngestSubscription<
         setState(InngestSubscriptionState.Closed);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, enabled, key]);
 
   // Buffer flushing

--- a/packages/realtime/src/topic.ts
+++ b/packages/realtime/src/topic.ts
@@ -8,7 +8,7 @@ export const topic: Realtime.Topic.Builder = (
   /**
    * TODO
    */
-  id
+  id,
 ) => {
   return new TopicDefinitionImpl(id);
 };
@@ -36,7 +36,7 @@ export class TopicDefinitionImpl<
   }
 
   public schema<const TSchema extends StandardSchemaV1>(
-    schema: TSchema
+    schema: TSchema,
   ): Realtime.Topic.Definition<
     TTopicId,
     StandardSchemaV1.InferInput<TSchema>,

--- a/packages/realtime/src/util.ts
+++ b/packages/realtime/src/util.ts
@@ -1,9 +1,9 @@
 type DeferredPromiseReturn<T> = {
-     promise: Promise<T>;
-     resolve: (value: T) => DeferredPromiseReturn<T>;
-     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-     reject: (reason: any) => DeferredPromiseReturn<T>;
-   };
+  promise: Promise<T>;
+  resolve: (value: T) => DeferredPromiseReturn<T>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason: any) => DeferredPromiseReturn<T>;
+};
 
 /**
  * Creates and returns Promise that can be resolved or rejected with the
@@ -13,21 +13,20 @@ type DeferredPromiseReturn<T> = {
  * functions. These can be ignored if the original Promise is all that's needed.
  */
 export const createDeferredPromise = <T>(): DeferredPromiseReturn<T> => {
-     let resolve: DeferredPromiseReturn<T>["resolve"];
-     let reject: DeferredPromiseReturn<T>["reject"];
+  let resolve: DeferredPromiseReturn<T>["resolve"];
+  let reject: DeferredPromiseReturn<T>["reject"];
 
-     const promise = new Promise<T>((_resolve, _reject) => {
-       resolve = (value: T) => {
-         _resolve(value);
-         return createDeferredPromise<T>();
-       };
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = (value: T) => {
+      _resolve(value);
+      return createDeferredPromise<T>();
+    };
 
-       reject = (reason) => {
-         _reject(reason);
-         return createDeferredPromise<T>();
-       };
-     });
+    reject = (reason) => {
+      _reject(reason);
+      return createDeferredPromise<T>();
+    };
+  });
 
-     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-     return { promise, resolve: resolve!, reject: reject! };
-   };
+  return { promise, resolve: resolve!, reject: reject! };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4
+      inngest:
+        specifier: ^3.32.7
+        version: 3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -437,9 +440,6 @@ importers:
       globals:
         specifier: ^15.14.0
         version: 15.14.0
-      inngest:
-        specifier: ^3.32.7
-        version: 3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
       jest:
         specifier: ^29.3.1
         version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.8.2))


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

- Loosens the `react` peer dependency for `@inngest/realtime`
- Make `app` optional in `useInngestSubscription()`

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A In progress
- [ ] ~Added unit/integration tests~ N/A Examples
- [x] Added changesets if applicable

## Related

- Waiting on some PRs to fix build issues:
  - #898 
  - #899