### PR TITLE
docs: fix camelCase inconsistency in README code example

### DIFF
--- a/packages/inngest/README.md
+++ b/packages/inngest/README.md
@@ -107,7 +107,7 @@ Inngest invokes functions via HTTP, so you need to _serve_ them using an adapter
 import { Inngest } from "inngest";
 // See the "inngest/next" adapter imported here:
 import { serve } from "inngest/next";
-import myFunction from "../userOnboardingCOmmunication"; // see above function
+import myFunction from "../userOnboardingCommunication"; // see above function
 
 // You can create this in a single file and import where it's needed
 const inngest = new Inngest({ id: "my-app" });


### PR DESCRIPTION
## Summary
Fixes inconsistent camelCase capitalization in README code example by correcting `"../userOnboardingCOmmunication"` to `"../userOnboardingCommunication"` in the import statement.

## What changed
- Fixed camelCase inconsistency in the import example
- Changed `userOnboardingCOmmunication` to `userOnboardingCommunication` (uppercase 'C' to lowercase 'c')

## Why
The uppercase 'C' as the second letter in "COmmunication" breaks standard camelCase naming conventions where only the first letter of each word (except the first word) should be capitalized.

## Checklist
- [x] ~~Added a [docs PR](https://github.com/inngest/website)~~ N/A This IS a docs change in the main repo
- [x] ~~Added unit/integration tests~~ N/A Only touches documentation
- [x] ~~Added changesets~~ N/A Documentation fix only

## Related
- First-time contributor 🙂