### PR TITLE
Use x-inngest-event-id-seed header

### DIFF
--- a/.changeset/brown-radios-enjoy.md
+++ b/.changeset/brown-radios-enjoy.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Use x-inngest-event-id-seed header instead of event idempotency ID

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -20,7 +20,7 @@ import { type IsAny, type IsEqual, type IsNever } from "@local/helpers/types";
 import { type Logger } from "@local/middleware/logger";
 import { type SendEventResponse } from "@local/types";
 import { literal } from "zod";
-import { assertType, createClient } from "../test/helpers";
+import { assertType, createClient, nodeVersion } from "../test/helpers";
 
 const testEvent: EventPayload = {
   name: "test",
@@ -474,35 +474,37 @@ describe("send", () => {
       );
     });
 
-    test("should use seed header for idempotency ID if none given", async () => {
-      const inngest = createClient({ id: "test" });
-      inngest.setEventKey(testEventKey);
+    if (nodeVersion?.major && nodeVersion.major >= 19) {
+      test("should use seed header for idempotency ID if none given", async () => {
+        const inngest = createClient({ id: "test" });
+        inngest.setEventKey(testEventKey);
 
-      const testEventWithoutId = {
-        name: "test.without.id",
-        data: {},
-      };
+        const testEventWithoutId = {
+          name: "test.without.id",
+          data: {},
+        };
 
-      const mockedFetch = jest.mocked(global.fetch);
+        const mockedFetch = jest.mocked(global.fetch);
 
-      await expect(inngest.send(testEventWithoutId)).resolves.toMatchObject({
-        ids: Array(1).fill(expect.any(String)),
+        await expect(inngest.send(testEventWithoutId)).resolves.toMatchObject({
+          ids: Array(1).fill(expect.any(String)),
+        });
+
+        expect(mockedFetch).toHaveBeenCalledTimes(2); // 2nd for dev server check
+        expect(mockedFetch.mock.calls[1]).toHaveLength(2);
+
+        const reqHeaders = mockedFetch.mock.calls[1]?.[1]?.headers as Record<
+          string,
+          string
+        >;
+        expect(reqHeaders).toBeDefined();
+        expect(typeof reqHeaders).toBe("object");
+
+        expect(reqHeaders[headerKeys.EventIdSeed]).toBeDefined();
+        expect(typeof reqHeaders[headerKeys.EventIdSeed]).toBe("string");
+        expect(reqHeaders[headerKeys.EventIdSeed]).toBeTruthy();
       });
-
-      expect(mockedFetch).toHaveBeenCalledTimes(2); // 2nd for dev server check
-      expect(mockedFetch.mock.calls[1]).toHaveLength(2);
-
-      const reqHeaders = mockedFetch.mock.calls[1]?.[1]?.headers as Record<
-        string,
-        string
-      >;
-      expect(reqHeaders).toBeDefined();
-      expect(typeof reqHeaders).toBe("object");
-
-      expect(reqHeaders[headerKeys.EventIdSeed]).toBeDefined();
-      expect(typeof reqHeaders[headerKeys.EventIdSeed]).toBe("string");
-      expect(reqHeaders[headerKeys.EventIdSeed]).toBeTruthy();
-    });
+    }
 
     test("should allow middleware to mutate input", async () => {
       const inngest = createClient({

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -465,7 +465,7 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
 
     let maxAttempts = 5;
 
-    // Atempt to set the event ID seed header. If it fails then disable retries
+    // Attempt to set the event ID seed header. If it fails then disable retries
     // (but we still want to send the event).
     try {
       const entropy = createEntropy(10);

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -139,6 +139,7 @@ export enum headerKeys {
   InngestServerKind = "x-inngest-server-kind",
   InngestExpectedServerKind = "x-inngest-expected-server-kind",
   InngestSyncKind = "x-inngest-sync-kind",
+  EventIdSeed = "x-inngest-event-id-seed",
   TraceParent = "traceparent",
   TraceState = "tracestate",
 }

--- a/packages/inngest/src/helpers/crypto.ts
+++ b/packages/inngest/src/helpers/crypto.ts
@@ -1,0 +1,21 @@
+/**
+ * Create a cryptographically secure random value.
+ *
+ * @throws {Error} If the crypto module is not available.
+ */
+export function createEntropy(byteLength: number): Uint8Array {
+  const bytes = new Uint8Array(byteLength);
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Crypto#browser_compatibility
+  const { crypto } = globalThis;
+  if (!crypto) {
+    // This should only happen in Node <19.
+    throw new Error("missing crypto module");
+  }
+  if (!crypto.getRandomValues) {
+    throw new Error("missing crypto.getRandomValues");
+  }
+
+  crypto.getRandomValues(bytes);
+  return bytes;
+}

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -1819,3 +1819,14 @@ export const checkIntrospection = ({ name, triggers }: CheckIntrospection) => {
  * @type T the type to check against.
  */
 export function assertType<T>(subject: T): asserts subject is T {}
+
+/**
+ * Get the current Node.js version.
+ */
+export const nodeVersion = process.version
+  ? (() => {
+      const [major, minor, patch] = process.versions.node.split(".").map(Number);
+
+      return { major, minor, patch };
+    })()
+  : undefined;


### PR DESCRIPTION
## Summary
Use the new `x-inngest-event-id-seed header` instead of setting the event idempotency ID.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Internal
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- SDK side of inngest/inngest#2287
