### PR TITLE
Make sure to use `eslint@^8.0.0` for rules that don't support flat config yet

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/rule-tester": "^6.11.0",
+    "eslint": "^8.0.0",
     "jest": "^29.3.1",
     "ts-jest": "^29.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,14 +56,17 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^6.11.0
-        version: 6.11.0(eslint@9.18.0)(typescript@5.5.2)
+        version: 6.11.0(eslint@8.53.0)(typescript@5.5.2)
       typescript:
         specifier: ~5.5.2
         version: 5.5.2
     devDependencies:
       '@typescript-eslint/rule-tester':
         specifier: ^6.11.0
-        version: 6.11.0(@eslint/eslintrc@3.2.0)(eslint@9.18.0)(typescript@5.5.2)
+        version: 6.11.0(@eslint/eslintrc@3.2.0)(eslint@8.53.0)(typescript@5.5.2)
+      eslint:
+        specifier: ^8.0.0
+        version: 8.53.0
       jest:
         specifier: ^29.3.1
         version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
@@ -7219,13 +7222,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@6.11.0(@eslint/eslintrc@3.2.0)(eslint@9.18.0)(typescript@5.5.2)':
+  '@typescript-eslint/rule-tester@6.11.0(@eslint/eslintrc@3.2.0)(eslint@8.53.0)(typescript@5.5.2)':
     dependencies:
       '@eslint/eslintrc': 3.2.0
       '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.5.2)
-      '@typescript-eslint/utils': 6.11.0(eslint@9.18.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 6.11.0(eslint@8.53.0)(typescript@5.5.2)
       ajv: 6.12.6
-      eslint: 9.18.0
+      eslint: 8.53.0
       lodash.merge: 4.6.2
       semver: 7.5.4
     transitivePeerDependencies:
@@ -7435,15 +7438,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.11.0(eslint@9.18.0)(typescript@5.5.2)':
+  '@typescript-eslint/utils@6.11.0(eslint@8.53.0)(typescript@5.5.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.18.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.11.0
       '@typescript-eslint/types': 6.11.0
       '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.5.2)
-      eslint: 9.18.0
+      eslint: 8.53.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`@inngest/eslint-plugin` doesn't yet support v9's flat config, so make sure we're testing it against `eslint@^8.0.0`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [x] Added unit/integration tests (covered by existing tests)
- [x] Added changesets if applicable
