### PR TITLE
fix(otel): support OTel SDK v2 in extendProvider()

### DIFF
--- a/.changeset/fix-otel-v2-extend-provider.md
+++ b/.changeset/fix-otel-v2-extend-provider.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `extendProvider()` for OTel SDK v2 where `addSpanProcessor()` was removed

--- a/packages/inngest/src/components/execution/otel/util.test.ts
+++ b/packages/inngest/src/components/execution/otel/util.test.ts
@@ -1,4 +1,4 @@
-import { trace } from "@opentelemetry/api";
+import { type TracerProvider, trace } from "@opentelemetry/api";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { InngestSpanProcessor } from "./processor.ts";
 import { extendProvider } from "./util.ts";
@@ -60,7 +60,7 @@ describe("extendProvider", () => {
     warnSpy.mockRestore();
   });
 
-  test("should call addSpanProcessor on the underlying provider", () => {
+  test("should call addSpanProcessor on the underlying provider (v1 path)", () => {
     const { provider, addSpanProcessor } = createProviderWithAddSpanProcessor();
     trace.setGlobalTracerProvider(provider);
 
@@ -71,5 +71,69 @@ describe("extendProvider", () => {
     expect(addSpanProcessor).toHaveBeenCalledWith(
       expect.any(InngestSpanProcessor),
     );
+  });
+
+  test("should push into _activeSpanProcessor._spanProcessors when addSpanProcessor is missing (v2 path)", () => {
+    // OTel SDK v2 BasicTracerProvider has no addSpanProcessor method.
+    // Simulate by creating a plain provider (v2 BasicTracerProvider) which
+    // exposes _activeSpanProcessor._spanProcessors at runtime.
+    const provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+
+    const result = extendProvider("auto");
+
+    expect(result.success).toBe(true);
+    expect((result as { processor: unknown }).processor).toBeInstanceOf(
+      InngestSpanProcessor,
+    );
+
+    // Verify the processor was pushed into the internal array
+    // biome-ignore lint/suspicious/noExplicitAny: accessing OTel internals for test assertion
+    const spanProcessors = (provider as any)._activeSpanProcessor
+      ._spanProcessors;
+    expect(spanProcessors).toContainEqual(expect.any(InngestSpanProcessor));
+  });
+
+  test("should succeed with behaviour 'extendProvider' via v2 path", () => {
+    const provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+
+    const result = extendProvider("extendProvider");
+
+    expect(result.success).toBe(true);
+  });
+
+  test("should warn and fail when provider has neither addSpanProcessor nor _activeSpanProcessor", () => {
+    const mockProvider = {
+      getTracer: vi.fn(),
+    };
+    trace.setGlobalTracerProvider(mockProvider as unknown as TracerProvider);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = extendProvider("extendProvider");
+
+    expect(result.success).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unable to add InngestSpanProcessor"),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test("should not warn on unknown provider when behaviour is 'auto'", () => {
+    const mockProvider = {
+      getTracer: vi.fn(),
+    };
+    trace.setGlobalTracerProvider(mockProvider as unknown as TracerProvider);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = extendProvider("auto");
+
+    expect(result.success).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -66,14 +66,7 @@ export const extendProvider = (
       ? globalProvider.getDelegate()
       : globalProvider;
 
-  if (
-    !existingProvider ||
-    !("addSpanProcessor" in existingProvider) ||
-    typeof existingProvider.addSpanProcessor !== "function"
-  ) {
-    // TODO Could we also add a function the user can provide that takes the
-    // processor and adds it? That way they could support many different
-    // providers.
+  if (!existingProvider) {
     if (behaviour !== "auto") {
       console.warn(
         "Existing OTel provider is not a BasicTracerProvider. Inngest's OTel middleware will not work, as it can only extend an existing processor if it's a BasicTracerProvider.",
@@ -84,7 +77,59 @@ export const extendProvider = (
   }
 
   const processor = new InngestSpanProcessor();
-  existingProvider.addSpanProcessor(processor);
 
-  return { success: true, processor };
+  // OTel SDK v1 exposes addSpanProcessor() on BasicTracerProvider.
+  if (
+    "addSpanProcessor" in existingProvider &&
+    typeof existingProvider.addSpanProcessor === "function"
+  ) {
+    existingProvider.addSpanProcessor(processor);
+    return { success: true, processor };
+  }
+
+  // OTel SDK v2 removed addSpanProcessor() — span processors are constructor-only.
+  // No public API exists to add processors post-construction (OTel issue #5299),
+  // so push into the internal _spanProcessors array.
+  // These fields are TypeScript `private` (not #private), so accessible at runtime.
+  const spanProcessors = getInternalSpanProcessors(existingProvider);
+  if (spanProcessors) {
+    spanProcessors.push(processor);
+    return { success: true, processor };
+  }
+
+  if (behaviour !== "auto") {
+    console.warn(
+      "Unable to add InngestSpanProcessor to existing OTel provider. " +
+        "The provider does not support addSpanProcessor() (OTel SDK v1) " +
+        "or expose _activeSpanProcessor._spanProcessors (OTel SDK v2).",
+    );
+  }
+
+  return { success: false };
 };
+
+/**
+ * Extract the internal span processors array from a BasicTracerProvider.
+ * Returns the mutable array if accessible, undefined otherwise.
+ *
+ * BasicTracerProvider._activeSpanProcessor is a MultiSpanProcessor,
+ * which holds a _spanProcessors: SpanProcessor[] array.
+ * Both are TypeScript `private` (not ES #private), so accessible at runtime.
+ *
+ * Wrapped in try/catch because this accesses internal OTel fields that may
+ * change — must never crash the host app.
+ */
+function getInternalSpanProcessors(
+  provider: unknown,
+): unknown[] | undefined {
+  try {
+    const active = (provider as Record<string, unknown>)
+      ?._activeSpanProcessor;
+    if (typeof active !== "object" || active === null) return undefined;
+
+    const arr = (active as Record<string, unknown>)._spanProcessors;
+    return Array.isArray(arr) ? arr : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -119,12 +119,9 @@ export const extendProvider = (
  * Wrapped in try/catch because this accesses internal OTel fields that may
  * change — must never crash the host app.
  */
-function getInternalSpanProcessors(
-  provider: unknown,
-): unknown[] | undefined {
+function getInternalSpanProcessors(provider: unknown): unknown[] | undefined {
   try {
-    const active = (provider as Record<string, unknown>)
-      ?._activeSpanProcessor;
+    const active = (provider as Record<string, unknown>)?._activeSpanProcessor;
     if (typeof active !== "object" || active === null) return undefined;
 
     const arr = (active as Record<string, unknown>)._spanProcessors;


### PR DESCRIPTION
## Summary

`extendProvider()` fails when the host app uses OTel SDK v2 because `BasicTracerProvider.addSpanProcessor()` was removed in v2.0.0. The duck-type check always fails → warning → no Inngest traces.

This PR:
- Tries `addSpanProcessor()` first (v1 compat)
- Falls back to pushing into the internal `_activeSpanProcessor._spanProcessors` array (v2)
- Helper is wrapped in try/catch — can never crash the host app
- Adds tests for the v2 path, unknown providers, and warning behavior

## Checklist

- _N/A — internal bug fix, no docs change needed_
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- Fixes #1324
- Follow-up to #1296 / PR #1297 (ProxyTracerProvider unwrapping)