### PR TITLE
Fix fanout writers throwing during some closures

### DIFF
--- a/.changeset/friendly-pillows-check.md
+++ b/.changeset/friendly-pillows-check.md
@@ -1,0 +1,5 @@
+---
+"@inngest/realtime": patch
+---
+
+Fix fanout writers throwing during some closures

--- a/packages/realtime/src/subscribe/StreamFanout.ts
+++ b/packages/realtime/src/subscribe/StreamFanout.ts
@@ -53,7 +53,13 @@ export class StreamFanout<TInput = unknown> {
    */
   close() {
     for (const writer of this.#writers) {
-      writer.close();
+      try {
+        writer.close();
+      } catch {
+        // Ignore errors, as we are closing the stream and the writer may
+        // already be closed, especially if the stream is closed before the
+        // writer is closed or if the stream is cancelled.
+      }
     }
 
     this.#writers.clear();


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Partial fix for #963, ignoring errors when ensuring fanout writers are closed as they may _already_ be closed due to errors/closures in the source of the transform.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Partial fix for #963 
