### PR TITLE
Add cancelled event to internal known schemas

### DIFF
--- a/.changeset/happy-swans-melt.md
+++ b/.changeset/happy-swans-melt.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add `inngest/function.cancelled` event to known internal schemas

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -20,6 +20,7 @@ describe("EventSchemas", () => {
       | `${internalEvents.FunctionFailed}`
       | `${internalEvents.FunctionFinished}`
       | `${internalEvents.FunctionInvoked}`
+      | `${internalEvents.FunctionCancelled}`
       | `${internalEvents.ScheduledTimer}`;
 
     type Actual = Schemas<typeof schemas>[keyof Schemas<

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -6,7 +6,7 @@ import {
 } from "../helpers/types.js";
 import type * as z from "../helpers/validators/zod.js";
 import {
-  CancelledEventPayload,
+  type CancelledEventPayload,
   type EventPayload,
   type FailureEventPayload,
   type FinishedEventPayload,

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -6,6 +6,7 @@ import {
 } from "../helpers/types.js";
 import type * as z from "../helpers/validators/zod.js";
 import {
+  CancelledEventPayload,
   type EventPayload,
   type FailureEventPayload,
   type FinishedEventPayload,
@@ -258,6 +259,7 @@ export class EventSchemas<
     [internalEvents.FunctionFailed]: FailureEventPayload;
     [internalEvents.FunctionFinished]: FinishedEventPayload;
     [internalEvents.FunctionInvoked]: InvokedEventPayload;
+    [internalEvents.FunctionCancelled]: CancelledEventPayload;
     [internalEvents.ScheduledTimer]: ScheduledTimerEventPayload;
   }>,
 > {

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1138,6 +1138,7 @@ describe("helper types", () => {
         | `${internalEvents.FunctionFailed}`
         | `${internalEvents.FunctionFinished}`
         | `${internalEvents.FunctionInvoked}`
+        | `${internalEvents.FunctionCancelled}`
         | `${internalEvents.ScheduledTimer}`
         | "foo"
         | "bar";

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -161,6 +161,7 @@ export enum internalEvents {
   FunctionFailed = "inngest/function.failed",
   FunctionInvoked = "inngest/function.invoked",
   FunctionFinished = "inngest/function.finished",
+  FunctionCancelled = "inngest/function.cancelled",
   ScheduledTimer = "inngest/scheduled.timer",
 }
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -131,6 +131,19 @@ export type FinishedEventPayload = {
 };
 
 /**
+ * The payload for an internal Inngest event that is sent when a function is
+ * cancelled.
+ */
+export type CancelledEventPayload = {
+  name: `${internalEvents.FunctionCancelled}`;
+  data: {
+    function_id: string;
+    run_id: string;
+    correlation_id?: string;
+  };
+};
+
+/**
  * The payload for any generic function invocation event. In practice, the event
  * data will be more specific to the function being invoked.
  *


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Since adding `inngest/function.cancelled` events in inngest/inngest#1989, these need adding to the known internal schemas to that users can listen to them.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Already documented in inngest/website#1010
- [ ] ~Added unit/integration tests~ N/A Covered by type guards
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Documented already in inngest/website#1010
- Added in inngest/inngest#1989
