### PR TITLE
Realtime/fix unmount cancel throw

### DIFF
--- a/packages/realtime/src/subscribe/StreamFanout.ts
+++ b/packages/realtime/src/subscribe/StreamFanout.ts
@@ -26,7 +26,15 @@ export class StreamFanout<TInput = unknown> {
       },
     });
 
-    this.#writers.add(writable.getWriter());
+    const writer = writable.getWriter();
+    this.#writers.add(writer);
+
+    // Eagerly remove the writer is the stream is closed
+    writer.closed
+      .catch(() => {}) // suppress unhandledpromiserejection fun
+      .finally(() => {
+        this.#writers.delete(writer);
+      });
 
     return readable;
   }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fix `@inngest/realtime` throwing:

```
TypeError: Failed to execute 'cancel' on 'ReadableStream': Cannot cancel a locked stream
```

This is caused by the reader (in an async `for await` loop) still being active, and us having to explicit way of cleaning it up.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable
