### PR TITLE
Remove `inngest` from `@inngest/realtime`

### DIFF
--- a/.changeset/chatty-pandas-know.md
+++ b/.changeset/chatty-pandas-know.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Public environment variables (such as `NEXT_PUBLIC_*`) are now also accessed when looking for Inngest during subscriptions

--- a/.changeset/early-hotels-doubt.md
+++ b/.changeset/early-hotels-doubt.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": minor
+---
+
+`useInngestSubscription()` no longer accepts an `app`; always use a `token` when subscribing on the client

--- a/.changeset/early-impalas-camp.md
+++ b/.changeset/early-impalas-camp.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Environment variables are also now captured in Deno and Netlify

--- a/.changeset/rotten-dolphins-try.md
+++ b/.changeset/rotten-dolphins-try.md
@@ -1,0 +1,17 @@
+---
+"@inngest/realtime": minor
+---
+
+`subscribe()` call no longer accepts an `app` as the first parameter
+
+One can be passed alongside other arguments, e.g.
+
+```ts
+subscribe({
+  app,
+  channel: "hello-world",
+  topics: ["messages"],
+});
+```
+
+An app is still required if you are not using a token retrieved from `getSubscriptionToken()`.

--- a/packages/realtime/src/api.ts
+++ b/packages/realtime/src/api.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { fetchWithAuthFallback, parseAsBoolean } from "./util";
+
+const tokenSchema = z.object({ jwt: z.string() });
+
+export const api = {
+  async getSubscriptionToken({
+    channel,
+    topics,
+    signingKey,
+    signingKeyFallback,
+    apiBaseUrl,
+  }: {
+    channel: string;
+    topics: string[];
+    signingKey: string;
+    signingKeyFallback: string | undefined;
+    apiBaseUrl: string | undefined;
+  }): Promise<string> {
+    let url: URL;
+    const path = "/v1/realtime/token";
+    const inputBaseUrl =
+      apiBaseUrl ||
+      process.env.INNGEST_BASE_URL ||
+      process.env.INNGEST_API_BASE_URL;
+
+    if (inputBaseUrl) {
+      url = new URL(path, inputBaseUrl);
+    } else if (process.env.INNGEST_DEV) {
+      try {
+        const devUrl = new URL(process.env.INNGEST_DEV);
+        url = new URL(path, devUrl);
+      } catch {
+        if (parseAsBoolean(process.env.INNGEST_DEV)) {
+          url = new URL(path, "http://localhost:8288/");
+        } else {
+          url = new URL(path, "https://api.inngest.com/");
+        }
+      }
+    } else {
+      url = new URL(
+        path,
+        process.env.NODE_ENV === "production"
+          ? "https://api.inngest.com/"
+          : "http://localhost:8288/",
+      );
+    }
+
+    const body = topics.map((topic) => ({
+      channel,
+      name: topic,
+      kind: "run",
+    }));
+
+    const res = await fetchWithAuthFallback({
+      authToken: signingKey,
+      authTokenFallback: signingKeyFallback,
+      fetch,
+      url,
+      options: {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Failed to get subscription token: ${res.status} ${
+          res.statusText
+        } - ${await res.text()}`,
+      );
+    }
+
+    const data = await res.json();
+    return tokenSchema.parse(data).jwt;
+  },
+};

--- a/packages/realtime/src/api.ts
+++ b/packages/realtime/src/api.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { fetchWithAuthFallback, parseAsBoolean } from "./util";
+import { fetchWithAuthFallback, getEnvVar, parseAsBoolean } from "./util";
 
 const tokenSchema = z.object({ jwt: z.string() });
 
@@ -21,17 +21,19 @@ export const api = {
     const path = "/v1/realtime/token";
     const inputBaseUrl =
       apiBaseUrl ||
-      process.env.INNGEST_BASE_URL ||
-      process.env.INNGEST_API_BASE_URL;
+      getEnvVar("INNGEST_BASE_URL") ||
+      getEnvVar("INNGEST_API_BASE_URL");
+
+    const devEnvVar = getEnvVar("INNGEST_DEV");
 
     if (inputBaseUrl) {
       url = new URL(path, inputBaseUrl);
-    } else if (process.env.INNGEST_DEV) {
+    } else if (devEnvVar) {
       try {
-        const devUrl = new URL(process.env.INNGEST_DEV);
+        const devUrl = new URL(devEnvVar);
         url = new URL(path, devUrl);
       } catch {
-        if (parseAsBoolean(process.env.INNGEST_DEV)) {
+        if (parseAsBoolean(devEnvVar)) {
           url = new URL(path, "http://localhost:8288/");
         } else {
           url = new URL(path, "https://api.inngest.com/");
@@ -40,7 +42,7 @@ export const api = {
     } else {
       url = new URL(
         path,
-        process.env.NODE_ENV === "production"
+        getEnvVar("NODE_ENV") === "production"
           ? "https://api.inngest.com/"
           : "http://localhost:8288/",
       );

--- a/packages/realtime/src/hooks.ts
+++ b/packages/realtime/src/hooks.ts
@@ -1,4 +1,3 @@
-import { Inngest } from "inngest";
 import { useEffect, useRef, useState } from "react";
 import { subscribe } from "./subscribe";
 import { type Realtime } from "./types";
@@ -48,18 +47,12 @@ export interface InngestSubscription<TToken extends Realtime.Subscribe.Token> {
 export function useInngestSubscription<
   const TToken extends Realtime.Subscribe.Token | null | undefined,
 >({
-  app = new Inngest({ id: "useInngestSubscription" }),
   token: tokenInput,
   refreshToken,
   key,
   enabled = true,
   bufferInterval = 0,
 }: {
-  /**
-   * TODO
-   */
-  app?: Inngest.Any;
-
   /**
    * TODO
    */
@@ -131,7 +124,7 @@ export function useInngestSubscription<
     const start = async () => {
       try {
         setState(InngestSubscriptionState.Connecting);
-        const stream = await subscribe(app, { ...token });
+        const stream = await subscribe({ ...token });
         if (cancelled) return;
 
         subscriptionRef.current = stream;

--- a/packages/realtime/src/index.test.ts
+++ b/packages/realtime/src/index.test.ts
@@ -342,7 +342,6 @@ describe("subscribe", () => {
       test("can subscribe with just strings", () => {
         const _fn = async () => {
           const stream = await subscribe(
-            app,
             {
               channel: "test",
               topics: ["foo", "bar"],
@@ -389,7 +388,7 @@ describe("subscribe", () => {
     describe("type-only channel import", () => {
       test("errors if channel name is incorrect", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             // @ts-expect-error Incorrect channel
             channel: typeOnlyChannel<typeof userChannel>("test"),
             topics: ["created", "updated"],
@@ -399,7 +398,7 @@ describe("subscribe", () => {
 
       test("errors if topic names are incorrect with static channel", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             channel: typeOnlyChannel<typeof staticChannel>("static"),
             // @ts-expect-error Incorrect topic
             topics: ["created", "updated", "test"],
@@ -409,7 +408,7 @@ describe("subscribe", () => {
 
       test("errors if topic names are incorrect with dynamic channel", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             channel: typeOnlyChannel<typeof userChannel>("user/123"),
             // @ts-expect-error Incorrect topic
             topics: ["created", "updated", "test"],
@@ -420,7 +419,6 @@ describe("subscribe", () => {
       test("can subscribe using types only of a static channel", () => {
         const _fn = async () => {
           const stream = await subscribe(
-            app,
             {
               channel: typeOnlyChannel<typeof staticChannel>("static"),
               topics: ["created", "updated"],
@@ -466,7 +464,6 @@ describe("subscribe", () => {
       test("can subscribe using types only of a dynamic channel", () => {
         const _fn = async () => {
           const stream = await subscribe(
-            app,
             {
               channel: typeOnlyChannel<typeof userChannel>("user/123"),
               topics: ["created", "updated"],
@@ -513,7 +510,7 @@ describe("subscribe", () => {
     describe("runtime channel import", () => {
       test("errors if static definition given", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             // @ts-expect-error Definition given
             channel: staticChannel,
             topics: ["created", "updated"],
@@ -523,7 +520,7 @@ describe("subscribe", () => {
 
       test("errors if dynamic definition given", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             // @ts-expect-error Definition given
             channel: userChannel,
             topics: ["created", "updated"],
@@ -533,7 +530,7 @@ describe("subscribe", () => {
 
       test("errors if topic names are incorrect with static channel", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             channel: staticChannel(),
             // @ts-expect-error Incorrect topic
             topics: ["created", "updated", "test"],
@@ -543,7 +540,7 @@ describe("subscribe", () => {
 
       test("errors if topic names are incorrect with dynamic channel", () => {
         const _fn = () => {
-          void subscribe(app, {
+          void subscribe({
             channel: userChannel("123"),
             // @ts-expect-error Incorrect topic
             topics: ["created", "updated", "test"],
@@ -553,7 +550,7 @@ describe("subscribe", () => {
 
       test("can subscribe with runtime import of a static channel", () => {
         const _fn = async () => {
-          const stream = await subscribe(app, {
+          const stream = await subscribe({
             channel: staticChannel(),
             topics: ["created", "updated"],
           });
@@ -586,7 +583,7 @@ describe("subscribe", () => {
 
       test("can subscribe with runtime import of a dynamic channel", () => {
         const _fn = async () => {
-          const stream = await subscribe(app, {
+          const stream = await subscribe({
             channel: userChannel("123"),
             topics: ["created", "updated"],
           });
@@ -626,7 +623,7 @@ describe("subscribe", () => {
             topics: ["foo", "bar"],
           });
 
-          const stream = await subscribe(app, token, (message) => {
+          const stream = await subscribe(token, (message) => {
             assertType<"test">(message.channel);
             assertType<"foo" | "bar">(message.topic);
 
@@ -670,7 +667,7 @@ describe("subscribe", () => {
             topics: ["created", "updated"],
           });
 
-          const stream = await subscribe(app, token, (message) => {
+          const stream = await subscribe(token, (message) => {
             assertType<"static">(message.channel);
             assertType<"created" | "updated">(message.topic);
 
@@ -714,7 +711,7 @@ describe("subscribe", () => {
             topics: ["created", "updated"],
           });
 
-          const stream = await subscribe(app, token, (message) => {
+          const stream = await subscribe(token, (message) => {
             assertType<"static">(message.channel);
             assertType<"created" | "updated">(message.topic);
 
@@ -758,7 +755,7 @@ describe("subscribe", () => {
             topics: ["created", "updated"],
           });
 
-          const stream = await subscribe(app, token, (message) => {
+          const stream = await subscribe(token, (message) => {
             assertType<`user/${string}`>(message.channel);
             assertType<"created" | "updated">(message.topic);
 
@@ -802,7 +799,7 @@ describe("subscribe", () => {
             topics: ["created", "updated"],
           });
 
-          const stream = await subscribe(app, token, (message) => {
+          const stream = await subscribe(token, (message) => {
             assertType<`user/${string}`>(message.channel);
             assertType<"created" | "updated">(message.topic);
 

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -38,8 +38,13 @@ export class TokenSubscription {
     signingKey: string | undefined,
     signingKeyFallback: string | undefined,
   ) {
-    this.#signingKey = signingKey;
-    this.#signingKeyFallback = signingKeyFallback;
+    this.#apiBaseUrl =
+      apiBaseUrl ||
+      process.env.INNGEST_BASE_URL ||
+      process.env.INNGEST_API_BASE_URL;
+    this.#signingKey = signingKey || process.env.INNGEST_SIGNING_KEY;
+    this.#signingKeyFallback =
+      signingKeyFallback || process.env.INNGEST_SIGNING_KEY_FALLBACK;
 
     if (typeof token.channel === "string") {
       this.#channelId = token.channel;

--- a/packages/realtime/src/subscribe/helpers.ts
+++ b/packages/realtime/src/subscribe/helpers.ts
@@ -1,5 +1,5 @@
 import type { Inngest } from "inngest";
-import { InngestApi } from "inngest/api/api";
+import type { InngestApi } from "inngest/api/api";
 import { Realtime } from "../types";
 import { TokenSubscription } from "./TokenSubscription";
 

--- a/packages/realtime/src/subscribe/helpers.ts
+++ b/packages/realtime/src/subscribe/helpers.ts
@@ -1,4 +1,5 @@
-import { Inngest } from "inngest";
+import type { Inngest } from "inngest";
+import { InngestApi } from "inngest/api/api";
 import { Realtime } from "../types";
 import { TokenSubscription } from "./TokenSubscription";
 
@@ -20,12 +21,12 @@ export const subscribe = async <
   /**
    * TODO
    */
-  app: Inngest.Like,
-
-  /**
-   * TODO
-   */
   token: {
+    /**
+     * TODO
+     */
+    app?: Inngest.Like;
+
     /**
      * TODO
      */
@@ -42,9 +43,14 @@ export const subscribe = async <
    */
   callback?: Realtime.Subscribe.Callback<TToken>,
 ): Promise<TOutput> => {
+  const app: Inngest.Any | undefined = token.app as Inngest.Any | undefined;
+  const api: InngestApi | undefined = app?.["inngestApi"];
+
   const subscription = new TokenSubscription(
-    app,
     token as Realtime.Subscribe.Token,
+    app?.apiBaseUrl,
+    api?.["signingKey"],
+    api?.["signingKeyFallback"],
   );
 
   const retStream = subscription.getJsonStream();

--- a/packages/realtime/src/subscribe/helpers.ts
+++ b/packages/realtime/src/subscribe/helpers.ts
@@ -1,6 +1,6 @@
 import type { Inngest } from "inngest";
 import type { InngestApi } from "inngest/api/api";
-import { Realtime } from "../types";
+import type { Realtime } from "../types";
 import { TokenSubscription } from "./TokenSubscription";
 
 /**

--- a/packages/realtime/src/util.ts
+++ b/packages/realtime/src/util.ts
@@ -102,3 +102,95 @@ export const parseAsBoolean = (value: unknown): boolean | undefined => {
 
   return undefined;
 };
+
+const publicEnvVarPrefixes = [
+  "", // Also search for the env var itself
+  "PUBLIC_",
+  "NEXT_PUBLIC_",
+  "REACT_APP_",
+  "NUXT_PUBLIC_",
+  "VUE_APP_",
+];
+
+/**
+ * Given a `key`, get the environment variable under that key.
+ */
+export const getEnvVar = (key: string): string | undefined => {
+  return allProcessEnv()[key];
+};
+
+/**
+ * Given a `key`, get the environment variable under that key or a
+ * public-prefixed version of it, such as `NEXT_PUBLIC_${key}`.
+ */
+export const getPublicEnvVar = (key: string): string | undefined => {
+  const env = allProcessEnv();
+
+  for (const prefix of publicEnvVarPrefixes) {
+    const envVar = env[prefix + key];
+
+    if (envVar !== undefined) {
+      return envVar;
+    }
+  }
+};
+
+export type EnvValue = string | undefined;
+export type Env = Record<string, EnvValue>;
+
+/**
+ * The Deno environment, which is not always available.
+ */
+declare const Deno: {
+  env: { toObject: () => Env };
+};
+
+/**
+ * The Netlify environment, which is not always available.
+ */
+declare const Netlify: {
+  env: { toObject: () => Env };
+};
+
+/**
+ * allProcessEnv returns the current process environment variables, or an empty
+ * object if they cannot be read, making sure we support environments other than
+ * Node such as Deno, too.
+ *
+ * Using this ensures we don't dangerously access `process.env` in environments
+ * where it may not be defined, such as Deno or the browser.
+ */
+export const allProcessEnv = (): Env => {
+  // Node, Bun, or Node-like environments
+  try {
+    if (process.env) {
+      return process.env;
+    }
+  } catch (_err) {
+    // noop
+  }
+
+  // Deno
+  try {
+    const env = Deno.env.toObject();
+
+    if (env) {
+      return env;
+    }
+  } catch (_err) {
+    // noop
+  }
+
+  // Netlify
+  try {
+    const env = Netlify.env.toObject();
+
+    if (env) {
+      return env;
+    }
+  } catch (_err) {
+    // noop
+  }
+
+  return {};
+};

--- a/packages/realtime/src/util.ts
+++ b/packages/realtime/src/util.ts
@@ -42,8 +42,8 @@ export async function fetchWithAuthFallback<TFetch extends typeof fetch>({
   options,
   url,
 }: {
-  authToken?: string;
-  authTokenFallback?: string;
+  authToken: string;
+  authTokenFallback: string | undefined;
   fetch: TFetch;
   options?: Parameters<TFetch>[1];
   url: URL | string;

--- a/packages/realtime/src/util.ts
+++ b/packages/realtime/src/util.ts
@@ -30,3 +30,75 @@ export const createDeferredPromise = <T>(): DeferredPromiseReturn<T> => {
 
   return { promise, resolve: resolve!, reject: reject! };
 };
+
+/**
+ * Send an HTTP request with the given signing key. If the response is a 401 or
+ * 403, then try again with the fallback signing key
+ */
+export async function fetchWithAuthFallback<TFetch extends typeof fetch>({
+  authToken,
+  authTokenFallback,
+  fetch,
+  options,
+  url,
+}: {
+  authToken?: string;
+  authTokenFallback?: string;
+  fetch: TFetch;
+  options?: Parameters<TFetch>[1];
+  url: URL | string;
+}): Promise<Response> {
+  let res = await fetch(url, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+
+  if ([401, 403].includes(res.status) && authTokenFallback) {
+    res = await fetch(url, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        Authorization: `Bearer ${authTokenFallback}`,
+      },
+    });
+  }
+
+  return res;
+}
+
+/**
+ * Given an unknown value, try to parse it as a `boolean`. Useful for parsing
+ * environment variables that could be a selection of different values such as
+ * `"true"`, `"1"`.
+ *
+ * If the value could not be confidently parsed as a `boolean` or was seen to be
+ * `undefined`, this function returns `undefined`.
+ */
+export const parseAsBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return Boolean(value);
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+
+    if (trimmed === "undefined") {
+      return undefined;
+    }
+
+    if (["true", "1"].includes(trimmed)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Removes runtime `inngest` imports from `@inngest/realtime`, allowing us to more safely import it in client-side code with more overzealous bundlers like Next.js and Cloudflare Workers.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Closes #931 
- Fixes #939
- Documented in inngest/website#1101
