### PR TITLE
NonRetriableError && RetryAfterError instanceof checks

### DIFF
--- a/.changeset/red-pumpkins-ring.md
+++ b/.changeset/red-pumpkins-ring.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+NonRetriableError && RetryAfterError instanceof checks help resolve issues of errors not working as expected in monorepos. 

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -28,6 +28,7 @@ import {
   EventSchemas,
   InngestMiddleware,
   NonRetriableError,
+  RetryAfterError,
 } from "../index.ts";
 import { type Logger, ProxyLogger } from "../middleware/logger.ts";
 import { createClient, runFnWithStack } from "../test/helpers.ts";
@@ -2769,6 +2770,150 @@ describe("runFn", () => {
                 },
                 expectedStepsRun: ["A"],
                 expectedErrors: ["Should not retry this step"],
+              },
+          }),
+        },
+      },
+    );
+
+    testFn(
+      "detects NonRetriableError by name when instanceof fails",
+      () => {
+        const fn = inngest.createFunction(
+          { id: "Foo" },
+          { event: "foo" },
+          async () => {
+            const error = new Error("Simulated monorepo error");
+            error.name = "NonRetriableError";
+            throw error;
+          },
+        );
+
+        return { fn, steps: {} };
+      },
+      {
+        [ExecutionVersion.V0]: {
+          hashes: {},
+          tests: () => ({
+            "detects NonRetriableError by name and sets retriable to false": {
+              expectedReturn: {
+                type: "function-rejected",
+                retriable: false,
+                error: expect.objectContaining({
+                  name: "NonRetriableError",
+                  message: "Simulated monorepo error",
+                }),
+              },
+              expectedErrors: ["Simulated monorepo error"],
+            },
+          }),
+        },
+        [ExecutionVersion.V1]: {
+          hashes: {},
+          tests: () => ({
+            "detects NonRetriableError by name and sets retriable to false": {
+              expectedReturn: {
+                type: "function-rejected",
+                retriable: false,
+                error: expect.objectContaining({
+                  name: "NonRetriableError",
+                  message: "Simulated monorepo error",
+                }),
+              },
+              expectedErrors: ["Simulated monorepo error"],
+              expectedStepsRun: [],
+            },
+          }),
+        },
+        [ExecutionVersion.V2]: {
+          hashes: {},
+          tests: () => ({
+            "detects NonRetriableError by name and sets retriable to false": {
+              expectedReturn: {
+                type: "function-rejected",
+                retriable: false,
+                error: expect.objectContaining({
+                  name: "NonRetriableError",
+                  message: "Simulated monorepo error",
+                }),
+              },
+              expectedErrors: ["Simulated monorepo error"],
+              expectedStepsRun: [],
+            },
+          }),
+        },
+      },
+    );
+
+    testFn(
+      "detects RetryAfterError by name when instanceof fails",
+      () => {
+        const fn = inngest.createFunction(
+          { id: "Foo" },
+          { event: "foo" },
+          async () => {
+            const error = new Error(
+              "Simulated monorepo retry error",
+            ) as Error & { retryAfter: string };
+            error.name = "RetryAfterError";
+            error.retryAfter = "30";
+            throw error;
+          },
+        );
+
+        return { fn, steps: {} };
+      },
+      {
+        [ExecutionVersion.V0]: {
+          hashes: {},
+          tests: () => ({
+            "detects RetryAfterError by name and sets retriable to retryAfter value":
+              {
+                expectedReturn: {
+                  type: "function-rejected",
+                  retriable: "30",
+                  error: expect.objectContaining({
+                    name: "RetryAfterError",
+                    message: "Simulated monorepo retry error",
+                  }),
+                },
+                expectedErrors: ["Simulated monorepo retry error"],
+              },
+          }),
+        },
+        [ExecutionVersion.V1]: {
+          hashes: {},
+          tests: () => ({
+            "detects RetryAfterError by name and sets retriable to retryAfter value":
+              {
+                expectedReturn: {
+                  type: "function-rejected",
+                  retriable: "30",
+                  error: expect.objectContaining({
+                    name: "RetryAfterError",
+                    message: "Simulated monorepo retry error",
+                  }),
+                },
+                expectedErrors: ["Simulated monorepo retry error"],
+                expectedStepsRun: [],
+              },
+          }),
+        },
+        [ExecutionVersion.V2]: {
+          hashes: {},
+          tests: () => ({
+            "detects RetryAfterError by name and sets retriable to retryAfter value":
+              {
+                expectedReturn: {
+                  type: "function-rejected",
+                  retriable: "30",
+                  error: expect.objectContaining({
+                    name: "RetryAfterError",
+                    message: "Simulated monorepo retry error",
+                  }),
+                },
+                expectedErrors: ["Simulated monorepo retry error"],
+                expectedStepsRun: [],
               },
           }),
         },

--- a/packages/inngest/src/components/RetryAfterError.ts
+++ b/packages/inngest/src/components/RetryAfterError.ts
@@ -45,6 +45,8 @@ export class RetryAfterError extends Error {
   ) {
     super(message);
 
+    this.name = "RetryAfterError";
+
     if (retryAfter instanceof Date) {
       this.retryAfter = retryAfter.toISOString();
     } else {

--- a/packages/inngest/src/components/execution/v0.ts
+++ b/packages/inngest/src/components/execution/v0.ts
@@ -566,8 +566,13 @@ export class V0InngestExecution
         // biome-ignore lint/suspicious/noExplicitAny: instanceof fails across module boundaries
         (error as any)?.name === "NonRetriableError"
       );
-      if (retriable && error instanceof RetryAfterError) {
-        retriable = error.retryAfter;
+      if (
+        retriable &&
+        (error instanceof RetryAfterError ||
+          // biome-ignore lint/suspicious/noExplicitAny: instanceof fails across module boundaries
+          (error as any)?.name === "RetryAfterError")
+      ) {
+        retriable = (error as RetryAfterError).retryAfter;
       }
 
       const serializedError = serializeError(error);

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -1116,8 +1116,13 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
         (error instanceof StepError &&
           error === this.state.recentlyRejectedStepError)
       );
-      if (retriable && error instanceof RetryAfterError) {
-        retriable = error.retryAfter;
+      if (
+        retriable &&
+        (error instanceof RetryAfterError ||
+          // biome-ignore lint/suspicious/noExplicitAny: instanceof fails across module boundaries
+          (error as any)?.name === "RetryAfterError")
+      ) {
+        retriable = (error as RetryAfterError).retryAfter;
       }
 
       const serializedError = minifyPrettyError(serializeError(error));

--- a/packages/inngest/src/components/execution/v2.ts
+++ b/packages/inngest/src/components/execution/v2.ts
@@ -1117,8 +1117,13 @@ class V2InngestExecution extends InngestExecution implements IInngestExecution {
         (error instanceof StepError &&
           error === this.state.recentlyRejectedStepError)
       );
-      if (retriable && error instanceof RetryAfterError) {
-        retriable = error.retryAfter;
+      if (
+        retriable &&
+        (error instanceof RetryAfterError ||
+          // biome-ignore lint/suspicious/noExplicitAny: instanceof fails across module boundaries
+          (error as any)?.name === "RetryAfterError")
+      ) {
+        retriable = (error as RetryAfterError).retryAfter;
       }
 
       const serializedError = minifyPrettyError(serializeError(error));


### PR DESCRIPTION
## Summary

Adds lint suppressions on top of @pingren's PR #1242  and uses the same pattern for checking `RetryAfterError`s

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- https://github.com/inngest/inngest-js/pull/1242
