### PR TITLE
feat: add staticSchema for type-only event schemas

### DIFF
--- a/packages/inngest/src/components/triggers/triggers.ts
+++ b/packages/inngest/src/components/triggers/triggers.ts
@@ -254,6 +254,24 @@ export function eventType<
 }
 
 /**
+ * Create a type-only schema that provides TypeScript types without runtime
+ * validation. Returns a hardcoded StandardSchemaV1 whose `validate` is a
+ * passthrough, so invalid data will not be rejected at runtime. Use this when
+ * you want event type safety without pulling in a validation library like Zod.
+ */
+export function staticSchema<
+  TSchema extends Record<string, unknown>,
+>(): StandardSchemaV1<TSchema> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "inngest",
+      validate: (value) => ({ value: value as TSchema }),
+    },
+  };
+}
+
+/**
  * Create an invoke trigger for function-to-function calls.
  *
  * This creates a trigger that allows your function to be invoked directly by

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -66,6 +66,7 @@ export {
   EventType,
   eventType,
   invoke,
+  staticSchema,
 } from "./components/triggers/triggers.ts";
 export {
   isInngest,


### PR DESCRIPTION
## Summary
Add `staticSchema()` for type-only event schemas without runtime validation

<img width="775" height="539" alt="Screenshot 2026-02-19 at 9 43 04 AM" src="https://github.com/user-attachments/assets/2d26de61-d80d-4994-b2ed-0969b4929fe3" />


## Checklist

- [x] Added unit/integration tests