### PR TITLE
Loosen `zod` dependency range

### DIFF
--- a/.changeset/silver-drinks-sing.md
+++ b/.changeset/silver-drinks-sing.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Loosen `zod` dependency range to allow for minor versions `>=3.22`

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -214,7 +214,7 @@
     "strip-ansi": "^5.2.0",
     "temporal-polyfill": "^0.2.5",
     "ulidx": "^2.4.1",
-    "zod": "~3.22.3"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       zod:
-        specifier: ~3.22.3
-        version: 3.22.3
+        specifier: ^3.22.3
+        version: 3.24.2
     devDependencies:
       '@actions/core':
         specifier: ^1.10.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,7 @@ importers:
         version: 2.4.1
       zod:
         specifier: ^3.22.3
-        version: 3.24.2
+        version: 3.22.3
     devDependencies:
       '@actions/core':
         specifier: ^1.10.0


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

See https://github.com/inngest/inngest-js/issues/933#issuecomment-2778464713. If a user has issues with this unlocked, they just need to upgrade for now.

It's imperfect, but unblocks some users as our pinned `zod` version is lagging behind.

#920 alleviates this issue.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A KTLO
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #933
- See https://github.com/inngest/inngest-js/issues/933#issuecomment-2778464713
- #920 solves the issue
