### PR TITLE
Add `getWebStream()` for streaming responses to browsers

### DIFF
--- a/.changeset/cool-falcons-grow.md
+++ b/.changeset/cool-falcons-grow.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Add `getWebStream()`, used to generate a stream with `Uint8Array` encoding appropriate for use within a `Response`

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -309,3 +309,54 @@ jobs:
 
             The last release was built and published from ${{ github.event.pull_request.head.sha }}.
           edit-mode: replace
+
+  prerelease_realtime:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/realtime
+    if: contains(github.event.pull_request.labels.*.name, 'prerelease/realtime')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-and-build
+        with:
+          install-dependencies: false
+          build: false
+
+      - run: pnpm install
+
+      - run: pnpm build
+
+      - name: Prerelease PR
+        run: node ../../scripts/release/prerelease.js
+        env:
+          TAG: pr-${{ github.event.pull_request.number }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_ENV: test # disable npm access checks; they don't work in CI
+
+      - name: Update PR with latest prerelease
+        uses: edumserrano/find-create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "<!-- pr-prerelease-comment-realtime -->"
+          comment-author: "inngest-release-bot"
+          body:
+            | # can be a single value or you can compose text with multi-line values
+            <!-- pr-prerelease-comment-realtime -->
+            A user has added the <kbd>[prerelease/realtime](https://github.com/inngest/inngest-js/labels/prerelease%2Frealtime)</kbd> label, so this PR will be published to npm with the tag `pr-${{ github.event.pull_request.number }}`. It will be updated with the latest changes as you push commits to this PR.
+
+            You can install this prerelease version with:
+
+            ```sh
+            npm install @inngest/realtime@pr-${{ github.event.pull_request.number }}
+            ```
+
+            The last release was built and published from ${{ github.event.pull_request.head.sha }}.
+          edit-mode: replace

--- a/packages/realtime/src/subscribe.ts
+++ b/packages/realtime/src/subscribe.ts
@@ -301,6 +301,7 @@ class TokenSubscription {
             return this.#sourceStreamContoller?.enqueue({
               channel: msg.channel,
               topic: msg.topic,
+
               data: msg.data,
               fnId: msg.fn_id,
               createdAt: msg.created_at || new Date(),
@@ -458,6 +459,7 @@ class TokenSubscription {
               channel: msg.channel,
               topic: msg.topic,
               kind: "chunk",
+
               data: msg.data,
               streamId: msg.stream_id,
               fnId: msg.fn_id,
@@ -466,8 +468,6 @@ class TokenSubscription {
             });
           }
 
-          // TODO Should we pass pings to the subcription so that we keep it
-          // alive?
           default: {
             this.#debug(
               `Received message on channel "${msg.channel}" with unhandled kind "${msg.kind}"`,
@@ -530,20 +530,6 @@ class TokenSubscription {
     const stream = new ReadableStream<Realtime.Message>({
       start: (_controller) => {
         controller = _controller;
-
-        // TEMP Add some data immediately to have something in the stream to
-        // consume to prove it's alive
-        controller.enqueue({
-          channel: "",
-          topic: "",
-          data: "INITIAL DATA TO TEST",
-          fnId: "",
-          createdAt: new Date(),
-          runId: "",
-          kind: "INITIAL",
-          envId: "",
-        });
-
         this.#createdStreamControllers.add(controller);
       },
 

--- a/packages/realtime/src/subscribe.ts
+++ b/packages/realtime/src/subscribe.ts
@@ -124,6 +124,7 @@ export const getSubscriptionToken = async <
 
 // Must be a new connection for every token used.
 class TokenSubscription {
+  #encoder = new TextEncoder();
   #app: Inngest.Any;
   #debug = debug("inngest:realtime");
 
@@ -539,10 +540,10 @@ class TokenSubscription {
   public getWebStream() {
     const { readable, writable } = new TransformStream<
       Realtime.Message,
-      string
+      Uint8Array
     >({
       transform: (chunk, controller) => {
-        controller.enqueue(JSON.stringify(chunk));
+        controller.enqueue(this.#encoder.encode(`${JSON.stringify(chunk)}\n`));
       },
     });
 

--- a/packages/realtime/src/subscribe.ts
+++ b/packages/realtime/src/subscribe.ts
@@ -301,7 +301,6 @@ class TokenSubscription {
             return this.#sourceStreamContoller?.enqueue({
               channel: msg.channel,
               topic: msg.topic,
-
               data: msg.data,
               fnId: msg.fn_id,
               createdAt: msg.created_at || new Date(),
@@ -459,7 +458,6 @@ class TokenSubscription {
               channel: msg.channel,
               topic: msg.topic,
               kind: "chunk",
-
               data: msg.data,
               streamId: msg.stream_id,
               fnId: msg.fn_id,
@@ -468,6 +466,8 @@ class TokenSubscription {
             });
           }
 
+          // TODO Should we pass pings to the subcription so that we keep it
+          // alive?
           default: {
             this.#debug(
               `Received message on channel "${msg.channel}" with unhandled kind "${msg.kind}"`,
@@ -530,6 +530,20 @@ class TokenSubscription {
     const stream = new ReadableStream<Realtime.Message>({
       start: (_controller) => {
         controller = _controller;
+
+        // TEMP Add some data immediately to have something in the stream to
+        // consume to prove it's alive
+        controller.enqueue({
+          channel: "",
+          topic: "",
+          data: "INITIAL DATA TO TEST",
+          fnId: "",
+          createdAt: new Date(),
+          runId: "",
+          kind: "INITIAL",
+          envId: "",
+        });
+
         this.#createdStreamControllers.add(controller);
       },
 

--- a/packages/realtime/src/subscribe.ts
+++ b/packages/realtime/src/subscribe.ts
@@ -542,7 +542,7 @@ class TokenSubscription {
       string
     >({
       transform: (chunk, controller) => {
-        controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
+        controller.enqueue(JSON.stringify(chunk));
       },
     });
 

--- a/packages/realtime/src/types.ts
+++ b/packages/realtime/src/types.ts
@@ -47,12 +47,22 @@ export namespace Realtime {
       cancel(): void;
 
       /**
-       * Get a new readable stream from the subscription.
+       * Get a new readable stream from the subscription that delivers JSON chunks.
        *
        * The stream starts when this function is called and will not contain any
        * messages that were sent before this function was called.
        */
       getStream(): ReadableStream<TData>;
+
+      /**
+       * Get a new readable stream from the subscription that delivers
+       * SSE-compatible chunks, which are compatible with the `EventSource` API
+       * and generally used for streaming data from a server to the browser.
+       *
+       * The stream starts when this function is called and will not contain any
+       * messages that were sent before this function was called.
+       */
+      getWebStream(): ReadableStream<TData>;
     };
 
     export type Callback<
@@ -439,7 +449,7 @@ export type IsEqual<A, B> = (<G>() => G extends A ? 1 : 2) extends <
   ? true
   : false;
 
-  /**
+/**
  * Given a type `T`, return `Then` if `T` is a string, number, or symbol
  * literal, else `Else`.
  *
@@ -466,14 +476,14 @@ export type IsEqual<A, B> = (<G>() => G extends A ? 1 : 2) extends <
  * ```
  */
 export type IsLiteral<T, Then = true, Else = false> = string extends T
-? Else
-: number extends T
   ? Else
-  : symbol extends T
+  : number extends T
     ? Else
-    : Then;
+    : symbol extends T
+      ? Else
+      : Then;
 
-    /**
+/**
  * Returns `true` if the given generic `T` is a string literal, e.g. `"foo"`, or
  * `false` if it is a string type, e.g. `string`.
  *

--- a/packages/realtime/src/types.ts
+++ b/packages/realtime/src/types.ts
@@ -62,7 +62,7 @@ export namespace Realtime {
        * The stream starts when this function is called and will not contain any
        * messages that were sent before this function was called.
        */
-      getWebStream(): ReadableStream<TData>;
+      getWebStream(): ReadableStream<Uint8Array>;
     };
 
     export type Callback<


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Introduces a new `getWebSteam()` method to use when passing the stream back as a `Response` to a browser.

This method is equivalent to the `getStream()` method, but will correctly encode data to be compliant with SSE.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Undocumented atm, likely coming following #906
- [ ] ~Added unit/integration tests~ N/A No suites for this yet
- [x] Added changesets if applicable

## Related

- Fixes for #906
