### PR TITLE
Import `async_hooks` without the `node:` prefix

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -27,7 +27,7 @@
     "dev": "pnpm install && concurrently --names Build,Lint --prefix-colors \"green.inverse,magenta.inverse\" --handle-input \"pnpm run dev:build\" \"pnpm run dev:lint\"",
     "dev:build": "nodemon -w src -e ts -i version.ts --delay 300ms -x 'pnpm run build'",
     "dev:lint": "nodemon -w src -e ts -i version.ts --delay 300ms -x 'pnpm run lint'",
-    "build:copy": "cp package.json LICENSE.md README.md CHANGELOG.md dist",
+    "build:copy": "cp package.json LICENSE.md README.md CHANGELOG.md dist && cp src/components/execution/als.import.cjs dist/components/execution",
     "local:pack": "pnpm run build && pnpm run build:copy && yarn pack --verbose --frozen-lockfile --filename inngest.tgz --cwd dist",
     "dev:example": "tsx scripts/runExample.ts",
     "bench": "tsx test/benchmark/main.ts"

--- a/packages/inngest/src/components/execution/als.import.cjs
+++ b/packages/inngest/src/components/execution/als.import.cjs
@@ -1,0 +1,31 @@
+/**
+ * This file is used to conditionally import the `AsyncLocalStorage` class from
+ * the `node:async_hooks` module. While this is available in most supported
+ * runtimes (Node, Bun, Deno), it is not available in all, especially browsers.
+ *
+ * This file safely imports the module, but also does it within a `.cjs`,
+ * meaning Webpack will not attempt to statically analyze the import and
+ * complain about it not being available in the browser before it attempts to
+ * import.
+ */
+let als;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
+  const { AsyncLocalStorage } = require("node:async_hooks");
+  als = new AsyncLocalStorage();
+} catch {
+  // eslint-disable-next-line no-undef
+  console.warn(
+    "node:async_hooks is not supported in this runtime. Experimental async context is disabled."
+  );
+
+  als = {
+    getStore: () => undefined,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+    run: (_, fn) => fn(),
+  };
+}
+
+// eslint-disable-next-line no-undef
+module.exports = { als };

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -43,24 +43,8 @@ export const getAsyncCtx = async (): Promise<AsyncContext | undefined> => {
  */
 export const getAsyncLocalStorage = async (): Promise<AsyncLocalStorageIsh> => {
   (globalThis as Record<string | symbol | number, unknown>)[alsSymbol] ??=
-    new Promise<AsyncLocalStorageIsh>(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
-      async (resolve) => {
-        try {
-          const { AsyncLocalStorage } = await import("async_hooks");
-
-          resolve(new AsyncLocalStorage<AsyncContext>());
-        } catch (err) {
-          console.warn(
-            "async_hooks is not supported in this runtime. Experimental async context is disabled."
-          );
-
-          resolve({
-            getStore: () => undefined,
-            run: (_, fn) => fn(),
-          });
-        }
-      }
+    import("./als.import.cjs" as string).then(
+      ({ als }: { als: AsyncLocalStorageIsh }) => als
     );
 
   return (globalThis as Record<string | symbol | number, unknown>)[

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -47,12 +47,12 @@ export const getAsyncLocalStorage = async (): Promise<AsyncLocalStorageIsh> => {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
       async (resolve) => {
         try {
-          const { AsyncLocalStorage } = await import("node:async_hooks");
+          const { AsyncLocalStorage } = await import("async_hooks");
 
           resolve(new AsyncLocalStorage<AsyncContext>());
         } catch (err) {
           console.warn(
-            "node:async_hooks is not supported in this runtime. Experimental async context is disabled."
+            "async_hooks is not supported in this runtime. Experimental async context is disabled."
           );
 
           resolve({


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Remove the `node:` prefix when importing `async_hooks` to calm overzealous Webpack configs when they see the `node:` prefix.

We may also be able to turn this in to a dynamic import, though that can be further restricted by other rules/environments.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Internal fix
- [ ] ~Added unit/integration tests~ N/A Covered
- [ ] Added changesets if applicable
- [x] Confirmed working on Node
- [x] Confirmed working on Bun
- [ ] Confirmed working on Deno
