### PR TITLE
Allow supplying env as environment variable

### DIFF
--- a/.changeset/stale-foxes-bake.md
+++ b/.changeset/stale-foxes-bake.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+- Connect: Allow supplying Inngest env as environment variable

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -577,7 +577,7 @@ class WebSocketWorkerConnection implements WorkerConnection {
       if (resp.status === 401) {
         throw new AuthError(
           `Failed initial API handshake request to ${targetUrl.toString()}${
-            envOverride ? ` (env: ${envOverride})` : ""
+            this._inngestEnv ? ` (env: ${this._inngestEnv})` : ""
           }, ${await resp.text()}`,
           attempt
         );

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -550,9 +550,8 @@ class WebSocketWorkerConnection implements WorkerConnection {
         : {}),
     };
 
-    const envOverride = this.inngest.env;
-    if (envOverride) {
-      headers[headerKeys.Environment] = envOverride;
+    if (this._inngestEnv) {
+      headers[headerKeys.Environment] = this._inngestEnv;
     }
 
     // refactor this to a more universal spot

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -4,8 +4,8 @@ import { ulid } from "ulidx";
 import { envKeys, headerKeys, queryKeys } from "../../helpers/consts.js";
 import {
   allProcessEnv,
+  getEnvironmentName,
   getPlatformName,
-  inngestHeaders,
 } from "../../helpers/env.js";
 import { parseFnData } from "../../helpers/functions.js";
 import { hashSigningKey } from "../../helpers/strings.js";
@@ -149,9 +149,7 @@ class WebSocketWorkerConnection implements WorkerConnection {
 
     this.options = this.applyDefaults(options);
 
-    this._inngestEnv = inngestHeaders({
-      inngestEnv: this.inngest.env ?? undefined,
-    })[headerKeys.Environment];
+    this._inngestEnv = this.inngest.env ?? getEnvironmentName();
 
     this.debug = debug("inngest:connect");
 

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -52,6 +52,8 @@ import {
 const ResponseAcknowlegeDeadline = 5_000;
 const WorkerHeartbeatInterval = 10_000;
 
+const InngestBranchEnvironmentSigningKeyPrefix = "signkey-branch-";
+
 interface connectionEstablishData {
   marshaledCapabilities: string;
   manualReadinessAck: boolean;
@@ -291,7 +293,9 @@ class WebSocketWorkerConnection implements WorkerConnection {
 
     if (
       this.options.signingKey &&
-      this.options.signingKey.startsWith("signkey-branch-") &&
+      this.options.signingKey.startsWith(
+        InngestBranchEnvironmentSigningKeyPrefix
+      ) &&
       !this._inngestEnv
     ) {
       throw new Error(


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

This PR ensures that passing the Inngest environment as an environment variable works, that all apps are configured to use the same environment override, if set, and that the environment name is specified using an override or environment variable if a signing key for a branch environment is used.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
