### PR TITLE
Use devserver URL for realtime, if set in env var

### DIFF
--- a/.changeset/dry-crabs-guess.md
+++ b/.changeset/dry-crabs-guess.md
@@ -1,0 +1,6 @@
+---
+"@inngest/realtime": patch
+"inngest": patch
+---
+
+Allow customization of the dev server URL in realtime

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -145,7 +145,7 @@ export enum headerKeys {
 
 export const defaultInngestApiBaseUrl = "https://api.inngest.com/";
 export const defaultInngestEventBaseUrl = "https://inn.gs/";
-export const defaultDevServerHost = "http://127.0.0.1:8288/";
+export const defaultDevServerHost = "http://localhost:8288/";
 
 /**
  * Events that Inngest may send internally that can be used to trigger

--- a/packages/inngest/src/helpers/devserver.ts
+++ b/packages/inngest/src/helpers/devserver.ts
@@ -60,4 +60,5 @@ export const devServerUrl = (
  * This guarantees a specific URL as a string, as opposed to the env export
  * which only returns a value of the env var is set.
  */
-export const devServerHost = (): string => envDevServerHost() || defaultDevServerHost;
+export const devServerHost = (): string =>
+  envDevServerHost() || defaultDevServerHost;

--- a/packages/inngest/src/helpers/devserver.ts
+++ b/packages/inngest/src/helpers/devserver.ts
@@ -1,4 +1,6 @@
 import { defaultDevServerHost } from "./consts.js";
+import { devServerHost as envDevServerHost } from "./env.js";
+// re-export from devserver.ts
 
 /**
  * A simple type map that we can transparently use `fetch` later without having
@@ -45,8 +47,17 @@ export const devServerAvailable = async (
  * @example devServerUrl("http://localhost:8288/", "/your-path")
  */
 export const devServerUrl = (
-  host: string = defaultDevServerHost,
+  host: string = devServerHost(),
   pathname = ""
 ): URL => {
   return new URL(pathname, host.includes("://") ? host : `http://${host}`);
 };
+
+/**
+ * devServerHost exports the development server's domain by inspecting env
+ * variables, or returns the default development server URL.
+ *
+ * This guarantees a specific URL as a string, as opposed to the env export
+ * which only returns a value of the env var is set.
+ */
+export const devServerHost = (): string => envDevServerHost() || defaultDevServerHost;

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -79,7 +79,7 @@ export class TokenSubscription {
         this.#app["mode"].isInferred &&
         !this.#app.apiBaseUrl
       ) {
-        const dsUrl = devServerUrl();
+        const dsUrl = devServerUrl().toString();
         const devAvailable = await devServerAvailable(
           dsUrl,
           this.#app["fetch"],

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { type Inngest } from "inngest";
-import { devServerAvailable } from "inngest/helpers/devserver";
+import { devServerAvailable, devServerHost } from "inngest/helpers/devserver";
 import { topic } from "../topic";
 import { Realtime } from "../types";
 import { createDeferredPromise } from "../util";
@@ -79,13 +79,14 @@ export class TokenSubscription {
         this.#app["mode"].isInferred &&
         !this.#app.apiBaseUrl
       ) {
+        const host = devServerHost();
         const devAvailable = await devServerAvailable(
-          "http://localhost:8288/",
+          host,
           this.#app["fetch"],
         );
 
         if (devAvailable) {
-          url = new URL(path, "http://localhost:8288/");
+          url = new URL(path, host);
         }
       }
     }

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { type Inngest } from "inngest";
-import { devServerAvailable, devServerHost } from "inngest/helpers/devserver";
+import { devServerAvailable, devServerUrl } from "inngest/helpers/devserver";
 import { topic } from "../topic";
 import { Realtime } from "../types";
 import { createDeferredPromise } from "../util";
@@ -79,14 +79,14 @@ export class TokenSubscription {
         this.#app["mode"].isInferred &&
         !this.#app.apiBaseUrl
       ) {
-        const host = devServerHost();
+        const dsUrl = devServerUrl();
         const devAvailable = await devServerAvailable(
-          host,
+          dsUrl,
           this.#app["fetch"],
         );
 
         if (devAvailable) {
-          url = new URL(path, host);
+          url = new URL(path, dsUrl);
         }
       }
     }


### PR DESCRIPTION
Ensures realtime works in development for non-localhost or custom port uses.
- [x] Added unit/integration tests
- [x] Added changesets if applicable
