### PR TITLE
feat(@inngest/test): allow passing `reqArgs`

### DIFF
--- a/.changeset/tasty-shrimps-notice.md
+++ b/.changeset/tasty-shrimps-notice.md
@@ -1,0 +1,5 @@
+---
+"@inngest/test": patch
+---
+
+Allow passing `reqArgs`, which can be used to test middleware that takes `reqArgs` and different `serve()` handlers in to account

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -263,6 +263,32 @@ and their guidance for mocking imports:
 - [`bun:test` (Bun)](https://bun.sh/docs/test/mocks#module-mocks-with-mock-module)
 - [`@std/testing` (Deno)](https://jsr.io/@std/testing/doc/mock/~)
 
+### Request arguments (reqArgs)
+
+Request arguments can be passed to the function execution to support middleware
+that relies on particular serve handler usage. These can be specified either when
+creating an `InngestTestEngine` instance or for individual executions:
+
+```ts
+// Set reqArgs for every execution
+const t = new InngestTestEngine({
+  function: helloWorld,
+  reqArgs: [request, response], // Express req/res objects for example
+});
+
+// Or for just one execution
+t.execute({
+  reqArgs: [request, response],
+});
+
+t.executeStep("my-step", {
+  reqArgs: [request, response],
+});
+```
+
+This is particularly useful when testing functions that use middleware requiring
+specific serve handler context.
+
 ### Custom
 
 While the package performs some basic mocks of the input object to a function in
@@ -309,7 +335,5 @@ const t = new InngestTestEngine({
 - `onFailure` handlers are not run automatically
 - Mocked step outputs do not model the JSON (de)serialization process yet, so
   some typing may be off (e.g. `Date`)
-- You cannot specify any `reqArgs` yet, which could affect some middleware usage
-  that relies on a particular serve handler being used
 - Calling `inngest.send()` within a function is not yet automatically mocked, likely
   resulting in an error

--- a/packages/test/src/InngestTestEngine.ts
+++ b/packages/test/src/InngestTestEngine.ts
@@ -60,6 +60,14 @@ export namespace InngestTestEngine {
     disableImmediateExecution?: boolean;
 
     /**
+     * Request arguments that will be passed to the function execution.
+     * 
+     * These can be used by middleware that relies on particular serve handler usage.
+     * If not provided, an empty array will be used.
+     */
+    reqArgs?: unknown[];
+
+    /**
      * A function that can transform the context sent to the function upon
      * execution, useful for mocking steps, events, or tracking property
      * accesses with proxies.
@@ -492,7 +500,7 @@ export class InngestTestEngine {
           event: events[0],
           events,
         },
-        reqArgs: [], // TODO allow passing?
+        reqArgs: options.reqArgs || [],
         headers: {},
         stepCompletionOrder: steps.map((step) => step.id),
         stepState: mockStepState,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->
1. Added reqArgs to the Options interface
2. Updated the execution logic - Modified `InngestTestEngine.ts` to use options.reqArgs || [] instead of the hardcoded empty array, allowing reqArgs to be passed through to the function execution.
4. Updated README


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A docs in readme
- [ ] ~~Added unit/integration tests~~ N/A no tests in `@inngest/test` yet
- [x] Added changesets if applicable

> What version bump do you think that should be? Minor or patch?