### PR TITLE
Allow arbitrary field/method access via ProxyLogger

### DIFF
--- a/.changeset/thin-birds-double.md
+++ b/.changeset/thin-birds-double.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow arbitrary field/method access to underlying logger

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules
 
 examples/**/*/.env
 examples/**/*/dist
+
+# AI
+CLAUDE.md

--- a/packages/inngest/src/middleware/logger.test.ts
+++ b/packages/inngest/src/middleware/logger.test.ts
@@ -61,4 +61,93 @@ describe("ProxyLogger", () => {
       expect(timeout).toBeCalledTimes(1);
     });
   });
+
+  describe("arbitrary property/method access", () => {
+    let internalLogger: Logger & {
+      foo: jest.MockedFunction<() => string>;
+      bar: string;
+      customLog: jest.MockedFunction<(msg: string) => void>;
+      anotherLogMethod: jest.MockedFunction<(msg: string) => void>;
+    };
+
+    beforeEach(() => {
+      internalLogger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        foo: jest.fn(() => "custom result"),
+        bar: "custom property",
+        customLog: jest.fn(),
+        anotherLogMethod: jest.fn(),
+      };
+
+      logger = new ProxyLogger(internalLogger);
+    });
+
+    test("should access custom methods on underlying logger", () => {
+      expect((logger as unknown as Logger & { foo: () => string }).foo()).toBe(
+        "custom result"
+      );
+      expect(internalLogger.foo).toHaveBeenCalledTimes(1);
+    });
+
+    test("should access custom properties on underlying logger", () => {
+      expect((logger as unknown as Logger & { bar: string }).bar).toBe(
+        "custom property"
+      );
+      expect(internalLogger.bar).toBe("custom property");
+    });
+
+    test("should call custom methods with correct arguments", () => {
+      (
+        logger as unknown as Logger & { customLog: (msg: string) => void }
+      ).customLog("test message");
+
+      expect(internalLogger.customLog).toHaveBeenCalledWith("test message");
+    });
+
+    test("should still respect enabled state for standard logging methods via proxy", () => {
+      logger.disable();
+
+      (logger as unknown as Logger & { info: (msg: string) => void }).info(
+        "disabled message"
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(internalLogger.info).not.toHaveBeenCalled();
+
+      logger.enable();
+      (logger as unknown as Logger & { info: (msg: string) => void }).info(
+        "enabled message"
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(internalLogger.info).toHaveBeenCalledWith("enabled message");
+    });
+
+    test("should call custom logging methods without enabled check", () => {
+      logger.disable();
+
+      (
+        logger as unknown as Logger & {
+          anotherLogMethod: (msg: string) => void;
+        }
+      ).anotherLogMethod("custom log message");
+
+      expect(internalLogger.anotherLogMethod).toHaveBeenCalledWith(
+        "custom log message"
+      );
+    });
+
+    test("error calling a method that doesn't exist on the underlying logger", () => {
+      expect(() => {
+        (
+          logger as unknown as Logger & {
+            doesNotExist: () => string;
+          }
+        ).doesNotExist();
+      }).toThrow();
+    });
+  });
 });

--- a/packages/inngest/src/middleware/logger.ts
+++ b/packages/inngest/src/middleware/logger.ts
@@ -57,6 +57,22 @@ export class ProxyLogger implements Logger {
 
   constructor(logger: Logger) {
     this.logger = logger;
+
+    // Return a Proxy to forward arbitrary property access to the underlying
+    // logger. For example, if the user provides a logger that has a `foo`
+    // method, they can call `foo` on the ProxyLogger and it will call the
+    // underlying logger's `foo` method.
+    return new Proxy(this, {
+      get(target, prop, receiver): unknown {
+        // Handle ProxyLogger's own methods/properties.
+        if (prop in target) {
+          return Reflect.get(target, prop, receiver);
+        }
+
+        // Forward property access to the underlying logger.
+        return Reflect.get(target.logger, prop, receiver);
+      },
+    }) as ProxyLogger;
   }
 
   info(...args: LogArg[]) {


### PR DESCRIPTION
## Summary
Allow access to arbitrary fields/methods via the `ProxyLogger`. For example, if I have a custom logger with the method `foo` then it'll be callable via the `ProxyLogger`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added unit/integration tests
- [x] Added changesets if applicable