### PR TITLE
Skip step targeting when the already fulfilled

### DIFF
--- a/.changeset/free-boats-stay.md
+++ b/.changeset/free-boats-stay.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Skip step targeting when the step is already fulfilled

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -272,6 +272,14 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
       (step) => step.hashedId === hashedStepIdToRun && step.fn
     );
 
+    if (step?.fulfilled) {
+      // Theoretically unreachable, but we've seen it happen. We saw a bug where
+      // the Executor requested the same parallel step twice, and on the second
+      // request there was already cached step data (i.e. already fulfilled). So
+      // this is merely a defensive measure
+      return;
+    }
+
     if (step) {
       return await this.executeStep(step);
     }


### PR DESCRIPTION
## Summary

When a step is targeted but also fulfilled, don't run the step. This happens when the Executor mistakenly sends an extra parallel step target (the `stepId` query param) even though the step is already cached in the request body's `steps` object

## Checklist

- [ ] Added unit/integration tests
- [x] Added changesets if applicable