### PR TITLE
fix(agent-kit): exporting serializeError for use in agentkit

### DIFF
--- a/.changeset/tricky-frogs-crash.md
+++ b/.changeset/tricky-frogs-crash.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+exporting serializeError for use in agentkit

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -79,6 +79,7 @@ export {
   isInngestMiddleware,
 } from "./helpers/assertions.ts";
 export { headerKeys, internalEvents, queryKeys } from "./helpers/consts.ts";
+export { serializeError } from "./helpers/errors.ts";
 export { slugify } from "./helpers/strings.ts";
 export type {
   IsStringLiteral,


### PR DESCRIPTION
If you try to install inngest version 3.42 or above, you'll see this error when trying to build AgentKit:
`Module '"inngest"' has no exported member 'serializeError'.`

This change exports `serializeError` from the inngest package so we are able to use it within AgentKit again. 

Additional changes in agentkit are needed to ensure compatibility with the latest version of inngest.

Once this is merged, we can merge [#230](https://github.com/inngest/agent-kit/pull/230) in AgentKit for additional changes needed to ensure compatibility with the latest version of inngest. 

## Related
[AgentKit #228](https://github.com/inngest/agent-kit/issues/228)
[AgentKit #218](https://github.com/inngest/agent-kit/issues/218)