### PR TITLE
Updates to Bun Example and Elysia Example

### DIFF
--- a/examples/bun/README.md
+++ b/examples/bun/README.md
@@ -1,15 +1,27 @@
 # runtime-bun
 
+## Getting Started
+
 To install dependencies:
 
 ```bash
 bun install
 ```
 
-To run:
+## Development
+
+### Inngest dev server
+
+To start the inngest dev server run `npx inngest-cli@latest dev`.
+
+This will start your inngest dev server at `localhost:8288`
+
+### Developement server
+
+To start the development server run:
 
 ```bash
-bun run index.ts
+bun dev
 ```
 
-This project was created using `bun init` in bun v1.0.25. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+If you visit `localhost:3000`, the demo event will send and you can check the function run in the inngest dev server at `localhost:8288`

--- a/examples/bun/index.ts
+++ b/examples/bun/index.ts
@@ -1,16 +1,21 @@
-import { serve } from "inngest/edge";
+import { serve } from "inngest/bun";
 import { functions, inngest } from "./inngest";
 
 const server = Bun.serve({
   port: 3000,
-  fetch(request: Request) {
-    const url = new URL(request.url);
-
-    if (url.pathname === "/api/inngest") {
+  routes: {
+    "/": async _ => {
+      await inngest.send({
+        name: "demo/event.sent",
+        data: {
+          message: "Message from Bun Server",
+        },
+      });
+      return new Response("Hello world!");
+    },
+    "/api/inngest": (request: Request) => {
       return serve({ client: inngest, functions })(request);
-    }
-
-    return new Response("Server");
+    },
   },
 });
 

--- a/examples/framework-elysiajs/README.md
+++ b/examples/framework-elysiajs/README.md
@@ -10,9 +10,9 @@ bun install
 
 ## Development
 
-### Bun setup for inngest dev server
+### Inngest dev server
 
-Now you can run either `bun run inngest:dev` or `npx inngest-cli@latest`.
+To start the inngest dev server run `npx inngest-cli@latest dev`.
 
 This will start your inngest dev server at `localhost:8288`
 

--- a/examples/framework-elysiajs/package.json
+++ b/examples/framework-elysiajs/package.json
@@ -2,19 +2,14 @@
   "name": "inngest-elysiajs",
   "version": "1.0.50",
   "scripts": {
-    "dev": "bun run --watch src/index.ts",
-    "inngest:dev": "inngest-cli dev"
+    "dev": "bun run --watch src/index.ts"
   },
   "dependencies": {
     "elysia": "latest",
     "inngest": "^3.40.2"
   },
   "devDependencies": {
-    "bun-types": "latest",
-    "inngest-cli": "^1.11.10"
+    "bun-types": "latest"
   },
-  "module": "src/index.js",
-  "trustedDependencies": [
-    "inngest-cli"
-  ]
+  "module": "src/index.js"
 }

--- a/examples/framework-elysiajs/src/index.ts
+++ b/examples/framework-elysiajs/src/index.ts
@@ -13,7 +13,7 @@ const inngestHandler = new Elysia().all("/api/inngest", ({ request }) =>
 
 const app = new Elysia()
   .use(inngestHandler)
-  .get("/", async function ({ status }) {
+  .get("/", async function () {
     await inngest.send({
       name: "test/hello.world",
       data: {


### PR DESCRIPTION
## Summary
Updated Bun example to give recommended setup. Also updated Elysia example to not include the inngest-cli package and instead have users run `npx inngest-cli@latest dev`. It is the path of least resistance and we can update it once bun fixes the npm compatibility issues.

## Checklist
- [x] Added a [docs PR](https://github.com/inngest/website/pull/1259) that references this PR
- [x] ~~Added unit/integration tests~~
- [x] ~~Added changesets if applicable~~
