### PR TITLE
Adding support for streaming responses in expressjs

### DIFF
--- a/.changeset/yule-tide-deer
+++ b/.changeset/yule-tide-deer
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add response streaming support to Express.

--- a/packages/inngest/src/express.ts
+++ b/packages/inngest/src/express.ts
@@ -104,6 +104,13 @@ export const serve = (options: ServeHandlerOptions): any => {
 
           return res.status(status).send(body);
         },
+        transformStreamingResponse: ({ body, headers, status }) => {
+          for (const [name, value] of Object.entries(headers)) {
+            res.setHeader(name, value);
+          }
+
+          return res.status(status).send(body);
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
You cannot currently stream responses when using the ExpressJS handler because it does not have a streaming response handler.

After some testing, I'm not entirely confident this is working. Would appreciate guidance from someone familiar with the internals. Also posted here https://discord.com/channels/842170679536517141/1375527248836296814.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR 
- [ ] ~Added unit/integration tests~ Checked the cloudflare implementation which has streaming support and there were no unit tests to follow from there
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
