### PR TITLE
Fix NonRetriableError instanceof check in monorepos

### DIFF
--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -561,7 +561,10 @@ export class V0InngestExecution
        * Ensure we give middleware the chance to decide on retriable behaviour
        * by looking at the error returned from output transformation.
        */
-      let retriable: boolean | string = !(error instanceof NonRetriableError);
+      let retriable: boolean | string = !(
+        error instanceof NonRetriableError ||
+        (error as any)?.name === "NonRetriableError"
+      );
       if (retriable && error instanceof RetryAfterError) {
         retriable = error.retryAfter;
       }

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -917,7 +917,10 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
       .catch<OutgoingOp>((error) => {
         let errorIsRetriable = true;
 
-        if (error instanceof NonRetriableError) {
+        if (
+          error instanceof NonRetriableError ||
+          (error as any)?.name === "NonRetriableError"
+        ) {
           errorIsRetriable = false;
         } else if (
           this.fnArg.maxAttempts &&
@@ -1049,6 +1052,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
        */
       let retriable: boolean | string = !(
         error instanceof NonRetriableError ||
+        (error as any)?.name === "NonRetriableError" ||
         (error instanceof StepError &&
           error === this.state.recentlyRejectedStepError)
       );

--- a/packages/inngest/src/components/execution/v2.ts
+++ b/packages/inngest/src/components/execution/v2.ts
@@ -551,7 +551,10 @@ class V2InngestExecution extends InngestExecution implements IInngestExecution {
       .catch<OutgoingOp>((error) => {
         let errorIsRetriable = true;
 
-        if (error instanceof NonRetriableError) {
+        if (
+          error instanceof NonRetriableError ||
+          (error as any)?.name === "NonRetriableError"
+        ) {
           errorIsRetriable = false;
         } else if (
           this.fnArg.maxAttempts &&
@@ -674,6 +677,7 @@ class V2InngestExecution extends InngestExecution implements IInngestExecution {
        */
       let retriable: boolean | string = !(
         error instanceof NonRetriableError ||
+        (error as any)?.name === "NonRetriableError" ||
         (error instanceof StepError &&
           error === this.state.recentlyRejectedStepError)
       );


### PR DESCRIPTION
Fixes NonRetriableError not being recognized in monorepo setups where different packages can load separate instances of the inngest module.

The SDK currently only uses `instanceof` to detect NonRetriableError. This fails when the error comes from a different module instance - common in monorepos.

Added `(error as any)?.name === "NonRetriableError"` as a fallback check in v0/v1/v2 execution handlers.

Fixes #1241
