### PR TITLE
Fix validation middleware silently failing

### DIFF
--- a/.changeset/friendly-colts-explode.md
+++ b/.changeset/friendly-colts-explode.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-validation": patch
+---
+
+Fix possibility of silently failing when multiple versions of Zod are installed

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -360,3 +360,55 @@ jobs:
 
             The last release was built and published from ${{ github.event.pull_request.head.sha }}.
           edit-mode: replace
+
+  prerelease_middleware-validation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/middleware-validation
+    if: contains(github.event.pull_request.labels.*.name, 'prerelease/middleware-validation')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-and-build
+        with:
+          install-dependencies: false
+          build: false
+
+      - run: pnpm install
+
+      - run: pnpm build
+
+      - name: Prerelease PR
+        run: node ../../scripts/release/prerelease.js
+        env:
+          TAG: pr-${{ github.event.pull_request.number }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_ENV: test # disable npm access checks; they don't work in CI
+          DIST_DIR: dist
+
+      - name: Update PR with latest prerelease
+        uses: edumserrano/find-create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "<!-- pr-prerelease-comment-middleware-validation -->"
+          comment-author: "inngest-release-bot"
+          body:
+            | # can be a single value or you can compose text with multi-line values
+            <!-- pr-prerelease-comment-middleware-validation -->
+            A user has added the <kbd>[prerelease/middleware-validation](https://github.com/inngest/inngest-js/labels/prerelease%2Fmiddleware-validation)</kbd> label, so this PR will be published to npm with the tag `pr-${{ github.event.pull_request.number }}`. It will be updated with the latest changes as you push commits to this PR.
+
+            You can install this prerelease version with:
+
+            ```sh
+            npm install @inngest/middleware-validation@pr-${{ github.event.pull_request.number }}
+            ```
+
+            The last release was built and published from ${{ github.event.pull_request.head.sha }}.
+          edit-mode: replace

--- a/packages/middleware-validation/src/middleware.ts
+++ b/packages/middleware-validation/src/middleware.ts
@@ -6,7 +6,7 @@ import {
   type InngestFunction,
   type MiddlewareOptions,
 } from "inngest";
-import { ZodType, type ZodObject } from "zod";
+import { type ZodObject } from "zod";
 
 /**
  * Middleware that validates events using Zod schemas passed using
@@ -232,7 +232,7 @@ export const validationMiddleware = (opts?: {
 
 const helpers = {
   isZodObject: (value: unknown): value is ZodObject<any> => {
-    return value instanceof ZodType && value._def.typeName === "ZodObject";
+    return (value as any)?._def?.typeName === "ZodObject";
   },
 
   isObject: (value: unknown): value is Record<string, any> => {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Removes the `instanceof` check when checking if a given runtime schema is compatible with Zod; this will not return truthy if the schema passed was created with a different version of Zod, which can happen if dependencies of an app both depend on different versions of Zod that are not compatible.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A Multi-package; covered
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Fixes #932
