### PR TITLE
Export types for convenience and discoverability

### DIFF
--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -1,5 +1,6 @@
 import { WaitGroup } from "@jpwilliams/waitgroup";
 import debug, { type Debugger } from "debug";
+import ms from "ms";
 import { envKeys, headerKeys, queryKeys } from "../../helpers/consts.js";
 import {
   allProcessEnv,
@@ -41,6 +42,7 @@ import { getHostname, onShutdown, retrieveSystemAttributes } from "./os.js";
 import {
   ConnectionState,
   DEFAULT_SHUTDOWN_SIGNALS,
+  type ConnectApp,
   type ConnectHandlerOptions,
   type WorkerConnection,
 } from "./types.js";
@@ -52,7 +54,6 @@ import {
   ReconnectError,
   waitWithCancel,
 } from "./util.js";
-import ms from "ms";
 
 const ResponseAcknowlegeDeadline = 5_000;
 
@@ -1276,6 +1277,15 @@ class WebSocketWorkerConnection implements WorkerConnection {
     };
   }
 }
+
+// Export types for convenience
+export {
+  DEFAULT_SHUTDOWN_SIGNALS,
+  type ConnectApp,
+  type ConnectHandlerOptions,
+  type ConnectionState,
+  type WorkerConnection,
+};
 
 export const connect = async (
   options: ConnectHandlerOptions


### PR DESCRIPTION
## Summary
With all types exported on the `"inngest/connect"` path along side the main `connect()` function, users can more easily click into this file and discover related types they may want to use. This is helpful compared to previously having to dig into the code or view the docs to know where these types are located. This also makes import statements simpler for end users as they can have all related imports on a single line.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-5009
