### PR TITLE
Fix cross-version `shouldOptimizeParallelism()` call

### DIFF
--- a/.changeset/fluffy-avocados-attend.md
+++ b/.changeset/fluffy-avocados-attend.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `shouldOptimizeParallelism()` error when attempting to serve functions using multiple versions of `inngest`

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1419,7 +1419,7 @@ export class InngestCommHandler<
     // Handle opting in to optimized parallelism in v3.
     if (
       version === ExecutionVersion.V1 &&
-      fn.fn["shouldOptimizeParallelism"]()
+      fn.fn["shouldOptimizeParallelism"]?.()
     ) {
       version = ExecutionVersion.V2;
     }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes cross-version `inngest` use when attempting to run functions that may have been created in another version of `inngest`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Cross-version
- [x] Added changesets if applicable
