### PR TITLE
SYS-285: Add support for conditional batching

### DIFF
--- a/.changeset/slimy-moons-know.md
+++ b/.changeset/slimy-moons-know.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Introduces support for the `if` expression on the batchEvents configuration. This can be used to determine which events are eligible for batching. For more details, check out the [batching documentation](https://innge.st/batching)!

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -407,6 +407,14 @@ export namespace InngestFunction {
        * information on how to use `key` expressions.
        */
       key?: string;
+
+      /**
+       * An optional boolean expression to determine an event's eligibility for batching
+       *
+       * See [batch documentation](https://innge.st/batching) for more
+       * information on how to use `if` expressions.
+       */
+      if?: string;
     };
 
     /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1192,6 +1192,7 @@ export const functionConfigSchema = z.strictObject({
       maxSize: z.number(),
       timeout: z.string(),
       key: z.string().optional(),
+      if: z.string().optional(),
     })
     .optional(),
   rateLimit: z


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add `if` support in the batch config. This conditional boolean expression, when provided, would determine which events get batched together for execution.

If the expression fails to evaluate or if it evaluates to false, the event will be treated ineligible for batching and will be scheduled for execution immediately.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related
- SYS-283
- OSS feature PR: https://github.com/inngest/inngest/pull/2818
- TODO: website PR
