### PR TITLE
Fix benchmarks failing to resolve files

### DIFF
--- a/packages/inngest/test/benchmark/util.ts
+++ b/packages/inngest/test/benchmark/util.ts
@@ -20,7 +20,11 @@ class BenchmarkRefs {
 export const loadBenchmarks = async (
   benchmarkNames: string[],
 ): Promise<BenchmarkRefs> => {
-  const caller = getCallerDir();
+  let caller = getCallerDir();
+  if (caller.startsWith("file://")) {
+    caller = caller.replace("file://", "");
+  }
+
   const rawBenchmarkPromises: Promise<BenchmarkRef | BenchmarkRef[]>[] = [];
 
   for (const benchmark of benchmarkNames) {


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes `pnpm run bench` in `inngest` in Node 24 failing to resolve the benchmarks to load.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A KTLO
- [x] Added changesets if applicable
