### PR TITLE
Fix connecting to prod realtime

### DIFF
--- a/.changeset/wet-seals-tease.md
+++ b/.changeset/wet-seals-tease.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Fix connecting to production; avoid `ws://` `301` redirect

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -367,8 +367,20 @@ export class TokenSubscription {
       };
 
       this.#ws.onerror = (event) => {
-        console.error("WebSocket error observed:", event);
-        ret.reject(event);
+        const serializedErr = {
+          event,
+          message: (event as ErrorEvent).message,
+          type: (event as ErrorEvent).type,
+          target: (event as ErrorEvent).target,
+          error: (event as ErrorEvent).error,
+          filename: (event as ErrorEvent).filename,
+          lineno: (event as ErrorEvent).lineno,
+          colno: (event as ErrorEvent).colno,
+        };
+
+        console.error("WebSocket error observed:", serializedErr);
+
+        ret.reject(serializedErr);
       };
 
       this.#ws.onclose = (event) => {

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -371,20 +371,8 @@ export class TokenSubscription {
       };
 
       this.#ws.onerror = (event) => {
-        const serializedErr = {
-          event,
-          message: (event as ErrorEvent).message,
-          type: (event as ErrorEvent).type,
-          target: (event as ErrorEvent).target,
-          error: (event as ErrorEvent).error,
-          filename: (event as ErrorEvent).filename,
-          lineno: (event as ErrorEvent).lineno,
-          colno: (event as ErrorEvent).colno,
-        };
-
-        console.error("WebSocket error observed:", serializedErr);
-
-        ret.reject(serializedErr);
+        console.error("WebSocket error observed:", event);
+        ret.reject(event);
       };
 
       this.#ws.onclose = (event) => {

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -71,10 +71,6 @@ export class TokenSubscription {
 
     if (this.#app.apiBaseUrl) {
       url = new URL(path, this.#app.apiBaseUrl);
-
-      // If INNGEST_API_BASE_URL=url is set instead of INNGEST_DEV=url, assume
-      // that we should be connecting to a dev server
-      url.protocol = "ws:";
     } else {
       url = new URL(path, "wss://api.inngest.com/");
 
@@ -91,11 +87,11 @@ export class TokenSubscription {
 
         if (devAvailable) {
           url = new URL(path, dsUrl);
-          url.protocol = "ws:";
         }
       }
     }
 
+    url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
     url.searchParams.set("token", token);
 
     return url;

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -71,8 +71,12 @@ export class TokenSubscription {
 
     if (this.#app.apiBaseUrl) {
       url = new URL(path, this.#app.apiBaseUrl);
+
+      // If INNGEST_API_BASE_URL=url is set instead of INNGEST_DEV=url, assume
+      // that we should be connecting to a dev server
+      url.protocol = "ws:";
     } else {
-      url = new URL(path, "https://api.inngest.com/");
+      url = new URL(path, "wss://api.inngest.com/");
 
       if (
         this.#app["mode"].isDev &&
@@ -87,11 +91,11 @@ export class TokenSubscription {
 
         if (devAvailable) {
           url = new URL(path, dsUrl);
+          url.protocol = "ws:";
         }
       }
     }
 
-    url.protocol = "ws:";
     url.searchParams.set("token", token);
 
     return url;

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -72,7 +72,7 @@ export class TokenSubscription {
     if (this.#app.apiBaseUrl) {
       url = new URL(path, this.#app.apiBaseUrl);
     } else {
-      url = new URL(path, "wss://api.inngest.com/");
+      url = new URL(path, "https://api.inngest.com/");
 
       if (
         this.#app["mode"].isDev &&


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fix bug where WebSocket connections do not allow being redirected, as is the case when hitting the prod API with `ws://`, causing a `301`.

Vercel's edge runtime appropriately complies with the WebSocket spec here, whereas their local `dev` doesn't, hence the discrepancy.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Complements inngest/inngest#2292
