### PR TITLE
Revert "obscure "node:async_hooks" import from bundlers"

### DIFF
--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -53,16 +53,7 @@ export const getAsyncLocalStorage = async (): Promise<AsyncLocalStorageIsh> => {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
       async (resolve) => {
         try {
-          // Obscure this import to keep bundlers from bundling it.
-          const dynamicImport = <T>(path: string): Promise<T> => {
-            const safePath = path.split("/").join("/");
-            return import(safePath) as Promise<T>;
-          };
-          const { AsyncLocalStorage } =
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-            await dynamicImport<typeof import("node:async_hooks")>(
-              "node:async_hooks"
-            );
+          const { AsyncLocalStorage } = await import("node:async_hooks");
 
           resolve(new AsyncLocalStorage<AsyncContext>());
         } catch (err) {


### PR DESCRIPTION
The inngest/inngest-js#1020 PR introduced breaking compatibility changes with Next.js, resulting in numerous bug reports in the past days.

The new code block raises the following error: 

```
Error: Cannot find module as expression is too dynamic
    at async (../../../src/components/execution/als.ts:63:12) {
  code: 'MODULE_NOT_FOUND'
}
```

resulting in the disablement of the ALS feature required for AgentKit to function in an Next.js project (and others):

```
node:async_hooks is not supported in this runtime. Experimental async context is disabled.
```

