### PR TITLE
Remove `match` option from `step.waitForEvent()`

### DIFF
--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -103,16 +103,6 @@ describe("waitForEvent", () => {
     });
   });
 
-  test("return simple field match if `match` string given", async () => {
-    await expect(
-      step.waitForEvent("id", { event: "event", match: "name", timeout: "2h" }),
-    ).resolves.toMatchObject({
-      opts: {
-        if: "event.name == async.name",
-      },
-    });
-  });
-
   test("return custom match statement if `if` given", async () => {
     await expect(
       step.waitForEvent("id", {
@@ -124,18 +114,6 @@ describe("waitForEvent", () => {
       opts: {
         if: "name == 123",
       },
-    });
-  });
-
-  describe("type errors", () => {
-    test("does not allow both `match` and `if`", () => {
-      // @ts-expect-error `match` and `if` cannot be defined together
-      void step.waitForEvent("id", {
-        event: "event",
-        match: "name",
-        if: "name",
-        timeout: "2h",
-      });
     });
   });
 });

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -390,9 +390,7 @@ export const createStepTools = <TClient extends Inngest.Any>(
         };
 
         if (typeof opts !== "string") {
-          if (opts?.match) {
-            matchOpts.if = `event.${opts.match} == async.${opts.match}`;
-          } else if (opts?.if) {
+          if (opts?.if) {
             matchOpts.if = opts.if;
           }
         }
@@ -809,50 +807,21 @@ type WaitForEventOpts<
    * {@link https://npm.im/ms}
    */
   timeout: number | string | Date;
-} & ExclusiveKeys<
-  {
-    /**
-     * If provided, the step function will wait for the incoming event to match
-     * particular criteria. If the event does not match, it will be ignored and
-     * the step function will wait for another event.
-     *
-     * It must be a string of a dot-notation field name within both events to
-     * compare, e.g. `"data.id"` or `"user.email"`.
-     *
-     * ```
-     * // Wait for an event where the `user.email` field matches
-     * match: "user.email"
-     * ```
-     *
-     * All of these are helpers for the `if` option, which allows you to specify
-     * a custom condition to check. This can be useful if you need to compare
-     * multiple fields or use a more complex condition.
-     *
-     * See the Inngest expressions docs for more information.
-     *
-     * {@link https://www.inngest.com/docs/functions/expressions}
-     *
-     * @deprecated Use `if` instead.
-     */
-    match?: string;
 
-    /**
-     * If provided, the step function will wait for the incoming event to match
-     * the given condition. If the event does not match, it will be ignored and
-     * the step function will wait for another event.
-     *
-     * The condition is a string of Google's Common Expression Language. For most
-     * simple cases, you might prefer to use `match` instead.
-     *
-     * See the Inngest expressions docs for more information.
-     *
-     * {@link https://www.inngest.com/docs/functions/expressions}
-     */
-    if?: string;
-  },
-  "match",
-  "if"
->;
+  /**
+   * If provided, the step function will wait for the incoming event to match
+   * the given condition. If the event does not match, it will be ignored and
+   * the step function will wait for another event.
+   *
+   * The condition is a string of Google's Common Expression Language. For most
+   * simple cases, you might prefer to use `match` instead.
+   *
+   * See the Inngest expressions docs for more information.
+   *
+   * {@link https://www.inngest.com/docs/functions/expressions}
+   */
+  if?: string;
+};
 
 /**
  * Options for `step.ai.infer()`.


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Removes `match` from `step.waitForEvent()`'s options; use `if` directly instead.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Migration guide for #920
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Breaking, so targeted for #920
