### PR TITLE
Fix `.fromSchema()` runtime schema being mismatched

### DIFF
--- a/.changeset/early-pianos-cry.md
+++ b/.changeset/early-pianos-cry.md
@@ -1,5 +1,6 @@
 ---
 "inngest": patch
+"@inngest/middleware-validation": patch
 ---
 
 Fix `.fromSchema()`-defined schemas not being compatible with `@inngest/middleware-validation`

--- a/.changeset/early-pianos-cry.md
+++ b/.changeset/early-pianos-cry.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `.fromSchema()`-defined schemas not being compatible with `@inngest/middleware-validation`

--- a/packages/inngest/src/components/EventSchemas.ts
+++ b/packages/inngest/src/components/EventSchemas.ts
@@ -445,7 +445,12 @@ export class EventSchemas<
   ): EventSchemas<Combine<S, StandardToNormalizedSchema<T>>> {
     this.addRuntimeSchemas(
       Object.entries(schemas).reduce((acc, [name, schema]) => {
-        return { ...acc, [name]: schema };
+        return {
+          ...acc,
+          [name]: {
+            data: schema,
+          },
+        };
       }, {}),
     );
 

--- a/packages/middleware-validation/package.json
+++ b/packages/middleware-validation/package.json
@@ -41,8 +41,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "inngest": "^3.42.3",
-    "zod": "^4.1.11"
+    "zod": "^3.25.76"
+  },
+  "peerDependencies": {
+    "inngest": "^3.42.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",

--- a/packages/middleware-validation/package.json
+++ b/packages/middleware-validation/package.json
@@ -44,7 +44,7 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "inngest": "^3.42.3"
+    "inngest": "*"
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",

--- a/packages/middleware-validation/package.json
+++ b/packages/middleware-validation/package.json
@@ -40,8 +40,9 @@
   "author": "Inngest Inc. <hello@inngest.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
     "inngest": "^3.42.3",
-    "zod": "3.25.76"
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",

--- a/packages/middleware-validation/package.json
+++ b/packages/middleware-validation/package.json
@@ -44,7 +44,7 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "inngest": "*"
+    "inngest": "^3.42.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",

--- a/packages/middleware-validation/src/middleware.test.ts
+++ b/packages/middleware-validation/src/middleware.test.ts
@@ -58,7 +58,7 @@ describe("validationMiddleware", () => {
     expect(result).toEqual("success");
   });
 
-  test("should validate a correct event with a Zod schema", async () => {
+  test("should validate a correct event with a Zod schema (fromZod)", async () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromZod({
@@ -86,7 +86,33 @@ describe("validationMiddleware", () => {
     expect(result).toEqual("success");
   });
 
-  test("should not allow an event through with an incorrect Zod schema", async () => {
+  test("should validate a correct event with a Zod schema (fromSchema)", async () => {
+    const inngest = new Inngest({
+      id: "test",
+      schemas: new EventSchemas().fromSchema({
+        test: z.object({
+          message: z.string(),
+        }),
+      }),
+      middleware: [validationMiddleware()],
+    });
+
+    const t = new InngestTestEngine({
+      function: inngest.createFunction(
+        { id: "test" },
+        { event: "test" },
+        () => "success",
+      ),
+      events: [{ name: "test", data: { message: "hello" } }],
+    });
+
+    const { result, error } = await t.execute();
+
+    expect(error).toBeUndefined();
+    expect(result).toEqual("success");
+  });
+
+  test("should not allow an event through with an incorrect Zod schema (fromZod)", async () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromZod({
@@ -114,8 +140,34 @@ describe("validationMiddleware", () => {
     expect(result).toBeUndefined();
   });
 
+  test("should not allow an event through with an incorrect Zod schema (fromSchema)", async () => {
+    const inngest = new Inngest({
+      id: "test",
+      schemas: new EventSchemas().fromSchema({
+        test: z.object({
+          message: z.string(),
+        }),
+      }),
+      middleware: [validationMiddleware()],
+    });
+
+    const t = new InngestTestEngine({
+      function: inngest.createFunction(
+        { id: "test" },
+        { event: "test" },
+        () => "success",
+      ),
+      events: [{ name: "test", data: { message: 123 } }],
+    });
+
+    const { result, error } = await t.execute();
+
+    expect(JSON.stringify(error)).toContain("failed validation");
+    expect(result).toBeUndefined();
+  });
+
   describe("inngest/function.invoked", () => {
-    test("should test against multiple schemas for `inngest/function.invoked`", async () => {
+    test("should test against multiple schemas for `inngest/function.invoked` (fromZod)", async () => {
       const inngest = new Inngest({
         id: "test",
         schemas: new EventSchemas().fromZod({
@@ -129,6 +181,35 @@ describe("validationMiddleware", () => {
               b: z.boolean(),
             }),
           },
+        }),
+        middleware: [validationMiddleware()],
+      });
+
+      const t = new InngestTestEngine({
+        function: inngest.createFunction(
+          { id: "test" },
+          { event: "b" },
+          () => "success",
+        ),
+        events: [{ name: "inngest/function.invoked", data: { b: true } }],
+      });
+
+      const { result, error } = await t.execute();
+
+      expect(error).toBeUndefined();
+      expect(result).toEqual("success");
+    });
+
+    test("should test against multiple schemas for `inngest/function.invoked` (fromSchema)", async () => {
+      const inngest = new Inngest({
+        id: "test",
+        schemas: new EventSchemas().fromSchema({
+          a: z.object({
+            a: z.boolean(),
+          }),
+          b: z.object({
+            b: z.boolean(),
+          }),
         }),
         middleware: [validationMiddleware()],
       });
@@ -199,7 +280,7 @@ describe("validationMiddleware", () => {
       expect(result).toBeUndefined();
     });
 
-    test("should succeed if an event has a schema", async () => {
+    test("should succeed if an event has a schema (fromZod)", async () => {
       const inngest = new Inngest({
         id: "test",
         schemas: new EventSchemas().fromZod({
@@ -227,7 +308,33 @@ describe("validationMiddleware", () => {
       expect(result).toEqual("success");
     });
 
-    test("should succeed if an `inngest/function.invoked` event has a schema", async () => {
+    test("should succeed if an event has a schema (fromSchema)", async () => {
+      const inngest = new Inngest({
+        id: "test",
+        schemas: new EventSchemas().fromSchema({
+          test: z.object({
+            message: z.string(),
+          }),
+        }),
+        middleware: [validationMiddleware({ disallowSchemalessEvents: true })],
+      });
+
+      const t = new InngestTestEngine({
+        function: inngest.createFunction(
+          { id: "test" },
+          { event: "test" },
+          () => "success",
+        ),
+        events: [{ name: "test", data: { message: "hello" } }],
+      });
+
+      const { result, error } = await t.execute();
+
+      expect(error).toBeUndefined();
+      expect(result).toEqual("success");
+    });
+
+    test("should succeed if an `inngest/function.invoked` event has a schema (fromZod)", async () => {
       const inngest = new Inngest({
         id: "test",
         schemas: new EventSchemas().fromZod({
@@ -256,9 +363,37 @@ describe("validationMiddleware", () => {
       expect(error).toBeUndefined();
       expect(result).toEqual("success");
     });
+
+    test("should succeed if an `inngest/function.invoked` event has a schema (fromSchema)", async () => {
+      const inngest = new Inngest({
+        id: "test",
+        schemas: new EventSchemas().fromSchema({
+          test: z.object({
+            message: z.string(),
+          }),
+        }),
+        middleware: [validationMiddleware({ disallowSchemalessEvents: true })],
+      });
+
+      const t = new InngestTestEngine({
+        function: inngest.createFunction(
+          { id: "test" },
+          { event: "test" },
+          () => "success",
+        ),
+        events: [
+          { name: "inngest/function.invoked", data: { message: "hello" } },
+        ],
+      });
+
+      const { result, error } = await t.execute();
+
+      expect(error).toBeUndefined();
+      expect(result).toEqual("success");
+    });
   });
 
-  test("handles a literal Zod schema", async () => {
+  test("handles a literal Zod schema (fromZod)", async () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromZod([
@@ -287,7 +422,7 @@ describe("validationMiddleware", () => {
     expect(result).toEqual("success");
   });
 
-  test("handles a nested Zod schema", async () => {
+  test("handles a nested Zod schema (fromZod)", async () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromZod({
@@ -317,7 +452,35 @@ describe("validationMiddleware", () => {
     expect(result).toEqual("success");
   });
 
-  test("validates all events in a batch", async () => {
+  test("handles a Zod schema (fromSchema)", async () => {
+    const inngest = new Inngest({
+      id: "test",
+      schemas: new EventSchemas().fromSchema({
+        test: z.object({
+          message: z.object({
+            content: z.string(),
+          }),
+        }),
+      }),
+      middleware: [validationMiddleware()],
+    });
+
+    const t = new InngestTestEngine({
+      function: inngest.createFunction(
+        { id: "test" },
+        { event: "test" },
+        () => "success",
+      ),
+      events: [{ name: "test", data: { message: { content: "hello" } } }],
+    });
+
+    const { result, error } = await t.execute();
+
+    expect(error).toBeUndefined();
+    expect(result).toEqual("success");
+  });
+
+  test("validates all events in a batch (fromZod)", async () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromZod({
@@ -348,13 +511,42 @@ describe("validationMiddleware", () => {
     expect(result).toBeUndefined();
   });
 
+  test("validates all events in a batch (fromSchema)", async () => {
+    const inngest = new Inngest({
+      id: "test",
+      schemas: new EventSchemas().fromSchema({
+        test: z.object({
+          message: z.string(),
+        }),
+      }),
+      middleware: [validationMiddleware()],
+    });
+
+    const t = new InngestTestEngine({
+      function: inngest.createFunction(
+        { id: "test" },
+        { event: "test" },
+        () => "success",
+      ),
+      events: [
+        { name: "test", data: { message: "hello" } },
+        { name: "test", data: { message: 123 } },
+      ],
+    });
+
+    const { result, error } = await t.execute();
+
+    expect(JSON.stringify(error)).toContain("failed validation");
+    expect(result).toBeUndefined();
+  });
+
   describe("onSendEvent", () => {
     describe("inngest.send()", () => {
       afterEach(() => {
         fetchMock.mockReset();
       });
 
-      test("should validate an event before sending it", async () => {
+      test("should validate an event before sending it (fromZod)", async () => {
         const inngest = new Inngest({
           id: "test",
           schemas: new EventSchemas().fromZod({
@@ -386,7 +578,37 @@ describe("validationMiddleware", () => {
         expect(result).toBeUndefined();
       });
 
-      test("should not validate an event before sending it if disabled", async () => {
+      test("should validate an event before sending it (fromSchema)", async () => {
+        const inngest = new Inngest({
+          id: "test",
+          schemas: new EventSchemas().fromSchema({
+            test: z.object({
+              message: z.string(),
+            }),
+          }),
+          middleware: [validationMiddleware()],
+        });
+
+        const t = new InngestTestEngine({
+          function: inngest.createFunction(
+            { id: "test" },
+            { event: "test" },
+            () =>
+              inngest.send({
+                name: "test",
+                data: { message: 123 as unknown as string },
+              }),
+          ),
+          events: [{ name: "test", data: { message: "hello" } }],
+        });
+
+        const { result, error } = await t.execute();
+
+        expect(JSON.stringify(error)).toContain("failed validation");
+        expect(result).toBeUndefined();
+      });
+
+      test("should not validate an event before sending it if disabled (fromZod)", async () => {
         fetchMock.postOnce(`${baseUrl}/e/${eventKey}`, {
           status: 200,
           ids: ["123"],
@@ -416,6 +638,35 @@ describe("validationMiddleware", () => {
           }),
         ).resolves.not.toThrow();
       });
+
+      test("should not validate an event before sending it if disabled (fromSchema)", async () => {
+        fetchMock.postOnce(`${baseUrl}/e/${eventKey}`, {
+          status: 200,
+          ids: ["123"],
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          fetch: fetchMock as typeof fetch,
+          baseUrl,
+          eventKey,
+          schemas: new EventSchemas().fromSchema({
+            test: z.object({
+              message: z.string(),
+            }),
+          }),
+          middleware: [
+            validationMiddleware({ disableOutgoingValidation: true }),
+          ],
+        });
+
+        await expect(
+          inngest.send({
+            name: "test",
+            data: { message: 123 as unknown as string },
+          }),
+        ).resolves.not.toThrow();
+      });
     });
 
     describe("step.sendEvent()", () => {
@@ -423,7 +674,7 @@ describe("validationMiddleware", () => {
         fetchMock.mockReset();
       });
 
-      test("should validate an event before sending it", async () => {
+      test("should validate an event before sending it (fromZod)", async () => {
         const inngest = new Inngest({
           id: "test",
           schemas: new EventSchemas().fromZod({
@@ -459,7 +710,41 @@ describe("validationMiddleware", () => {
         expect(result).toBeUndefined();
       });
 
-      test("should not validate an event before sending it if disabled", async () => {
+      test("should validate an event before sending it (fromSchema)", async () => {
+        const inngest = new Inngest({
+          id: "test",
+          schemas: new EventSchemas().fromSchema({
+            test: z.object({
+              message: z.string(),
+            }),
+          }),
+          middleware: [validationMiddleware()],
+          logger: { error: () => undefined } as Logger,
+        });
+
+        const fn = inngest.createFunction(
+          { id: "test" },
+          { event: "test" },
+          async ({ step }) => {
+            await step.sendEvent("id", {
+              name: "test",
+              data: { message: 123 as unknown as string },
+            });
+          },
+        );
+
+        const t = new InngestTestEngine({
+          function: fn,
+          events: [{ name: "test", data: { message: "hello" } }],
+        });
+
+        const { result, error } = await t.execute();
+
+        expect(JSON.stringify(error)).toContain("failed validation");
+        expect(result).toBeUndefined();
+      });
+
+      test("should not validate an event before sending it if disabled (fromZod)", async () => {
         fetchMock.post(`${baseUrl}/e/${eventKey}`, {
           status: 200,
           ids: ["123"],
@@ -476,6 +761,46 @@ describe("validationMiddleware", () => {
                 message: z.string(),
               }),
             },
+          }),
+          middleware: [
+            validationMiddleware({ disableOutgoingValidation: true }),
+          ],
+        });
+
+        const fn = inngest.createFunction(
+          { id: "test" },
+          { event: "test" },
+          async ({ step }) => {
+            await step.sendEvent("id", {
+              name: "test",
+              data: { message: 123 as unknown as string },
+            });
+          },
+        );
+
+        const t = new InngestTestEngine({
+          function: fn,
+          events: [{ name: "test", data: { message: "hello" } }],
+        });
+
+        await expect(t.execute()).resolves.not.toThrow();
+      });
+
+      test("should not validate an event before sending it if disabled (fromSchema)", async () => {
+        fetchMock.post(`${baseUrl}/e/${eventKey}`, {
+          status: 200,
+          ids: ["123"],
+        });
+
+        const inngest = new Inngest({
+          id: "test",
+          fetch: fetchMock as typeof fetch,
+          baseUrl,
+          eventKey,
+          schemas: new EventSchemas().fromSchema({
+            test: z.object({
+              message: z.string(),
+            }),
           }),
           middleware: [
             validationMiddleware({ disableOutgoingValidation: true }),

--- a/packages/middleware-validation/src/middleware.test.ts
+++ b/packages/middleware-validation/src/middleware.test.ts
@@ -1,7 +1,8 @@
 import { InngestTestEngine } from "@inngest/test";
 import FetchMock from "fetch-mock-jest";
 import { EventSchemas, Inngest, type Logger } from "inngest";
-import { z } from "zod";
+import { z } from "zod/v3";
+import { z as z4 } from "zod/v4";
 import { validationMiddleware } from "./middleware";
 
 const baseUrl = "https://unreachable.com";
@@ -90,8 +91,8 @@ describe("validationMiddleware", () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromSchema({
-        test: z.object({
-          message: z.string(),
+        test: z4.object({
+          message: z4.string(),
         }),
       }),
       middleware: [validationMiddleware()],
@@ -144,8 +145,8 @@ describe("validationMiddleware", () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromSchema({
-        test: z.object({
-          message: z.string(),
+        test: z4.object({
+          message: z4.string(),
         }),
       }),
       middleware: [validationMiddleware()],
@@ -204,11 +205,11 @@ describe("validationMiddleware", () => {
       const inngest = new Inngest({
         id: "test",
         schemas: new EventSchemas().fromSchema({
-          a: z.object({
-            a: z.boolean(),
+          a: z4.object({
+            a: z4.boolean(),
           }),
-          b: z.object({
-            b: z.boolean(),
+          b: z4.object({
+            b: z4.boolean(),
           }),
         }),
         middleware: [validationMiddleware()],
@@ -312,8 +313,8 @@ describe("validationMiddleware", () => {
       const inngest = new Inngest({
         id: "test",
         schemas: new EventSchemas().fromSchema({
-          test: z.object({
-            message: z.string(),
+          test: z4.object({
+            message: z4.string(),
           }),
         }),
         middleware: [validationMiddleware({ disallowSchemalessEvents: true })],
@@ -368,8 +369,8 @@ describe("validationMiddleware", () => {
       const inngest = new Inngest({
         id: "test",
         schemas: new EventSchemas().fromSchema({
-          test: z.object({
-            message: z.string(),
+          test: z4.object({
+            message: z4.string(),
           }),
         }),
         middleware: [validationMiddleware({ disallowSchemalessEvents: true })],
@@ -456,9 +457,9 @@ describe("validationMiddleware", () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromSchema({
-        test: z.object({
-          message: z.object({
-            content: z.string(),
+        test: z4.strictObject({
+          message: z4.object({
+            content: z4.string(),
           }),
         }),
       }),
@@ -515,8 +516,8 @@ describe("validationMiddleware", () => {
     const inngest = new Inngest({
       id: "test",
       schemas: new EventSchemas().fromSchema({
-        test: z.object({
-          message: z.string(),
+        test: z4.object({
+          message: z4.string(),
         }),
       }),
       middleware: [validationMiddleware()],
@@ -582,8 +583,8 @@ describe("validationMiddleware", () => {
         const inngest = new Inngest({
           id: "test",
           schemas: new EventSchemas().fromSchema({
-            test: z.object({
-              message: z.string(),
+            test: z4.object({
+              message: z4.string(),
             }),
           }),
           middleware: [validationMiddleware()],
@@ -651,8 +652,8 @@ describe("validationMiddleware", () => {
           baseUrl,
           eventKey,
           schemas: new EventSchemas().fromSchema({
-            test: z.object({
-              message: z.string(),
+            test: z4.object({
+              message: z4.string(),
             }),
           }),
           middleware: [
@@ -714,8 +715,8 @@ describe("validationMiddleware", () => {
         const inngest = new Inngest({
           id: "test",
           schemas: new EventSchemas().fromSchema({
-            test: z.object({
-              message: z.string(),
+            test: z4.object({
+              message: z4.string(),
             }),
           }),
           middleware: [validationMiddleware()],
@@ -798,8 +799,8 @@ describe("validationMiddleware", () => {
           baseUrl,
           eventKey,
           schemas: new EventSchemas().fromSchema({
-            test: z.object({
-              message: z.string(),
+            test: z4.object({
+              message: z4.string(),
             }),
           }),
           middleware: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,10 +84,10 @@ importers:
         version: 8.53.0
       jest:
         specifier: ^29.3.1
-        version: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
+        version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2)))(typescript@5.5.2)
+        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/eslint-plugin-internal:
     dependencies:
@@ -388,8 +388,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       inngest:
-        specifier: ^3.42.3
-        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76)
+        specifier: '*'
+        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -414,13 +414,13 @@ importers:
         version: 1.5.1(node-fetch@2.7.0)
       jest:
         specifier: ^29.3.1
-        version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+        version: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
       nock:
         specifier: ^13.2.9
         version: 13.2.9
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -7584,7 +7584,7 @@ snapshots:
       jest-util: 29.5.0
       slash: 3.0.0
 
-  '@jest/core@29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))':
+  '@jest/core@29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))':
     dependencies:
       '@jest/console': 29.5.0
       '@jest/reporters': 29.5.0
@@ -7598,7 +7598,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -7633,6 +7633,40 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
       jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
+      jest-haste-map: 29.5.0
+      jest-message-util: 29.5.0
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-resolve-dependencies: 29.5.0
+      jest-runner: 29.5.0
+      jest-runtime: 29.5.0
+      jest-snapshot: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      jest-watcher: 29.5.0
+      micromatch: 4.0.5
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.5.0(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))':
+    dependencies:
+      '@jest/console': 29.5.0
+      '@jest/reporters': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/transform': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 22.13.10
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.5.0
+      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -9675,7 +9709,7 @@ snapshots:
     optionalDependencies:
       vite: 7.0.2(@types/node@22.13.10)(jiti@2.5.1)
 
-  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)(tsx@3.12.7))':
+  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
@@ -11421,46 +11455,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76):
-    dependencies:
-      '@bufbuild/protobuf': 2.2.3
-      '@inngest/ai': 0.1.3
-      '@jpwilliams/waitgroup': 2.1.1
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/auto-instrumentations-node': 0.56.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      '@standard-schema/spec': 1.0.0
-      '@types/debug': 4.1.12
-      canonicalize: 1.0.8
-      chalk: 4.1.2
-      cross-fetch: 4.0.0
-      debug: 4.4.3
-      hash.js: 1.1.7
-      json-stringify-safe: 5.0.1
-      ms: 2.1.3
-      serialize-error-cjs: 0.1.3
-      strip-ansi: 5.2.0
-      temporal-polyfill: 0.2.5
-      zod: 3.25.76
-    optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1))
-      '@vercel/node': 2.15.9
-      aws-lambda: 1.0.7
-      express: 4.19.2
-      fastify: 4.21.0
-      h3: 1.8.1
-      hono: 4.2.7
-      koa: 2.14.2
-      next: 13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0)
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)(zod@3.25.76):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
@@ -11537,6 +11531,46 @@ snapshots:
       koa: 2.14.2
       next: 13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0)
       typescript: 5.5.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76):
+    dependencies:
+      '@bufbuild/protobuf': 2.2.3
+      '@inngest/ai': 0.1.3
+      '@jpwilliams/waitgroup': 2.1.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/auto-instrumentations-node': 0.56.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.0.0
+      '@types/debug': 4.1.12
+      canonicalize: 1.0.8
+      chalk: 4.1.2
+      cross-fetch: 4.0.0
+      debug: 4.4.3
+      hash.js: 1.1.7
+      json-stringify-safe: 5.0.1
+      ms: 2.1.3
+      serialize-error-cjs: 0.1.3
+      strip-ansi: 5.2.0
+      temporal-polyfill: 0.2.5
+      zod: 3.25.76
+    optionalDependencies:
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))
+      '@vercel/node': 2.15.9
+      aws-lambda: 1.0.7
+      express: 4.19.2
+      fastify: 4.21.0
+      h3: 1.8.1
+      hono: 4.2.7
+      koa: 2.14.2
+      next: 13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11870,16 +11904,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)):
+  jest-cli@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -11908,7 +11942,26 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)):
+  jest-cli@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
+    dependencies:
+      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+
+  jest-config@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.23.6
       '@jest/test-sequencer': 29.5.0
@@ -11934,7 +11987,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.13.10
-      ts-node: 10.9.1(@types/node@22.13.10)(typescript@5.6.3)
+      ts-node: 10.9.1(@types/node@22.13.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11968,6 +12021,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jest-config@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.23.6
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.23.6)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.13.10
+      ts-node: 10.9.1(@types/node@24.3.0)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
+
   jest-config@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.23.6
@@ -11995,6 +12078,36 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
       ts-node: 10.9.1(@types/node@24.3.0)(typescript@5.5.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-config@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.23.6
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.23.6)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.3.0
+      ts-node: 10.9.1(@types/node@24.3.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12232,12 +12345,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)):
+  jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+      jest-cli: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -12249,6 +12362,17 @@ snapshots:
       '@jest/types': 29.5.0
       import-local: 3.1.0
       jest-cli: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+
+  jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
+    dependencies:
+      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -13620,17 +13744,17 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  ts-jest@29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)))(typescript@5.5.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
+      jest: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.6.3
+      typescript: 5.5.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.23.6
@@ -13648,6 +13772,23 @@ snapshots:
       make-error: 1.3.6
       semver: 7.6.3
       typescript: 5.5.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.23.6
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.23.6)
+
+  ts-jest@29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)))(typescript@5.6.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.23.6
@@ -13677,7 +13818,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3):
+  ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -13691,7 +13832,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.6.3
+      typescript: 5.5.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -13711,6 +13852,25 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.3.0
+      acorn: 8.14.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -14222,7 +14382,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)(tsx@3.12.7))
+      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,7 +388,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       inngest:
-        specifier: '*'
+        specifier: ^3.42.3
         version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76)
       zod:
         specifier: ^3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,10 +389,10 @@ importers:
         version: 1.0.0
       inngest:
         specifier: ^3.42.3
-        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@4.1.11)
+        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76)
       zod:
-        specifier: ^4.1.11
-        version: 4.1.11
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: ^9.7.0
@@ -11421,7 +11421,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@4.1.11):
+  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -11445,7 +11445,7 @@ snapshots:
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
-      zod: 4.1.11
+      zod: 3.25.76
     optionalDependencies:
       '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1))
       '@vercel/node': 2.15.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,10 +84,10 @@ importers:
         version: 8.53.0
       jest:
         specifier: ^29.3.1
-        version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+        version: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)))(typescript@5.5.2)
+        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2)))(typescript@5.5.2)
 
   packages/eslint-plugin-internal:
     dependencies:
@@ -338,7 +338,7 @@ importers:
         version: 1.5.1(node-fetch@2.7.0)
       inngest:
         specifier: ^3.42.3
-        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2)(zod@4.0.17)
+        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2)(zod@4.1.11)
       jest:
         specifier: ^29.3.1
         version: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
@@ -374,7 +374,7 @@ importers:
         version: 15.14.0
       inngest:
         specifier: ^3.42.3
-        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2)(zod@4.0.17)
+        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2)(zod@4.1.11)
       typescript:
         specifier: ~5.4.0
         version: 5.4.2
@@ -384,12 +384,15 @@ importers:
 
   packages/middleware-validation:
     dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       inngest:
         specifier: ^3.42.3
-        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76)
+        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@4.1.11)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.1.11
+        version: 4.1.11
     devDependencies:
       '@eslint/js':
         specifier: ^9.7.0
@@ -411,13 +414,13 @@ importers:
         version: 1.5.1(node-fetch@2.7.0)
       jest:
         specifier: ^29.3.1
-        version: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
+        version: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
       nock:
         specifier: ^13.2.9
         version: 13.2.9
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -487,7 +490,7 @@ importers:
     dependencies:
       inngest:
         specifier: ^3.42.3
-        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)(zod@4.0.17)
+        version: 3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)(zod@4.1.11)
       tinyspy:
         specifier: ^3.0.2
         version: 3.0.2
@@ -6656,6 +6659,9 @@ packages:
   zod@4.0.17:
     resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
 
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
@@ -7578,7 +7584,7 @@ snapshots:
       jest-util: 29.5.0
       slash: 3.0.0
 
-  '@jest/core@29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))':
+  '@jest/core@29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.5.0
       '@jest/reporters': 29.5.0
@@ -7592,7 +7598,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -7627,40 +7633,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
       jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
-      jest-haste-map: 29.5.0
-      jest-message-util: 29.5.0
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.5.0
-      jest-resolve-dependencies: 29.5.0
-      jest-runner: 29.5.0
-      jest-runtime: 29.5.0
-      jest-snapshot: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      jest-watcher: 29.5.0
-      micromatch: 4.0.5
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.5.0(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))':
-    dependencies:
-      '@jest/console': 29.5.0
-      '@jest/reporters': 29.5.0
-      '@jest/test-result': 29.5.0
-      '@jest/transform': 29.5.0
-      '@jest/types': 29.5.0
-      '@types/node': 22.13.10
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -9131,7 +9103,7 @@ snapshots:
 
   '@types/node-fetch@2.6.3':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 24.3.0
       form-data: 3.0.1
 
   '@types/node@12.20.55': {}
@@ -11449,6 +11421,46 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@4.1.11):
+    dependencies:
+      '@bufbuild/protobuf': 2.2.3
+      '@inngest/ai': 0.1.3
+      '@jpwilliams/waitgroup': 2.1.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/auto-instrumentations-node': 0.56.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.0.0
+      '@types/debug': 4.1.12
+      canonicalize: 1.0.8
+      chalk: 4.1.2
+      cross-fetch: 4.0.0
+      debug: 4.4.3
+      hash.js: 1.1.7
+      json-stringify-safe: 5.0.1
+      ms: 2.1.3
+      serialize-error-cjs: 0.1.3
+      strip-ansi: 5.2.0
+      temporal-polyfill: 0.2.5
+      zod: 4.1.11
+    optionalDependencies:
+      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1))
+      '@vercel/node': 2.15.9
+      aws-lambda: 1.0.7
+      express: 4.19.2
+      fastify: 4.21.0
+      h3: 1.8.1
+      hono: 4.2.7
+      koa: 2.14.2
+      next: 13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0)
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@22.13.10)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.8.2)(zod@3.25.76):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
@@ -11489,7 +11501,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2)(zod@4.0.17):
+  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.5.2)(zod@4.1.11):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -11513,7 +11525,7 @@ snapshots:
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
-      zod: 4.0.17
+      zod: 4.1.11
     optionalDependencies:
       '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))
       '@vercel/node': 2.15.9
@@ -11529,7 +11541,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76):
+  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2)(zod@4.1.11):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -11553,47 +11565,7 @@ snapshots:
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
-      zod: 3.25.76
-    optionalDependencies:
-      '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))
-      '@vercel/node': 2.15.9
-      aws-lambda: 1.0.7
-      express: 4.19.2
-      fastify: 4.21.0
-      h3: 1.8.1
-      hono: 4.2.7
-      koa: 2.14.2
-      next: 13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0)
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.4.2)(zod@4.0.17):
-    dependencies:
-      '@bufbuild/protobuf': 2.2.3
-      '@inngest/ai': 0.1.3
-      '@jpwilliams/waitgroup': 2.1.1
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/auto-instrumentations-node': 0.56.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      '@standard-schema/spec': 1.0.0
-      '@types/debug': 4.1.12
-      canonicalize: 1.0.8
-      chalk: 4.1.2
-      cross-fetch: 4.0.0
-      debug: 4.4.3
-      hash.js: 1.1.7
-      json-stringify-safe: 5.0.1
-      ms: 2.1.3
-      serialize-error-cjs: 0.1.3
-      strip-ansi: 5.2.0
-      temporal-polyfill: 0.2.5
-      zod: 4.0.17
+      zod: 4.1.11
     optionalDependencies:
       '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))
       '@vercel/node': 2.15.9
@@ -11609,7 +11581,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)(zod@4.0.17):
+  inngest@3.42.3(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)(zod@4.1.11):
     dependencies:
       '@bufbuild/protobuf': 2.2.3
       '@inngest/ai': 0.1.3
@@ -11633,7 +11605,7 @@ snapshots:
       serialize-error-cjs: 0.1.3
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
-      zod: 4.0.17
+      zod: 4.1.11
     optionalDependencies:
       '@sveltejs/kit': 1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1))
       '@vercel/node': 2.15.9
@@ -11898,16 +11870,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)):
+  jest-cli@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+      jest-config: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -11936,26 +11908,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
-      '@jest/test-result': 29.5.0
-      '@jest/types': 29.5.0
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      prompts: 2.4.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-
-  jest-config@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)):
+  jest-config@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.23.6
       '@jest/test-sequencer': 29.5.0
@@ -11981,7 +11934,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.13.10
-      ts-node: 10.9.1(@types/node@22.13.10)(typescript@5.5.2)
+      ts-node: 10.9.1(@types/node@22.13.10)(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12015,36 +11968,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
-    dependencies:
-      '@babel/core': 7.23.6
-      '@jest/test-sequencer': 29.5.0
-      '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.23.6)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.5.0
-      jest-environment-node: 29.5.0
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.5.0
-      jest-runner: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.13.10
-      ts-node: 10.9.1(@types/node@24.3.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
-
   jest-config@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2)):
     dependencies:
       '@babel/core': 7.23.6
@@ -12072,36 +11995,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
       ts-node: 10.9.1(@types/node@24.3.0)(typescript@5.5.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  jest-config@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
-    dependencies:
-      '@babel/core': 7.23.6
-      '@jest/test-sequencer': 29.5.0
-      '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.23.6)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.5.0
-      jest-environment-node: 29.5.0
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.5.0
-      jest-runner: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 24.3.0
-      ts-node: 10.9.1(@types/node@24.3.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12339,12 +12232,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)):
+  jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+      jest-cli: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -12356,17 +12249,6 @@ snapshots:
       '@jest/types': 29.5.0
       import-local: 3.1.0
       jest-cli: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.5.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-
-  jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.5.0(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
-      '@jest/types': 29.5.0
-      import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -13738,17 +13620,17 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  ts-jest@29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2)))(typescript@5.5.2):
+  ts-jest@29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2))
+      jest: 29.5.0(@types/node@22.13.10)(ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3))
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.5.2
+      typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.23.6
@@ -13766,23 +13648,6 @@ snapshots:
       make-error: 1.3.6
       semver: 7.6.3
       typescript: 5.5.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.23.6
-      '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.23.6)
-
-  ts-jest@29.1.0(@babel/core@7.23.6)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.23.6))(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)))(typescript@5.6.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
-      jest-util: 29.5.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.23.6
@@ -13812,7 +13677,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@22.13.10)(typescript@5.5.2):
+  ts-node@10.9.1(@types/node@22.13.10)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -13826,7 +13691,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.2
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -13846,25 +13711,6 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.3.0
-      acorn: 8.14.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -14568,3 +14414,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.0.17: {}
+
+  zod@4.1.11: {}


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Fixes a bug whereby the runtime schemas being added when using `.fromSchema()` were not compatible with `@inngest/middleware-validation`.

`@inngest/middleware-validation` tests are expected to fail, as they use the latest published `inngest`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [x] Added unit/integration tests
- [x] Added changesets if applicable
