### PR TITLE
Bump up `resolveAfterPending()` default count

### DIFF
--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -35,7 +35,7 @@ export const createFrozenPromise = (): Promise<unknown> => {
  * Returns a Promise that resolves after the current event loop's microtasks
  * have finished, but before the next event loop tick.
  */
-export const resolveAfterPending = (count = 10): Promise<void> => {
+export const resolveAfterPending = (count = 100): Promise<void> => {
   /**
    * This uses a brute force implementation that will continue to enqueue
    * microtasks 10 times before resolving. This is to ensure that the microtask


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Bump the `resolveAfterPending()` default microtask shim to count from `10` to `100`.

Pre-#858 this was `1000` and functions with high step counts were suffering from slow memoization times, so it was changed to `10`. `10`, however, is very low, and doesn't give much overhead for promises to correctly resolve. A major piece that this protects against is being able to appropriately batch steps, which is a unique need of the `v1` execution version.

In `v2` (enabled with `optimizeParallelism: true` following #862), this batching and the parallel index warnings are no longer needed.

Because of this, we reset this shimming to a happy middleground of `100`, allowing complex tools such as `@inngest/agent-kit` to appropriately handle repeated step IDs without firing warnings off.

This does have a very slight performance hit, but with optimized parallelism soon being the default, that performance hit will disappear.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Internal
- [ ] ~Added unit/integration tests~ N/A Covered
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Partially reverses one of the optimizations made in #858
- Mentions `optimizeParallelism`, added in #862
