### PR TITLE
When executing, use the `serve()` call's client instead of the function's

### DIFF
--- a/.changeset/dry-weeks-lay.md
+++ b/.changeset/dry-weeks-lay.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+When executing, use the `serve()` call's client instead of the function's

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1465,6 +1465,7 @@ export class InngestCommHandler<
           return {
             version,
             partialOptions: {
+              client: this.client,
               runId: ctx?.run_id || "",
               data: {
                 event: event as EventPayload,
@@ -1503,6 +1504,7 @@ export class InngestCommHandler<
           return {
             version,
             partialOptions: {
+              client: this.client,
               runId: ctx?.run_id || "",
               data: {
                 event: event as EventPayload,
@@ -1542,6 +1544,7 @@ export class InngestCommHandler<
           return {
             version,
             partialOptions: {
+              client: this.client,
               runId: ctx?.run_id || "",
               data: {
                 event: event as EventPayload,

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -151,6 +151,7 @@ describe("runFn", () => {
             const execution = fn["createExecution"]({
               version: PREFERRED_EXECUTION_VERSION,
               partialOptions: {
+                client: fn["client"],
                 data: fromPartial({
                   event: { name: "foo", data: { foo: "foo" } },
                 }),
@@ -196,6 +197,7 @@ describe("runFn", () => {
             const execution = fn["createExecution"]({
               version: PREFERRED_EXECUTION_VERSION,
               partialOptions: {
+                client: fn["client"],
                 data: fromPartial({
                   event: { name: "foo", data: { foo: "foo" } },
                 }),

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -256,7 +256,6 @@ export class InngestFunction<
 
   protected createExecution(opts: CreateExecutionOptions): IInngestExecution {
     const options: InngestExecutionOptions = {
-      client: this.client,
       fn: this,
       ...opts.partialOptions,
     };
@@ -649,5 +648,5 @@ export namespace InngestFunction {
 
 export type CreateExecutionOptions = {
   version: ExecutionVersion;
-  partialOptions: Omit<InngestExecutionOptions, "client" | "fn">;
+  partialOptions: Omit<InngestExecutionOptions, "fn">;
 };

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -96,6 +96,7 @@ export const getStepTools = (
     ["createExecution"]({
       version: PREFERRED_EXECUTION_VERSION,
       partialOptions: {
+        client,
         data: fromPartial({
           event: { name: "foo", data: {} },
         }),
@@ -141,6 +142,7 @@ export const runFnWithStack = async (
   const execution = fn["createExecution"]({
     version: opts?.executionVersion ?? PREFERRED_EXECUTION_VERSION,
     partialOptions: {
+      client: fn['client'],
       data: fromPartial({
         event: opts?.event || { name: "foo", data: {} },
       }),


### PR DESCRIPTION
## Summary

When we execute, we were previously using the function's client, causing us to sometimes miss env vars as they are only found on the `serve()` call's client.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] ~Added unit/integration tests~ N/A
- [x] Added changesets if applicable
