### PR TITLE
include data keys to sentry for querying

### DIFF
--- a/packages/middleware-sentry/src/middleware.ts
+++ b/packages/middleware-sentry/src/middleware.ts
@@ -22,6 +22,14 @@ export interface SentryMiddlewareOptions {
    * @default false
    */
   disableAutomaticFlush?: boolean;
+
+  /**
+   * If `true`, the Sentry middleware will include the event.data.* keys as tags
+   * in Sentry.
+   *
+   * @default false
+   */
+  includeDataAsTags?: boolean;
 }
 
 /**
@@ -81,6 +89,17 @@ export const sentryMiddleware = (
               "inngest.event.name": ctx.event.name,
               "inngest.run.id": ctx.runId,
             };
+
+            if (opts?.includeDataAsTags && ctx.event?.data) {
+              Object.entries(ctx.event.data).forEach(([key, value]) => {
+                if (value !== null && value !== undefined) {
+                  sharedTags[`inngest.data.${key}`] =
+                    typeof value === "object"
+                      ? JSON.stringify(value)
+                      : String(value);
+                }
+              });
+            }
 
             scope.setTags(sharedTags);
 


### PR DESCRIPTION
## Summary
This PR introduces a new optional configuration option, `includeDataAsTags`, to the Sentry middleware. When enabled, this feature allows event data keys to be included as Sentry tags, enhancing queryability and observability.  

### Changes
- Added `includeDataAsTags?: boolean` option to the `SentryMiddlewareOptions` interface.  
- When enabled, the middleware extracts all keys from `ctx.event.data` and adds them as Sentry tags with the prefix `inngest.data`.  
- Object values are JSON-stringified; primitive values are converted to strings.  
- Null and undefined values are filtered out to avoid unnecessary tag clutter.  

### Motivation
This enhancement improves debugging and monitoring workflows for Inngest functions. By making event data searchable through Sentry tags, developers can leverage more powerful filtering and querying, resulting in better insights and faster issue resolution.  
