### PR TITLE
Add support for latest generation + thinking config in Gemini models

### DIFF
--- a/.changeset/dry-geckos-fold.md
+++ b/.changeset/dry-geckos-fold.md
@@ -1,0 +1,6 @@
+---
+"@inngest/ai": patch
+---
+
+added support for latest thinking and generation config for gemini models
+created unit and smoke tests for AI models + adapters

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@actions/github": "^6.0.0",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/packages/ai/.env.example
+++ b/packages/ai/.env.example
@@ -1,0 +1,11 @@
+# Environment variables for @inngest/ai smoke tests
+# Copy this file to .env and fill in your API keys to run smoke tests
+
+# Required for Gemini smoke tests
+GEMINI_API_KEY=your_google_ai_api_key_here
+
+# Optional: Other AI provider API keys for future smoke tests
+OPENAI_API_KEY=your_openai_api_key_here
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here
+AZURE_OPENAI_ENDPOINT=your_azure_openai_endpoint_here

--- a/packages/ai/.gitignore
+++ b/packages/ai/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 *.tgz
+.env

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,1 +1,116 @@
 # @inngest/ai
+
+AI adapter package for Inngest, providing type-safe interfaces to various AI providers including OpenAI, Anthropic, Gemini, Grok, and Azure OpenAI.
+
+## Installation
+
+```bash
+npm install @inngest/ai
+```
+
+## Usage
+
+```typescript
+import { openai, anthropic, gemini } from "@inngest/ai/models";
+
+// Use with Inngest step.ai
+const result = await step.ai.infer("Analyze this data", {
+  model: openai({ model: "gpt-4" }),
+  body: {
+    messages: [{ role: "user", content: "What is machine learning?" }],
+  },
+});
+```
+
+## Development
+
+### Running Tests
+
+This package includes comprehensive smoke tests that verify our type definitions work correctly with real AI provider APIs.
+
+#### Unit Tests
+
+Run the standard unit tests (when they exist):
+
+```bash
+pnpm test
+```
+
+#### Smoke Tests
+
+Smoke tests make actual API calls to AI providers to ensure our type definitions are accurate and complete. **Note: These tests will consume API credits and should only be run when needed.**
+
+##### Setup
+
+1. Copy the environment example file:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Add your API keys to `.env`:
+
+   ```bash
+   # Required for Gemini smoke tests
+   GEMINI_API_KEY=your_gemini_api_key_here
+
+   # Optional: Other providers for future smoke tests
+   OPENAI_API_KEY=your_openai_api_key_here
+   ANTHROPIC_API_KEY=your_anthropic_api_key_here
+   # ... see .env.example for full list
+   ```
+
+##### Running Smoke Tests
+
+```bash
+# Run all smoke tests (requires API keys)
+pnpm test:smoke
+
+# Run smoke tests in watch mode for development
+pnpm test:smoke:watch
+```
+
+##### What Smoke Tests Cover
+
+The smoke tests verify:
+
+- **Basic text generation** - Simple prompts and responses
+- **Thinking features** - Gemini's reasoning capabilities with thinking budgets
+- **Structured output** - JSON schema validation and response formatting
+- **Parameter validation** - Temperature, token limits, stop sequences, etc.
+- **Error handling** - Invalid API keys and malformed requests
+- **Token usage tracking** - Usage metadata accuracy and completeness
+- **Advanced features** - Multi-candidate generation, sampling parameters
+
+##### Cost Considerations
+
+- Smoke tests are designed to use minimal tokens while thoroughly testing functionality
+- Most tests use small `maxOutputTokens` limits (50-400 tokens)
+- Thinking tests may use more tokens due to internal reasoning
+- Set `RUN_PAID_TESTS=false` in your `.env` to skip expensive tests
+
+### Architecture
+
+This package provides:
+
+- **Type-safe adapters** for each AI provider's API format
+- **Model creators** that handle authentication and configuration
+- **Comprehensive TypeScript definitions** with extensive JSDoc documentation
+- **Developer-friendly interfaces** with usage examples and best practices
+
+### Contributing
+
+When adding new AI providers or updating existing ones:
+
+1. Add comprehensive type definitions with JSDoc documentation
+2. Include usage examples for complex features
+3. Add smoke tests to verify real-world functionality
+4. Update this README with any new setup requirements
+
+### Supported Providers
+
+- **OpenAI** - GPT models and embeddings
+- **Anthropic** - Claude models
+- **Google Gemini** - Gemini models with thinking features
+- **Grok** - Grok models (OpenAI-compatible)
+- **Azure OpenAI** - Azure-hosted OpenAI models

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -87,7 +87,6 @@ The smoke tests verify:
 - Smoke tests are designed to use minimal tokens while thoroughly testing functionality
 - Most tests use small `maxOutputTokens` limits (50-400 tokens)
 - Thinking tests may use more tokens due to internal reasoning
-- Set `RUN_PAID_TESTS=false` in your `.env` to skip expensive tests
 
 ### Architecture
 

--- a/packages/ai/eslint.config.mjs
+++ b/packages/ai/eslint.config.mjs
@@ -6,7 +6,8 @@ import tseslint from "typescript-eslint";
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
-  { languageOptions: { globals: globals.browser } },
+  { ignores: ["dist/**"] },
+  { languageOptions: { globals: globals.node } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   eslintPluginPrettierRecommended,

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "lint": "eslint",
     "postversion": "pnpm run build",
     "release": "node ../../scripts/release/publish.js && pnpm dlx jsr publish --allow-slow-types --allow-dirty",
     "release:version": "node ../../scripts/release/jsrVersion.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -10,7 +10,11 @@
     "build": "tsc",
     "postversion": "pnpm run build",
     "release": "node ../../scripts/release/publish.js && pnpm dlx jsr publish --allow-slow-types --allow-dirty",
-    "release:version": "node ../../scripts/release/jsrVersion.js"
+    "release:version": "node ../../scripts/release/jsrVersion.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:smoke": "vitest run --config vitest.smoke.config.ts",
+    "test:smoke:watch": "vitest --config vitest.smoke.config.ts"
   },
   "files": [
     "dist"
@@ -50,9 +54,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",
+    "dotenv": "^17.0.1",
     "eslint": "^9.18.0",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^15.14.0",
-    "typescript-eslint": "^7.16.1"
+    "typescript-eslint": "^7.16.1",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/ai/src/adapter.ts
+++ b/packages/ai/src/adapter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import { type AnthropicAiAdapter } from "./adapters/anthropic.js";
 import { type GeminiAiAdapter } from "./adapters/gemini.js";
 import { type GrokAiAdapter } from "./adapters/grok.js";
@@ -106,7 +105,12 @@ export namespace AiAdapter {
   /**
    * Supported I/O formats for AI models.
    */
-  export type Format = "openai-chat" | "anthropic" | "gemini" | "grok" | "azure-openai";
+  export type Format =
+    | "openai-chat"
+    | "anthropic"
+    | "gemini"
+    | "grok"
+    | "azure-openai";
 
   /**
    * A function that creates a model that adheres to an existng AI adapter

--- a/packages/ai/src/adapters/anthropic.ts
+++ b/packages/ai/src/adapters/anthropic.ts
@@ -23,7 +23,6 @@ export namespace AnthropicAiAdapter {
    * details and options.
    */
   export type Model =
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | (string & {})
     | "claude-opus-4-0"
     | "claude-opus-4-20250514"
@@ -45,7 +44,6 @@ export namespace AnthropicAiAdapter {
     | "claude-instant-1.2";
 
   export type Beta =
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | (string & {})
     | "message-batches-2024-09-24"
     | "prompt-caching-2024-07-31"

--- a/packages/ai/src/adapters/azure-openai.ts
+++ b/packages/ai/src/adapters/azure-openai.ts
@@ -17,7 +17,6 @@ export namespace AzureOpenAiAiAdapter {
    * You can also use custom deployment names by providing any string.
    */
   export type Deployment =
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | (string & {})
     // Chat models
     | "gpt-4o"

--- a/packages/ai/src/adapters/gemini.ts
+++ b/packages/ai/src/adapters/gemini.ts
@@ -91,6 +91,13 @@ export namespace GeminiAiAdapter {
     role?: "user" | "model" | "system";
   }
 
+  /**
+   * A part of the content. Can be text, image, video, audio, document, function call, or function response.
+   *
+   * ⚠️ **Inngest Limitation**: While Inngest's step.ai supports sending multimodal content
+   * (images, videos, audio, documents) to Gemini models, workflow processing capabilities
+   * are optimized for text-based interactions.
+   */
   export type Part =
     | TextPart
     | ImagePart
@@ -105,6 +112,50 @@ export namespace GeminiAiAdapter {
      * The text content.
      */
     text: string;
+    /**
+     * Whether this text part contains a thought summary.
+     *
+     * **Understanding Thought Parts:**
+     * When thinking is enabled with `includeThoughts: true`, the model can return
+     * thought summaries that provide insights into the model's internal reasoning process.
+     * These appear as separate text parts in the response with `thought: true`.
+     *
+     * **Response Structure:**
+     * - `thought: true` = This part contains reasoning/thinking content
+     * - `thought: false` or `undefined` = This part contains the final answer
+     *
+     * @example Processing thought vs. answer parts
+     * ```typescript
+     * response.candidates[0].content.parts.forEach(part => {
+     *   if (part.text) {
+     *     if (part.thought) {
+     *       console.log("🧠 Reasoning:", part.text);
+     *     } else {
+     *       console.log("💡 Answer:", part.text);
+     *     }
+     *   }
+     * });
+     * ```
+     *
+     * @example Separating thoughts from final response
+     * ```typescript
+     * const thoughts = response.candidates[0].content.parts
+     *   .filter(part => part.thought && part.text)
+     *   .map(part => part.text);
+     *
+     * const finalAnswer = response.candidates[0].content.parts
+     *   .filter(part => !part.thought && part.text)
+     *   .map(part => part.text)
+     *   .join('');
+     * ```
+     *
+     * @see {@link ThinkingConfig.includeThoughts} - Enable this feature
+     * @see {@link https://ai.google.dev/gemini-api/docs/thinking | Thinking Documentation}
+     *
+     * **Note:** You can identify thought summaries by checking this boolean property when
+     * iterating through the response parts.
+     */
+    thought?: boolean;
   }
 
   export interface ImagePart {
@@ -302,43 +353,889 @@ export namespace GeminiAiAdapter {
     OFF = "OFF",
   }
 
+  /**
+   * Configuration options for model generation and outputs.
+   *
+   * Use this interface to control how Gemini generates responses, from basic parameters
+   * like temperature and token limits to advanced features like thinking, structured output,
+   * and multimodal responses.
+   *
+   * @example Basic text generation
+   * ```typescript
+   * const config: GenerationConfig = {
+   *   temperature: 0.7,
+   *   maxOutputTokens: 1000,
+   *   stopSequences: ["\n\n"]
+   * };
+   * ```
+   *
+   * @example Structured JSON output
+   * ```typescript
+   * const config: GenerationConfig = {
+   *   responseMimeType: "application/json",
+   *   responseSchema: {
+   *     type: "object",
+   *     properties: {
+   *       name: { type: "string" },
+   *       age: { type: "number" }
+   *     }
+   *   }
+   * };
+   * ```
+   *
+   * @example Thinking mode for complex reasoning
+   * ```typescript
+   * const config: GenerationConfig = {
+   *   thinkingConfig: {
+   *     thinkingBudget: 2048,  // Higher budget for complex tasks
+   *     includeThoughts: true   // Get reasoning insights
+   *   }
+   * };
+   * ```
+   *
+   * @see {@link https://ai.google.dev/gemini-api/docs/text-generation | Gemini Text Generation Guide}
+   * @see {@link https://ai.google.dev/gemini-api/docs/thinking | Gemini Thinking Guide}
+   * @see {@link https://ai.google.dev/gemini-api/docs/structured-output | Structured Output Guide}
+   */
   export interface GenerationConfig {
     /**
-     * Temperature controls the randomness of the output.
+     * Controls the randomness of the output.
+     *
+     * **Recommended Values:**
+     * - `0.0-0.3`: Deterministic, factual responses (good for Q&A, analysis)
+     * - `0.4-0.7`: Balanced creativity and consistency (good for general chat)
+     * - `0.8-1.0`: Highly creative responses (good for creative writing)
+     * - `1.0+`: Maximum creativity, may be less coherent
+     *
+     * Values can range over [0.0, 2.0], inclusive. A value closer to 0.0 will produce
+     * more focused and deterministic responses, while higher values increase randomness
+     * and creativity.
+     *
+     * @example
+     * ```typescript
+     * // For factual Q&A
+     * temperature: 0.1
+     *
+     * // For creative writing
+     * temperature: 0.9
+     * ```
+     *
+     * @see {@link topP} - Use together with topP for fine-tuned control
+     * @see {@link seed} - Use with seed for reproducible results
+     *
+     * Note: The default value varies by model.
      */
     temperature?: number;
+
     /**
-     * Top-p changes how the model selects tokens for output.
+     * The maximum cumulative probability of tokens to consider when sampling (nucleus sampling).
+     *
+     * **Recommended Values:**
+     * - `0.1-0.3`: Very focused responses, less diverse vocabulary
+     * - `0.8-0.95`: Balanced approach (most common)
+     * - `0.95-1.0`: Full vocabulary range
+     *
+     * The model uses combined Top-k and Top-p (nucleus) sampling. Tokens are sorted
+     * based on their assigned probabilities so that only the most likely tokens are
+     * considered. Top-k sampling directly limits the maximum number of tokens to consider,
+     * while Nucleus sampling limits the number of tokens based on the cumulative probability.
+     *
+     * @example
+     * ```typescript
+     * // Conservative, focused responses
+     * topP: 0.8,
+     * topK: 40
+     *
+     * // More diverse vocabulary
+     * topP: 0.95,
+     * topK: undefined  // Let topP handle it
+     * ```
+     *
+     * @see {@link temperature} - Use together for optimal control
+     * @see {@link topK} - Alternative token limiting approach
+     *
+     * Note: The default value varies by Model and is specified by the Model.top_p
+     * attribute returned from the getModel function.
      */
     topP?: number;
+
     /**
-     * Top-k changes how the model selects tokens for output.
+     * The maximum number of tokens to consider when sampling.
+     *
+     * **Recommended Values:**
+     * - `1-10`: Very focused responses (good for factual queries)
+     * - `20-40`: Balanced approach (most common)
+     * - `40+`: More creative responses
+     *
+     * Gemini models use Top-p (nucleus) sampling or a combination of Top-k and nucleus
+     * sampling. Top-k sampling considers the set of topK most probable tokens. Models
+     * running with nucleus sampling don't allow topK setting.
+     *
+     * **Tip:** If you're using topP, you might not need topK. Many developers prefer
+     * topP for more natural control over response diversity.
+     *
+     * @example
+     * ```typescript
+     * // Very deterministic
+     * topK: 1,
+     * temperature: 0.1
+     *
+     * // Balanced creativity
+     * topK: 40,
+     * topP: 0.9
+     * ```
+     *
+     * @see {@link topP} - Often preferred over topK
+     * @see {@link temperature} - Use together for fine control
+     *
+     * Note: The default value varies by Model. An empty topK attribute indicates
+     * that the model doesn't apply top-k sampling and doesn't allow setting topK on requests.
      */
     topK?: number;
+
     /**
-     * The maximum number of tokens to generate.
+     * The maximum number of tokens to include in a response candidate.
+     *
+     * **Planning Your Token Budget:**
+     * - **Short answers:** 50-200 tokens
+     * - **Paragraph responses:** 200-500 tokens
+     * - **Articles/Essays:** 1000-4000 tokens
+     * - **Long-form content:** 4000+ tokens
+     *
+     * **Important:** When using thinking models, this limit applies to the final response,
+     * not the thinking tokens (which are controlled by `thinkingBudget`).
+     *
+     * @example
+     * ```typescript
+     * // Quick answers
+     * maxOutputTokens: 100
+     *
+     * // Detailed explanations
+     * maxOutputTokens: 1000
+     *
+     * // Long-form content
+     * maxOutputTokens: 4000
+     * ```
+     *
+     * @see {@link thinkingConfig.thinkingBudget} - Controls thinking tokens separately
+     * @see {@link stopSequences} - Alternative way to control response length
+     *
+     * Note: The default value varies by model, see the Model.output_token_limit
+     * attribute of the Model returned from the getModel function.
      */
     maxOutputTokens?: number;
+
     /**
-     * A list of strings that will stop generation if they are generated.
+     * The set of character sequences (up to 5) that will stop output generation.
+     *
+     * **Common Use Cases:**
+     * - Stop at double newlines: `["\n\n"]`
+     * - Stop at specific markers: `["END", "STOP"]`
+     * - Stop at code block endings: `["```"]`
+     * - Stop at section breaks: `["---", "###"]`
+     *
+     * If specified, the API will stop at the first appearance of a stop_sequence.
+     * The stop sequence will not be included as part of the response.
+     *
+     * @example
+     * ```typescript
+     * // Stop at paragraph breaks
+     * stopSequences: ["\n\n"]
+     *
+     * // Stop at multiple markers
+     * stopSequences: ["END", "CONCLUSION", "---"]
+     *
+     * // Stop at code block end
+     * stopSequences: ["```"]
+     * ```
+     *
+     * @see {@link maxOutputTokens} - Hard limit on response length
+     *
+     * **Limit:** Maximum of 5 sequences
      */
     stopSequences?: Array<string>;
+
     /**
-     * Controls the likelihood of the model generating the same sequence of tokens.
+     * Presence penalty applied to the next token's logprobs if the token has already
+     * been seen in the response.
+     *
+     * **Recommended Values:**
+     * - `0.0`: No penalty (default)
+     * - `0.1-0.5`: Light penalty, reduces some repetition
+     * - `0.6-1.0`: Strong penalty, encourages new vocabulary
+     * - `1.0+`: Maximum penalty, strong vocabulary diversity
+     *
+     * This penalty is binary on/off and not dependent on the number of times the token
+     * is used (after the first). Use frequencyPenalty for a penalty that increases with each use.
+     *
+     * **Use Case:** Preventing the model from repeating the same concepts or words.
+     *
+     * @example
+     * ```typescript
+     * // Reduce repetitive language
+     * presencePenalty: 0.3,
+     *
+     * // Strong diversity (creative writing)
+     * presencePenalty: 0.8,
+     * frequencyPenalty: 0.5
+     * ```
+     *
+     * @see {@link frequencyPenalty} - Complementary penalty that increases with usage
+     *
+     * A positive penalty will discourage the use of tokens that have already been used
+     * in the response, increasing the vocabulary.
+     *
+     * A negative penalty will encourage the use of tokens that have already been used
+     * in the response, decreasing the vocabulary.
      */
     presencePenalty?: number;
+
     /**
-     * Controls the likelihood of the model generating the same token.
+     * Frequency penalty applied to the next token's logprobs, multiplied by the number
+     * of times each token has been seen in the response so far.
+     *
+     * **Recommended Values:**
+     * - `0.0`: No penalty (default)
+     * - `0.1-0.3`: Light penalty, natural reduction of repetition
+     * - `0.4-0.7`: Moderate penalty, noticeable vocabulary expansion
+     * - `0.8-1.0`: Strong penalty, maximum vocabulary diversity
+     *
+     * A positive penalty will discourage the use of tokens that have already been used,
+     * proportional to the number of times the token has been used: The more a token is
+     * used, the more difficult it is for the model to use that token again increasing
+     * the vocabulary of responses.
+     *
+     * **Use Case:** Preventing the model from getting stuck in repetitive loops.
+     *
+     * @example
+     * ```typescript
+     * // Prevent repetitive patterns
+     * frequencyPenalty: 0.2,
+     *
+     * // Maximum vocabulary diversity
+     * presencePenalty: 0.6,
+     * frequencyPenalty: 0.8
+     * ```
+     *
+     * @see {@link presencePenalty} - Binary penalty for any repeated token
+     *
+     * **Caution:** A negative penalty will encourage the model to reuse tokens proportional
+     * to the number of times the token has been used. Small negative values will reduce
+     * the vocabulary of a response. Larger negative values will cause the model to start
+     * repeating a common token until it hits the maxOutputTokens limit.
      */
     frequencyPenalty?: number;
+
     /**
-     * Controls the resolution of media in the response.
+     * MIME type of the generated candidate text.
+     *
+     * **Supported Types:**
+     * - `"text/plain"`: Default text output
+     * - `"application/json"`: Structured JSON responses
+     * - `"text/x.enum"`: Enum string responses
+     *
+     * **Common Use Cases:**
+     * - API responses that need structured data
+     * - Form validation with specific formats
+     * - Data extraction with consistent schema
+     *
+     * @example
+     * ```typescript
+     * // JSON API response
+     * responseMimeType: "application/json",
+     * responseSchema: {
+     *   type: "object",
+     *   properties: {
+     *     status: { type: "string" },
+     *     data: { type: "array" }
+     *   }
+     * }
+     *
+     * // Plain text (default)
+     * responseMimeType: "text/plain"
+     * ```
+     *
+     * @see {@link responseSchema} - Define JSON structure when using application/json
+     * @see {@link responseJsonSchema} - Alternative JSON schema format
+     * @see {@link https://ai.google.dev/gemini-api/docs/structured-output | Structured Output Guide}
+     *
+     * Refer to the docs for a list of all supported text MIME types.
+     */
+    responseMimeType?: string;
+
+    /**
+     * Output schema of the generated candidate text. Schemas must be a subset of the
+     * OpenAPI schema and can be objects, primitives or arrays.
+     *
+     * **Schema Examples:**
+     *
+     * @example Simple object
+     * ```typescript
+     * responseSchema: {
+     *   type: "object",
+     *   properties: {
+     *     name: { type: "string" },
+     *     age: { type: "number" },
+     *     active: { type: "boolean" }
+     *   },
+     *   required: ["name"]
+     * }
+     * ```
+     *
+     * @example Array of objects
+     * ```typescript
+     * responseSchema: {
+     *   type: "array",
+     *   items: {
+     *     type: "object",
+     *     properties: {
+     *       id: { type: "string" },
+     *       title: { type: "string" }
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * @example Enum values
+     * ```typescript
+     * responseSchema: {
+     *   type: "string",
+     *   enum: ["approved", "pending", "rejected"]
+     * }
+     * ```
+     *
+     * If set, a compatible responseMimeType must also be set. Compatible MIME types:
+     * - `application/json`: Schema for JSON response
+     *
+     * @see {@link responseMimeType} - Must be "application/json" when using schemas
+     * @see {@link responseJsonSchema} - Alternative format for JSON schemas
+     * @see {@link https://ai.google.dev/gemini-api/docs/structured-output | Structured Output Guide}
+     *
+     * Refer to the JSON text generation guide for more details.
+     */
+    responseSchema?: object;
+
+    /**
+     * Output schema of the generated response. This is an alternative to responseSchema
+     * that accepts JSON Schema format.
+     *
+     * **When to Use:**
+     * - You already have JSON Schema definitions
+     * - You need features not supported in OpenAPI subset
+     * - You're migrating from other systems using JSON Schema
+     *
+     * If set, responseSchema must be omitted, but responseMimeType is required.
+     *
+     * **Supported JSON Schema Features:**
+     * - `$id`, `$defs`, `$ref`, `$anchor`
+     * - `type`, `format`, `title`, `description`
+     * - `enum` (for strings and numbers)
+     * - `items`, `prefixItems`, `minItems`, `maxItems`
+     * - `minimum`, `maximum`, `anyOf`, `oneOf`
+     * - `properties`, `additionalProperties`, `required`
+     * - `propertyOrdering` (non-standard)
+     *
+     * @example
+     * ```typescript
+     * responseJsonSchema: {
+     *   "$schema": "http://json-schema.org/draft-07/schema#",
+     *   "type": "object",
+     *   "properties": {
+     *     "users": {
+     *       "type": "array",
+     *       "items": { "$ref": "#/$defs/User" }
+     *     }
+     *   },
+     *   "$defs": {
+     *     "User": {
+     *       "type": "object",
+     *       "properties": {
+     *         "name": { "type": "string" }
+     *       }
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * @see {@link responseSchema} - Simpler OpenAPI-style alternative
+     * @see {@link responseMimeType} - Must be set to "application/json"
+     *
+     * **Note:** Cyclic references are unrolled to a limited degree and may only be
+     * used within non-required properties.
+     */
+    responseJsonSchema?: any;
+
+    /**
+     * The requested modalities of the response. Represents the set of modalities that
+     * the model can return, and should be expected in the response.
+     *
+     * **Available Modalities:**
+     * - `"text"`: Text responses (default)
+     * - `"image"`: Generated images
+     * - `"audio"`: Generated audio/speech
+     *
+     * This is an exact match to the modalities of the response. A model may have
+     * multiple combinations of supported modalities. If the requested modalities do
+     * not match any of the supported combinations, an error will be returned.
+     *
+     * An empty list is equivalent to requesting only text.
+     *
+     * @example
+     * ```typescript
+     * // Text only (default)
+     * responseModalities: ["text"]
+     *
+     * // Text with images
+     * responseModalities: ["text", "image"]
+     *
+     * // Audio responses
+     * responseModalities: ["audio"]
+     * ```
+     *
+     * ⚠️ **Inngest Limitation**: Inngest's step.ai currently only supports text-based
+     * responses. While you can request other modalities (images, audio), Inngest
+     * workflows cannot process non-text response content.
+     *
+     * @see {@link speechConfig} - Configure audio generation parameters
+     */
+    responseModalities?: Array<string>;
+
+    /**
+     * Number of generated responses to return.
+     *
+     * **Use Cases:**
+     * - `1`: Single best response (default, most efficient)
+     * - `2-5`: Multiple options for A/B testing or variety
+     * - `>5`: Batch generation for analysis
+     *
+     * If unset, this will default to 1.
+     *
+     * @example
+     * ```typescript
+     * // Generate multiple creative options
+     * candidateCount: 3,
+     * temperature: 0.8
+     *
+     * // Single deterministic response
+     * candidateCount: 1,
+     * temperature: 0.1
+     * ```
+     *
+     * @see {@link temperature} - Higher temperatures work well with multiple candidates
+     *
+     * **Note:** This doesn't work for previous generation models (Gemini 1.0 family).
+     * **Cost Impact:** Multiple candidates multiply your token usage.
+     */
+    candidateCount?: number;
+
+    /**
+     * Seed used in decoding for reproducible results.
+     *
+     * **Use Cases:**
+     * - Testing and debugging with consistent outputs
+     * - A/B testing with controlled variables
+     * - Reproducible research experiments
+     * - Generating consistent examples in documentation
+     *
+     * If not set, the request uses a randomly generated seed.
+     *
+     * @example
+     * ```typescript
+     * // Reproducible responses
+     * seed: 12345,
+     * temperature: 0.7  // Still get creative responses, but consistently
+     *
+     * // Different seed for variation
+     * seed: 67890,
+     * temperature: 0.7
+     * ```
+     *
+     * @see {@link temperature} - Combine with temperature for controlled randomness
+     *
+     * **Note:** Same seed + same parameters = same response (usually)
+     */
+    seed?: number;
+
+    /**
+     * If true, export the logprobs results in response.
+     *
+     * **Use Cases:**
+     * - Analyzing model confidence in responses
+     * - Building custom scoring systems
+     * - Research and model analysis
+     * - Detecting uncertain or low-confidence outputs
+     *
+     * @example
+     * ```typescript
+     * // Get detailed probability information
+     * responseLogprobs: true,
+     * logprobs: 5  // Top 5 token probabilities
+     * ```
+     *
+     * @see {@link logprobs} - Control how many top probabilities to return
+     *
+     * **Performance Note:** Enabling logprobs may slightly increase response time.
+     */
+    responseLogprobs?: boolean;
+
+    /**
+     * Only valid if responseLogprobs=True. This sets the number of top logprobs to
+     * return at each decoding step in the Candidate.logprobs_result.
+     *
+     * **Recommended Values:**
+     * - `1-3`: Basic confidence analysis
+     * - `5-10`: Detailed probability analysis
+     * - `10+`: Research and deep analysis
+     *
+     * @example
+     * ```typescript
+     * // Basic confidence checking
+     * responseLogprobs: true,
+     * logprobs: 3
+     *
+     * // Detailed analysis
+     * responseLogprobs: true,
+     * logprobs: 10
+     * ```
+     *
+     * @see {@link responseLogprobs} - Must be true to use this parameter
+     *
+     * **Performance Note:** Higher values increase response size and processing time.
+     */
+    logprobs?: number;
+
+    /**
+     * Enables enhanced civic answers. It may not be available for all models.
+     *
+     * **Use Cases:**
+     * - Political or civic information queries
+     * - Elections and voting information
+     * - Government and policy discussions
+     * - Public affairs and civic engagement
+     *
+     * @example
+     * ```typescript
+     * // For civic/political content
+     * enableEnhancedCivicAnswers: true
+     * ```
+     *
+     * **Note:** Check model documentation for availability.
+     */
+    enableEnhancedCivicAnswers?: boolean;
+
+    /**
+     * The speech generation config.
+     *
+     * **Configuration Options:**
+     * - Voice selection and characteristics
+     * - Speech rate and pitch control
+     * - Audio format preferences
+     * - Language and accent settings
+     *
+     * @example
+     * ```typescript
+     * speechConfig: {
+     *   voice: "en-US-Journey-F",
+     *   rate: 1.0,
+     *   pitch: 0.0
+     * }
+     * ```
+     *
+     * @see {@link responseModalities} - Include "audio" to enable speech output
+     * @see {@link https://ai.google.dev/gemini-api/docs/audio-generation | Audio Generation Guide}
+     *
+     * ⚠️ **Inngest Limitation**: Inngest's step.ai currently does not support
+     * text-to-speech capabilities. This property can be set but the generated
+     * audio output cannot be processed within Inngest workflows.
+     */
+    speechConfig?: object;
+
+    /**
+     * Config for thinking features. An error will be returned if this field is set
+     * for models that don't support thinking.
+     *
+     * **When to Use Thinking:**
+     * - Complex mathematical problems
+     * - Multi-step reasoning tasks
+     * - Code analysis and debugging
+     * - Research and analysis tasks
+     * - Planning and strategy problems
+     *
+     * **Performance Trade-offs:**
+     * - Higher thinking budget = better reasoning but slower responses
+     * - Lower thinking budget = faster responses but simpler reasoning
+     * - Dynamic thinking = optimal balance based on task complexity
+     *
+     * @example
+     * ```typescript
+     * // Complex reasoning task
+     * thinkingConfig: {
+     *   thinkingBudget: 4096,  // High budget for complex problems
+     *   includeThoughts: true   // See the reasoning process
+     * }
+     *
+     * // Quick task with light thinking
+     * thinkingConfig: {
+     *   thinkingBudget: 512,
+     *   includeThoughts: false
+     * }
+     *
+     * // Dynamic thinking (recommended)
+     * thinkingConfig: {
+     *   thinkingBudget: -1,     // Let model decide
+     *   includeThoughts: true
+     * }
+     * ```
+     *
+     * @see {@link ThinkingConfig} - Detailed configuration options
+     * @see {@link https://ai.google.dev/gemini-api/docs/thinking | Gemini Thinking Guide}
+     *
+     * **Supported Models:** Gemini 2.5 series models only.
+     */
+    thinkingConfig?: ThinkingConfig;
+
+    /**
+     * If specified, the media resolution specified will be used.
+     *
+     * **Resolution Options:**
+     * - `MEDIA_RESOLUTION_LOW`: Faster processing, lower quality
+     * - `MEDIA_RESOLUTION_MEDIUM`: Balanced approach (recommended)
+     * - `MEDIA_RESOLUTION_HIGH`: Best quality, slower processing
+     * - `MEDIA_RESOLUTION_UNSPECIFIED`: Use model default
+     *
+     * **Use Cases:**
+     * - Low: Quick prototyping, thumbnails
+     * - Medium: General use, good balance
+     * - High: Final production, detailed analysis
+     *
+     * @example
+     * ```typescript
+     * // High quality for production
+     * mediaResolution: "MEDIA_RESOLUTION_HIGH"
+     *
+     * // Fast processing for prototypes
+     * mediaResolution: "MEDIA_RESOLUTION_LOW"
+     * ```
+     *
+     * **Note:** Affects both input processing and output generation speed.
      */
     mediaResolution?:
       | "MEDIA_RESOLUTION_UNSPECIFIED"
       | "MEDIA_RESOLUTION_LOW"
       | "MEDIA_RESOLUTION_MEDIUM"
       | "MEDIA_RESOLUTION_HIGH";
+  }
+
+  /**
+   * Configuration options for thinking features in Gemini models.
+   *
+   * Thinking features allow the model to use an internal "thinking process" that
+   * significantly improves their reasoning and multi-step planning abilities, making
+   * them highly effective for complex tasks such as coding, advanced mathematics,
+   * and data analysis.
+   *
+   * **When to Enable Thinking:**
+   * - Mathematical problem solving
+   * - Code debugging and analysis
+   * - Multi-step reasoning tasks
+   * - Research and planning
+   * - Complex decision making
+   *
+   * **Performance Considerations:**
+   * - Thinking tokens are separate from output tokens
+   * - Higher budgets = better reasoning but increased cost and latency
+   * - Dynamic thinking (-1) automatically adjusts based on task complexity
+   *
+   * @example Basic thinking setup
+   * ```typescript
+   * const thinkingConfig: ThinkingConfig = {
+   *   thinkingBudget: 1024,     // Moderate thinking budget
+   *   includeThoughts: true     // Show reasoning process
+   * };
+   * ```
+   *
+   * @example Dynamic thinking (recommended)
+   * ```typescript
+   * const thinkingConfig: ThinkingConfig = {
+   *   thinkingBudget: -1,       // Let model decide optimal budget
+   *   includeThoughts: true     // Get insights into reasoning
+   * };
+   * ```
+   *
+   * @example High-complexity tasks
+   * ```typescript
+   * const thinkingConfig: ThinkingConfig = {
+   *   thinkingBudget: 8192,     // Maximum budget for complex problems
+   *   includeThoughts: true     // Essential for debugging reasoning
+   * };
+   * ```
+   *
+   * @example Fast execution mode
+   * ```typescript
+   * const thinkingConfig: ThinkingConfig = {
+   *   thinkingBudget: 512,      // Minimal thinking for speed
+   *   includeThoughts: false    // Skip thought summaries for faster responses
+   * };
+   * ```
+   *
+   * @see {@link https://ai.google.dev/gemini-api/docs/thinking | Gemini Thinking Guide}
+   * @see {@link GenerationConfig.maxOutputTokens} - Controls final response length separately
+   *
+   * **Supported Models:** Gemini 2.5 series models only.
+   * **Pricing Note:** You're charged for both thinking tokens and output tokens.
+   */
+  export interface ThinkingConfig {
+    /**
+     * The number of thinking tokens to use when generating a response.
+     *
+     * **Recommended Budgets by Task Type:**
+     *
+     * **Simple Tasks (128-512 tokens):**
+     * - Basic math problems
+     * - Simple code explanations
+     * - Straightforward analysis
+     *
+     * **Medium Tasks (512-2048 tokens):**
+     * - Multi-step calculations
+     * - Code debugging
+     * - Research summaries
+     * - Planning tasks
+     *
+     * **Complex Tasks (2048-8192 tokens):**
+     * - Advanced mathematics
+     * - Complex code analysis
+     * - Multi-layered reasoning
+     * - Research with multiple sources
+     *
+     * **Special Values:**
+     * - `0`: Disable thinking entirely (faster, less reasoning)
+     * - `-1`: **Dynamic thinking** - model chooses optimal budget automatically
+     *
+     * A higher token count generally allows for more detailed reasoning, which can be
+     * beneficial for tackling more complex tasks. If latency is more important, use a
+     * lower budget or disable thinking by setting thinkingBudget to 0.
+     *
+     * Setting the thinkingBudget to -1 turns on **dynamic thinking**, meaning the model
+     * will adjust the budget based on the complexity of the request.
+     *
+     * **Model-Specific Ranges:**
+     * - **Gemini 2.5 Pro**: 128 to 32768 (cannot disable thinking)
+     * - **Gemini 2.5 Flash**: 0 to 24576 (thinkingBudget = 0 disables thinking)
+     * - **Gemini 2.5 Flash Lite**: 512 to 24576 (thinkingBudget = 0 disables thinking)
+     *
+     * @example Task-specific budgets
+     * ```typescript
+     * // Simple math problem
+     * thinkingBudget: 256
+     *
+     * // Code debugging
+     * thinkingBudget: 1024
+     *
+     * // Complex research analysis
+     * thinkingBudget: 4096
+     *
+     * // Let model decide (recommended)
+     * thinkingBudget: -1
+     * ```
+     *
+     * @example Performance vs. quality trade-offs
+     * ```typescript
+     * // Maximum speed, minimal thinking
+     * thinkingBudget: 0,        // Gemini Flash/Flash Lite only
+     * includeThoughts: false
+     *
+     * // Balanced approach
+     * thinkingBudget: 1024,
+     * includeThoughts: true
+     *
+     * // Maximum reasoning quality
+     * thinkingBudget: 8192,
+     * includeThoughts: true
+     * ```
+     *
+     * @see {@link includeThoughts} - Control whether to return reasoning summaries
+     * @see {@link GenerationConfig.maxOutputTokens} - Separate limit for final response
+     *
+     * **Important:** Depending on the prompt, the model might overflow or underflow the token budget.
+     * **Pricing:** You're charged for all thinking tokens used, even if they don't appear in the response.
+     */
+    thinkingBudget?: number;
+
+    /**
+     * Whether to include thought summaries in the response.
+     *
+     * **What are Thought Summaries?**
+     * Thought summaries are synthesized versions of the model's raw thoughts and offer
+     * insights into the model's internal reasoning process. They help you understand
+     * how the model arrived at its conclusion.
+     *
+     * **When to Enable (true):**
+     * - Debugging model reasoning
+     * - Educational content showing problem-solving steps
+     * - Research and analysis tasks
+     * - Building trust through transparency
+     * - Complex problem solving where process matters
+     *
+     * **When to Disable (false):**
+     * - Production APIs where only final answers matter
+     * - High-throughput applications optimizing for speed
+     * - Simple tasks where reasoning isn't important
+     * - Minimizing response size and processing time
+     *
+     * **Technical Details:**
+     * - Thinking budgets apply to the model's raw thoughts, not summaries
+     * - Summaries are additional content beyond the raw thinking tokens
+     * - You can identify thought parts by checking the `thought` property on text parts
+     *
+     * @example Accessing thought summaries
+     * ```typescript
+     * // Enable thought summaries
+     * const config = {
+     *   thinkingConfig: {
+     *     thinkingBudget: 2048,
+     *     includeThoughts: true
+     *   }
+     * };
+     *
+     * // Process response to separate thoughts from final answer
+     * response.candidates[0].content.parts.forEach(part => {
+     *   if (part.thought) {
+     *     console.log("Reasoning:", part.text);
+     *   } else {
+     *     console.log("Final Answer:", part.text);
+     *   }
+     * });
+     * ```
+     *
+     * @example Educational math problem
+     * ```typescript
+     * // Show step-by-step reasoning for learning
+     * const config = {
+     *   thinkingConfig: {
+     *     thinkingBudget: 1024,
+     *     includeThoughts: true    // Students can see the thinking process
+     *   }
+     * };
+     * ```
+     *
+     * @example Production API
+     * ```typescript
+     * // Fast responses, no reasoning shown
+     * const config = {
+     *   thinkingConfig: {
+     *     thinkingBudget: 512,
+     *     includeThoughts: false   // Only final answers for API consumers
+     *   }
+     * };
+     * ```
+     *
+     * @see {@link thinkingBudget} - Controls how much thinking the model does
+     * @see {@link https://ai.google.dev/gemini-api/docs/thinking | Thought Summaries Documentation}
+     *
+     * **Response Structure:** When enabled, you can access the summary by iterating through
+     * the response parameter's parts, and checking the `thought` boolean property.
+     */
+    includeThoughts?: boolean;
   }
 
   export interface GenerateContentResponse {
@@ -444,19 +1341,173 @@ export namespace GeminiAiAdapter {
     publicationDate?: string;
   }
 
+  /**
+   * Usage metadata about the response, including token counts and costs.
+   *
+   * **Understanding Token Usage:**
+   * - `promptTokenCount`: Tokens in your input (prompt, images, etc.)
+   * - `candidatesTokenCount`: Tokens in the generated response text
+   * - `totalTokenCount`: Total tokens processed (prompt + candidates + thinking)
+   * - `thoughtsTokenCount`: Tokens used for internal reasoning (when thinking enabled)
+   *
+   * **Cost Calculation:**
+   * Total cost = (promptTokenCount × input_price) + (candidatesTokenCount × output_price) + (thoughtsTokenCount × output_price)
+   *
+   * @example Monitoring token usage
+   * ```typescript
+   * const usage = response.usageMetadata;
+   * console.log(`Input tokens: ${usage.promptTokenCount}`);
+   * console.log(`Output tokens: ${usage.candidatesTokenCount}`);
+   * console.log(`Thinking tokens: ${usage.thoughtsTokenCount || 0}`);
+   * console.log(`Total tokens: ${usage.totalTokenCount}`);
+   * ```
+   *
+   * @example Cost estimation
+   * ```typescript
+   * const usage = response.usageMetadata;
+   * const inputCost = usage.promptTokenCount * INPUT_PRICE_PER_TOKEN;
+   * const outputCost = (usage.candidatesTokenCount + (usage.thoughtsTokenCount || 0)) * OUTPUT_PRICE_PER_TOKEN;
+   * const totalCost = inputCost + outputCost;
+   * ```
+   *
+   * @see {@link https://ai.google.dev/pricing | Gemini API Pricing}
+   */
   export interface UsageMetadata {
     /**
      * The number of tokens in the prompt.
+     *
+     * **What's Included:**
+     * - Text content in your messages
+     * - Encoded images, videos, audio files
+     * - Function declarations and tool configs
+     * - System instructions
+     *
+     * **Cost Impact:** Input tokens are typically cheaper than output tokens.
+     *
+     * @example
+     * ```typescript
+     * // This affects promptTokenCount:
+     * const request = {
+     *   contents: [{ parts: [{ text: "Hello, world!" }] }],  // ~3 tokens
+     *   systemInstruction: { parts: [{ text: "Be helpful" }] }, // ~2 tokens
+     *   tools: [...] // Additional tokens for function declarations
+     * };
+     * ```
      */
     promptTokenCount?: number;
+
     /**
-     * The number of tokens in the response.
+     * The number of tokens in the response candidates.
+     *
+     * **What's Included:**
+     * - Generated text content
+     * - Function call responses
+     * - Structured JSON output
+     *
+     * **What's NOT Included:**
+     * - Thinking tokens (counted separately in `thoughtsTokenCount`)
+     * - Metadata or system-generated content
+     *
+     * **Cost Impact:** Output tokens are typically more expensive than input tokens.
+     *
+     * @example
+     * ```typescript
+     * // Ways to control candidatesTokenCount:
+     * const config = {
+     *   maxOutputTokens: 500,        // Hard limit
+     *   stopSequences: ["\n\n"],     // Early stopping
+     *   responseMimeType: "application/json"  // Can affect token efficiency
+     * };
+     * ```
+     *
+     * @see {@link GenerationConfig.maxOutputTokens} - Control response length
      */
     candidatesTokenCount?: number;
+
     /**
-     * The total number of tokens processed.
+     * The total number of tokens processed in this request.
+     *
+     * **Calculation:**
+     * `totalTokenCount = promptTokenCount + candidatesTokenCount + thoughtsTokenCount`
+     *
+     * **Use Cases:**
+     * - Overall usage monitoring
+     * - Rate limiting calculations
+     * - Performance optimization
+     * - Cost tracking across requests
+     *
+     * @example Usage monitoring
+     * ```typescript
+     * const usage = response.usageMetadata;
+     *
+     * // Log total usage
+     * console.log(`Total tokens used: ${usage.totalTokenCount}`);
+     *
+     * // Check against limits
+     * if (usage.totalTokenCount > DAILY_TOKEN_LIMIT) {
+     *   console.warn("Approaching daily token limit");
+     * }
+     *
+     * // Calculate efficiency
+     * const efficiency = usage.candidatesTokenCount / usage.totalTokenCount;
+     * console.log(`Output efficiency: ${(efficiency * 100).toFixed(1)}%`);
+     * ```
      */
     totalTokenCount?: number;
+
+    /**
+     * The number of thinking tokens generated when thinking is enabled.
+     *
+     * **Important Details:**
+     * - Only present when using thinking models (Gemini 2.5+)
+     * - These are "internal" tokens used for reasoning
+     * - You're charged for these tokens at output token rates
+     * - Not included in `candidatesTokenCount`
+     *
+     * **Cost Impact:**
+     * When thinking is turned on, response pricing is the sum of output tokens and thinking tokens.
+     * This field provides the total number of generated thinking tokens.
+     *
+     * **Optimization Tips:**
+     * - Use lower `thinkingBudget` for cost control
+     * - Use `thinkingBudget: -1` for dynamic allocation
+     * - Set `thinkingBudget: 0` to disable thinking entirely (Flash models only)
+     *
+     * @example Thinking cost analysis
+     * ```typescript
+     * const usage = response.usageMetadata;
+     *
+     * if (usage.thoughtsTokenCount) {
+     *   console.log(`Thinking tokens: ${usage.thoughtsTokenCount}`);
+     *   console.log(`Final answer tokens: ${usage.candidatesTokenCount}`);
+     *
+     *   const thinkingRatio = usage.thoughtsTokenCount / usage.totalTokenCount;
+     *   console.log(`Thinking ratio: ${(thinkingRatio * 100).toFixed(1)}%`);
+     *
+     *   // Cost breakdown
+     *   const thinkingCost = usage.thoughtsTokenCount * OUTPUT_PRICE_PER_TOKEN;
+     *   const answerCost = usage.candidatesTokenCount * OUTPUT_PRICE_PER_TOKEN;
+     *   console.log(`Thinking cost: ${thinkingCost}, Answer cost: ${answerCost}`);
+     * }
+     * ```
+     *
+     * @example Optimizing thinking usage
+     * ```typescript
+     * // Monitor thinking efficiency
+     * const usage = response.usageMetadata;
+     * const thinkingEfficiency = usage.candidatesTokenCount / (usage.thoughtsTokenCount || 1);
+     *
+     * if (thinkingEfficiency < 0.1) {
+     *   console.warn("High thinking-to-output ratio - consider lower thinkingBudget");
+     * }
+     * ```
+     *
+     * @see {@link ThinkingConfig.thinkingBudget} - Control thinking token allocation
+     * @see {@link https://ai.google.dev/gemini-api/docs/thinking | Thinking Pricing Details}
+     *
+     * **Note:** This field will be `undefined` for models that don't support thinking or when thinking is disabled.
+     */
+    thoughtsTokenCount?: number;
   }
 
   export interface PromptFeedback {

--- a/packages/ai/src/adapters/gemini.ts
+++ b/packages/ai/src/adapters/gemini.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import { type AiAdapter } from "../adapter.js";
 
 export interface GeminiAiAdapter extends AiAdapter {
@@ -24,7 +23,6 @@ export namespace GeminiAiAdapter {
    * details and options.
    */
   export type Model =
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | (string & {})
     | "gemini-1.5-flash"
     | "gemini-1.5-flash-8b"
@@ -763,7 +761,7 @@ export namespace GeminiAiAdapter {
      * **Note:** Cyclic references are unrolled to a limited degree and may only be
      * used within non-required properties.
      */
-    responseJsonSchema?: any;
+    responseJsonSchema?: object;
 
     /**
      * The requested modalities of the response. Represents the set of modalities that

--- a/packages/ai/src/models/anthropic.ts
+++ b/packages/ai/src/models/anthropic.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import { type AiAdapter } from "../adapter.js";
 import { type AnthropicAiAdapter } from "../adapters/anthropic.js";
 import { envKeys, processEnv } from "../env";

--- a/packages/ai/src/models/azure-openai.ts
+++ b/packages/ai/src/models/azure-openai.ts
@@ -35,7 +35,7 @@ export const azureOpenai: AiAdapter.ModelCreator<
   // Construct Azure-specific URL with deployment and API version
   const url = new URL(
     `openai/deployments/${options.deployment}/chat/completions`,
-    options.endpoint
+    options.endpoint,
   );
   url.searchParams.set("api-version", options.apiVersion);
 

--- a/packages/ai/src/models/gemini.ts
+++ b/packages/ai/src/models/gemini.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import { type AiAdapter } from "../adapter.js";
 import { type GeminiAiAdapter } from "../adapters/gemini.js";
 import { envKeys, processEnv } from "../env";
@@ -25,7 +24,7 @@ export const gemini: AiAdapter.ModelCreator<
 
   const url = new URL(
     `models/${options.model}:generateContent?key=${authKey}`,
-    baseUrl
+    baseUrl,
   );
 
   const headers: Record<string, string> = {};

--- a/packages/ai/src/models/gemini.ts
+++ b/packages/ai/src/models/gemini.ts
@@ -35,7 +35,31 @@ export const gemini: AiAdapter.ModelCreator<
     authKey,
     format: "gemini",
     onCall(_, body) {
-      Object.assign(body, options.defaultParameters);
+      if (!options.defaultParameters) {
+        return;
+      }
+
+      const { generationConfig: defaultGenerationConfig, ...otherDefaults } =
+        options.defaultParameters;
+
+      // Assign top-level defaults first, user-provided values will override
+      Object.assign(body, {
+        ...otherDefaults,
+        ...body,
+      });
+
+      // Then, deep-merge generationConfig
+      if (defaultGenerationConfig) {
+        body.generationConfig = {
+          ...defaultGenerationConfig,
+          ...(body.generationConfig || {}),
+          // And ensure nested thinkingConfig is also deep-merged
+          thinkingConfig: {
+            ...defaultGenerationConfig.thinkingConfig,
+            ...(body.generationConfig?.thinkingConfig || {}),
+          },
+        };
+      }
     },
     headers,
     options,

--- a/packages/ai/src/models/gemini.ts
+++ b/packages/ai/src/models/gemini.ts
@@ -25,7 +25,7 @@ export const gemini: AiAdapter.ModelCreator<
 
   const url = new URL(
     `models/${options.model}:generateContent?key=${authKey}`,
-    baseUrl,
+    baseUrl
   );
 
   const headers: Record<string, string> = {};

--- a/packages/ai/src/models/gemini.ts
+++ b/packages/ai/src/models/gemini.ts
@@ -82,8 +82,8 @@ export namespace Gemini {
     model: Gemini.Model;
 
     /**
-     * The Anthropic API key to use for authenticating your request. By default
-     * we'll search for and use the `ANTHROPIC_API_KEY` environment variable.
+     * The Gemini API key to use for authenticating your request. By default
+     * we'll search for and use the `GEMINI_API_KEY` environment variable.
      */
     apiKey?: string;
 

--- a/packages/ai/src/models/grok.ts
+++ b/packages/ai/src/models/grok.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import { type AiAdapter } from "../adapter.js";
 import { GrokAiAdapter } from "../adapters/grok.js";
 import { envKeys, processEnv } from "../env";
@@ -35,7 +34,6 @@ export namespace Grok {
    * IDs of models to use.
    */
   export type Model =
-    // eslint-disable-next-line @typescript-eslint/ban-types
     | (string & {})
     | "grok-2-1212"
     | "grok-2"

--- a/packages/ai/test/smoke/gemini.smoke.test.ts
+++ b/packages/ai/test/smoke/gemini.smoke.test.ts
@@ -14,7 +14,7 @@ describe("Gemini AI Adapter Smoke Tests", () => {
     if (!apiKey) {
       throw new Error(
         "GEMINI_API_KEY environment variable is required for smoke tests. " +
-          "Copy .env.example to .env and add your API key."
+          "Copy .env.example to .env and add your API key.",
       );
     }
   });

--- a/packages/ai/test/smoke/gemini.smoke.test.ts
+++ b/packages/ai/test/smoke/gemini.smoke.test.ts
@@ -1,0 +1,375 @@
+import { describe, test, expect, beforeAll, beforeEach } from "vitest";
+import { config } from "dotenv";
+import { gemini } from "../../src/models/gemini.js";
+import type { GeminiAiAdapter } from "../../src/adapters/gemini.js";
+
+// Load environment variables
+config();
+
+describe("Gemini AI Adapter Smoke Tests", () => {
+  let apiKey: string;
+
+  beforeAll(() => {
+    apiKey = process.env.GEMINI_API_KEY || "";
+    if (!apiKey) {
+      throw new Error(
+        "GEMINI_API_KEY environment variable is required for smoke tests. " +
+          "Copy .env.example to .env and add your API key."
+      );
+    }
+  });
+
+  // Add 2-second delay between tests to avoid rate limiting
+  beforeEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  });
+
+  test("Adapter configuration and URL construction", () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey,
+    });
+
+    // Test adapter properties
+    expect(model.format).toBe("gemini");
+    expect(model.url).toContain("gemini-2.0-flash-exp");
+    expect(model.url).toContain("generateContent");
+    expect(model.url).toContain("key=");
+    expect(model.authKey).toBe(apiKey);
+    expect(model.options.model).toBe("gemini-2.0-flash-exp");
+    expect(model.onCall).toBeDefined();
+    expect(typeof model.onCall).toBe("function");
+  });
+
+  test("Base URL configuration", () => {
+    const model = gemini({
+      model: "gemini-1.5-flash",
+      apiKey,
+      baseUrl: "https://custom-api.example.com/v1/",
+    });
+
+    expect(model.url).toContain("https://custom-api.example.com/v1/");
+    expect(model.url).toContain("gemini-1.5-flash");
+    expect(model.url).toContain("generateContent");
+  });
+
+  test("onCall transformation with default parameters", () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey,
+      defaultParameters: {
+        generationConfig: {
+          temperature: 0.8,
+          maxOutputTokens: 500,
+        },
+      },
+    });
+
+    const inputBody: GeminiAiAdapter.GenerateContentRequest = {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "Hello" }],
+        },
+      ],
+    };
+
+    const bodyToTransform = JSON.parse(JSON.stringify(inputBody));
+
+    // Test onCall applies default parameters
+    model.onCall!(model, bodyToTransform);
+
+    expect(bodyToTransform.generationConfig).toBeDefined();
+    expect(bodyToTransform.generationConfig.temperature).toBe(0.8);
+    expect(bodyToTransform.generationConfig.maxOutputTokens).toBe(500);
+  });
+
+  test("onCall transformation preserves existing parameters", () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey,
+      defaultParameters: {
+        generationConfig: {
+          temperature: 0.8,
+          maxOutputTokens: 500,
+        },
+      },
+    });
+
+    const inputBody: GeminiAiAdapter.GenerateContentRequest = {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "Hello" }],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.2, // Should override default
+        topP: 0.9, // Should be preserved
+      },
+    };
+
+    const bodyToTransform = JSON.parse(JSON.stringify(inputBody));
+
+    // Test onCall merges parameters correctly
+    model.onCall!(model, bodyToTransform);
+
+    expect(bodyToTransform.generationConfig.temperature).toBe(0.2); // Original preserved
+    expect(bodyToTransform.generationConfig.topP).toBe(0.9); // Original preserved
+    expect(bodyToTransform.generationConfig.maxOutputTokens).toBe(500); // Default applied
+  });
+
+  test("Real API integration - basic text generation", async () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey,
+    });
+
+    const requestBody: GeminiAiAdapter.GenerateContentRequest = {
+      contents: [
+        {
+          role: "user",
+          parts: [
+            { text: "Say hello and explain what you are in one sentence." },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.7,
+        maxOutputTokens: 100,
+      },
+    };
+
+    // Apply adapter transformations
+    const body = JSON.parse(JSON.stringify(requestBody));
+    model.onCall!(model, body);
+
+    // Make actual API call using adapter configuration
+    const response = await fetch(model.url!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...model.headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.ok).toBe(true);
+
+    const result: GeminiAiAdapter.GenerateContentResponse =
+      await response.json();
+
+    // Validate response structure matches our types
+    expect(result.candidates).toBeDefined();
+    expect(result.candidates?.length).toBeGreaterThan(0);
+    expect(result.candidates?.[0]?.content.parts).toBeDefined();
+    expect(result.candidates?.[0]?.finishReason).toBeDefined();
+    expect(result.usageMetadata).toBeDefined();
+    expect(result.usageMetadata?.totalTokenCount).toBeGreaterThan(0);
+    expect(result.usageMetadata?.promptTokenCount).toBeGreaterThan(0);
+    expect(result.usageMetadata?.candidatesTokenCount).toBeGreaterThan(0);
+  });
+
+  test("Real API integration - thinking features", async () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-thinking-exp",
+      apiKey,
+    });
+
+    const requestBody: GeminiAiAdapter.GenerateContentRequest = {
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: "Calculate 15 - 7 + 12. Show your work.",
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.1,
+        maxOutputTokens: 400,
+        thinkingConfig: {
+          thinkingBudget: 512,
+          includeThoughts: true,
+        },
+      },
+    };
+
+    // Apply adapter transformations
+    const body = JSON.parse(JSON.stringify(requestBody));
+    model.onCall!(model, body);
+
+    // Make actual API call
+    const response = await fetch(model.url!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...model.headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.ok).toBe(true);
+
+    const result: GeminiAiAdapter.GenerateContentResponse =
+      await response.json();
+
+    // Validate thinking-specific features
+    expect(result.candidates).toBeDefined();
+    expect(result.usageMetadata).toBeDefined();
+    expect(result.usageMetadata?.thoughtsTokenCount).toBeGreaterThan(0);
+    expect(result.usageMetadata?.totalTokenCount).toBeGreaterThan(0);
+  });
+
+  test("Real API integration - structured JSON output", async () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey,
+    });
+
+    const requestBody: GeminiAiAdapter.GenerateContentRequest = {
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: "Generate a person profile with name, age, and hobbies.",
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.1,
+        maxOutputTokens: 200,
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            age: { type: "number" },
+            hobbies: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+          required: ["name", "age", "hobbies"],
+        },
+      },
+    };
+
+    // Apply adapter transformations
+    const body = JSON.parse(JSON.stringify(requestBody));
+    model.onCall!(model, body);
+
+    // Make actual API call
+    const response = await fetch(model.url!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...model.headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.ok).toBe(true);
+
+    const result: GeminiAiAdapter.GenerateContentResponse =
+      await response.json();
+
+    expect(result.candidates).toBeDefined();
+    expect(result.candidates?.[0]?.finishReason).toBe("STOP");
+
+    const firstPart = result.candidates?.[0]?.content.parts[0];
+    expect(firstPart).toBeDefined();
+    expect("text" in firstPart!).toBe(true);
+
+    if ("text" in firstPart!) {
+      const jsonText = firstPart.text;
+      expect(() => JSON.parse(jsonText)).not.toThrow();
+
+      const parsed = JSON.parse(jsonText);
+      expect(parsed).toHaveProperty("name");
+      expect(parsed).toHaveProperty("age");
+      expect(parsed).toHaveProperty("hobbies");
+      expect(typeof parsed.name).toBe("string");
+      expect(typeof parsed.age).toBe("number");
+      expect(Array.isArray(parsed.hobbies)).toBe(true);
+    }
+  });
+
+  test("Error handling - invalid API key", async () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey: "invalid-key",
+    });
+
+    const requestBody: GeminiAiAdapter.GenerateContentRequest = {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "Hello" }],
+        },
+      ],
+      generationConfig: {
+        maxOutputTokens: 10,
+      },
+    };
+
+    // Apply adapter transformations
+    const body = JSON.parse(JSON.stringify(requestBody));
+    model.onCall!(model, body);
+
+    // Make API call with invalid key
+    const response = await fetch(model.url!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...model.headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(400);
+  });
+
+  test("Type safety - input and output types", () => {
+    const model = gemini({
+      model: "gemini-2.0-flash-exp",
+      apiKey,
+    });
+
+    // Test that types are correctly defined
+    expect(model.format).toBe("gemini");
+
+    // These should compile without errors due to proper typing
+    const input: (typeof model)["~types"]["input"] = {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "Hello" }],
+        },
+      ],
+    };
+
+    const mockOutput: (typeof model)["~types"]["output"] = {
+      candidates: [
+        {
+          content: {
+            parts: [{ text: "Hello!" }],
+          },
+        },
+      ],
+      usageMetadata: {
+        totalTokenCount: 10,
+        promptTokenCount: 5,
+        candidatesTokenCount: 5,
+      },
+    };
+
+    expect(input.contents).toBeDefined();
+    expect(mockOutput.candidates).toBeDefined();
+  });
+});

--- a/packages/ai/test/unit/gemini.unit.test.ts
+++ b/packages/ai/test/unit/gemini.unit.test.ts
@@ -66,10 +66,10 @@ describe("Gemini Adapter Unit Tests", () => {
       });
 
       expect(model.url).toContain(
-        "https://generativelanguage.googleapis.com/v1beta/"
+        "https://generativelanguage.googleapis.com/v1beta/",
       );
       expect(model.url).toContain(
-        "models/gemini-2.0-flash-exp:generateContent"
+        "models/gemini-2.0-flash-exp:generateContent",
       );
       expect(model.url).toContain("key=test-key");
     });
@@ -258,7 +258,7 @@ describe("Gemini Adapter Unit Tests", () => {
       });
       expect(body.safetySettings).toBeDefined();
       expect(body.safetySettings![0].category).toBe(
-        GeminiAiAdapter.HarmCategory.HARM_CATEGORY_HARASSMENT
+        GeminiAiAdapter.HarmCategory.HARM_CATEGORY_HARASSMENT,
       );
     });
 

--- a/packages/ai/test/unit/gemini.unit.test.ts
+++ b/packages/ai/test/unit/gemini.unit.test.ts
@@ -1,0 +1,528 @@
+import { describe, test, expect } from "vitest";
+import { gemini } from "../../src/models/gemini.js";
+import type { Gemini } from "../../src/models/gemini.js";
+import { GeminiAiAdapter } from "../../src/adapters/gemini.js";
+
+describe("Gemini Adapter Unit Tests", () => {
+  describe("Model Creation", () => {
+    test("creates adapter with required options", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-api-key",
+      });
+
+      expect(model).toBeDefined();
+      expect(model.format).toBe("gemini");
+      expect(model.authKey).toBe("test-api-key");
+      expect(model.options.model).toBe("gemini-2.0-flash-exp");
+      expect(model.onCall).toBeDefined();
+      expect(typeof model.onCall).toBe("function");
+    });
+
+    test("uses environment variable when no API key provided", () => {
+      // Mock the environment variable
+      const originalEnv = process.env.GEMINI_API_KEY;
+      process.env.GEMINI_API_KEY = "env-api-key";
+
+      const model = gemini({
+        model: "gemini-1.5-flash",
+      });
+
+      expect(model.authKey).toBe("env-api-key");
+
+      // Restore original environment
+      if (originalEnv !== undefined) {
+        process.env.GEMINI_API_KEY = originalEnv;
+      } else {
+        delete process.env.GEMINI_API_KEY;
+      }
+    });
+
+    test("explicit API key takes precedence over environment", () => {
+      const originalEnv = process.env.GEMINI_API_KEY;
+      process.env.GEMINI_API_KEY = "env-api-key";
+
+      const model = gemini({
+        model: "gemini-1.5-flash",
+        apiKey: "explicit-api-key",
+      });
+
+      expect(model.authKey).toBe("explicit-api-key");
+
+      // Restore original environment
+      if (originalEnv !== undefined) {
+        process.env.GEMINI_API_KEY = originalEnv;
+      } else {
+        delete process.env.GEMINI_API_KEY;
+      }
+    });
+  });
+
+  describe("URL Construction", () => {
+    test("constructs correct URL with default base URL", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+      });
+
+      expect(model.url).toContain(
+        "https://generativelanguage.googleapis.com/v1beta/"
+      );
+      expect(model.url).toContain(
+        "models/gemini-2.0-flash-exp:generateContent"
+      );
+      expect(model.url).toContain("key=test-key");
+    });
+
+    test("constructs correct URL with custom base URL", () => {
+      const model = gemini({
+        model: "gemini-1.5-flash",
+        apiKey: "test-key",
+        baseUrl: "https://custom-api.example.com/v1/",
+      });
+
+      expect(model.url).toContain("https://custom-api.example.com/v1/");
+      expect(model.url).toContain("models/gemini-1.5-flash:generateContent");
+      expect(model.url).toContain("key=test-key");
+    });
+
+    test("handles base URL without trailing slash", () => {
+      const model = gemini({
+        model: "gemini-1.5-flash",
+        apiKey: "test-key",
+        baseUrl: "https://custom-api.example.com/v1",
+      });
+
+      expect(model.url).toContain("https://custom-api.example.com/v1/");
+      expect(model.url).toContain("models/gemini-1.5-flash:generateContent");
+    });
+
+    test("supports different model names", () => {
+      const models = [
+        "gemini-1.5-flash",
+        "gemini-1.5-flash-8b",
+        "gemini-1.5-pro",
+        "gemini-2.0-flash",
+        "gemini-2.0-flash-thinking-exp",
+        "text-embedding-004",
+      ];
+
+      models.forEach((modelName) => {
+        const model = gemini({
+          model: modelName as Gemini.Model,
+          apiKey: "test-key",
+        });
+
+        expect(model.url).toContain(`models/${modelName}:generateContent`);
+        expect(model.options.model).toBe(modelName);
+      });
+    });
+  });
+
+  describe("Parameter Transformation (onCall)", () => {
+    test("applies default parameters when body is empty", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: {
+          generationConfig: {
+            temperature: 0.8,
+            maxOutputTokens: 500,
+            topP: 0.9,
+          },
+        },
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+      };
+
+      model.onCall!(model, body);
+
+      expect(body.generationConfig).toBeDefined();
+      expect(body.generationConfig!.temperature).toBe(0.8);
+      expect(body.generationConfig!.maxOutputTokens).toBe(500);
+      expect(body.generationConfig!.topP).toBe(0.9);
+    });
+
+    test("preserves existing parameters over defaults", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: {
+          generationConfig: {
+            temperature: 0.8,
+            maxOutputTokens: 500,
+            topP: 0.9,
+          },
+        },
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.2, // Should override default
+          topK: 40, // Should be preserved
+        },
+      };
+
+      model.onCall!(model, body);
+
+      expect(body.generationConfig!.temperature).toBe(0.2); // User value preserved
+      expect(body.generationConfig!.topK).toBe(40); // User value preserved
+      expect(body.generationConfig!.maxOutputTokens).toBe(500); // Default applied
+      expect(body.generationConfig!.topP).toBe(0.9); // Default applied
+    });
+
+    test("handles nested parameter merging correctly", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: {
+          generationConfig: {
+            temperature: 0.8,
+            maxOutputTokens: 500,
+            thinkingConfig: {
+              thinkingBudget: 1024,
+              includeThoughts: false,
+            },
+          },
+        },
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.2,
+          thinkingConfig: {
+            includeThoughts: true, // Should override default
+          },
+        },
+      };
+
+      model.onCall!(model, body);
+
+      expect(body.generationConfig!.temperature).toBe(0.2);
+      expect(body.generationConfig!.maxOutputTokens).toBe(500);
+      expect(body.generationConfig!.thinkingConfig!.includeThoughts).toBe(true); // User value
+      expect(body.generationConfig!.thinkingConfig!.thinkingBudget).toBe(1024); // Default value
+    });
+
+    test("applies top-level default parameters", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: {
+          systemInstruction: {
+            parts: [{ text: "You are a helpful assistant." }],
+          },
+          safetySettings: [
+            {
+              category: GeminiAiAdapter.HarmCategory.HARM_CATEGORY_HARASSMENT,
+              threshold:
+                GeminiAiAdapter.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
+            },
+          ],
+        },
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+      };
+
+      model.onCall!(model, body);
+
+      expect(body.systemInstruction).toBeDefined();
+      expect(body.systemInstruction!.parts[0]).toEqual({
+        text: "You are a helpful assistant.",
+      });
+      expect(body.safetySettings).toBeDefined();
+      expect(body.safetySettings![0].category).toBe(
+        GeminiAiAdapter.HarmCategory.HARM_CATEGORY_HARASSMENT
+      );
+    });
+
+    test("does not override existing top-level parameters", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: {
+          systemInstruction: {
+            parts: [{ text: "Default instruction" }],
+          },
+        },
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+        systemInstruction: {
+          parts: [{ text: "User instruction" }],
+        },
+      };
+
+      model.onCall!(model, body);
+
+      expect(body.systemInstruction!.parts[0]).toEqual({
+        text: "User instruction",
+      });
+    });
+
+    test("handles no default parameters gracefully", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.7,
+        },
+      };
+
+      const originalBody = JSON.parse(JSON.stringify(body));
+
+      model.onCall!(model, body);
+
+      // Body should remain unchanged when no defaults
+      expect(body).toEqual(originalBody);
+    });
+  });
+
+  describe("Type Safety", () => {
+    test("has correct input and output types", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+      });
+
+      // Test input type
+      const input: (typeof model)["~types"]["input"] = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.7,
+          maxOutputTokens: 100,
+          thinkingConfig: {
+            thinkingBudget: 512,
+            includeThoughts: true,
+          },
+        },
+      };
+
+      expect(input.contents).toBeDefined();
+      expect(input.generationConfig?.temperature).toBe(0.7);
+      expect(input.generationConfig?.thinkingConfig?.thinkingBudget).toBe(512);
+
+      // Test output type
+      const output: (typeof model)["~types"]["output"] = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: "Hello!", thought: false },
+                { text: "Thinking...", thought: true },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: {
+          totalTokenCount: 50,
+          promptTokenCount: 20,
+          candidatesTokenCount: 25,
+          thoughtsTokenCount: 5,
+        },
+      };
+
+      expect(output.candidates).toBeDefined();
+      expect(output.usageMetadata?.thoughtsTokenCount).toBe(5);
+    });
+
+    test("format is correctly typed", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+      });
+
+      expect(model.format).toBe("gemini");
+
+      // TypeScript should enforce this at compile time
+      const format: "gemini" = model.format;
+      expect(format).toBe("gemini");
+    });
+
+    test("supports all documented model types", () => {
+      const modelTypes: Gemini.Model[] = [
+        "gemini-1.5-flash",
+        "gemini-1.5-flash-8b",
+        "gemini-1.5-pro",
+        "gemini-1.0-pro",
+        "gemini-2.0-flash",
+        "gemini-2.0-flash-lite",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite-preview-06-17",
+        "text-embedding-004",
+        "aqa",
+      ];
+
+      modelTypes.forEach((modelType) => {
+        expect(() => {
+          gemini({
+            model: modelType,
+            apiKey: "test-key",
+          });
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe("Configuration Validation", () => {
+    test("adapter properties are correctly set", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        baseUrl: "https://custom.example.com/",
+        defaultParameters: {
+          generationConfig: {
+            temperature: 0.5,
+          },
+        },
+      });
+
+      expect(model.format).toBe("gemini");
+      expect(model.authKey).toBe("test-key");
+      expect(model.url).toContain("https://custom.example.com/");
+      expect(model.headers).toBeDefined();
+      expect(typeof model.headers).toBe("object");
+      expect(model.options).toBeDefined();
+      expect(model.options.model).toBe("gemini-2.0-flash-exp");
+      expect(model.options.apiKey).toBe("test-key");
+      expect(model.options.baseUrl).toBe("https://custom.example.com/");
+      expect(model.options.defaultParameters).toBeDefined();
+    });
+
+    test("empty headers object is created", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+      });
+
+      expect(model.headers).toEqual({});
+      expect(typeof model.headers).toBe("object");
+    });
+
+    test("options object contains all provided configuration", () => {
+      const options = {
+        model: "gemini-1.5-pro" as const,
+        apiKey: "test-key",
+        baseUrl: "https://custom.example.com/",
+        defaultParameters: {
+          generationConfig: {
+            temperature: 0.9,
+            maxOutputTokens: 1000,
+          },
+        },
+      };
+
+      const model = gemini(options);
+
+      expect(model.options).toEqual(options);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    test("handles empty API key gracefully", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "",
+      });
+
+      expect(model.authKey).toBe("");
+      expect(model.url).toContain("key=");
+    });
+
+    test("handles undefined default parameters", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: undefined,
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+      };
+
+      const originalBody = JSON.parse(JSON.stringify(body));
+
+      expect(() => model.onCall!(model, body)).not.toThrow();
+      expect(body).toEqual(originalBody);
+    });
+
+    test("handles empty generationConfig in defaults", () => {
+      const model = gemini({
+        model: "gemini-2.0-flash-exp",
+        apiKey: "test-key",
+        defaultParameters: {
+          generationConfig: {},
+        },
+      });
+
+      const body: GeminiAiAdapter.GenerateContentRequest = {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Hello" }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.7,
+        },
+      };
+
+      model.onCall!(model, body);
+
+      expect(body.generationConfig!.temperature).toBe(0.7);
+    });
+  });
+});

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*", "*.config.ts", "**/*.test.ts", "**/*.spec.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Include all test files except smoke tests by default
+    include: ["src/**/*.{test,spec}.{js,ts}", "test/**/*.{test,spec}.{js,ts}"],
+    exclude: [
+      "node_modules/**",
+      "dist/**",
+      "test/smoke/**", // Exclude smoke tests from default test run
+    ],
+    environment: "node",
+  },
+});

--- a/packages/ai/vitest.smoke.config.ts
+++ b/packages/ai/vitest.smoke.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Only include smoke tests
+    include: ["test/smoke/**/*.{test,spec}.{js,ts}"],
+    environment: "node",
+    testTimeout: 30000, // Longer timeout for network calls
+    hookTimeout: 10000, // Longer hook timeout for setup/teardown
+  },
+});

--- a/packages/inngest/tsconfig.json
+++ b/packages/inngest/tsconfig.json
@@ -38,5 +38,5 @@
       "@local/*": ["./src/*"]
     }
   },
-  "include": ["./src/**/*", "./scripts/**/*"]
+  "include": ["./src/**/*"]
 }

--- a/packages/inngest/tsconfig.json
+++ b/packages/inngest/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "rootDir": "./src",
     "outDir": "./dist",
     "types": ["node", "jest"],
     "moduleResolution": "node",
@@ -38,5 +37,5 @@
       "@local/*": ["./src/*"]
     }
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*", "./scripts/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@edge-runtime/vm@3.0.3)(@types/debug@4.1.12)(@types/node@22.13.10)
 
   packages/ai:
     dependencies:
@@ -39,6 +42,9 @@ importers:
       '@eslint/js':
         specifier: ^9.7.0
         version: 9.7.0
+      dotenv:
+        specifier: ^17.0.1
+        version: 17.0.1
       eslint:
         specifier: ^9.18.0
         version: 9.18.0
@@ -51,6 +57,9 @@ importers:
       typescript-eslint:
         specifier: ^7.16.1
         version: 7.16.1(eslint@9.18.0)(typescript@5.7.3)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@edge-runtime/vm@3.0.3)(@types/node@22.10.5)
 
   packages/eslint-plugin:
     dependencies:
@@ -169,7 +178,7 @@ importers:
         version: 5.1.1
       '@sveltejs/kit':
         specifier: ^1.27.3
-        version: 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))
+        version: 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))
       '@total-typescript/shoehorn':
         specifier: ^0.1.1
         version: 0.1.1
@@ -338,7 +347,7 @@ importers:
         version: 1.5.1(node-fetch@2.7.0)
       inngest:
         specifier: 3.21.0
-        version: 3.21.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2)
+        version: 3.21.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2)
       jest:
         specifier: ^29.3.1
         version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
@@ -374,7 +383,7 @@ importers:
         version: 15.14.0
       inngest:
         specifier: ^3.19.11
-        version: 3.19.20(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2)
+        version: 3.19.20(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2)
       typescript:
         specifier: ~5.4.0
         version: 5.4.2
@@ -386,7 +395,7 @@ importers:
     dependencies:
       inngest:
         specifier: ^3.23.1
-        version: 3.25.1(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)
+        version: 3.25.1(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)
       zod:
         specifier: ^3.0.0
         version: 3.22.3
@@ -396,7 +405,7 @@ importers:
         version: 9.7.0
       '@inngest/test':
         specifier: ^0.1.6
-        version: 0.1.6(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)
+        version: 0.1.6(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -435,7 +444,7 @@ importers:
         version: 4.3.4
       inngest:
         specifier: ^3.34.2
-        version: 3.34.2(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
+        version: 3.34.2(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -487,7 +496,7 @@ importers:
     dependencies:
       inngest:
         specifier: ^3.31.1
-        version: 3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
+        version: 3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)
       tinyspy:
         specifier: ^3.0.2
         version: 3.0.2
@@ -807,15 +816,33 @@ packages:
     resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.25.6':
+    resolution: {integrity: sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.17.19':
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.18.20':
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.6':
+    resolution: {integrity: sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -825,9 +852,15 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.18.20':
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.6':
+    resolution: {integrity: sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
@@ -837,9 +870,15 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.18.20':
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.6':
+    resolution: {integrity: sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -849,9 +888,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.18.20':
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.6':
+    resolution: {integrity: sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
@@ -861,9 +906,15 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.18.20':
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.6':
+    resolution: {integrity: sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -873,9 +924,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.18.20':
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.6':
+    resolution: {integrity: sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
@@ -885,9 +942,15 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.18.20':
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.6':
+    resolution: {integrity: sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -897,9 +960,15 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.18.20':
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.6':
+    resolution: {integrity: sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
@@ -909,9 +978,15 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.18.20':
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.6':
+    resolution: {integrity: sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -921,9 +996,15 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.18.20':
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.6':
+    resolution: {integrity: sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
@@ -933,9 +1014,15 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.18.20':
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.6':
+    resolution: {integrity: sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -945,9 +1032,15 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.18.20':
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.6':
+    resolution: {integrity: sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
@@ -957,9 +1050,15 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.18.20':
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.6':
+    resolution: {integrity: sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -969,9 +1068,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.18.20':
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.6':
+    resolution: {integrity: sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
@@ -981,9 +1086,15 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.18.20':
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.6':
+    resolution: {integrity: sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -993,11 +1104,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.18.20':
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/linux-x64@0.25.6':
+    resolution: {integrity: sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.6':
+    resolution: {integrity: sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-x64@0.17.19':
     resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
@@ -1005,11 +1128,23 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.18.20':
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.6':
+    resolution: {integrity: sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.6':
+    resolution: {integrity: sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.17.19':
     resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
@@ -1017,11 +1152,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.18.20':
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.6':
+    resolution: {integrity: sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.6':
+    resolution: {integrity: sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/sunos-x64@0.17.19':
     resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
@@ -1029,9 +1176,15 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.18.20':
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.6':
+    resolution: {integrity: sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -1041,9 +1194,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.18.20':
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.6':
+    resolution: {integrity: sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1053,9 +1212,15 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.18.20':
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.6':
+    resolution: {integrity: sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -1065,9 +1230,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.18.20':
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.6':
+    resolution: {integrity: sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1312,9 +1483,6 @@ packages:
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -1949,6 +2117,106 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.44.2':
+    resolution: {integrity: sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    resolution: {integrity: sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.44.2':
+    resolution: {integrity: sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    resolution: {integrity: sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    resolution: {integrity: sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    resolution: {integrity: sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
+    cpu: [x64]
+    os: [win32]
+
   '@sentry/core@8.14.0':
     resolution: {integrity: sha512-kEB8R3hMxdJRzwZwNqIxwrnmKx/iNl2ZHL/48/ywJu4u+qkBqQs9OsR+ACa+eZyAZTY5T0cPRGsUcNdnwy1ZAg==}
     engines: {node: '>=14.18'}
@@ -2049,6 +2317,9 @@ packages:
   '@types/bunyan@1.8.11':
     resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/connect@3.4.35':
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
 
@@ -2070,6 +2341,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/eslint@8.56.10':
     resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
 
@@ -2078,6 +2352,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/express-serve-static-core@4.19.5':
     resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
@@ -2367,6 +2644,64 @@ packages:
   '@vercel/static-config@2.0.17':
     resolution: {integrity: sha512-2f50OTVrN07x7pH+XNW0e7cj7T+Ufg+19+a2N3/XZBjQmV+FaMlmSLiaQ4tBxp2H8lWWHzENua7ZSSQPtRZ3/A==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -2509,6 +2844,10 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-listen@3.0.0:
     resolution: {integrity: sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==}
     engines: {node: '>= 14'}
@@ -2648,6 +2987,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
@@ -2685,6 +3028,10 @@ packages:
     resolution: {integrity: sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==}
     engines: {node: '>=12.13'}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2703,6 +3050,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -2918,6 +3269,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
@@ -2928,6 +3288,10 @@ packages:
 
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
@@ -3030,6 +3394,10 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dotenv@17.0.1:
+    resolution: {integrity: sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==}
+    engines: {node: '>=12'}
+
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
@@ -3075,6 +3443,9 @@ packages:
   es-abstract@1.21.1:
     resolution: {integrity: sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
@@ -3217,9 +3588,14 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.6:
+    resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.1.1:
@@ -3444,6 +3820,10 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
   expect@29.5.0:
     resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3509,6 +3889,14 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fetch-mock-jest@1.5.1:
     resolution: {integrity: sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==}
@@ -4416,6 +4804,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -4538,6 +4929,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -4565,6 +4957,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.1.4:
+    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
+
   lru-cache@10.0.3:
     resolution: {integrity: sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==}
     engines: {node: 14 || >=16.14}
@@ -4581,6 +4976,9 @@ packages:
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -4719,6 +5117,11 @@ packages:
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -4958,6 +5361,16 @@ packages:
   pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
@@ -4978,9 +5391,16 @@ packages:
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -5008,8 +5428,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.4.45:
-    resolution: {integrity: sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -5259,9 +5679,9 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rollup@3.29.4:
-    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+  rollup@4.44.2:
+    resolution: {integrity: sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-applescript@5.0.0:
@@ -5395,6 +5815,9 @@ packages:
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5468,6 +5891,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -5475,6 +5901,9 @@ packages:
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
@@ -5539,6 +5968,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -5618,8 +6050,34 @@ packages:
     resolution: {integrity: sha512-iNgFugVuQgBKrqeO/mpiTTgmBsTP0WL6yeuLfLs/Ctf0pI/ixGqIRm8sDCwMcXGe9WWvt2sGXI5mNqZbValmJg==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
   titleize@3.0.0:
@@ -5935,15 +6393,26 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@4.5.3:
-    resolution: {integrity: sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@5.4.19:
+    resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': '>= 14'
+      '@types/node': ^18.0.0 || >=20.0.0
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
+      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
       terser: ^5.4.0
@@ -5956,11 +6425,53 @@ packages:
         optional: true
       sass:
         optional: true
+      sass-embedded:
+        optional: true
       stylus:
         optional: true
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vite@7.0.2:
+    resolution: {integrity: sha512-hxdyZDY1CM6SNpKI4w4lcUc3Mtkd9ej4ECWVHSMrOdSinVc2zYOAppHeGc/hzmRo3pxM5blMzkuWHOJA/3NiFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vitefu@0.2.5:
@@ -5969,6 +6480,59 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   walker@1.0.8:
@@ -6014,6 +6578,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.3:
@@ -6166,7 +6735,7 @@ snapshots:
       '@babel/traverse': 7.23.6
       '@babel/types': 7.23.6
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6176,8 +6745,8 @@ snapshots:
   '@babel/generator@7.23.6':
     dependencies:
       '@babel/types': 7.23.6
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
   '@babel/helper-compilation-targets@7.23.6':
@@ -6336,7 +6905,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.6
       '@babel/types': 7.23.6
-      debug: 4.3.4
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6365,7 +6934,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.3
 
   '@changesets/assemble-release-plan@5.2.4':
     dependencies:
@@ -6374,7 +6943,7 @@ snapshots:
       '@changesets/get-dependents-graph': 1.3.6
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
-      semver: 7.5.4
+      semver: 7.6.3
 
   '@changesets/changelog-git@0.1.14':
     dependencies:
@@ -6444,7 +7013,7 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.5.4
+      semver: 7.6.3
 
   '@changesets/get-github-info@0.5.2':
     dependencies:
@@ -6552,136 +7121,217 @@ snapshots:
       '@esbuild-kit/core-utils': 3.1.0
       get-tsconfig: 4.7.0
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.6':
+    optional: true
+
   '@esbuild/android-arm64@0.17.19':
     optional: true
 
-  '@esbuild/android-arm64@0.18.20':
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.6':
     optional: true
 
   '@esbuild/android-arm@0.17.19':
     optional: true
 
-  '@esbuild/android-arm@0.18.20':
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.25.6':
     optional: true
 
   '@esbuild/android-x64@0.17.19':
     optional: true
 
-  '@esbuild/android-x64@0.18.20':
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.6':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.19':
     optional: true
 
-  '@esbuild/darwin-arm64@0.18.20':
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.6':
     optional: true
 
   '@esbuild/darwin-x64@0.17.19':
     optional: true
 
-  '@esbuild/darwin-x64@0.18.20':
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.6':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.19':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.18.20':
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.6':
     optional: true
 
   '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
-  '@esbuild/freebsd-x64@0.18.20':
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.6':
     optional: true
 
   '@esbuild/linux-arm64@0.17.19':
     optional: true
 
-  '@esbuild/linux-arm64@0.18.20':
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.6':
     optional: true
 
   '@esbuild/linux-arm@0.17.19':
     optional: true
 
-  '@esbuild/linux-arm@0.18.20':
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.6':
     optional: true
 
   '@esbuild/linux-ia32@0.17.19':
     optional: true
 
-  '@esbuild/linux-ia32@0.18.20':
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.6':
     optional: true
 
   '@esbuild/linux-loong64@0.17.19':
     optional: true
 
-  '@esbuild/linux-loong64@0.18.20':
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.6':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.19':
     optional: true
 
-  '@esbuild/linux-mips64el@0.18.20':
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.6':
     optional: true
 
   '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
-  '@esbuild/linux-ppc64@0.18.20':
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.6':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.19':
     optional: true
 
-  '@esbuild/linux-riscv64@0.18.20':
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.6':
     optional: true
 
   '@esbuild/linux-s390x@0.17.19':
     optional: true
 
-  '@esbuild/linux-s390x@0.18.20':
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.6':
     optional: true
 
   '@esbuild/linux-x64@0.17.19':
     optional: true
 
-  '@esbuild/linux-x64@0.18.20':
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.6':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.6':
     optional: true
 
   '@esbuild/netbsd-x64@0.17.19':
     optional: true
 
-  '@esbuild/netbsd-x64@0.18.20':
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.6':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.6':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.19':
     optional: true
 
-  '@esbuild/openbsd-x64@0.18.20':
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.6':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.6':
     optional: true
 
   '@esbuild/sunos-x64@0.17.19':
     optional: true
 
-  '@esbuild/sunos-x64@0.18.20':
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.6':
     optional: true
 
   '@esbuild/win32-arm64@0.17.19':
     optional: true
 
-  '@esbuild/win32-arm64@0.18.20':
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.6':
     optional: true
 
   '@esbuild/win32-ia32@0.17.19':
     optional: true
 
-  '@esbuild/win32-ia32@0.18.20':
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.6':
     optional: true
 
   '@esbuild/win32-x64@0.17.19':
     optional: true
 
-  '@esbuild/win32-x64@0.18.20':
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.6':
     optional: true
 
   '@eslint-community/eslint-utils@4.3.0(eslint@8.36.0)':
@@ -6845,9 +7495,9 @@ snapshots:
       '@types/node': 22.10.5
       typescript: 5.8.2
 
-  '@inngest/test@0.1.6(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)':
+  '@inngest/test@0.1.6(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)':
     dependencies:
-      inngest: 3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)
+      inngest: 3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)
       tinyspy: 3.0.2
       ulid: 2.3.0
     transitivePeerDependencies:
@@ -7071,7 +7721,7 @@ snapshots:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/node': 22.13.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
@@ -7099,7 +7749,7 @@ snapshots:
 
   '@jest/source-map@29.4.3':
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
@@ -7121,7 +7771,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.6
       '@jest/types': 29.5.0
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -7151,8 +7801,8 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
@@ -7168,14 +7818,12 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.20':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -8013,6 +8661,66 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    optional: true
+
   '@sentry/core@8.14.0':
     dependencies:
       '@sentry/types': 8.14.0
@@ -8043,9 +8751,9 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))':
+  '@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))
       '@types/cookie': 0.5.4
       cookie: 0.5.0
       devalue: 4.3.2
@@ -8059,13 +8767,13 @@ snapshots:
       svelte: 4.2.5
       tiny-glob: 0.2.9
       undici: 5.26.5
-      vite: 4.5.3(@types/node@20.14.8)
+      vite: 7.0.2(@types/node@20.14.8)(tsx@3.12.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))':
+  '@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@types/cookie': 0.5.4
       cookie: 0.5.0
       devalue: 4.3.2
@@ -8079,55 +8787,55 @@ snapshots:
       svelte: 4.2.5
       tiny-glob: 0.2.9
       undici: 5.26.5
-      vite: 4.5.3(@types/node@22.13.10)
+      vite: 7.0.2(@types/node@22.13.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7)))(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))
-      debug: 4.3.4
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))
+      debug: 4.4.0
       svelte: 4.2.5
-      vite: 4.5.3(@types/node@20.14.8)
+      vite: 7.0.2(@types/node@20.14.8)(tsx@3.12.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
-      debug: 4.3.4
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
+      debug: 4.4.0
       svelte: 4.2.5
-      vite: 4.5.3(@types/node@22.13.10)
+      vite: 7.0.2(@types/node@22.13.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))':
+  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8)))(svelte@4.2.5)(vite@4.5.3(@types/node@20.14.8))
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7)))(svelte@4.2.5)(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
       svelte: 4.2.5
       svelte-hmr: 0.15.3(svelte@4.2.5)
-      vite: 4.5.3(@types/node@20.14.8)
-      vitefu: 0.2.5(vite@4.5.3(@types/node@20.14.8))
+      vite: 7.0.2(@types/node@20.14.8)(tsx@3.12.7)
+      vitefu: 0.2.5(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))':
+  '@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
       svelte: 4.2.5
       svelte-hmr: 0.15.3(svelte@4.2.5)
-      vite: 4.5.3(@types/node@22.13.10)
-      vitefu: 0.2.5(vite@4.5.3(@types/node@22.13.10))
+      vite: 7.0.2(@types/node@22.13.10)
+      vitefu: 0.2.5(vite@7.0.2(@types/node@22.13.10))
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -8191,6 +8899,10 @@ snapshots:
     dependencies:
       '@types/node': 22.13.10
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/connect@3.4.35':
     dependencies:
       '@types/node': 22.13.10
@@ -8216,6 +8928,8 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/eslint@8.56.10':
     dependencies:
       '@types/estree': 1.0.6
@@ -8226,6 +8940,8 @@ snapshots:
       '@types/eslint': 8.56.10
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
@@ -8618,7 +9334,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.11.0(typescript@5.8.2)
       '@typescript-eslint/utils': 6.11.0(eslint@8.36.0)(typescript@5.8.2)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 8.36.0
       ts-api-utils: 1.0.3(typescript@5.8.2)
     optionalDependencies:
@@ -8630,7 +9346,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.2)
       '@typescript-eslint/utils': 7.16.1(eslint@8.53.0)(typescript@5.5.2)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 8.53.0
       ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
@@ -8642,7 +9358,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.6.3)
       '@typescript-eslint/utils': 7.16.1(eslint@8.53.0)(typescript@5.6.3)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 8.53.0
       ts-api-utils: 1.3.0(typescript@5.6.3)
     optionalDependencies:
@@ -8654,7 +9370,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.4.2)
       '@typescript-eslint/utils': 7.16.1(eslint@9.18.0)(typescript@5.4.2)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 9.18.0
       ts-api-utils: 1.3.0(typescript@5.4.2)
     optionalDependencies:
@@ -8666,7 +9382,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.7.3)
       '@typescript-eslint/utils': 7.16.1(eslint@9.18.0)(typescript@5.7.3)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 9.18.0
       ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
@@ -8678,7 +9394,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.8.2)
       '@typescript-eslint/utils': 7.16.1(eslint@9.18.0)(typescript@5.8.2)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 9.18.0
       ts-api-utils: 1.3.0(typescript@5.8.2)
     optionalDependencies:
@@ -8697,7 +9413,7 @@ snapshots:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.3
       ts-api-utils: 1.0.3(typescript@5.5.2)
     optionalDependencies:
       typescript: 5.5.2
@@ -8711,7 +9427,7 @@ snapshots:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.3
       ts-api-utils: 1.0.3(typescript@5.8.2)
     optionalDependencies:
       typescript: 5.8.2
@@ -8722,7 +9438,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
-      debug: 4.3.4
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8737,7 +9453,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
-      debug: 4.3.4
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8752,7 +9468,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
-      debug: 4.3.4
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8767,7 +9483,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
-      debug: 4.3.4
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8782,7 +9498,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
-      debug: 4.3.4
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8923,6 +9639,88 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.2.0
+      tinyrainbow: 1.2.0
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@22.10.5))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@22.10.5)
+
+  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@22.13.10))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.0.2(@types/node@22.13.10)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.17
+      pathe: 1.1.2
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.1.4
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.1.4
+      tinyrainbow: 2.0.0
+
   abbrev@1.1.1: {}
 
   abort-controller@3.0.0:
@@ -9057,6 +9855,8 @@ snapshots:
       es-shim-unscopables: 1.0.0
 
   arrify@1.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   async-listen@3.0.0: {}
 
@@ -9251,6 +10051,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cache-content-type@1.0.1:
     dependencies:
       mime-types: 2.1.35
@@ -9281,6 +10083,14 @@ snapshots:
 
   case-anything@2.1.13: {}
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.4
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9297,6 +10107,8 @@ snapshots:
   char-regex@1.0.2: {}
 
   chardet@0.7.0: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -9345,7 +10157,7 @@ snapshots:
   code-red@1.0.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
       acorn: 8.14.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
@@ -9495,6 +10307,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -9503,6 +10319,8 @@ snapshots:
   decamelize@1.2.0: {}
 
   dedent@0.7.0: {}
+
+  deep-eql@5.0.2: {}
 
   deep-equal@1.0.1: {}
 
@@ -9576,6 +10394,8 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@17.0.1: {}
 
   dotenv@8.6.0: {}
 
@@ -9652,6 +10472,8 @@ snapshots:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.9
+
+  es-module-lexer@1.7.0: {}
 
   es-set-tostringtag@2.0.1:
     dependencies:
@@ -9777,30 +10599,60 @@ snapshots:
       '@esbuild/win32-ia32': 0.17.19
       '@esbuild/win32-x64': 0.17.19
 
-  esbuild@0.18.20:
+  esbuild@0.21.5:
     optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.6:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.6
+      '@esbuild/android-arm': 0.25.6
+      '@esbuild/android-arm64': 0.25.6
+      '@esbuild/android-x64': 0.25.6
+      '@esbuild/darwin-arm64': 0.25.6
+      '@esbuild/darwin-x64': 0.25.6
+      '@esbuild/freebsd-arm64': 0.25.6
+      '@esbuild/freebsd-x64': 0.25.6
+      '@esbuild/linux-arm': 0.25.6
+      '@esbuild/linux-arm64': 0.25.6
+      '@esbuild/linux-ia32': 0.25.6
+      '@esbuild/linux-loong64': 0.25.6
+      '@esbuild/linux-mips64el': 0.25.6
+      '@esbuild/linux-ppc64': 0.25.6
+      '@esbuild/linux-riscv64': 0.25.6
+      '@esbuild/linux-s390x': 0.25.6
+      '@esbuild/linux-x64': 0.25.6
+      '@esbuild/netbsd-arm64': 0.25.6
+      '@esbuild/netbsd-x64': 0.25.6
+      '@esbuild/openbsd-arm64': 0.25.6
+      '@esbuild/openbsd-x64': 0.25.6
+      '@esbuild/openharmony-arm64': 0.25.6
+      '@esbuild/sunos-x64': 0.25.6
+      '@esbuild/win32-arm64': 0.25.6
+      '@esbuild/win32-ia32': 0.25.6
+      '@esbuild/win32-x64': 0.25.6
 
   escalade@3.1.1: {}
 
@@ -10092,7 +10944,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -10104,7 +10956,7 @@ snapshots:
 
   execa@7.2.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 4.3.1
       is-stream: 3.0.0
@@ -10117,6 +10969,8 @@ snapshots:
   exit-hook@2.2.1: {}
 
   exit@0.1.2: {}
+
+  expect-type@1.2.2: {}
 
   expect@29.5.0:
     dependencies:
@@ -10245,6 +11099,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fdir@6.4.6(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   fetch-mock-jest@1.5.1(node-fetch@2.7.0):
     dependencies:
@@ -10580,7 +11438,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10634,7 +11492,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inngest@3.19.20(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2):
+  inngest@3.19.20(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2):
     dependencies:
       '@types/debug': 4.1.12
       canonicalize: 1.0.8
@@ -10648,7 +11506,7 @@ snapshots:
       strip-ansi: 5.2.0
       zod: 3.22.3
     optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@vercel/node': 2.15.9
       aws-lambda: 1.0.7
       express: 4.19.2
@@ -10662,7 +11520,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.21.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2):
+  inngest@3.21.0(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2):
     dependencies:
       '@types/debug': 4.1.12
       canonicalize: 1.0.8
@@ -10676,7 +11534,7 @@ snapshots:
       strip-ansi: 5.2.0
       zod: 3.22.3
     optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@vercel/node': 2.15.9
       aws-lambda: 1.0.7
       express: 4.19.2
@@ -10690,7 +11548,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.25.1(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3):
+  inngest@3.25.1(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3):
     dependencies:
       '@types/debug': 4.1.12
       canonicalize: 1.0.8
@@ -10704,7 +11562,7 @@ snapshots:
       strip-ansi: 5.2.0
       zod: 3.22.3
     optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@vercel/node': 2.15.9
       aws-lambda: 1.0.7
       express: 4.19.2
@@ -10718,7 +11576,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3):
+  inngest@3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -10736,7 +11594,7 @@ snapshots:
       ulidx: 2.4.1
       zod: 3.22.3
     optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@vercel/node': 2.15.9
       aws-lambda: 1.0.7
       express: 4.19.2
@@ -10750,7 +11608,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2):
+  inngest@3.32.7(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -10768,7 +11626,7 @@ snapshots:
       ulidx: 2.4.1
       zod: 3.22.3
     optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@vercel/node': 2.15.9
       aws-lambda: 1.0.7
       express: 4.19.2
@@ -10782,7 +11640,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.34.2(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2):
+  inngest@3.34.2(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -10801,7 +11659,7 @@ snapshots:
       ulidx: 2.4.1
       zod: 3.22.3
     optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@4.5.3(@types/node@22.13.10))
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10))
       '@vercel/node': 2.15.9
       aws-lambda: 1.0.7
       express: 4.19.2
@@ -10933,7 +11791,7 @@ snapshots:
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   is-regex@1.1.4:
     dependencies:
@@ -11008,7 +11866,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -11068,7 +11926,7 @@ snapshots:
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11087,7 +11945,7 @@ snapshots:
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11106,7 +11964,7 @@ snapshots:
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11125,7 +11983,7 @@ snapshots:
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11401,7 +12259,7 @@ snapshots:
       jest-pnp-resolver: 1.2.3(jest-resolve@29.5.0)
       jest-util: 29.5.0
       jest-validate: 29.5.0
-      resolve: 1.22.2
+      resolve: 1.22.10
       resolve.exports: 2.0.1
       slash: 3.0.0
 
@@ -11572,6 +12430,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -11728,6 +12588,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.1.4: {}
+
   lru-cache@10.0.3: {}
 
   lru-cache@4.1.5:
@@ -11744,6 +12606,10 @@ snapshots:
       yallist: 4.0.0
 
   magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -11851,6 +12717,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@1.0.0: {}
+
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -12104,9 +12972,15 @@ snapshots:
 
   pathe@1.1.1: {}
 
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   periscopic@3.1.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
@@ -12126,7 +13000,11 @@ snapshots:
 
   picocolors@1.1.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pify@4.0.1: {}
 
@@ -12163,10 +13041,10 @@ snapshots:
       picocolors: 1.1.0
       source-map-js: 1.2.1
 
-  postcss@8.4.45:
+  postcss@8.5.6:
     dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.0
+      nanoid: 3.3.11
+      picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
@@ -12402,8 +13280,30 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup@3.29.4:
+  rollup@4.44.2:
+    dependencies:
+      '@types/estree': 1.0.8
     optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.44.2
+      '@rollup/rollup-android-arm64': 4.44.2
+      '@rollup/rollup-darwin-arm64': 4.44.2
+      '@rollup/rollup-darwin-x64': 4.44.2
+      '@rollup/rollup-freebsd-arm64': 4.44.2
+      '@rollup/rollup-freebsd-x64': 4.44.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.44.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.44.2
+      '@rollup/rollup-linux-arm64-gnu': 4.44.2
+      '@rollup/rollup-linux-arm64-musl': 4.44.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.44.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-musl': 4.44.2
+      '@rollup/rollup-linux-s390x-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-musl': 4.44.2
+      '@rollup/rollup-win32-arm64-msvc': 4.44.2
+      '@rollup/rollup-win32-ia32-msvc': 4.44.2
+      '@rollup/rollup-win32-x64-msvc': 4.44.2
       fsevents: 2.3.3
 
   run-applescript@5.0.0:
@@ -12536,6 +13436,8 @@ snapshots:
       get-intrinsic: 1.2.0
       object-inspect: 1.12.3
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.0.2: {}
@@ -12610,9 +13512,13 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  std-env@3.9.0: {}
 
   stream-transform@2.1.3:
     dependencies:
@@ -12679,6 +13585,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.1(@babel/core@7.23.6)(react@19.0.0):
     dependencies:
       client-only: 0.0.1
@@ -12717,7 +13627,7 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
       locate-character: 3.0.0
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       periscopic: 3.1.0
 
   synckit@0.8.5:
@@ -12761,7 +13671,24 @@ snapshots:
 
   tiny-lru@11.0.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyspy@3.0.2: {}
+
+  tinyspy@4.0.3: {}
 
   titleize@3.0.0: {}
 
@@ -12832,7 +13759,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.4
+      semver: 7.6.3
       typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -12849,7 +13776,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.4
+      semver: 7.6.3
       typescript: 5.5.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -12866,7 +13793,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.4
+      semver: 7.6.3
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -12883,7 +13810,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.4
+      semver: 7.6.3
       typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -13181,7 +14108,7 @@ snapshots:
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:
@@ -13214,7 +14141,7 @@ snapshots:
 
   v8-to-istanbul@9.1.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
 
@@ -13229,33 +14156,166 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@4.5.3(@types/node@20.14.8):
+  vite-node@2.1.9(@types/node@22.10.5):
     dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.45
-      rollup: 3.29.4
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.19(@types/node@22.10.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@3.2.4(@types/node@22.13.10):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.0.2(@types/node@22.13.10)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@5.4.19(@types/node@22.10.5):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.44.2
+    optionalDependencies:
+      '@types/node': 22.10.5
+      fsevents: 2.3.3
+
+  vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7):
+    dependencies:
+      esbuild: 0.25.6
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.14.8
       fsevents: 2.3.3
+      tsx: 3.12.7
 
-  vite@4.5.3(@types/node@22.13.10):
+  vite@7.0.2(@types/node@22.13.10):
     dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.45
-      rollup: 3.29.4
+      esbuild: 0.25.6
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.13.10
       fsevents: 2.3.3
+
+  vitefu@0.2.5(vite@7.0.2(@types/node@20.14.8)(tsx@3.12.7)):
+    optionalDependencies:
+      vite: 7.0.2(@types/node@20.14.8)(tsx@3.12.7)
+
+  vitefu@0.2.5(vite@7.0.2(@types/node@22.13.10)):
+    optionalDependencies:
+      vite: 7.0.2(@types/node@22.13.10)
     optional: true
 
-  vitefu@0.2.5(vite@4.5.3(@types/node@20.14.8)):
+  vitest@2.1.9(@edge-runtime/vm@3.0.3)(@types/node@22.10.5):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@22.10.5))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.19(@types/node@22.10.5)
+      vite-node: 2.1.9(@types/node@22.10.5)
+      why-is-node-running: 2.3.0
     optionalDependencies:
-      vite: 4.5.3(@types/node@20.14.8)
+      '@edge-runtime/vm': 3.0.3
+      '@types/node': 22.10.5
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
-  vitefu@0.2.5(vite@4.5.3(@types/node@22.13.10)):
+  vitest@3.2.4(@edge-runtime/vm@3.0.3)(@types/debug@4.1.12)(@types/node@22.13.10):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@22.13.10))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.0.2(@types/node@22.13.10)
+      vite-node: 3.2.4(@types/node@22.13.10)
+      why-is-node-running: 2.3.0
     optionalDependencies:
-      vite: 4.5.3(@types/node@22.13.10)
-    optional: true
+      '@edge-runtime/vm': 3.0.3
+      '@types/debug': 4.1.12
+      '@types/node': 22.13.10
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   walker@1.0.8:
     dependencies:
@@ -13316,6 +14376,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.3: {}
 


### PR DESCRIPTION
### Summary

This pull request introduces enhancements to the Gemini AI adapter - adding support for the latest generation and thinking config. It also establishes a testing framework for AI models, using Gemini as the foundational example.

The primary goals of this update are:
1.  To enable developers to leverage the latest capabilities of Gemini models, such as `thinkingConfig` for complex reasoning and fine-grained `generationConfig` for precise output control
2.  To create a standardized and reliable testing methodology for AI integrations, ensuring both the local adapter logic and the live API interactions work as expected

---

### Key Changes

*   **Gemini Model & Adapter (`packages/ai`)**
    *   **Expanded API Support:** The Gemini adapter now fully supports the `generationConfig` and the nested `thinkingConfig` parameters. This allows for advanced control over model behavior, including enabling reasoning steps, setting thinking budgets, and requesting structured JSON outputs.
    *   **Comprehensive Documentation:** Added extensive JSDoc comments to all new and existing types in `packages/ai/src/adapters/gemini.ts`. This inline documentation provides clear explanations, examples, and best practices for each parameter, significantly improving the developer experience.
    *   **Enhanced Parameter Merging:** The `onCall` transformation logic has been updated to correctly deep-merge default parameters, ensuring that nested configurations like `thinkingConfig` are combined correctly with user-provided settings

*   **New Testing Framework (`packages/ai`)**
    *   **Unit Tests:** A suite of local unit tests (`packages/ai/test/unit/gemini.unit.test.ts`) has been created using Vitest. These tests validate the adapter's internal logic—including parameter merging, URL construction and type safety - all without requiring any external API calls.
    *   **Smoke Tests:** A new smoke test suite (`packages/ai/test/smoke/gemini.smoke.test.ts`) has been added to perform live integration tests against the Gemini API. These tests verify the end-to-end functionality for text generation, structured JSON output and the new thinking features - ensuring the adapter works correctly in a real-world scenario.

*   **Build & Configuration**
    *   **Testing Scripts:** Added two distinct testing scripts to `packages/ai/package.json`:
        *   `test`: Runs the fast, local unit tests.
        *   `test:smoke`: Runs the live integration smoke tests (requires a GEMINI_API_KEY)
    *   **Vite Configuration:** Introduced `vitest.config.ts` for unit tests and `vitest.smoke.config.ts` for smoke tests to manage the two testing environments.
    *   **Environment Setup:** Included a `.env.example` file in the `packages/ai` directory to guide users in setting up the API keys required for the smoke tests.
    *   **TypeScript and Workspace:** Updated `tsconfig.json` files to support the Vitest environment and ensure type safety across the new test files

---

### How to Test

To validate the changes, you can run the new test suites from the `packages/ai` directory:

1.  **Run Unit Tests (Local, No API Key Needed):**
    ```sh
    pnpm test
    ```

2.  **Run Smoke Tests (Requires API Key):**
    *   First, create a `.env` file in `packages/ai` by copying the example: `cp .env.example .env`
    *   Add your `GEMINI_API_KEY` to the new `.env` file.
    *   Run the smoke tests:
        ```sh
        pnpm test:smoke
        ```

---

### Future Work

This pull request establishes a blueprint for testing our AI model integrations. As a next step, we can and should introduce similar smoke tests for our other AI models to ensure their reliability and correctness. This initial implementation for Gemini serves as a proposal for how we can proceed with testing across other models and capabilities.

---

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
Raised by a customer in slack who reported this issue:
```
Object literal may only specify known properties, and 'thinkingBudget' does not exist in type 'Partial<GenerateContentRequest>'.ts(2353)

Object literal may only specify known properties, and 'thinkingBudget' does not exist in type 'GenerationConfig'.ts(2353)
```

He was able to work around this by adding thinkingConfig within generationConfig and type asserting as any.
