### PR TITLE
Fix steps sometimes resolving out of order

### DIFF
--- a/.changeset/flat-donuts-bow.md
+++ b/.changeset/flat-donuts-bow.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix steps sometimes resolving out of order

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -140,7 +140,6 @@ export const parseFnData = (data: unknown) => {
                         .transform((v) => (Array.isArray(v) ? v : [])),
                       current: z.number(),
                     })
-                    .passthrough()
                     .optional()
                     .nullable(),
                 })
@@ -177,7 +176,6 @@ export const parseFnData = (data: unknown) => {
                         .transform((v) => (Array.isArray(v) ? v : [])),
                       current: z.number(),
                     })
-                    .passthrough()
                     .optional()
                     .nullable(),
                 })
@@ -213,7 +211,6 @@ export const parseFnData = (data: unknown) => {
                         .transform((v) => (Array.isArray(v) ? v : [])),
                       current: z.number(),
                     })
-                    .passthrough()
                     .optional()
                     .nullable(),
                 })
@@ -301,7 +298,7 @@ export const fetchAllFnData = async ({
     // If we don't have a stack here, we need to at least set something.
     // TODO We should be passed this by the steps API.
     const stepIds = Object.keys(result.steps || {});
-    if (stepIds.length && !result.ctx?.stack?.length) {
+    if (stepIds.length && !result.ctx?.stack?.stack?.length) {
       result.ctx = {
         ...(result.ctx as NonNullable<typeof result.ctx>),
         stack: {


### PR DESCRIPTION
## Summary
Fix a bug where steps sometimes resolved out of order. We found this issue after users reported issues with `Promise.race`.

The root cause was a line that didn't get the correct sub property. The use of Zod's `passthrough()` method prevented TypeScript from catching the bug.

## Checklist
- [x] Added changesets if applicable
