### PR TITLE
docs: add extra info about running local tests

### DIFF
--- a/packages/inngest/CONTRIBUTING.md
+++ b/packages/inngest/CONTRIBUTING.md
@@ -53,6 +53,9 @@ pnpm run itest framework-nextjs-app-router
 
 You can also use this method to ship a snapshot of the library with an application. This is a nice way to generate and ship snapshot versions without requiring a release to npm.
 
+> [!TIP]
+> Please note that when you run `pnpm test`, you should **not** have a dev server running locally or you are likely to encounter failures that are unrelated to your changes.
+
 ## Releasing
 
 To release to production, we use [Changesets](https://github.com/changesets/changesets). This means that releasing and changelog generation is all managed through PRs, where a bot will guide you through the process of adding release notes to PRs.


### PR DESCRIPTION
## Summary
Add a callout to let folks know that they shouldn't have any local devserver running to run the tests.

## Checklist
- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
