### PR TITLE
fix(realtime): add missing dependencies to useInngestSubscription hook

### DIFF
--- a/packages/realtime/src/hooks.ts
+++ b/packages/realtime/src/hooks.ts
@@ -115,7 +115,7 @@ export function useInngestSubscription<
         setState(InngestSubscriptionState.Error);
       }
     }
-  }, []);
+  }, [enabled, token, refreshToken]);
 
   // Subscription management
   useEffect(() => {


### PR DESCRIPTION
- Add `enabled`, `token`, and `refreshToken` to useEffect dependency array
- Prevent stale closures and ensure effect runs when authentication state changes
- Fix potential bugs where hook would not respond to token or enabled prop updates

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
[inngest/inngest#1146](https://github.com/inngest/inngest-js/issues/1146)

