### PR TITLE
Add Standard Schema to `referenceFunction()`

### DIFF
--- a/.changeset/fair-elephants-beg.md
+++ b/.changeset/fair-elephants-beg.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `InngestFunctionReference.Like` for comparing referenced functions across versions

--- a/.changeset/polite-dots-fly.md
+++ b/.changeset/polite-dots-fly.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add Standard Schema to `referenceFunction()`

--- a/packages/inngest/src/components/EventSchemas.test.ts
+++ b/packages/inngest/src/components/EventSchemas.test.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { z as z_v3 } from "zod/v3";
 import type { internalEvents } from "../helpers/consts.ts";
 import type { IsAny, IsEqual } from "../helpers/types.ts";
-import { assertType } from "../test/helpers.ts";
 import type { FailureEventPayload } from "../types.ts";
 import { EventSchemas } from "./EventSchemas.ts";
 import { type GetEvents, Inngest } from "./Inngest.ts";

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -19,7 +19,7 @@ import {
   referenceFunction,
 } from "../index.ts";
 import type { Logger } from "../middleware/logger.ts";
-import { assertType, createClient, nodeVersion } from "../test/helpers.ts";
+import { createClient, nodeVersion } from "../test/helpers.ts";
 import type { SendEventResponse } from "../types.ts";
 import type { createStepTools } from "./InngestStepTools.ts";
 

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -30,7 +30,7 @@ import {
   NonRetriableError,
 } from "../index.ts";
 import { type Logger, ProxyLogger } from "../middleware/logger.ts";
-import { assertType, createClient, runFnWithStack } from "../test/helpers.ts";
+import { createClient, runFnWithStack } from "../test/helpers.ts";
 import {
   type ClientOptions,
   type FailureEventPayload,

--- a/packages/inngest/src/components/InngestFunctionReference.test.ts
+++ b/packages/inngest/src/components/InngestFunctionReference.test.ts
@@ -1,0 +1,609 @@
+import { z } from "zod";
+import type { IsAny, IsEqual } from "../helpers/types.ts";
+import type { MinimalEventPayload } from "../types";
+import { EventSchemas } from "./EventSchemas";
+import { Inngest } from "./Inngest.ts";
+import {
+  InngestFunctionReference,
+  referenceFunction,
+} from "./InngestFunctionReference.ts";
+
+describe("referenceFunction", () => {
+  describe("basic functionality", () => {
+    test("creates a function reference with just functionId", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+      expect(fnRef.opts.functionId).toBe("test-function");
+      expect(fnRef.opts.appId).toBeUndefined();
+
+      // Type assertions
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+      assertType<IsEqual<ActualInput, MinimalEventPayload>>(true);
+      assertType<IsEqual<ActualOutput, unknown>>(true);
+    });
+
+    test("creates a function reference with functionId and appId", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        appId: "test-app",
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+      expect(fnRef.opts.functionId).toBe("test-function");
+      expect(fnRef.opts.appId).toBe("test-app");
+
+      // Type assertions - should still default to MinimalEventPayload/unknown without schemas
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+      assertType<IsEqual<ActualInput, MinimalEventPayload>>(true);
+      assertType<IsEqual<ActualOutput, unknown>>(true);
+    });
+
+    test("creates a function reference with schemas", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        schemas: {
+          data: z.object({ value: z.number() }),
+          return: z.object({ result: z.string() }),
+        },
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+      expect(fnRef.opts.functionId).toBe("test-function");
+      expect(fnRef.opts.appId).toBeUndefined();
+
+      // Type assertions - should infer types from schemas
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // Input should have data field with the schema type
+      type InputData = ActualInput["data"];
+      assertType<IsAny<InputData>>(false);
+      assertType<IsEqual<InputData, { value: number }>>(true);
+
+      // Output should match return schema
+      assertType<IsEqual<ActualOutput, { result: string }>>(true);
+    });
+
+    test("creates a function reference with all parameters", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        appId: "test-app",
+        schemas: {
+          data: z.object({ value: z.number() }),
+          return: z.object({ result: z.string() }),
+        },
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+      expect(fnRef.opts.functionId).toBe("test-function");
+      expect(fnRef.opts.appId).toBe("test-app");
+
+      // Type assertions - schemas should work regardless of appId
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // Input should have data field with the schema type
+      type InputData = ActualInput["data"];
+      assertType<IsAny<InputData>>(false);
+      assertType<IsEqual<InputData, { value: number }>>(true);
+
+      // Output should match return schema
+      assertType<IsEqual<ActualOutput, { result: string }>>(true);
+    });
+  });
+
+  describe("type inference", () => {
+    test("infers unknown types when no schemas are provided", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+      });
+
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      // Check that types are not any
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // Without schemas, input should be MinimalEventPayload
+      assertType<IsEqual<ActualInput, MinimalEventPayload>>(true);
+      // Without schemas, output should be unknown
+      assertType<IsEqual<ActualOutput, unknown>>(true);
+    });
+
+    test("infers correct types from Zod schemas", () => {
+      const dataSchema = z.object({ value: z.number() });
+      const returnSchema = z.object({ result: z.string() });
+
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        schemas: {
+          data: dataSchema,
+          return: returnSchema,
+        },
+      });
+
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      // Check that types are not any
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // Input should include the required data field with the correct schema
+      type InputData = ActualInput["data"];
+      assertType<IsAny<InputData>>(false);
+      assertType<IsEqual<InputData, { value: number }>>(true);
+
+      // Output should match the return schema
+      assertType<IsEqual<ActualOutput, { result: string }>>(true);
+    });
+
+    test("infers types from an InngestFunction passed as generic", () => {
+      const inngest = new Inngest({
+        id: "test",
+        schemas: new EventSchemas().fromSchema({
+          "test/event": z.object({ someValue: z.string() }),
+        }),
+      });
+
+      // Create a test function to reference
+      const testFunction = inngest.createFunction(
+        { id: "test-function" },
+        { event: "test/event" },
+        async ({ event }) => {
+          return { success: true, value: event.data.someValue };
+        },
+      );
+
+      // Reference the function by passing it as a generic
+      const fnRef = referenceFunction<typeof testFunction>({
+        functionId: "test-function",
+      });
+
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      // Check that types are not any
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // The types should be properly inferred from the function
+      // Input should have the event structure
+      assertType<IsEqual<ActualInput["data"], { someValue: string }>>(true);
+
+      // Output should match the function's return type
+      type ExpectedOutput = { success: boolean; value: string };
+      assertType<IsEqual<ActualOutput, ExpectedOutput>>(true);
+    });
+
+    test("handles optional data schema correctly", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        schemas: {
+          return: z.object({ result: z.string() }),
+        },
+      });
+
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      // Check that output type is not any
+      assertType<IsAny<ActualOutput>>(false);
+      assertType<IsEqual<ActualOutput, { result: string }>>(true);
+    });
+
+    test("handles optional return schema correctly", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        schemas: {
+          data: z.object({ value: z.number() }),
+        },
+      });
+
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      // Check that types are not any
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // Input data should match the schema
+      type InputData = ActualInput["data"];
+      assertType<IsAny<InputData>>(false);
+      assertType<IsEqual<InputData, { value: number }>>(true);
+
+      // Output should be unknown when not provided
+      assertType<IsEqual<ActualOutput, unknown>>(true);
+    });
+  });
+
+  describe("cross-app references", () => {
+    test("creates reference for same-app function without appId", () => {
+      const fnRef = referenceFunction({
+        functionId: "local-function",
+      });
+
+      expect(fnRef.opts.appId).toBeUndefined();
+      // When appId is not provided, it should be treated as a local function
+
+      // Type assertions - appId doesn't affect type inference
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsEqual<ActualInput, MinimalEventPayload>>(true);
+    });
+
+    test("creates reference for cross-app function with appId", () => {
+      const fnRef = referenceFunction({
+        functionId: "remote-function",
+        appId: "another-app",
+      });
+
+      expect(fnRef.opts.appId).toBe("another-app");
+      // When appId is provided, it should be treated as a cross-app reference
+
+      // Type assertions - cross-app references still default to MinimalEventPayload/unknown
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+      assertType<IsEqual<ActualInput, MinimalEventPayload>>(true);
+      assertType<IsEqual<ActualOutput, unknown>>(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles empty string functionId", () => {
+      const fnRef = referenceFunction({
+        functionId: "",
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+      expect(fnRef.opts.functionId).toBe("");
+    });
+
+    test("handles empty string appId", () => {
+      const fnRef = referenceFunction({
+        functionId: "test-function",
+        appId: "",
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+      expect(fnRef.opts.appId).toBe("");
+    });
+
+    test("handles complex Zod schemas", () => {
+      const complexDataSchema = z.object({
+        nested: z.object({
+          value: z.number(),
+          array: z.array(z.string()),
+        }),
+        optional: z.string().optional(),
+        union: z.union([z.literal("a"), z.literal("b")]),
+      });
+
+      const complexReturnSchema = z.discriminatedUnion("type", [
+        z.object({ type: z.literal("success"), data: z.any() }),
+        z.object({ type: z.literal("error"), message: z.string() }),
+      ]);
+
+      const fnRef = referenceFunction({
+        functionId: "complex-function",
+        schemas: {
+          data: complexDataSchema,
+          return: complexReturnSchema,
+        },
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+
+      // Type assertions - complex schemas should be correctly resolved
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+      type ActualOutput = typeof fnRef extends InngestFunctionReference<
+        infer _,
+        infer TOutput
+      >
+        ? TOutput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+      assertType<IsAny<ActualOutput>>(false);
+
+      // Input data should match complex schema
+      type InputData = ActualInput["data"];
+      assertType<IsAny<InputData>>(false);
+      type ExpectedInputData = {
+        nested: {
+          value: number;
+          array: string[];
+        };
+        optional?: string;
+        union: "a" | "b";
+      };
+      assertType<IsEqual<InputData, ExpectedInputData>>(true);
+
+      // Output should be a discriminated union
+      type ExpectedOutput =
+        // biome-ignore lint/suspicious/noExplicitAny: z.any() returns any type
+        { type: "success"; data: any } | { type: "error"; message: string };
+      assertType<IsEqual<ActualOutput, ExpectedOutput>>(true);
+    });
+
+    test("handles schemas with transforms", () => {
+      const transformSchema = z.object({
+        date: z.string().transform((val) => new Date(val)),
+        number: z.string().transform((val) => parseInt(val, 10)),
+      });
+
+      const fnRef = referenceFunction({
+        functionId: "transform-function",
+        schemas: {
+          data: transformSchema,
+        },
+      });
+
+      expect(fnRef).toBeInstanceOf(InngestFunctionReference);
+
+      // Type assertions - transforms should resolve to output types
+      type ActualInput = typeof fnRef extends InngestFunctionReference<
+        infer TInput,
+        infer _
+      >
+        ? TInput
+        : never;
+
+      assertType<IsAny<ActualInput>>(false);
+
+      // Input data should have the transformed types
+      type InputData = ActualInput["data"];
+      assertType<IsAny<InputData>>(false);
+      type ExpectedInputData = {
+        date: Date;
+        number: number;
+      };
+      assertType<IsEqual<InputData, ExpectedInputData>>(true);
+    });
+  });
+
+  describe("namespace types", () => {
+    test("InngestFunctionReference.Any matches any reference", () => {
+      const fnRef1 = referenceFunction({
+        functionId: "test1",
+      });
+
+      const fnRef2 = referenceFunction({
+        functionId: "test2",
+        schemas: {
+          data: z.object({ value: z.number() }),
+        },
+      });
+
+      // Both should be assignable to InngestFunctionReference.Any
+      const any1: InngestFunctionReference.Any = fnRef1;
+      const any2: InngestFunctionReference.Any = fnRef2;
+
+      expect(any1).toBeInstanceOf(InngestFunctionReference);
+      expect(any2).toBeInstanceOf(InngestFunctionReference);
+
+      // Type assertion - verify that Any type accepts different reference types
+      type IsAssignable1 = typeof fnRef1 extends InngestFunctionReference.Any
+        ? true
+        : false;
+      type IsAssignable2 = typeof fnRef2 extends InngestFunctionReference.Any
+        ? true
+        : false;
+
+      assertType<IsAssignable1>(true);
+      assertType<IsAssignable2>(true);
+    });
+
+    test("HelperArgs type structure", () => {
+      // Test that the type accepts the expected shape
+      type TestArgs = InngestFunctionReference.HelperArgs<
+        z.ZodType<{ value: number }>,
+        z.ZodType<{ result: string }>
+      >;
+
+      const args: TestArgs = {
+        functionId: "test",
+        appId: "app",
+        schemas: {
+          data: z.object({ value: z.number() }),
+          return: z.object({ result: z.string() }),
+        },
+      };
+
+      expect(args.functionId).toBe("test");
+    });
+
+    test("InngestFunctionReference.Like type for duck typing", () => {
+      // The Like interface uses Symbol.toStringTag for structural typing
+      // This allows checking if something "looks like" a function reference
+
+      // Create actual function references
+      const basicRef = referenceFunction({
+        functionId: "basic-function",
+      });
+
+      const typedRef = referenceFunction({
+        functionId: "typed-function",
+        schemas: {
+          data: z.object({ value: z.number() }),
+          return: z.object({ result: z.string() }),
+        },
+      });
+
+      // Create a mock object that satisfies the Like interface
+      const mockLikeRef: InngestFunctionReference.Like = {
+        [Symbol.toStringTag]: InngestFunctionReference.Tag,
+      };
+
+      // Test that actual references DO extend Like
+      // (now that the class has the Symbol.toStringTag getter)
+      type BasicExtendsLike = typeof basicRef extends InngestFunctionReference.Like
+        ? true
+        : false;
+      type TypedExtendsLike = typeof typedRef extends InngestFunctionReference.Like
+        ? true
+        : false;
+
+      // These should be true because InngestFunctionReference class
+      // now has Symbol.toStringTag property via getter
+      assertType<BasicExtendsLike>(true);
+      assertType<TypedExtendsLike>(true);
+
+      // Test that the mock object satisfies Like
+      type MockSatisfiesLike = typeof mockLikeRef extends InngestFunctionReference.Like
+        ? true
+        : false;
+      assertType<MockSatisfiesLike>(true);
+
+      // Test that Like can be used as a type guard pattern
+      function acceptsLike(ref: InngestFunctionReference.Like) {
+        return ref[Symbol.toStringTag];
+      }
+
+      // This should work with the mock
+      expect(acceptsLike(mockLikeRef)).toBe("Inngest.FunctionReference");
+
+      // This should also work with actual references now
+      expect(acceptsLike(basicRef)).toBe("Inngest.FunctionReference");
+      expect(acceptsLike(typedRef)).toBe("Inngest.FunctionReference");
+
+      // Runtime checks for actual references
+      expect(basicRef).toBeInstanceOf(InngestFunctionReference);
+      expect(typedRef).toBeInstanceOf(InngestFunctionReference);
+
+      // Verify Symbol.toStringTag is properly set
+      expect(basicRef[Symbol.toStringTag]).toBe("Inngest.FunctionReference");
+      expect(typedRef[Symbol.toStringTag]).toBe("Inngest.FunctionReference");
+    });
+  });
+});

--- a/packages/inngest/src/components/InngestFunctionReference.test.ts
+++ b/packages/inngest/src/components/InngestFunctionReference.test.ts
@@ -567,12 +567,10 @@ describe("referenceFunction", () => {
 
       // Test that actual references DO extend Like
       // (now that the class has the Symbol.toStringTag getter)
-      type BasicExtendsLike = typeof basicRef extends InngestFunctionReference.Like
-        ? true
-        : false;
-      type TypedExtendsLike = typeof typedRef extends InngestFunctionReference.Like
-        ? true
-        : false;
+      type BasicExtendsLike =
+        typeof basicRef extends InngestFunctionReference.Like ? true : false;
+      type TypedExtendsLike =
+        typeof typedRef extends InngestFunctionReference.Like ? true : false;
 
       // These should be true because InngestFunctionReference class
       // now has Symbol.toStringTag property via getter
@@ -580,9 +578,8 @@ describe("referenceFunction", () => {
       assertType<TypedExtendsLike>(true);
 
       // Test that the mock object satisfies Like
-      type MockSatisfiesLike = typeof mockLikeRef extends InngestFunctionReference.Like
-        ? true
-        : false;
+      type MockSatisfiesLike =
+        typeof mockLikeRef extends InngestFunctionReference.Like ? true : false;
       assertType<MockSatisfiesLike>(true);
 
       // Test that Like can be used as a type guard pattern

--- a/packages/inngest/src/components/InngestFunctionReference.ts
+++ b/packages/inngest/src/components/InngestFunctionReference.ts
@@ -35,6 +35,10 @@ export class InngestFunctionReference<
    */
   _TOutput,
 > {
+  get [Symbol.toStringTag](): typeof InngestFunctionReference.Tag {
+    return InngestFunctionReference.Tag;
+  }
+
   constructor(public readonly opts: { functionId: string; appId?: string }) {}
 }
 
@@ -78,6 +82,8 @@ export const referenceFunction = <
  * @public
  */
 export namespace InngestFunctionReference {
+  export const Tag = "Inngest.FunctionReference" as const;
+
   /**
    * Represents any `InngestFunctionReference`.
    *
@@ -88,6 +94,10 @@ export namespace InngestFunctionReference {
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     any
   >;
+
+  export interface Like {
+    readonly [Symbol.toStringTag]: typeof InngestFunctionReference.Tag;
+  }
 
   /**
    * Arguments used by {@link referenceFunction} to create a reference to an

--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -1,11 +1,6 @@
 import { ExecutionVersion } from "../helpers/consts.ts";
 import type { IsEqual, IsUnknown } from "../helpers/types.ts";
-import {
-  assertType,
-  createClient,
-  runFnWithStack,
-  testClientId,
-} from "../test/helpers.ts";
+import { createClient, runFnWithStack, testClientId } from "../test/helpers.ts";
 import { StepOpCode } from "../types.ts";
 import { Inngest } from "./Inngest.ts";
 import { referenceFunction } from "./InngestFunctionReference.ts";

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -4,7 +4,6 @@ import { Temporal } from "temporal-polyfill";
 import { z } from "zod/v3";
 import type { IsEqual } from "../helpers/types.ts";
 import {
-  assertType,
   createClient,
   getStepTools,
   type StepTools,

--- a/packages/inngest/src/helpers/jsonify.test.ts
+++ b/packages/inngest/src/helpers/jsonify.test.ts
@@ -1,5 +1,4 @@
 import type { IsAny, IsEqual, IsUnknown } from "../helpers/types.ts";
-import { assertType } from "../test/helpers.ts";
 import type { Jsonify } from "./jsonify.ts";
 
 describe("Jsonify", () => {

--- a/packages/inngest/src/helpers/promises.test.ts
+++ b/packages/inngest/src/helpers/promises.test.ts
@@ -1,4 +1,3 @@
-import { assertType } from "../test/helpers.ts";
 import { runAsPromise } from "./promises.ts";
 
 describe("runAsPromise", () => {

--- a/packages/inngest/src/helpers/types.test.ts
+++ b/packages/inngest/src/helpers/types.test.ts
@@ -1,4 +1,3 @@
-import { assertType } from "../test/helpers.ts";
 import type { IsEqual, RecursiveTuple } from "./types.ts";
 
 describe("RecursiveTuple", () => {

--- a/packages/inngest/src/helpers/validators/index.ts
+++ b/packages/inngest/src/helpers/validators/index.ts
@@ -1,5 +1,5 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { IsUnknown } from "../types.ts";
-import type * as z from "./zod";
 
 /**
  * Given an input value, infer the output type.
@@ -16,8 +16,8 @@ export type ResolveSchema<
   TUnknownFallback = TFallback,
 > = IsUnknown<TInput> extends true
   ? TUnknownFallback
-  : TInput extends z.ZodTypeAny
-    ? z.ZodInfer<TInput>
+  : TInput extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<TInput>
     : TFallback;
 
 /**
@@ -25,11 +25,11 @@ export type ResolveSchema<
  *
  * @public
  */
-export type ValidSchemaInput = z.ValidZodValue;
+export type ValidSchemaInput = StandardSchemaV1;
 
 /**
  * A valid output schema.
  *
  * @public
  */
-export type ValidSchemaOutput = z.ZodTypeAny;
+export type ValidSchemaOutput = StandardSchemaV1;

--- a/packages/inngest/src/middleware/dependencyInjection.test.ts
+++ b/packages/inngest/src/middleware/dependencyInjection.test.ts
@@ -1,5 +1,4 @@
 import { Inngest } from "../components/Inngest.ts";
-import { assertType } from "../test/helpers.ts";
 import { dependencyInjectionMiddleware } from "./dependencyInjection.ts";
 
 describe("Mutates ctx", () => {

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -1795,12 +1795,6 @@ export const checkIntrospection = ({ name, triggers }: CheckIntrospection) => {
 };
 
 /**
- * assert the subject satisfies the specified type T
- * @type T the type to check against.
- */
-export function assertType<T>(subject: T): asserts subject is T {}
-
-/**
  * Get the current Node.js version.
  */
 export const nodeVersion = process.version

--- a/packages/inngest/vitest.config.ts
+++ b/packages/inngest/vitest.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
     hideSkippedTests: true,
     typecheck: {
       tsconfig: "./tsconfig.types.json",
+      enabled: true,
+      include: ["**\/*.{test,spec}.?(c|m)[jt]s?(x)"],
     },
   },
 });


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds support of Standard Schema to `referenceFunction()`.

Also a few bundled changes as they touched the same area:

- Adds a touch more type checking to tests
- Adds `InngestFunctionReference.Like`

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- Addresses https://github.com/inngest/inngest-js/issues/1076#issuecomment-3342218821
- Documented in inngest/website#1285
