### PR TITLE
feat: add Anthropic OTEL instrumentation

### DIFF
--- a/.changeset/tidy-houses-wave.md
+++ b/.changeset/tidy-houses-wave.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add Anthropic Open Telemetry instrumentation so that calls to the Anthropic API are automatically captured.

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -282,6 +282,7 @@
     "@opentelemetry/resources": ">=2.0.0 <3.0.0",
     "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0",
     "@standard-schema/spec": "^1.0.0",
+    "@traceloop/instrumentation-anthropic": "^0.20.0",
     "@types/debug": "^4.1.12",
     "@types/ms": "~2.1.0",
     "canonicalize": "^1.0.8",

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -6,6 +6,7 @@ import {
   registerInstrumentations,
 } from "@opentelemetry/instrumentation";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { AnthropicInstrumentation } from "@traceloop/instrumentation-anthropic";
 import { InngestSpanProcessor } from "./processor.ts";
 
 export type Behaviour = "createProvider" | "extendProvider" | "off" | "auto";
@@ -25,6 +26,7 @@ export const createProvider = (
   const instrList: Instrumentations = [
     ...instrumentations,
     ...getNodeAutoInstrumentations(),
+    new AnthropicInstrumentation(),
   ];
 
   registerInstrumentations({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
+      '@traceloop/instrumentation-anthropic':
+        specifier: ^0.20.0
+        version: 0.20.0
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -1746,6 +1749,10 @@ packages:
   '@octokit/types@12.3.0':
     resolution: {integrity: sha512-nJ8X2HRr234q3w/FcovDlA+ttUU4m1eJAourvfUUtwAWeqL8AsyRqfnLvVnYn3NFbUnsmzQCzLNdFerPwdmcDQ==}
 
+  '@opentelemetry/api-logs@0.203.0':
+    resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
@@ -2407,6 +2414,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation@0.203.0':
+    resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.207.0':
     resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2933,6 +2946,14 @@ packages:
 
   '@total-typescript/shoehorn@0.1.1':
     resolution: {integrity: sha512-XSPcazQsC2Cr7eCiAI+M2bTmMziBvFWYTYMgUDKLbU6i+7m3I2BF5gXF5vKDO8577fONs9CvmTvVa7+nMHMfxg==}
+
+  '@traceloop/ai-semantic-conventions@0.20.0':
+    resolution: {integrity: sha512-bvivhZU6U8TW4TKktYnjdTi+7GE4WxI8epaGjawalSKDunmxaA+4UVFQ+4tSCBvp2Scby+gnYNaTZSrtABfOlQ==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-anthropic@0.20.0':
+    resolution: {integrity: sha512-xQcPxVrKr3yT9+ZEM3skYXikJc/ocZlGDIcsBQ3mMwL3Weq1QL7jx/uGLXvrSO2Yh0DWUjWI6Q/oiRCEUM6P8w==}
+    engines: {node: '>=14'}
 
   '@ts-morph/common@0.11.1':
     resolution: {integrity: sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==}
@@ -5461,6 +5482,7 @@ packages:
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
     engines: {node: '>= 0.6'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -6853,6 +6875,9 @@ packages:
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -8720,6 +8745,10 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 19.0.2
 
+  '@opentelemetry/api-logs@0.203.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -9744,6 +9773,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      import-in-the-middle: 1.13.1
+      require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -10367,6 +10405,21 @@ snapshots:
       tslib: 2.6.2
 
   '@total-typescript/shoehorn@0.1.1': {}
+
+  '@traceloop/ai-semantic-conventions@0.20.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@traceloop/instrumentation-anthropic@0.20.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.37.0
+      '@traceloop/ai-semantic-conventions': 0.20.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ts-morph/common@0.11.1':
     dependencies:
@@ -15630,6 +15683,8 @@ snapshots:
   tslib@2.4.0: {}
 
   tslib@2.6.2: {}
+
+  tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
 


### PR DESCRIPTION
## Summary
Adds the [@traceloop/instrumentation-anthropic](https://github.com/traceloop/openllmetry-js/tree/main/packages/instrumentation-anthropic) package so that we're able to automatically instrument Anthropic calls like we do for OpenAI. We're adding this one manually because it isn't automatically included in auto-instrumentation-node.

Note that the data it's returning _is_ slightly different from the OpenAI results, and that there's a display bug seemingly caused by one of the captured attributes being the entire prompt.

<img width="1622" height="1054" alt="Screenshot 2025-11-13 at 11 22 31 PM" src="https://github.com/user-attachments/assets/8a5dddaa-c662-4a34-aacf-ea9003f79399" />

<img width="1622" height="1054" alt="Screenshot 2025-11-13 at 11 23 48 PM" src="https://github.com/user-attachments/assets/96a158dc-9d01-493d-852d-2f5e94ee08f8" />



## Checklist


## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
