### PR TITLE
Add new OpenAI models gpt-5.2 and gpt-5.1

### DIFF
--- a/packages/ai/src/models/openai.ts
+++ b/packages/ai/src/models/openai.ts
@@ -43,6 +43,8 @@ export namespace OpenAi {
    */
   export type Model =
     | (string & {})
+    | "gpt-5.2"
+    | "gpt-5.1"
     | "gpt-5"
     | "gpt-5-mini"
     | "gpt-5-nano"


### PR DESCRIPTION
## Summary

This PR adds support for the new OpenAI models gpt-5.2 and gpt-5.1.

These models are now included in the available model list so they can be selected and used. This ensures compatibility with the latest OpenAI releases and allows users to take advantage of improved performance and capabilities.