### PR TITLE
Normalize Lambda headers for mocked requests

### DIFF
--- a/.changeset/eleven-ghosts-behave.md
+++ b/.changeset/eleven-ghosts-behave.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Normalize headers in `"inngest/lambda"` - mocked requests with non-lowercase headers are now handled

--- a/packages/inngest/src/lambda.test.ts
+++ b/packages/inngest/src/lambda.test.ts
@@ -7,7 +7,15 @@ testFramework("AWS Lambda", LambdaHandler, {
     return [
       {
         path: req.path,
-        headers: req.headers,
+        // Intentionally make headers uppercase to ensure we test normalizing
+        // them for mocked Lambda requests, which do not normalize.
+        // See https://github.com/inngest/inngest-js/pull/937
+        headers: Object.fromEntries(
+          Object.entries(req.headers).map(([key, value]) => [
+            key.toUpperCase(),
+            value,
+          ])
+        ),
         httpMethod: req.method,
         queryStringParameters: req.query,
         body:

--- a/packages/inngest/src/lambda.ts
+++ b/packages/inngest/src/lambda.ts
@@ -94,6 +94,18 @@ export const serve = (
         return (ev as APIGatewayProxyEventV2).version === "2.0";
       })(event);
 
+      // Create a map of headers
+      const headersMap = new Map<string, string | undefined>([
+        ...Object.entries(event.headers).map(
+          ([key, value]) =>
+            [key.toLowerCase().trim(), value] as [string, string | undefined]
+        ),
+      ]);
+
+      const getHeader = (key: string): string | undefined => {
+        return headersMap.get(key.toLowerCase().trim());
+      };
+
       return {
         body: () => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -105,7 +117,7 @@ export const serve = (
               : "{}"
           );
         },
-        headers: (key) => event.headers[key],
+        headers: getHeader,
         method: () => {
           return eventIsV2
             ? event.requestContext.http.method
@@ -113,8 +125,8 @@ export const serve = (
         },
         url: () => {
           const path = eventIsV2 ? event.requestContext.http.path : event.path;
-          const proto = event.headers["x-forwarded-proto"] || "https";
-          const url = new URL(path, `${proto}://${event.headers.host || ""}`);
+          const proto = getHeader("x-forwarded-proto") || "https";
+          const url = new URL(path, `${proto}://${getHeader("host") || ""}`);
 
           return url;
         },


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Mocked Lambda headers are not neccessarily lowercase, and are delivered with single- and multi-value headers separate!

We can't use `Headers` here as that's Node 18+ and we support 14+.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
