### PR TITLE
Add `signingKey` option to `new Inngest()` app

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -424,8 +424,9 @@ export class InngestCommHandler<
 
     this.inngestRegisterUrl = new URL("/fn/register", this.apiBaseUrl);
 
-    this.signingKey = options.signingKey;
-    this.signingKeyFallback = options.signingKeyFallback;
+    this.signingKey = options.signingKey || this.client["signingKey"];
+    this.signingKeyFallback =
+      options.signingKeyFallback || this.client["signingKeyFallback"];
     this._serveHost = options.serveHost || this.env[envKeys.InngestServeHost];
     this._servePath = options.servePath || this.env[envKeys.InngestServePath];
 
@@ -1922,8 +1923,6 @@ export class InngestCommHandler<
       if (!this.signingKey) {
         this.signingKey = String(this.env[envKeys.InngestSigningKey]);
       }
-
-      this.client["inngestApi"].setSigningKey(this.signingKey);
     }
 
     if (this.env[envKeys.InngestSigningKeyFallback]) {
@@ -1932,21 +1931,9 @@ export class InngestCommHandler<
           this.env[envKeys.InngestSigningKeyFallback]
         );
       }
-
-      this.client["inngestApi"].setSigningKeyFallback(this.signingKeyFallback);
     }
 
-    if (!this.client["eventKeySet"]() && this.env[envKeys.InngestEventKey]) {
-      this.client.setEventKey(String(this.env[envKeys.InngestEventKey]));
-    }
-
-    // v2 -> v3 migration warnings
-    if (this.env[envKeys.InngestDevServerUrl]) {
-      this.log(
-        "warn",
-        `Use of ${envKeys.InngestDevServerUrl} has been deprecated in v3; please use ${envKeys.InngestBaseUrl} instead. See https://www.inngest.com/docs/sdk/migration`
-      );
-    }
+    this.client["loadModeEnvVars"](this.env);
   }
 
   /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -655,6 +655,36 @@ export interface ClientOptions {
   eventKey?: string;
 
   /**
+   * A key used to sign requests to and from Inngest in order to prove that the
+   * source is legitimate.
+   *
+   * You must provide a signing key to communicate securely with Inngest. If
+   * your key is not provided here, we'll try to retrieve it from the
+   * `INNGEST_SIGNING_KEY` environment variable.
+   *
+   * You can retrieve your signing key from the Inngest UI inside the "Secrets"
+   * section at {@link https://app.inngest.com/secrets}. We highly recommend
+   * that you add this to your platform's available environment variables as
+   * `INNGEST_SIGNING_KEY`.
+   *
+   * If no key can be found, you will not be able to register your functions or
+   * receive events from Inngest.
+   *
+   * Note that though setting a `signingKey` when calling `serve()` is
+   * deprecated, that value will still overwrite this one if provided.
+   */
+  signingKey?: string;
+
+  /**
+   * The same as signingKey, except used as a fallback when auth fails using the
+   * primary signing key.
+   *
+   * Note that though setting a `signingKeyFallback` when calling `serve()` is
+   * deprecated, that value will still overwrite this one if provided.
+   */
+  signingKeyFallback?: string;
+
+  /**
    * The base URL to use when contacting Inngest.
    *
    * Defaults to https://inn.gs/ for sending events and https://api.inngest.com
@@ -801,12 +831,18 @@ export interface RegisterOptions {
    *
    * If no key can be found, you will not be able to register your functions or
    * receive events from Inngest.
+   *
+   * @deprecated If you want to explicitly set this value, set it when creating
+   * the app in `new Inngest()` instead.
    */
   signingKey?: string;
 
   /**
    * The same as signingKey, except used as a fallback when auth fails using the
    * primary signing key.
+   *
+   * @deprecated If you want to explicitly set this value, set it when creating
+   * the app in `new Inngest()` instead.
    */
   signingKeyFallback?: string;
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds to ability to provide a `signingKey` and `signingKeyFallback` when creating a `new Inngest()` app.

Until #920, the precedence for the signing key used is:

1. Explicit `signingKey` in `new Inngest()`
2. Explicit `signingKey` in `serve()` (now `@deprecated`)
3. `INNGEST_SIGNING_KEY` env var (in global)
4. `INNGEST_SIGNING_KEY` env var (as late env)

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Explicit `signingKey` in `serve()` will be removed in #920
