### PR TITLE
Add ability for signal waits to supersede others

### DIFF
--- a/.changeset/silly-yaks-hope.md
+++ b/.changeset/silly-yaks-hope.md
@@ -1,0 +1,13 @@
+---
+"inngest": minor
+---
+
+Add ability for signal waits to supersede others
+
+```ts
+await step.waitForSignal("step-id", {
+  signal: "my-signal",
+  timeout: "5m",
+  onConflict: "replace",
+});
+```

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -325,6 +325,9 @@ export const createStepTools = <TClient extends Inngest.Any>(
         opts: {
           signal: opts.signal,
           timeout: timeStr(opts.timeout),
+          ...(opts.supersedeOnConflict
+            ? { supersede: Boolean(opts.supersedeOnConflict) }
+            : {}),
         },
       };
     }),
@@ -770,6 +773,18 @@ type WaitForSignalOpts = {
    * {@link https://npm.im/ms}
    */
   timeout: number | string | Date;
+
+  /**
+   * When this `step.waitForSignal()` call is made, choose whether an existing
+   * wait for the same signal should cause this run to be cancelled or if we
+   * should supersede it.
+   *
+   * Be aware that if this is `true`, the previous wait will be removed and will
+   * remain pending until it reaches its timeout.
+   *
+   * @default false
+   */
+  supersedeOnConflict?: boolean;
 };
 
 /**

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -325,9 +325,7 @@ export const createStepTools = <TClient extends Inngest.Any>(
         opts: {
           signal: opts.signal,
           timeout: timeStr(opts.timeout),
-          ...(opts.overwriteOnConflict
-            ? { overwrite: Boolean(opts.overwriteOnConflict) }
-            : {}),
+          conflict: opts.onConflict,
         },
       };
     }),
@@ -776,15 +774,16 @@ type WaitForSignalOpts = {
 
   /**
    * When this `step.waitForSignal()` call is made, choose whether an existing
-   * wait for the same signal should cause this run to be cancelled or if we
-   * should overwrite it.
+   * wait for the same signal should be replaced, or whether this run should
+   * fail.
    *
-   * Be aware that if this is `true`, the previous wait will be removed and will
-   * remain pending until it reaches its timeout.
+   * `"replace"` will replace any existing wait with this one, and the existing
+   * wait will remain pending until it reaches its timeout.
    *
-   * @default false
+   * `"fail"` will cause this run to fail if there is already a wait for the
+   * same signal.
    */
-  overwriteOnConflict?: boolean;
+  onConflict: "replace" | "fail";
 };
 
 /**

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -325,8 +325,8 @@ export const createStepTools = <TClient extends Inngest.Any>(
         opts: {
           signal: opts.signal,
           timeout: timeStr(opts.timeout),
-          ...(opts.supersedeOnConflict
-            ? { supersede: Boolean(opts.supersedeOnConflict) }
+          ...(opts.overwriteOnConflict
+            ? { overwrite: Boolean(opts.overwriteOnConflict) }
             : {}),
         },
       };
@@ -777,14 +777,14 @@ type WaitForSignalOpts = {
   /**
    * When this `step.waitForSignal()` call is made, choose whether an existing
    * wait for the same signal should cause this run to be cancelled or if we
-   * should supersede it.
+   * should overwrite it.
    *
    * Be aware that if this is `true`, the previous wait will be removed and will
    * remain pending until it reaches its timeout.
    *
    * @default false
    */
-  supersedeOnConflict?: boolean;
+  overwriteOnConflict?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add the ability for `step.waitForSignal()` to overwrite any other existing waits in any run in the environment.

```ts
await step.waitForSignal("step-id", {
  signal: "my-signal",
  timeout: "5m",
  onConflict: "replace",
});
```

Also requires a new option for every `step.waitForSignal()` call: `onConflict`.
- `onConflict: "replace"` will replace any existing wait with this one, leaving the replaced wait to time out
- `onConflict: "fail"` will fail this run if another wait for the same signal exists - this was the previous default behaviour

This is a required option for now to make it so it's a considered part of every wait. It may fall back to be optional with a default later.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Requires inngest/inngest#2449
