### PR TITLE
obscure "node:async_hooks" import from bundlers

### DIFF
--- a/.changeset/fair-seals-rush.md
+++ b/.changeset/fair-seals-rush.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+The optional import of Node.js module "node:async_hooks" is more likely to by dynamic, even after bundling this library. This change makes this feature-detecting dynamic import work correctly when bundled for the Convex JS runtime.

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -53,7 +53,16 @@ export const getAsyncLocalStorage = async (): Promise<AsyncLocalStorageIsh> => {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
       async (resolve) => {
         try {
-          const { AsyncLocalStorage } = await import("node:async_hooks");
+          // Obscure this import to keep bundlers from bundling it.
+          const dynamicImport = <T>(path: string): Promise<T> => {
+            const safePath = path.split("/").join("/");
+            return import(safePath) as Promise<T>;
+          };
+          const { AsyncLocalStorage } =
+            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+            await dynamicImport<typeof import("node:async_hooks")>(
+              "node:async_hooks"
+            );
 
           resolve(new AsyncLocalStorage<AsyncContext>());
         } catch (err) {


### PR DESCRIPTION
## Summary
Obscure the dynamic import of an optional Node.js dependency to prevent bundlers from attempting to inline the code. This ensures this import will happen at runtime even when this code is bundled.

This makes the bundled code work in environments without Node.js APIs like the Convex JS runtime without erroring on undefined imports that would otherwise require a stub/polyfill. Maybe this helps in Cloudflare too when Node.js compatibilty is not turned on.

---

The code that previously compiled to
```js
        try {
            const { AsyncLocalStorage } = await Promise.resolve().then(() => __importStar(require("node:async_hooks")));
            resolve(new AsyncLocalStorage());
        }
```
(see https://app.unpkg.com/inngest@3.39.2/files/components/execution/als.js#L60-61)

now compiles to
```js
        try {
            // Obscure this import to keep bundlers from bundling it.
            const dynamicImport = (path) => {
                const safePath = path.split("/").join("/");
                return Promise.resolve(`${safePath}`).then(s => __importStar(require(s)));
            };
            const { AsyncLocalStorage } = 
            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
            await dynamicImport("node:async_hooks");
            resolve(new AsyncLocalStorage());
        }
```
This is a pattern that esbuild (tested) and hopefully any reasonable bundler will leave as a runtime import/require.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A This would require some plumbing to test, lmk if hooking up a package test makes sense. " -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A just for library developers
- [ ] ~~Added unit/integration tests~~ N/A this would require some plumbing to test, lmk if that's desirable
- [x] Added changesets if applicable

## Related
Discord thread with @djfarrelly on the Convex server https://discord.com/channels/1019350475847499849/1387074958487720047/1387074958487720047