### PR TITLE
feat(realtime): `clear` function

### DIFF
--- a/packages/realtime/src/hooks.ts
+++ b/packages/realtime/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { subscribe } from "./subscribe";
 import { type Realtime } from "./types";
 
@@ -39,6 +39,14 @@ export interface InngestSubscription<TToken extends Realtime.Subscribe.Token> {
    * TODO
    */
   state: InngestSubscriptionState;
+
+  /**
+   * Clears all accumulated message data from the internal state.
+   * 
+   * This includes data, freshData, and latestData arrays.
+   * Does not affect the connection or error state.
+   */
+  clear: () => void;
 }
 
 /**
@@ -210,11 +218,18 @@ export function useInngestSubscription<
     };
   }, [bufferInterval]);
 
+  const clear = useCallback(() => {
+    setData([]);
+    setFreshData([]);
+    messageBuffer.current = [];
+  }, []);
+
   return {
     data,
     latestData: data[data.length - 1] ?? null,
     freshData,
     error,
     state,
+    clear,
   } as unknown as InngestSubscription<NonNullable<TToken>>;
 }


### PR DESCRIPTION
## Summary
Added a `clear` function to the `useInngestSubscription` return value that allows users to clear all accumulated message data from the internal state. This would be useful for scenarios like:
- User-triggered "clear history" actions
- Resetting data when switching contexts or filters
- Cleaning up before important new data arrives
- Memory management for long-running subscriptions (e.g. revalidating from the server)

**What it clears**:
- data array (all accumulated messages)
- freshData array (recent messages)
- latestData (as it's derived from data)

**Preserves**:
- Current subscription connection and state
- Error state (errors are separate from message data)
- All subscription settings and configuration

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] ~~Added unit/integration tests~~ N/A: no tests yet for React hook
- [ ] Added changesets if applicable

