### PR TITLE
Set `"inngest.traceref"` for userland spans

### DIFF
--- a/packages/inngest/src/components/execution/otel/consts.ts
+++ b/packages/inngest/src/components/execution/otel/consts.ts
@@ -3,10 +3,12 @@ export const debugPrefix = "inngest:otel";
 export enum TraceStateKey {
   AppId = "inngest@app",
   FunctionId = "inngest@fn",
+  TraceRef = "inngest@traceref",
 }
 
 export enum Attribute {
   InngestTraceparent = "inngest.traceparent",
+  InngestTraceRef = "inngest.traceref",
   InngestRunId = "sdk.run.id",
   InngestAppId1 = "sdk.app.id",
   InngestAppId2 = "sys.app.id",

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -45,6 +45,7 @@ export type ParentState = {
   runId: string;
   appId: string | undefined;
   functionId: string | undefined;
+  traceRef: string | undefined;
 };
 
 /**
@@ -166,6 +167,7 @@ export class InngestSpanProcessor implements SpanProcessor {
     // them back in later versions.
     let appId: string | undefined;
     let functionId: string | undefined;
+    let traceRef: string | undefined;
 
     if (tracestate) {
       try {
@@ -175,6 +177,7 @@ export class InngestSpanProcessor implements SpanProcessor {
 
         appId = entries[TraceStateKey.AppId];
         functionId = entries[TraceStateKey.FunctionId];
+        traceRef = entries[TraceStateKey.TraceRef];
       } catch (err) {
         processorDebug(
           "failed to parse tracestate",
@@ -204,6 +207,7 @@ export class InngestSpanProcessor implements SpanProcessor {
         functionId,
         runId,
         traceparent,
+        traceRef,
       },
       span
     );
@@ -325,6 +329,10 @@ export class InngestSpanProcessor implements SpanProcessor {
     // Executor that we don't need to parrot this back.
     if (parentState.functionId) {
       span.setAttribute(Attribute.InngestFunctionId, parentState.functionId);
+    }
+
+    if (parentState.traceRef) {
+      span.setAttribute(Attribute.InngestTraceRef, parentState.traceRef);
     }
   }
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Sets an `"inngest.traceref"` attribute to otel spans if one has been passed to the request. The SDK side for ...

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Internal
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
