### PR TITLE
Make `INNGEST_CONNECT_ISOLATE_EXECUTION` opt-out

### DIFF
--- a/examples/connect-example/index.ts
+++ b/examples/connect-example/index.ts
@@ -54,9 +54,6 @@ connect({
     },
   ],
   instanceId: "my-worker",
-  rewriteGatewayEndpoint: (endpoint) => {
-    return endpoint.replace("connect-gateway:8080", "localhost:8100");
-  },
 }).then(async (conn) => {
   console.log("Connected!");
 

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -121,6 +121,21 @@ class WebSocketWorkerConnection implements WorkerConnection {
       }
     }
 
+    // Check for worker thread env var (opt-out: false/0 disables isolation)
+    if (options.isolateExecution === undefined) {
+      const envValue = env[envKeys.InngestConnectIsolateExecution];
+      if (envValue === "0" || envValue === "false") {
+        options.isolateExecution = false;
+      }
+    }
+
+    if (options.gatewayUrl === undefined) {
+      const envValue = env[envKeys.InngestConnectGatewayUrl];
+      if (envValue) {
+        options.gatewayUrl = envValue;
+      }
+    }
+
     return options;
   }
 

--- a/packages/inngest/src/components/connect/strategies/core/connection.ts
+++ b/packages/inngest/src/components/connect/strategies/core/connection.ts
@@ -62,7 +62,7 @@ export interface Connection {
 export interface ConnectionCoreConfig extends BaseConnectionConfig {
   instanceId?: string;
   maxWorkerConcurrency?: number;
-  rewriteGatewayEndpoint?: (endpoint: string) => string;
+  gatewayUrl?: string;
   appIds: string[];
 }
 
@@ -304,16 +304,12 @@ export class ConnectionCore {
       );
     }, 10_000);
 
-    let finalEndpoint = startResp.gatewayEndpoint;
-    if (this.config.rewriteGatewayEndpoint) {
-      const rewritten = this.config.rewriteGatewayEndpoint(
-        startResp.gatewayEndpoint,
-      );
-      this.callbacks.log("Rewriting gateway endpoint", {
+    const finalEndpoint = this.config.gatewayUrl || startResp.gatewayEndpoint;
+    if (finalEndpoint !== startResp.gatewayEndpoint) {
+      this.callbacks.log("Overriding gateway endpoint", {
         original: startResp.gatewayEndpoint,
-        rewritten,
+        override: finalEndpoint,
       });
-      finalEndpoint = rewritten;
     }
 
     this.callbacks.log("Connecting to gateway", {

--- a/packages/inngest/src/components/connect/strategies/sameThread/index.ts
+++ b/packages/inngest/src/components/connect/strategies/sameThread/index.ts
@@ -33,7 +33,7 @@ export class SameThreadStrategy extends BaseStrategy {
         instanceId: config.options.instanceId,
         maxWorkerConcurrency: config.options.maxWorkerConcurrency,
         mode: config.mode,
-        rewriteGatewayEndpoint: config.options.rewriteGatewayEndpoint,
+        gatewayUrl: config.options.gatewayUrl,
       },
       {
         log: (message, data) => this.debugLog(message, data),

--- a/packages/inngest/src/components/connect/strategies/workerThread/index.ts
+++ b/packages/inngest/src/components/connect/strategies/workerThread/index.ts
@@ -284,18 +284,12 @@ export class WorkerThreadStrategy extends BaseStrategy {
   }
 
   private async buildSerializableConfig(): Promise<SerializableConfig> {
-    if (this.config.options.rewriteGatewayEndpoint) {
-      // TODO: Figure out how to support this. Currently, we don't support it
-      throw new Error(
-        "rewriteGatewayEndpoint is not supported in worker threads",
-      );
-    }
-
     return {
       apiBaseUrl: this.config.apiBaseUrl,
       appIds: Object.keys(this.config.requestHandlers),
       connectionData: this.config.connectionData,
       envName: this.config.envName,
+      gatewayUrl: this.config.options.gatewayUrl,
       handleShutdownSignals: this.config.options.handleShutdownSignals,
       hashedFallbackKey: this.config.hashedFallbackKey,
       hashedSigningKey: this.config.hashedSigningKey,

--- a/packages/inngest/src/components/connect/strategies/workerThread/protocol.ts
+++ b/packages/inngest/src/components/connect/strategies/workerThread/protocol.ts
@@ -4,10 +4,6 @@ import type { BaseConnectionConfig } from "../core/types.ts";
 /**
  * Serializable configuration for the worker thread. This contains all the data
  * needed to establish and maintain a connection.
- *
- * Extends BaseConnectionConfig with worker-specific options. Note that
- * `rewriteGatewayEndpoint` is not supported in worker threads since functions
- * cannot be serialized.
  */
 export interface SerializableConfig extends BaseConnectionConfig {
   /**
@@ -19,6 +15,11 @@ export interface SerializableConfig extends BaseConnectionConfig {
    * Max worker concurrency.
    */
   maxWorkerConcurrency?: number;
+
+  /**
+   * Override the gateway WebSocket endpoint.
+   */
+  gatewayUrl?: string;
 
   /**
    * Signals to handle for graceful shutdown.

--- a/packages/inngest/src/components/connect/strategies/workerThread/runner.ts
+++ b/packages/inngest/src/components/connect/strategies/workerThread/runner.ts
@@ -131,11 +131,7 @@ class WorkerRunner {
     this.core = new ConnectionCore(
       {
         ...this.config,
-
-        // TODO: Figure out how to support this. Currently, we don't support it
-        // because functions can't be passed to worker threads (since they
-        // aren't serializable)
-        rewriteGatewayEndpoint: undefined,
+        gatewayUrl: this.config.gatewayUrl,
       },
       {
         log: (message, data) => this.log(message, data),

--- a/packages/inngest/src/components/connect/types.ts
+++ b/packages/inngest/src/components/connect/types.ts
@@ -33,18 +33,28 @@ export interface ConnectHandlerOptions extends RegisterOptions {
    */
   handleShutdownSignals?: string[];
 
-  rewriteGatewayEndpoint?: (endpoint: string) => string;
+  /**
+   * Override the gateway WebSocket endpoint. When set, this URL is used
+   * instead of the endpoint returned by the Inngest API.
+   *
+   * Useful when there is a proxy between the worker and the gateway
+   * that requires a different hostname (e.g. `ws://localhost:8100`).
+   *
+   * Can also be set via the `INNGEST_CONNECT_GATEWAY_URL` environment variable.
+   * This option takes precedence over the env var.
+   */
+  gatewayUrl?: string;
 
   /**
    * Enable running the WebSocket connection, heartbeater, and lease extender
    * in a separate worker thread. This prevents thread-blocking user code from
    * interfering with connection health.
    *
-   * Only works in Node.js environments that support worker_threads.
+   * Only works in environments that support worker_threads.
    *
-   * Can also be enabled via the INNGEST_CONNECT_ISOLATE_EXECUTION environment variable.
+   * Can also be disabled via the INNGEST_CONNECT_ISOLATE_EXECUTION=false environment variable.
    *
-   * @default false
+   * @default true
    */
   isolateExecution?: boolean;
 }

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -39,6 +39,7 @@ export enum envKeys {
   InngestAllowInBandSync = "INNGEST_ALLOW_IN_BAND_SYNC",
   InngestConnectMaxWorkerConcurrency = "INNGEST_CONNECT_MAX_WORKER_CONCURRENCY",
   InngestConnectIsolateExecution = "INNGEST_CONNECT_ISOLATE_EXECUTION",
+  InngestConnectGatewayUrl = "INNGEST_CONNECT_GATEWAY_URL",
 
   /**
    * @deprecated It's unknown what this env var was used for, but we do not


### PR DESCRIPTION
## Summary

Make the connection isolation opt out, but provide a working way to provide the workers with the gateway rewrite. 

## Checklist

- [x] Added unit/integration tests

## Related
[EXE-1320](https://linear.app/inngest/issue/EXE-1320/make-inngest-connect-isolate-execution-opt-out)