### PR TITLE
feat(models): add GPT-5 model variants to OpenAi type

### DIFF
--- a/packages/ai/src/models/openai.ts
+++ b/packages/ai/src/models/openai.ts
@@ -42,6 +42,9 @@ export namespace OpenAi {
    */
   export type Model =
     | (string & {})
+    | "gpt-5"
+    | "gpt-5-mini"
+    | "gpt-5-nano"
     | "gpt-4.1-mini"
     | "gpt-4.1"
     | "gpt-4.5-preview"


### PR DESCRIPTION
Added "gpt-5", "gpt-5-mini", and "gpt-5-nano" to the Model type definition in packages/ai/src/models/openai.ts.

This update ensures that developers can use the latest GPT-5 model family with full type safety in Inngest AI integrations.

## Summary

Added new GPT-5 model variants to the `OpenAi` type definition inside `packages/ai/src/models/openai.ts`.  
This ensures that the `Model` type now supports `"gpt-5"`, `"gpt-5-mini"`, and `"gpt-5-nano"` alongside the existing GPT-4 series.  
The change improves type safety for developers using the latest GPT-5 models in Inngest AI integrations.

## Checklist

- ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A – This change is only an internal type definition update, no docs affected.  
- [ ] Added unit/integration tests – **(Pending)** Need to confirm if type additions require specific test cases or integration validation.  
- ~~Added changesets if applicable~~ N/A – No runtime changes, only a type definition update.  

## Related

- INN-#1047 
- Related to OpenAI’s GPT-5 model release and ensuring Inngest supports the new variants.
