### PR TITLE
Fix: Bun Create command not working as expected

### DIFF
--- a/examples/framework-elysiajs/README.md
+++ b/examples/framework-elysiajs/README.md
@@ -2,13 +2,7 @@
 
 ## Getting Started
 
-To get started with this template, simply paste this command into your terminal:
-
-```bash
-bun create github.com/inngest/inngest-js/tree/main/examples/framework-elysiajs inngest-elysiajs
-```
-
-Then run
+To install dependencies:
 
 ```bash
 bun install


### PR DESCRIPTION
## Summary
`bun create` only looks at the the repo name and no deeper into the github url used when creating a new project from a repository name. For now until the Bun team gets back to me want to have a placeholder there for just installing dependencies and will update when they get back to me.

- [X] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [X] ~~Added unit/integration tests~~
- [X] ~~Added changesets if applicable~~

