### PR TITLE
refactor: remove `step.invoke` string argument

### DIFF
--- a/packages/inngest/MIGRATION.md
+++ b/packages/inngest/MIGRATION.md
@@ -98,3 +98,33 @@ serve({ client, functions, streaming: true });
 ## Edge Environment Improvements
 
 In v4, fetch and configuration are now resolved lazily at first use rather than eagerly at client construction. This means you no longer need to manually bind `globalThis.fetch` before creating an Inngest client in edge environments (Cloudflare Workers, Vercel Edge, Deno, etc.).
+
+## Remove String Function IDs in `step.invoke()`
+
+Passing a raw string to `step.invoke()` is no longer supported. Use `referenceFunction()` or pass an imported function instance instead.
+
+```typescript
+// Old (v3) - No longer works
+await step.invoke("my-step", {
+  function: "my-app-other-fn",
+  data: { foo: "bar" },
+});
+
+// New (v4) - Use referenceFunction for cross-app invocation
+import { referenceFunction } from "inngest";
+
+await step.invoke("my-step", {
+  function: referenceFunction({ appId: "my-app", functionId: "other-fn" }),
+  data: { foo: "bar" },
+});
+
+// Or pass an imported function instance directly
+import { otherFn } from "./other-fn";
+
+await step.invoke("my-step", {
+  function: otherFn,
+  data: { foo: "bar" },
+});
+```
+
+The `referenceFunction()` helper provides type safety and avoids the footgun of manually constructing the `appId-functionId` string.

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -854,19 +854,6 @@ describe("invoke", () => {
         });
       });
 
-      test("with `function` string", async () => {
-        await expect(
-          step.invoke("id", {
-            function: "some-client-some-fn",
-            data: { foo: "foo" },
-          }),
-        ).resolves.toMatchObject({
-          opts: {
-            function_id: "some-client-some-fn",
-          },
-        });
-      });
-
       test("with `function` ref instance", async () => {
         await expect(
           step.invoke("id", {
@@ -963,10 +950,6 @@ describe("invoke", () => {
       ReturnType<T>
     >;
 
-    test("allows specifying function as a string", () => {
-      const _test = () => invoke("id", { function: "test-fn", data: "foo" });
-    });
-
     test("allows specifying function as an instance", () => {
       const fn = client.createFunction(
         { id: "fn" },
@@ -975,10 +958,6 @@ describe("invoke", () => {
       );
 
       const _test = () => invoke("id", { function: fn, data: { foo: "" } });
-    });
-
-    test("allows specifying function as a string", () => {
-      const _test = () => invoke("id", { function: "fn", data: { foo: "" } });
     });
 
     test("allows specifying function as a reference function", () => {

--- a/packages/inngest/src/test/functions/step-invoke-not-found/index.ts
+++ b/packages/inngest/src/test/functions/step-invoke-not-found/index.ts
@@ -1,3 +1,4 @@
+import { referenceFunction } from "inngest";
 import { inngest } from "../client";
 
 export default inngest.createFunction(
@@ -5,7 +6,7 @@ export default inngest.createFunction(
   { event: "demo/step.invoke.not-found" },
   async ({ step }) => {
     await step.invoke("invoke-non-existent-fn", {
-      function: "non-existant-fn",
+      function: referenceFunction({ functionId: "non-existant-fn" }),
     });
   },
 );

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1509,8 +1509,7 @@ export type MetadataTarget =
  */
 export type InvokeTargetFunctionDefinition =
   | Public<InngestFunctionReference.Any>
-  | Public<InngestFunction.Any>
-  | string;
+  | Public<InngestFunction.Any>;
 
 /**
  * Given an invocation target, extract the payload that will be used to trigger


### PR DESCRIPTION
## Summary
Remove the ability to just pass a string to `step.invoke` because it was a footgun 

## Related
[EXE-1132: Remove `function: string` in `step.invoke`](https://linear.app/inngest/issue/EXE-1132/remove-function-string-in-stepinvoke)
