### PR TITLE
Fix bug - allow base url override when subscribing

### DIFF
--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -43,10 +43,10 @@ export class TokenSubscription {
     this.#signingKey = signingKey;
     this.#signingKeyFallback = signingKeyFallback;
 
-    if (this.#apiBaseUrl === undefined) {
-        this.#apiBaseURL =
-      getEnvVar("INNGEST_BASE_URL") ||
-      getEnvVar("INNGEST_API_BASE_URL");
+    if (!this.#apiBaseUrl) {
+      this.#apiBaseURL =
+        getEnvVar("INNGEST_BASE_URL") ||
+        getEnvVar("INNGEST_API_BASE_URL");
     }
 
     if (typeof token.channel === "string") {

--- a/packages/realtime/src/subscribe/TokenSubscription.ts
+++ b/packages/realtime/src/subscribe/TokenSubscription.ts
@@ -43,6 +43,12 @@ export class TokenSubscription {
     this.#signingKey = signingKey;
     this.#signingKeyFallback = signingKeyFallback;
 
+    if (this.#apiBaseUrl === undefined) {
+        this.#apiBaseURL =
+      getEnvVar("INNGEST_BASE_URL") ||
+      getEnvVar("INNGEST_API_BASE_URL");
+    }
+
     if (typeof token.channel === "string") {
       this.#channelId = token.channel;
 


### PR DESCRIPTION
We don't use env vars when subscribing to the URL but should.
- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
