### PR TITLE
fix: base64 encode body in sync checkpoint request

### DIFF
--- a/.changeset/fix-checkpoint-body-encoding.md
+++ b/.changeset/fix-checkpoint-body-encoding.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix sync checkpoint request body encoding for Go server compatibility

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -3,6 +3,31 @@ import { EventSchemas, InngestCommHandler } from "../index.ts";
 import { serve } from "../next.ts";
 import { createClient } from "../test/helpers.ts";
 
+describe("createHttpEvent", () => {
+  test("base64 encodes body for Go []byte unmarshaling", async () => {
+    const testBody = '{"foo":"bar"}';
+
+    // Test the encoding logic directly since createHttpEvent is private
+    const encodeBody = (body: string) => {
+      const str = typeof body === "string" ? body : JSON.stringify(body);
+      return typeof btoa !== "undefined"
+        ? btoa(str)
+        : Buffer.from(str).toString("base64");
+    };
+
+    const encoded = encodeBody(testBody);
+
+    // Body should be base64 encoded
+    const expectedBase64 = Buffer.from(testBody).toString("base64");
+    expect(encoded).toBe(expectedBase64);
+    expect(encoded).toBe("eyJmb28iOiJiYXIifQ==");
+
+    // Verify it decodes back correctly (as Go server would)
+    const decoded = Buffer.from(encoded, "base64").toString();
+    expect(decoded).toBe(testBody);
+  });
+});
+
 describe("#153", () => {
   test('does not throw "type instantiation is excessively deep and possibly infinite" for looping type', () => {
     const literalSchema = z.union([

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -930,8 +930,12 @@ export class InngestCommHandler<
     );
 
     // TODO For body, we can add `textBody()` to the actions
+    // Body must be base64 encoded as the server expects []byte which unmarshals from base64 in JSON
     const bodyPromise = actions.textBody!(reason).then((body) => {
-      return typeof body === "string" ? body : stringify(body);
+      const str = typeof body === "string" ? body : stringify(body);
+      return typeof btoa !== "undefined"
+        ? btoa(str)
+        : Buffer.from(str).toString("base64");
     });
 
     const [contentType, domain, ip, method, path, queryParams, body] =


### PR DESCRIPTION
## Summary

The experimental sync checkpoint API (`createExperimentalEndpointWrapper`) fails with `400 Invalid request body` when calling `/v1/checkpoint`.

**Root cause:** The server expects `event.data.body` as `[]byte`, which in Go JSON unmarshals from base64:

https://github.com/inngest/inngest/blob/main/pkg/api/apiv1/checkpoint_types.go#L58

```go
type NewAPIRunData struct {
    // ...
    Body []byte `json:"body"`
}
```

The SDK was sending it as a plain string, causing JSON unmarshaling to fail.

**Fix:** Base64 encode the body before sending:

```ts
const bodyPromise = actions.textBody!(reason).then((body) => {
  const str = typeof body === "string" ? body : stringify(body);
  return typeof btoa !== "undefined"
    ? btoa(str)
    : Buffer.from(str).toString("base64");
});
```

**Tested locally** with inngest dev server v1.15.3:
- Before: `Error: Failed to checkpoint new run: 400 Bad Request - {"error":"Invalid request body"}`
- After: `handled sync checkpoint run_id=... ops=1 complete=true`

## Checklist

- [x] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A bugfix only
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- Affects `createExperimentalEndpointWrapper` from `inngest/edge`
