### PR TITLE
fix(extended-traces): include client headers in trace exports

### DIFF
--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -289,6 +289,7 @@ export class InngestSpanProcessor implements SpanProcessor {
             url: url.href,
 
             headers: {
+              ...app["headers"],
               Authorization: `Bearer ${app["inngestApi"]["signingKey"]}`,
             },
           });


### PR DESCRIPTION
## Summary

Include client headers in trace exports, which should hopefully help with extended traces not showing up as expected in branch environments because they depend on `x-inngest-env`:

> If you are sending events without an Inngest SDK, you'll need to pass the x-inngest-env header along with your request. For more information about this and sending events from any environment with the Event API, [read the send() reference](https://www.inngest.com/docs/reference/events/send#send-events-via-http-event-api).

<small>[Relevant documentation.](https://www.inngest.com/docs/platform/environments#branch-environments). </small>
