### PR TITLE
docs: fix typo in CONTRIBUTING.md getting started section

### DIFF
--- a/packages/inngest/CONTRIBUTING.md
+++ b/packages/inngest/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Prerequisites:
 
 1. Clone this repository
-2. Intall [`pnpm`](https://pnpm.io/installation)
+2. Install [`pnpm`](https://pnpm.io/installation)
 3. Install [Volta](https://volta.sh/) to manage consistent Node versions (optional)
 
 ### Development


### PR DESCRIPTION
## Summary
Fixed a typo in `packages/inngest/CONTRIBUTING.md`. 
Changed "Intall" to "Install" in the Prerequisites section.

## Checklist
- [ ] ~~Added a docs PR~~ N/A This is a direct edit to the repo guidelines.
- [ ] ~~Added unit/integration tests~~ N/A Documentation only.
- [ ] ~~Added changesets if applicable~~ N/A No package version bump required for docs.


