### PR TITLE
chore: remove event.user

### DIFF
--- a/packages/inngest/src/components/InngestMiddleware.test.ts
+++ b/packages/inngest/src/components/InngestMiddleware.test.ts
@@ -791,7 +791,7 @@ describe("stacking and inference", () => {
                             payloads: [
                               {
                                 name: "foo",
-                                user: { userFromMiddleware: true },
+                                data: { dataFromMiddleware: true },
                               },
                             ],
                           };
@@ -828,10 +828,7 @@ describe("stacking and inference", () => {
                 opts: expect.objectContaining({
                   payload: {
                     data: {
-                      dataFromStep: true,
-                    },
-                    user: {
-                      userFromMiddleware: true,
+                      dataFromMiddleware: true,
                     },
                   },
                 }),

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -680,8 +680,8 @@ export const createStepTools = <TClient extends Inngest.Any>(
         );
       }
 
-      const { _type, function: fn, data, user, v, timeout } = parsedFnOpts.data;
-      const payload = { data, user, v } satisfies MinimalEventPayload;
+      const { _type, function: fn, data, v, timeout } = parsedFnOpts.data;
+      const payload = { data, v } satisfies MinimalEventPayload;
       const opts: {
         payload: MinimalEventPayload;
         function_id: string;
@@ -875,7 +875,6 @@ const getDeferredStepTooling = async (): Promise<GenericStepTools> => {
  */
 export const invokePayloadSchema = z.object({
   data: z.record(z.any()).optional(),
-  user: z.record(z.any()).optional(),
   v: z.string().optional(),
 });
 

--- a/packages/inngest/src/helpers/functions.test.ts
+++ b/packages/inngest/src/helpers/functions.test.ts
@@ -10,7 +10,6 @@ const generateEvent = (): EventPayload => {
   return {
     name: randomstr(),
     data: { hello: "world" },
-    user: {},
     ts: 0,
   };
 };

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -1374,7 +1374,6 @@ export const testFramework = (
             id: "",
             name: "inngest/scheduled.timer",
             ts: 1674082830001,
-            user: {},
             v: "1",
           };
 
@@ -1402,7 +1401,7 @@ export const testFramework = (
                 method: "POST",
                 headers: {
                   [headerKeys.Signature]:
-                    "t=1687306735&s=70312c7815f611a4aa0b6f985910a85a6c232c845838d7f49f1d05fd8b2b0779",
+                    "t=1687306735&s=eece58c8cf7cfc21a5751b1969c9aef525c96257b42b556c2782c83d26ea0d87",
                 },
                 url: "/api/inngest?fnId=test-test&stepId=step",
                 body,
@@ -1427,7 +1426,6 @@ export const testFramework = (
               id: "",
               name: "inngest/scheduled.timer",
               ts: 1674082830001,
-              user: {},
               v: "1",
             };
 
@@ -1455,7 +1453,7 @@ export const testFramework = (
                   method: "POST",
                   headers: {
                     [headerKeys.Signature]:
-                      "t=1687306735&s=70312c7815f611a4aa0b6f985910a85a6c232c845838d7f49f1d05fd8b2b0779",
+                      "t=1687306735&s=eece58c8cf7cfc21a5751b1969c9aef525c96257b42b556c2782c83d26ea0d87",
                   },
                   url: "/api/inngest?fnId=test-test&stepId=step",
                   body,
@@ -1480,7 +1478,6 @@ export const testFramework = (
               id: "",
               name: "inngest/scheduled.timer",
               ts: 1674082830001,
-              user: {},
               v: "1",
             };
 
@@ -1508,7 +1505,7 @@ export const testFramework = (
                   method: "POST",
                   headers: {
                     [headerKeys.Signature]:
-                      "t=1687306735&s=70312c7815f611a4aa0b6f985910a85a6c232c845838d7f49f1d05fd8b2b0779",
+                      "t=1687306735&s=eece58c8cf7cfc21a5751b1969c9aef525c96257b42b556c2782c83d26ea0d87",
                   },
                   url: "/api/inngest?fnId=test-test&stepId=step",
                   body,
@@ -1547,7 +1544,6 @@ export const testFramework = (
               id: "",
               name: "inngest/scheduled.timer",
               ts: 1674082830001,
-              user: {},
               v: "1",
             };
 
@@ -1576,7 +1572,7 @@ export const testFramework = (
                   method: "POST",
                   headers: {
                     [headerKeys.Signature]:
-                      "t=1687306735&s=70312c7815f611a4aa0b6f985910a85a6c232c845838d7f49f1d05fd8b2b0779",
+                      "t=1687306735&s=eece58c8cf7cfc21a5751b1969c9aef525c96257b42b556c2782c83d26ea0d87",
                   },
                   url: "/api/inngest?fnId=test-test&stepId=step",
                   body,
@@ -1637,14 +1633,13 @@ export const testFramework = (
 export const sendEvent = async (
   name: string,
   data?: Record<string, unknown>,
-  user?: Record<string, unknown>,
 ): Promise<string> => {
   const res = await fetch("http://localhost:8288/e/key", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ name, data: data || {}, user, ts: Date.now() }),
+    body: JSON.stringify({ name, data: data || {}, ts: Date.now() }),
   });
 
   if (!res.ok) {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -603,13 +603,6 @@ export interface MinimalEventPayload<TData = any> {
   data?: TData;
 
   /**
-   * Any user data associated with the event
-   * All fields ending in "_id" will be used to attribute the event to a particular user
-   */
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  user?: any;
-
-  /**
    * A specific event schema version
    * (optional)
    */


### PR DESCRIPTION
## Summary
Nuke the no-longer-supported `event.user` property



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
[EXE-1129: Remove `event.user`](https://linear.app/inngest/issue/EXE-1129/remove-eventuser)
