### PR TITLE
Update to use latest pre-built deps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1762596750,
+        "narHash": "sha256-rXXuz51Bq7DHBlfIjN7jO8Bu3du5TV+3DSADBX7/9YQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "b6a8526db03f735b89dd5ff348f53f752e7ddc8e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,15 +6,8 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-      ...
-    }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         corepack = pkgs.stdenv.mkDerivation {
@@ -27,8 +20,7 @@
           '';
         };
 
-      in
-      {
+      in {
         devShells.default = pkgs.mkShell {
           packages = [ corepack ];
 
@@ -43,10 +35,7 @@
             nodePackages.yaml-language-server
           ];
 
-          shellHook = ''
-            export COREPACK_ENABLE_AUTO_PIN=0
-          '';
+          COREPACK_ENABLE_AUTO_PIN = "0";
         };
-      }
-    );
+      });
 }


### PR DESCRIPTION
## Summary

Was just trying to look at some stuff quickly and nix started a nodejs compilation.

Saw this was from May 2025 and was building an RC version of node 24, so bumped the flake version and have it use the latest prebuilt for faster loading.
