### PR TITLE
fix: handle memoized steps in correct order

### DIFF
--- a/.changeset/tiny-trains-tickle.md
+++ b/.changeset/tiny-trains-tickle.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix: handle memoized steps in correct order, preventing any issues with incorrect results being returned from `Promise.race`. 


### PR DESCRIPTION
## Summary

Fix a bug where when `optimizedParallelism` was set to true, an incorrect result could be returned from `Promise.race` that I found when testing #1281 



## Checklist
- [ ] Added changesets if applicable

## Related
#1281 
