### PR TITLE
Neutral platform; allow but don't assume Node

### DIFF
--- a/packages/inngest/tsdown.config.ts
+++ b/packages/inngest/tsdown.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
   outDir: "dist",
   tsconfig: "tsconfig.build.json",
   target: "node20",
+  platform: "neutral",
   sourcemap: true,
   failOnWarn: true, // keep the build as good we can
   minify: false, // let bundlers handle minification if they want it


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Previous versions of `tsdown` had issue with this setting and some of our condition `node:*` imports, though seems good now.

This should help us avoid assuming node and trying to import from `node:module`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Bug fix
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related

- Potential for #1117
