### PR TITLE
refactor: JIT event key setting

### DIFF
--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1,6 +1,6 @@
 import type { Mock } from "vitest";
 import { literal } from "zod/v3";
-import { dummyEventKey, envKeys, headerKeys } from "../helpers/consts.ts";
+import { envKeys, headerKeys } from "../helpers/consts.ts";
 import type { IsAny, IsEqual } from "../helpers/types.ts";
 import {
   type EventPayload,
@@ -213,6 +213,19 @@ describe("send", () => {
       );
     });
 
+    test("should succeed in dev mode without event key", async () => {
+      const inngest = createClient({
+        id: "test",
+        isDev: true,
+      });
+
+      await expect(
+        inngest.send({ name: "test", data: {} }),
+      ).resolves.toMatchObject({
+        ids: Array(1).fill(expect.any(String)),
+      });
+    });
+
     test("should succeed if event key specified at instantiation", async () => {
       const inngest = createClient({ id: "test", eventKey: testEventKey });
 
@@ -254,7 +267,7 @@ describe("send", () => {
 
     test("should succeed if event key given at runtime", async () => {
       const inngest = createClient({ id: "test" });
-      inngest.setEventKey(testEventKey);
+      inngest.setEnvVars({ [envKeys.InngestEventKey]: testEventKey });
 
       await expect(inngest.send(testEvent)).resolves.toMatchObject({
         ids: Array(1).fill(expect.any(String)),
@@ -273,8 +286,7 @@ describe("send", () => {
     });
 
     test("should succeed if an empty list of payloads is given", async () => {
-      const inngest = createClient({ id: "test" });
-      inngest.setEventKey(testEventKey);
+      const inngest = createClient({ id: "test", eventKey: testEventKey });
 
       await expect(inngest.send([])).resolves.toMatchObject({
         ids: Array(0).fill(expect.any(String)),
@@ -421,8 +433,7 @@ describe("send", () => {
     });
 
     test("should insert `ts` timestamp ", async () => {
-      const inngest = createClient({ id: "test" });
-      inngest.setEventKey(testEventKey);
+      const inngest = createClient({ id: "test", eventKey: testEventKey });
 
       const testEventWithoutTs = {
         name: "test.without.ts",
@@ -453,8 +464,7 @@ describe("send", () => {
     });
 
     test("should insert blank `data` if none given", async () => {
-      const inngest = createClient({ id: "test" });
-      inngest.setEventKey(testEventKey);
+      const inngest = createClient({ id: "test", eventKey: testEventKey });
 
       const testEventWithoutData = {
         name: "test.without.data",
@@ -484,8 +494,7 @@ describe("send", () => {
 
     if (nodeVersion?.major && nodeVersion.major >= 19) {
       test("should use seed header for idempotency ID if none given", async () => {
-        const inngest = createClient({ id: "test" });
-        inngest.setEventKey(testEventKey);
+        const inngest = createClient({ id: "test", eventKey: testEventKey });
 
         const testEventWithoutId = {
           name: "test.without.id",
@@ -778,10 +787,40 @@ describe("setEnvVars", () => {
 
   test("updates event key from env", () => {
     const inngest = createClient({ id: "test" });
-    expect(inngest["eventKey"]).toBe(dummyEventKey);
+    expect(inngest["eventKey"]).toBe(undefined);
 
     inngest.setEnvVars({ [envKeys.InngestEventKey]: "new-key" });
     expect(inngest["eventKey"]).toBe("new-key");
+  });
+
+  test("setEnvVars without event key preserves existing key", () => {
+    const inngest = createClient({ id: "test", eventKey: "my-key" });
+    inngest.setEnvVars({ SOME_OTHER_VAR: "value" });
+    expect(inngest["eventKey"]).toBe("my-key");
+  });
+
+  test("options eventKey takes priority over env", () => {
+    const inngest = createClient({ id: "test", eventKey: "options-key" });
+    inngest.setEnvVars({ [envKeys.InngestEventKey]: "env-key" });
+    expect(inngest["eventKey"]).toBe("options-key");
+  });
+});
+
+describe("eventKeySet", () => {
+  test("returns false when no key set", () => {
+    const inngest = createClient({ id: "test" });
+    expect(inngest["eventKeySet"]()).toBe(false);
+  });
+
+  test("returns true when key is set via options", () => {
+    const inngest = createClient({ id: "test", eventKey: "my-key" });
+    expect(inngest["eventKeySet"]()).toBe(true);
+  });
+
+  test("returns true when key is set via env", () => {
+    const inngest = createClient({ id: "test" });
+    inngest.setEnvVars({ [envKeys.InngestEventKey]: "my-key" });
+    expect(inngest["eventKeySet"]()).toBe(true);
   });
 });
 

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -105,11 +105,6 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
    */
   private readonly options: TClientOpts;
 
-  /**
-   * Inngest event key, used to send events to Inngest Cloud.
-   */
-  private eventKey = "";
-
   private readonly inngestApi: InngestApi;
 
   private readonly _userProvidedFetch?: FetchT;
@@ -188,6 +183,12 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
       this._env[envKeys.InngestEventApiBaseUrl] ||
       this._env[envKeys.InngestBaseUrl] ||
       this.resolveDefaultUrl(defaultInngestEventBaseUrl)
+    );
+  }
+
+  get eventKey(): string | undefined {
+    return (
+      this.options.eventKey || this._env[envKeys.InngestEventKey] || undefined
     );
   }
 
@@ -293,8 +294,6 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
       fetch: () => this.fetch,
     });
 
-    this.loadEnvDependentConfig();
-
     this.logger = logger;
 
     this.middleware = this.initializeMiddleware([
@@ -322,16 +321,8 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
     env: Record<string, string | undefined> = allProcessEnv(),
   ): this {
     this._env = { ...this._env, ...env };
-    this.loadEnvDependentConfig();
 
     return this;
-  }
-
-  // TODO: In v4 this will be updated as part of EXE-1151
-  private loadEnvDependentConfig(): void {
-    this.setEventKey(
-      this.options.eventKey || this._env[envKeys.InngestEventKey] || "",
-    );
   }
 
   /**
@@ -435,24 +426,8 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
     return new Error(`Inngest API Error: ${response.status} ${errorMessage}`);
   }
 
-  /**
-   * Set the event key for this instance of Inngest. This is useful if for some
-   * reason the key is not available at time of instantiation or present in the
-   * `INNGEST_EVENT_KEY` environment variable.
-   */
-  public setEventKey(
-    /**
-     * Inngest event key, used to send events to Inngest Cloud. Use this is your
-     * key is for some reason not available at time of instantiation or present
-     * in the `INNGEST_EVENT_KEY` environment variable.
-     */
-    eventKey: string,
-  ): void {
-    this.eventKey = eventKey || dummyEventKey;
-  }
-
   private eventKeySet(): boolean {
-    return Boolean(this.eventKey) && this.eventKey !== dummyEventKey;
+    return this.eventKey !== undefined;
   }
 
   /**
@@ -729,7 +704,10 @@ export class Inngest<TClientOpts extends ClientOptions = ClientOptions>
 
         // We don't need to do fallback auth here because this uses event keys and
         // not signing keys
-        const url = new URL(`e/${this.eventKey}`, this.eventBaseUrl);
+        const url = new URL(
+          `e/${this.eventKey ?? dummyEventKey}`,
+          this.eventBaseUrl,
+        );
         const response = await this.fetch(url.href, {
           method: "POST",
           body: stringify(payloads),

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -5,7 +5,6 @@ import { getAsyncCtx } from "../experimental";
 import {
   debugPrefix,
   defaultMaxRetries,
-  dummyEventKey,
   ExecutionVersion,
   envKeys,
   forwardedHeaders,
@@ -535,10 +534,10 @@ export class InngestCommHandler<
   }
 
   private get hashedEventKey(): string | undefined {
-    if (!this.client["eventKey"] || this.client["eventKey"] === dummyEventKey) {
+    if (!this.client.eventKey) {
       return undefined;
     }
-    return hashEventKey(this.client["eventKey"]);
+    return hashEventKey(this.client.eventKey);
   }
 
   // hashedSigningKey creates a sha256 checksum of the signing key with the

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -515,7 +515,6 @@ export const fixEventKeyMissingSteps = [
   `Pass a key to the \`new Inngest()\` constructor using the \`${
     "eventKey" satisfies keyof ClientOptions
   }\` option`,
-  `Use \`inngest.${"setEventKey" satisfies keyof Inngest.Any}()\` at runtime`,
 ];
 
 /**


### PR DESCRIPTION
## Summary
Instead of a dummy event key being set across the app, we *only* tack that in when we're sending in dev with an undefined key.


## Checklist

- [x] Added unit/integration tests

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
[EXE-1151: Client's `eventKey` field is never set to the dummy event key](https://linear.app/inngest/issue/EXE-1151/clients-eventkey-field-is-never-set-to-the-dummy-event-key)
