### PR TITLE
Fix requiring signing key for dev in `@inngest/realtime`

### DIFF
--- a/.changeset/empty-cows-talk.md
+++ b/.changeset/empty-cows-talk.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Fix requiring signing key for dev in `@inngest/realtime`

--- a/.changeset/tall-geese-confess.md
+++ b/.changeset/tall-geese-confess.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Fix debug log incorrectly displaying topics we're subscribing to

--- a/packages/realtime/src/api.ts
+++ b/packages/realtime/src/api.ts
@@ -13,7 +13,7 @@ export const api = {
   }: {
     channel: string;
     topics: string[];
-    signingKey: string;
+    signingKey: string | undefined;
     signingKeyFallback: string | undefined;
     apiBaseUrl: string | undefined;
   }): Promise<string> {

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -122,12 +122,6 @@ export class TokenSubscription {
         "No subscription token key passed; attempting to retrieve one automatically...",
       );
 
-      if (!this.#signingKey) {
-        throw new Error(
-          "No subscription token key passed but have no signing key so cannot retrieve one",
-        );
-      }
-
       key = (
         await this.lazilyGetSubscriptionToken({
           ...this.token,
@@ -439,12 +433,12 @@ export class TokenSubscription {
       /**
        * TODO
        */
-      signingKey: string;
+      signingKey: string | undefined;
 
       /**
        * TODO
        */
-      signingKeyFallback?: string | undefined;
+      signingKeyFallback: string | undefined;
     },
   ): Promise<TToken> {
     const channelId =

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -109,7 +109,7 @@ export class TokenSubscription {
     this.#debug(
       `Establishing connection to channel "${
         this.#channelId
-      }" with topics ${JSON.stringify(this.#topics)}...`,
+      }" with topics ${JSON.stringify([...this.#topics.keys()])}...`,
     );
 
     if (typeof WebSocket === "undefined") {

--- a/packages/realtime/src/util.ts
+++ b/packages/realtime/src/util.ts
@@ -42,7 +42,7 @@ export async function fetchWithAuthFallback<TFetch extends typeof fetch>({
   options,
   url,
 }: {
-  authToken: string;
+  authToken: string | undefined;
   authTokenFallback: string | undefined;
   fetch: TFetch;
   options?: Parameters<TFetch>[1];
@@ -52,7 +52,7 @@ export async function fetchWithAuthFallback<TFetch extends typeof fetch>({
     ...options,
     headers: {
       ...options?.headers,
-      Authorization: `Bearer ${authToken}`,
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
     },
   });
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Addresses #958 by removing the need for a signing key in a dev env for `@inngest/realtime`; this was an overzealous check that is harder to confidently make without the presence of an app.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Fix
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Caused by #949 
- Fixes #958 
