### PR TITLE
export JsonifyObject type

### DIFF
--- a/packages/inngest/src/helpers/jsonify.ts
+++ b/packages/inngest/src/helpers/jsonify.ts
@@ -46,7 +46,7 @@ type FilterJsonableKeys<T extends object> = {
 /**
 JSON serialize objects (not including arrays) and classes.
 */
-type JsonifyObject<T extends object> = {
+export type JsonifyObject<T extends object> = {
   [Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
 };
 


### PR DESCRIPTION
## Summary
I'm trying to create a type for `step` (from `inngest.createFunction` > `step`), so that I can use it in a separate function and access the `step.ai.wrap` method.

e.g.
```ts
import { InngestStep } from '../client';

export const createStreamTextStep = (
  step: InngestStep,
  publish: Realtime.PublishFn,
) {
  // some code
  return step.ai.wrap(stepName, callGenerateText, streamTextProps.messages);
}
```

To create that type, I'm importing `GetStepTools` and doing the following:

```ts
import { EventSchemas, Inngest, type GetStepTools } from "inngest";
import type { Events } from "./types.ts";
import { realtimeMiddleware } from "@inngest/realtime";

export type InngestStep = GetStepTools<typeof inngest>;

export const inngest = new Inngest({
  id: "my-id",
  schemas: new EventSchemas().fromRecord<Events>(),
  middleware: [realtimeMiddleware()],
});
```

I have 2 modules that reference `InngestStep`, and in both modules, the exported module's primary function is getting the following error:

`"Exported variable 'myFunction' has or is using name JsonifyObject from external module "/path/to/node_modules/inngest/helpers/jsonify" but cannot be named."`

From my very rudimentary understanding, `GetStepTools` is referencing the type `JsonifyObject` somewhere in the chain of types, however since it's not being exported from this module, typescript is unable to “name” it in the generated .d.ts file in our compilation.

This was tested by explicitly exporting `JsonifyObject` in node_modules and resolved the issue.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A touches nested helper type only
- [ ] ~~Added unit/integration tests~~ N/A only the primarily used `Jsonify` includes tests for types, didn't seem necessary
- [ ] ~~Added changesets if applicable~~ N/A
