### PR TITLE
EXE-834 Add `endpointAdapter` to Express adapter

### DIFF
--- a/packages/inngest/src/express.ts
+++ b/packages/inngest/src/express.ts
@@ -22,12 +22,16 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import type { Request, Response } from "express";
+import type { Inngest } from "./components/Inngest.ts";
 import {
   InngestCommHandler,
   type ServeHandlerOptions,
+  type SyncHandlerOptions,
 } from "./components/InngestCommHandler.ts";
+import { handleDurableEndpointProxyRequest } from "./components/InngestDurableEndpointProxy.ts";
+import { InngestEndpointAdapter } from "./components/InngestEndpointAdapter.ts";
 import type { Either } from "./helpers/types.ts";
-import type { SupportedFrameworkName } from "./types.ts";
+import type { RegisterOptions, SupportedFrameworkName } from "./types.ts";
 
 /**
  * The name of the framework, used to identify the framework in Inngest
@@ -35,37 +39,17 @@ import type { SupportedFrameworkName } from "./types.ts";
  */
 export const frameworkName: SupportedFrameworkName = "express";
 
-/**
- * Serve and register any declared functions with Inngest, making them available
- * to be triggered by events.
- *
- * The return type is currently `any` to ensure there's no required type matches
- * between the `express` and `vercel` packages. This may change in the future to
- * appropriately infer.
- *
- * @example
- * ```ts
- * import { serve } from "inngest/express";
- * import { inngest } from "./src/inngest/client";
- * import fnA from "./src/inngest/fnA"; // Your own function
- *
- * // Important:  ensure you add JSON middleware to process incoming JSON POST payloads.
- * app.use(express.json());
- * app.use(
- *   // Expose the middleware on our recommended path at `/api/inngest`.
- *   "/api/inngest",
- *   serve({ client: inngest, functions: [fnA] })
- * );
- * ```
- *
- * @public
- */
-// Has explicit return type to avoid JSR-defined "slow types"
-// biome-ignore lint/suspicious/noExplicitAny: intentional
-export const serve = (options: ServeHandlerOptions): any => {
-  const handler = new InngestCommHandler({
+// biome-ignore lint/suspicious/noExplicitAny: intentional to avoid type portability issues
+export type ExpressHandler = (...args: any[]) => any;
+
+const commHandler = (
+  options: RegisterOptions & { client: Inngest.Like },
+  syncOptions?: SyncHandlerOptions,
+) => {
+  return new InngestCommHandler({
     frameworkName,
     ...options,
+    syncOptions,
     handler: (
       req: Either<VercelRequest, Request>,
       res: Either<Response, VercelResponse>,
@@ -143,9 +127,124 @@ export const serve = (options: ServeHandlerOptions): any => {
             }
           }
         },
+
+        experimentalTransformSyncResponse: async (data) => {
+          const expressRes = data as Response;
+          const headers: Record<string, string> = {};
+
+          const rawHeaders = expressRes.getHeaders?.() || {};
+          for (const [k, v] of Object.entries(rawHeaders)) {
+            if (typeof v === "string") {
+              headers[k] = v;
+            } else if (Array.isArray(v)) {
+              headers[k] = v.join(", ");
+            }
+          }
+
+          return {
+            headers,
+            status: expressRes.statusCode || 200,
+            body: "",
+          };
+        },
       };
     },
   });
-
-  return handler.createHandler();
 };
+
+/**
+ * Serve and register any declared functions with Inngest, making them available
+ * to be triggered by events.
+ *
+ * The return type is currently `any` to ensure there's no required type matches
+ * between the `express` and `vercel` packages. This may change in the future to
+ * appropriately infer.
+ *
+ * @example
+ * ```ts
+ * import { serve } from "inngest/express";
+ * import { inngest } from "./src/inngest/client";
+ * import fnA from "./src/inngest/fnA"; // Your own function
+ *
+ * // Important:  ensure you add JSON middleware to process incoming JSON POST payloads.
+ * app.use(express.json());
+ * app.use(
+ *   // Expose the middleware on our recommended path at `/api/inngest`.
+ *   "/api/inngest",
+ *   serve({ client: inngest, functions: [fnA] })
+ * );
+ * ```
+ *
+ * @public
+ */
+// Has explicit return type to avoid JSR-defined "slow types"
+// biome-ignore lint/suspicious/noExplicitAny: intentional
+export const serve = (options: ServeHandlerOptions): any => {
+  return commHandler(options).createHandler();
+};
+
+/**
+ * Creates a durable endpoint proxy handler for Express environments.
+ */
+const createDurableEndpointProxyHandler = (
+  options: InngestEndpointAdapter.ProxyHandlerOptions,
+): ExpressHandler => {
+  return async (
+    req: Either<VercelRequest, Request>,
+    res: Either<Response, VercelResponse>,
+  ): Promise<void> => {
+    const runId = req.query?.runId;
+    const token = req.query?.token;
+
+    const result = await handleDurableEndpointProxyRequest(
+      options.client as Inngest.Any,
+      {
+        runId: Array.isArray(runId)
+          ? (runId[0] ?? null)
+          : (runId?.toString() ?? null),
+        token: Array.isArray(token)
+          ? (token[0] ?? null)
+          : (token?.toString() ?? null),
+        method: req.method || "GET",
+      },
+    );
+
+    for (const [name, value] of Object.entries(result.headers)) {
+      res.setHeader(name, value);
+    }
+
+    res.status(result.status).send(result.body);
+  };
+};
+
+/**
+ * In Express, create a function that can wrap any endpoint to be able to use
+ * steps seamlessly within that API.
+ *
+ * @example
+ * ```ts
+ * import express from "express";
+ * import { Inngest, step } from "inngest";
+ * import { endpointAdapter } from "inngest/express";
+ *
+ * const inngest = new Inngest({
+ *   id: "my-app",
+ *   endpointAdapter,
+ * });
+ *
+ * const app = express();
+ * app.use(express.json());
+ *
+ * app.get("/api/durable", inngest.endpoint(async (req, res) => {
+ *   const foo = await step.run("my-step", () => ({ foo: "bar" }));
+ *   res.json({ result: foo });
+ * }));
+ * ```
+ */
+export const endpointAdapter: InngestEndpointAdapter.Like & {
+  createProxyHandler: (
+    options: InngestEndpointAdapter.ProxyHandlerOptions,
+  ) => ExpressHandler;
+} = InngestEndpointAdapter.create((options) => {
+  return commHandler(options, options).createSyncHandler();
+}, createDurableEndpointProxyHandler);


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add an Express Durable Endpoints adapter.

```ts
import express from "express";
import { Inngest, step } from "inngest";
import { endpointAdapter } from "inngest/express";

const inngest = new Inngest({
  id: "my-app",
  endpointAdapter,
});

const app = express();
app.use(express.json());

app.get(
  "/api/durable",
  inngest.endpoint(async (req, res) => {
    const foo = await step.run("my-step", () => ({ foo: "bar" }));
    res.json({ result: foo });
  }),
);

```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A post-merge
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-834
