### PR TITLE
Add Exports for Connect Types

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -225,6 +225,14 @@
       },
       "import": "./internals.js",
       "require": "./internals.cjs"
+    },
+    "./components/connect/types": {
+      "types": {
+        "import": "./components/connect/types.d.ts",
+        "require": "./components/connect/types.d.cts"
+      },
+      "import": "./components/connect/types.js",
+      "require": "./components/connect/types.cjs"
     }
   },
   "homepage": "https://github.com/inngest/inngest-js#readme",


### PR DESCRIPTION
## Summary
When using TypeScript & ESM, the [example code for Connect](https://www.inngest.com/docs/setup/connect#getting-started) isn't currently valid and errors with:

`"Cannot find module 'inngest/components/connect/types' or its corresponding type declarations."`.

Adds the necessary `exports` to `package.json` so the example code compiles.


