### PR TITLE
allow untyped error cause deserialization

### DIFF
--- a/packages/inngest/src/components/StepError.ts
+++ b/packages/inngest/src/components/StepError.ts
@@ -31,7 +31,7 @@ export class StepError extends Error {
 
     // Try setting the cause if we have one
     this.cause = parsedErr.cause
-      ? deserializeError(parsedErr.cause)
+      ? deserializeError(parsedErr.cause, true)
       : undefined;
   }
 }


### PR DESCRIPTION
## Summary
When deserializing step error causes, we need to allow untyped deserialization.


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
