### PR TITLE
When (de)serializing errors, allow `unknown` `cause`, but still parse

### DIFF
--- a/.changeset/wicked-dogs-compete.md
+++ b/.changeset/wicked-dogs-compete.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+`Error.cause` can now be any `unknown` value, though we still attempt to recursively expand causes until we hit an `unknown` value

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -41,15 +41,29 @@ const baseJsonErrorSchema = z.object({
   stack: z.string().trim().optional(),
 });
 
+const maybeJsonErrorSchema: z.ZodType<{
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+}> = z.lazy(() =>
+  z.object({
+    name: z.string().trim(),
+    message: z.string().trim(),
+    stack: z.string().trim().optional(),
+    cause: z.union([maybeJsonErrorSchema, z.unknown()]).optional(),
+  })
+);
+
 export type JsonError = z.infer<typeof baseJsonErrorSchema> & {
   name: string;
   message: string;
-  cause?: JsonError;
+  cause?: unknown;
 };
 
 export const jsonErrorSchema = baseJsonErrorSchema
   .extend({
-    cause: z.lazy(() => jsonErrorSchema).optional(),
+    cause: z.union([maybeJsonErrorSchema, z.unknown()]).optional(),
   })
   .passthrough()
   .catch({})


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

`Error.cause` should be `unknown`, though we still wish to _attempt_ to parse it as an `Error` so that we can recursively expand causes as they would be before JSON (de)serialization.

These changes loosen `serializeError` and `deserializeError` to allow recursively expanding `cause` and falling back to `unknown`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Complements inngest/inngest#2088
