### PR TITLE
fix: parent userland spans under correct step during checkpointing

### DIFF
--- a/.changeset/bumpy-readers-smell.md
+++ b/.changeset/bumpy-readers-smell.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix: use deterministic IDs for correct checkpointed parenting

--- a/packages/inngest/src/components/execution/otel/consts.ts
+++ b/packages/inngest/src/components/execution/otel/consts.ts
@@ -13,4 +13,5 @@ export enum Attribute {
   InngestAppId1 = "sdk.app.id",
   InngestAppId2 = "sys.app.id",
   InngestFunctionId = "sys.function.id",
+  InngestStepParentSpanId = "inngest.step.parentSpanId",
 }

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -19,6 +19,7 @@ import {
   defaultDevServerHost,
   defaultInngestApiBaseUrl,
 } from "../../../helpers/consts.ts";
+import { deterministicSpanID } from "../../../helpers/deterministicId.ts";
 import { devServerAvailable } from "../../../helpers/devserver.ts";
 import { devServerHost } from "../../../helpers/env.ts";
 import type { Inngest } from "../../Inngest.ts";
@@ -31,7 +32,7 @@ const processorDebug = Debug(`${debugPrefix}:InngestSpanProcessor`);
 /**
  * A set of resource attributes that are used to identify the Inngest app and
  *  the function that is being executed. This is used to store the resource
- * attributes for the spans that are exported to the Inngest endpoint, and cache
+ *  attributes for the spans that are exported to the Inngest endpoint, and cache
  *  them for later use.
  */
 let _resourceAttributes: Resource | undefined;
@@ -46,6 +47,7 @@ export type ParentState = {
   appId: string | undefined;
   functionId: string | undefined;
   traceRef: string | undefined;
+  rootSpanId: string;
 };
 
 /**
@@ -123,6 +125,23 @@ export class InngestSpanProcessor implements SpanProcessor {
       this.#traceParents.delete(spanId);
     }
   });
+
+  /**
+   * Tracks the currently-executing step for each execution, keyed by root span
+   * ID. Used to compute deterministic parent span IDs for userland spans when
+   * checkpointing is enabled and multiple steps run in a single invocation.
+   */
+  #activeStepContext = new Map<
+    string,
+    { hashedStepId: string; attempt: number }
+  >();
+
+  /**
+   * Root span IDs that have had at least one step execution declared, meaning
+   * they are checkpointing runs. Used to filter out infrastructure spans
+   * (checkpoint POSTs, dev server polls) that fire between steps.
+   */
+  #checkpointingRoots = new Set<string>();
 
   /**
    * In order to only capture a subset of spans, we need to declare the initial
@@ -208,9 +227,40 @@ export class InngestSpanProcessor implements SpanProcessor {
         runId,
         traceparent,
         traceRef,
+        rootSpanId: span.spanContext().spanId,
       },
       span,
+      true,
     );
+  }
+
+  /**
+   * Declare that a step is currently executing. Userland spans created while
+   * a step context is active will have their `inngest.traceparent` rewritten
+   * to reference a deterministic span ID derived from the step, matching the
+   * span the Go executor will create via checkpoint.
+   */
+  public declareStepExecution(
+    rootSpanId: string,
+    hashedStepId: string,
+    attempt: number,
+  ): void {
+    processorDebug(
+      "declareStepExecution: rootSpanId=%s hashedStepId=%s attempt=%d",
+      rootSpanId,
+      hashedStepId,
+      attempt,
+    );
+    this.#checkpointingRoots.add(rootSpanId);
+    this.#activeStepContext.set(rootSpanId, { hashedStepId, attempt });
+  }
+
+  /**
+   * Clear the active step context after a step finishes executing.
+   */
+  public clearStepExecution(rootSpanId: string): void {
+    processorDebug("clearStepExecution: rootSpanId=%s", rootSpanId);
+    this.#activeStepContext.delete(rootSpanId);
   }
 
   /**
@@ -308,12 +358,42 @@ export class InngestSpanProcessor implements SpanProcessor {
    * Mark a span as being tracked by this processor, meaning it will be exported
    * to the Inggest endpoint when it ends.
    */
-  private trackSpan(parentState: ParentState, span: Span): void {
+  private trackSpan(
+    parentState: ParentState,
+    span: Span,
+    isRoot = false,
+  ): void {
+    const trackDebug = processorDebug.extend("trackSpan");
     const spanId = span.spanContext().spanId;
 
     this.#spanCleanup.register(span, spanId, span);
     this.#spansToExport.add(span);
     this.#traceParents.set(spanId, parentState);
+
+    // For direct children of the root span during step execution, set a
+    // dedicated attribute with the deterministic step span ID. The Go executor
+    // creates executor.step spans with the same deterministic ID (from the same
+    // seed), so the ingestion can parent userland spans under the correct step.
+    if (!isRoot) {
+      const spanParentId =
+        (span as unknown as ReadableSpan).parentSpanContext?.spanId ??
+        (span as unknown as { parentSpanId?: string }).parentSpanId;
+
+      if (spanParentId === parentState.rootSpanId) {
+        const stepCtx = this.#activeStepContext.get(parentState.rootSpanId);
+        if (stepCtx) {
+          const seed = stepCtx.hashedStepId + ":" + String(stepCtx.attempt);
+          const newSpanId = deterministicSpanID(seed);
+          trackDebug(
+            "setting inngest.step.parentSpanId=%s (seed=%s) on span %s",
+            newSpanId,
+            seed,
+            spanId,
+          );
+          span.setAttribute(Attribute.InngestStepParentSpanId, newSpanId);
+        }
+      }
+    }
 
     span.setAttribute(Attribute.InngestTraceparent, parentState.traceparent);
     span.setAttribute(Attribute.InngestRunId, parentState.runId);
@@ -359,9 +439,11 @@ export class InngestSpanProcessor implements SpanProcessor {
   onStart(span: Span): void {
     const debug = processorDebug.extend("onStart");
     const spanId = span.spanContext().spanId;
-    // 🤫 It seems to work
-    const parentSpanId = (span as unknown as ReadableSpan).parentSpanContext
-      ?.spanId;
+    // Support both OTel SDK v2.x (parentSpanContext.spanId) and v1.x
+    // (parentSpanId as a plain string) since users may have either version.
+    const parentSpanId =
+      (span as unknown as ReadableSpan).parentSpanContext?.spanId ??
+      (span as unknown as { parentSpanId?: string }).parentSpanId;
 
     // The root span isn't captured here, but we can capture children of it
     // here.
@@ -375,6 +457,17 @@ export class InngestSpanProcessor implements SpanProcessor {
 
     const parentState = this.#traceParents.get(parentSpanId);
     if (parentState) {
+      // In checkpointing mode, only track spans during active step execution.
+      // This filters out infrastructure spans (checkpoint POSTs, dev server
+      // polls) that fire between steps and would otherwise pollute the tree.
+      if (
+        this.#checkpointingRoots.has(parentState.rootSpanId) &&
+        !this.#activeStepContext.has(parentState.rootSpanId)
+      ) {
+        debug("skipping span", spanId, "- checkpointing between steps");
+        return;
+      }
+
       // This span is a child of a span we care about, so add it to the list of
       // tracked spans so that we also capture its children
       debug(

--- a/packages/inngest/src/components/execution/v1.ts
+++ b/packages/inngest/src/components/execution/v1.ts
@@ -108,6 +108,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
    * If we're not supposed to run a particular step, this will be `undefined`.
    */
   private timeout?: ReturnType<typeof createTimeoutPromise>;
+  private rootSpanId?: string;
 
   /**
    * If we're checkpointing and have been given a maximum runtime, this will be
@@ -182,6 +183,7 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
           },
           async () => {
             return tracer.startActiveSpan("inngest.execution", (span) => {
+              this.rootSpanId = span.spanContext().spanId;
               clientProcessorMap.get(this.options.client)?.declareStartingSpan({
                 span,
                 runId: this.options.runId,
@@ -1018,11 +1020,27 @@ class V1InngestExecution extends InngestExecution implements IInngestExecution {
 
     this.debug(`executing step "${id}"`);
 
+    if (this.rootSpanId && this.options.checkpointingConfig) {
+      clientProcessorMap
+        .get(this.options.client)
+        ?.declareStepExecution(
+          this.rootSpanId,
+          hashedId,
+          this.options.data?.attempt ?? 0,
+        );
+    }
+
     let interval: GoInterval | undefined;
 
     return goIntervalTiming(() => runAsPromise(fn))
       .finally(async () => {
         this.debug(`finished executing step "${id}"`);
+
+        if (this.rootSpanId && this.options.checkpointingConfig) {
+          clientProcessorMap
+            .get(this.options.client)
+            ?.clearStepExecution(this.rootSpanId);
+        }
 
         if (store?.execution) {
           delete store.execution.executingStep;

--- a/packages/inngest/src/components/execution/v2.ts
+++ b/packages/inngest/src/components/execution/v2.ts
@@ -107,6 +107,7 @@ class V2InngestExecution extends InngestExecution implements IInngestExecution {
    * If we're not supposed to run a particular step, this will be `undefined`.
    */
   private timeout?: ReturnType<typeof createTimeoutPromise>;
+  private rootSpanId?: string;
 
   /**
    * If we're checkpointing and have been given a maximum runtime, this will be
@@ -181,6 +182,7 @@ class V2InngestExecution extends InngestExecution implements IInngestExecution {
           },
           async () => {
             return tracer.startActiveSpan("inngest.execution", (span) => {
+              this.rootSpanId = span.spanContext().spanId;
               clientProcessorMap.get(this.options.client)?.declareStartingSpan({
                 span,
                 runId: this.options.runId,
@@ -1062,11 +1064,27 @@ class V2InngestExecution extends InngestExecution implements IInngestExecution {
 
     this.debug(`executing step "${id}"`);
 
+    if (this.rootSpanId && this.options.checkpointingConfig) {
+      clientProcessorMap
+        .get(this.options.client)
+        ?.declareStepExecution(
+          this.rootSpanId,
+          hashedId,
+          this.options.data?.attempt ?? 0,
+        );
+    }
+
     let interval: GoInterval | undefined;
 
     return goIntervalTiming(() => runAsPromise(fn))
       .finally(async () => {
         this.debug(`finished executing step "${id}"`);
+
+        if (this.rootSpanId && this.options.checkpointingConfig) {
+          clientProcessorMap
+            .get(this.options.client)
+            ?.clearStepExecution(this.rootSpanId);
+        }
 
         if (store?.execution) {
           delete store.execution.executingStep;

--- a/packages/inngest/src/helpers/deterministicId.test.ts
+++ b/packages/inngest/src/helpers/deterministicId.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { deterministicSpanID } from "./deterministicId.ts";
+
+describe("deterministicSpanID", () => {
+  // Expected values verified against Go's DeterministicSpanConfig().SpanID output.
+  // These are the 3rd uint64 from chacha8rand (after 16 bytes of TraceID).
+  const cases: [string, string][] = [
+    ["test-seed-for-deterministic-span", "1f9f1fae2c8b51c4"],
+    ["hello", "b5c2db5b06a644c5"],
+    ["00000000-0000-0000-0000-000000000000", "51706347ebf6ef86"],
+    // Real step seeds from DB-verified runs:
+    ["86f7e437faa5a7fce15d1ddcb9eaeaea377667b8:0", "b017a66031df8079"],
+    ["e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98:0", "a9a8b204ae8104ed"],
+  ];
+
+  test.each(cases)("seed %j → %s", (seed, expected) => {
+    expect(deterministicSpanID(seed)).toBe(expected);
+  });
+
+  test("returns a 16-character hex string", () => {
+    const id = deterministicSpanID("anything");
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("is deterministic across calls", () => {
+    const a = deterministicSpanID("same-seed");
+    const b = deterministicSpanID("same-seed");
+    expect(a).toBe(b);
+  });
+
+  test("different seeds produce different IDs", () => {
+    const a = deterministicSpanID("seed-a");
+    const b = deterministicSpanID("seed-b");
+    expect(a).not.toBe(b);
+  });
+
+  // Additional edge-case test vectors verified against Go's DeterministicSpanConfig.
+  describe("edge cases", () => {
+    const edgeCases: [string, string][] = [
+      // Empty string seed
+      ["", "dd9fc5ea353468a4"],
+      // Very long seed (10000 'a' characters)
+      ["a".repeat(10000), "955541c801f27c55"],
+      // Null byte in seed
+      ["hello\x00world", "8999f00b74c5d24d"],
+      // UTF-8 multibyte characters (emoji)
+      ["emoji-\u{1F600}-test", "1af63e4dd8245a1d"],
+      // Special characters
+      ["special!@#$%^&*()_+-=[]{}|;':\",./<>?", "b668435cd33ce0e1"],
+    ];
+
+    test.each(edgeCases)("seed %j → %s", (seed, expected) => {
+      expect(deterministicSpanID(seed)).toBe(expected);
+    });
+  });
+
+  // Production-format seeds: {sha1(stepName)}:{attempt}
+  // These match the exact format used by the Go executor:
+  //   fmt.Sprintf("%s:%d", gen.ID, runCtx.AttemptCount())
+  // where gen.ID is the SHA-1 hex hash of the step name.
+  describe("production-format seeds", () => {
+    const productionCases: [string, string, string][] = [
+      // [description, seed, expectedSpanID]
+      [
+        "step-1 attempt 0",
+        "cd59ee9a8137151d1499d3d2eb40ba51aa91e0aa:0",
+        "71d50495f5a32d76",
+      ],
+      [
+        "step-1 attempt 1",
+        "cd59ee9a8137151d1499d3d2eb40ba51aa91e0aa:1",
+        "66ccae63f003f30c",
+      ],
+      [
+        "step-1 attempt 2",
+        "cd59ee9a8137151d1499d3d2eb40ba51aa91e0aa:2",
+        "e488e4c433ddfb1b",
+      ],
+      [
+        "my-step attempt 0",
+        "8376129f22207d6e1acaa1c92de099dcb1ba24db:0",
+        "979694712fbc957c",
+      ],
+      [
+        "Send welcome email attempt 0",
+        "d1eefd9de6e03a9f863a9b51d0140d6d0d58e609:0",
+        "4d2647281790ca8f",
+      ],
+    ];
+
+    test.each(productionCases)("%s → %s", (_desc, seed, expected) => {
+      expect(deterministicSpanID(seed)).toBe(expected);
+    });
+
+    test("different attempts produce different span IDs", () => {
+      const base = "cd59ee9a8137151d1499d3d2eb40ba51aa91e0aa";
+      const ids = [0, 1, 2].map((attempt) =>
+        deterministicSpanID(`${base}:${attempt}`),
+      );
+      expect(new Set(ids).size).toBe(3);
+    });
+  });
+});

--- a/packages/inngest/src/helpers/deterministicId.ts
+++ b/packages/inngest/src/helpers/deterministicId.ts
@@ -1,0 +1,357 @@
+/**
+ * Produces span IDs identical to the Go executor's
+ * `DeterministicSpanConfig(seed).SpanID` in `pkg/tracing/tracer.go`.
+ *
+ * Algorithm: SHA-256 the seed, interpret the 32-byte digest as a ChaCha8
+ * key, then read 24 bytes from Go's `chacha8rand` PRNG
+ * (https://c2sp.org/chacha8rand) — 16 bytes for TraceID (discarded) plus
+ * 8 bytes for SpanID (returned).  This is the 3rd uint64 in the
+ * interleaved output buffer (buf[2] = word 1 from blocks 0 and 1).
+ *
+ * Uses `hash.js` for SHA-256 (same as the rest of the SDK) so it works in
+ * Node, browsers, and edge runtimes without `node:crypto`.
+ */
+import hashjs from "hash.js";
+
+const { sha256 } = hashjs;
+
+/**
+ * Compute a deterministic 8-byte span ID from an arbitrary seed string,
+ * byte-for-byte compatible with Go's `DeterministicSpanConfig(seed).SpanID`.
+ *
+ * Returns the span ID as a 16-character hex string (the format OTel uses).
+ */
+export function deterministicSpanID(seed: string): string {
+  const hash = sha256().update(seed).digest(); // number[]
+  const third = chacha8randThirdUint64(hash);
+  return uint64ToLEHex(third);
+}
+
+// ---------------------------------------------------------------------------
+// chacha8rand – Go's math/rand/v2.ChaCha8 PRNG (3rd uint64)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute blocks 0 and 1 (counters 0,1) and return the 3rd uint64 (buf[2])
+ * of the interleaved output buffer.  This matches `DeterministicSpanConfig.SpanID`
+ * which reads 16 bytes (TraceID = buf[0..1]) then 8 bytes (SpanID = buf[2]).
+ *
+ * The chacha8rand interleaved layout is:
+ *   buf[2*i]   = block0[i] | block1[i] << 32
+ *   buf[2*i+1] = block2[i] | block3[i] << 32
+ * So buf[2] = buf[2*1] = block0[1] | block1[1] << 32 = s1 from both blocks.
+ */
+function chacha8randThirdUint64(key: number[]): bigint {
+  // Interpret 32-byte key as 4 little-endian uint64 → 8 uint32 words.
+  const k = new Uint32Array(8);
+  for (let i = 0; i < 8; i++) {
+    k[i] =
+      (key[i * 4]! |
+        (key[i * 4 + 1]! << 8) |
+        (key[i * 4 + 2]! << 16) |
+        (key[i * 4 + 3]! << 24)) >>>
+      0;
+  }
+
+  // We only need block-column 0 (counter = 0) to get the first uint64.
+  // Initial state: [constants | key | counter=0 | nonce=0]
+  let s0 = 0x61707865;
+  let s1 = 0x3320646e;
+  let s2 = 0x79622d32;
+  let s3 = 0x6b206574;
+  let s4 = k[0]!;
+  let s5 = k[1]!;
+  let s6 = k[2]!;
+  let s7 = k[3]!;
+  let s8 = k[4]!;
+  let s9 = k[5]!;
+  let s10 = k[6]!;
+  let s11 = k[7]!;
+  let s12 = 0; // counter
+  let s13 = 0; // nonce
+  let s14 = 0;
+  let s15 = 0;
+
+  // Save key words for partial addition later (positions 4-11).
+  const ok4 = s4,
+    ok5 = s5,
+    ok6 = s6,
+    ok7 = s7;
+  const ok8 = s8,
+    ok9 = s9,
+    ok10 = s10,
+    ok11 = s11;
+
+  // 4 double-rounds = 8 quarter-round rounds (ChaCha8).
+  for (let i = 0; i < 4; i++) {
+    // Column rounds
+    s0 = (s0 + s4) >>> 0;
+    s12 ^= s0;
+    s12 = ((s12 << 16) | (s12 >>> 16)) >>> 0;
+    s8 = (s8 + s12) >>> 0;
+    s4 ^= s8;
+    s4 = ((s4 << 12) | (s4 >>> 20)) >>> 0;
+    s0 = (s0 + s4) >>> 0;
+    s12 ^= s0;
+    s12 = ((s12 << 8) | (s12 >>> 24)) >>> 0;
+    s8 = (s8 + s12) >>> 0;
+    s4 ^= s8;
+    s4 = ((s4 << 7) | (s4 >>> 25)) >>> 0;
+
+    s1 = (s1 + s5) >>> 0;
+    s13 ^= s1;
+    s13 = ((s13 << 16) | (s13 >>> 16)) >>> 0;
+    s9 = (s9 + s13) >>> 0;
+    s5 ^= s9;
+    s5 = ((s5 << 12) | (s5 >>> 20)) >>> 0;
+    s1 = (s1 + s5) >>> 0;
+    s13 ^= s1;
+    s13 = ((s13 << 8) | (s13 >>> 24)) >>> 0;
+    s9 = (s9 + s13) >>> 0;
+    s5 ^= s9;
+    s5 = ((s5 << 7) | (s5 >>> 25)) >>> 0;
+
+    s2 = (s2 + s6) >>> 0;
+    s14 ^= s2;
+    s14 = ((s14 << 16) | (s14 >>> 16)) >>> 0;
+    s10 = (s10 + s14) >>> 0;
+    s6 ^= s10;
+    s6 = ((s6 << 12) | (s6 >>> 20)) >>> 0;
+    s2 = (s2 + s6) >>> 0;
+    s14 ^= s2;
+    s14 = ((s14 << 8) | (s14 >>> 24)) >>> 0;
+    s10 = (s10 + s14) >>> 0;
+    s6 ^= s10;
+    s6 = ((s6 << 7) | (s6 >>> 25)) >>> 0;
+
+    s3 = (s3 + s7) >>> 0;
+    s15 ^= s3;
+    s15 = ((s15 << 16) | (s15 >>> 16)) >>> 0;
+    s11 = (s11 + s15) >>> 0;
+    s7 ^= s11;
+    s7 = ((s7 << 12) | (s7 >>> 20)) >>> 0;
+    s3 = (s3 + s7) >>> 0;
+    s15 ^= s3;
+    s15 = ((s15 << 8) | (s15 >>> 24)) >>> 0;
+    s11 = (s11 + s15) >>> 0;
+    s7 ^= s11;
+    s7 = ((s7 << 7) | (s7 >>> 25)) >>> 0;
+
+    // Diagonal rounds
+    s0 = (s0 + s5) >>> 0;
+    s15 ^= s0;
+    s15 = ((s15 << 16) | (s15 >>> 16)) >>> 0;
+    s10 = (s10 + s15) >>> 0;
+    s5 ^= s10;
+    s5 = ((s5 << 12) | (s5 >>> 20)) >>> 0;
+    s0 = (s0 + s5) >>> 0;
+    s15 ^= s0;
+    s15 = ((s15 << 8) | (s15 >>> 24)) >>> 0;
+    s10 = (s10 + s15) >>> 0;
+    s5 ^= s10;
+    s5 = ((s5 << 7) | (s5 >>> 25)) >>> 0;
+
+    s1 = (s1 + s6) >>> 0;
+    s12 ^= s1;
+    s12 = ((s12 << 16) | (s12 >>> 16)) >>> 0;
+    s11 = (s11 + s12) >>> 0;
+    s6 ^= s11;
+    s6 = ((s6 << 12) | (s6 >>> 20)) >>> 0;
+    s1 = (s1 + s6) >>> 0;
+    s12 ^= s1;
+    s12 = ((s12 << 8) | (s12 >>> 24)) >>> 0;
+    s11 = (s11 + s12) >>> 0;
+    s6 ^= s11;
+    s6 = ((s6 << 7) | (s6 >>> 25)) >>> 0;
+
+    s2 = (s2 + s7) >>> 0;
+    s13 ^= s2;
+    s13 = ((s13 << 16) | (s13 >>> 16)) >>> 0;
+    s8 = (s8 + s13) >>> 0;
+    s7 ^= s8;
+    s7 = ((s7 << 12) | (s7 >>> 20)) >>> 0;
+    s2 = (s2 + s7) >>> 0;
+    s13 ^= s2;
+    s13 = ((s13 << 8) | (s13 >>> 24)) >>> 0;
+    s8 = (s8 + s13) >>> 0;
+    s7 ^= s8;
+    s7 = ((s7 << 7) | (s7 >>> 25)) >>> 0;
+
+    s3 = (s3 + s4) >>> 0;
+    s14 ^= s3;
+    s14 = ((s14 << 16) | (s14 >>> 16)) >>> 0;
+    s9 = (s9 + s14) >>> 0;
+    s4 ^= s9;
+    s4 = ((s4 << 12) | (s4 >>> 20)) >>> 0;
+    s3 = (s3 + s4) >>> 0;
+    s14 ^= s3;
+    s14 = ((s14 << 8) | (s14 >>> 24)) >>> 0;
+    s9 = (s9 + s14) >>> 0;
+    s4 ^= s9;
+    s4 = ((s4 << 7) | (s4 >>> 25)) >>> 0;
+  }
+
+  // Partial addition: only key positions (4-11) get the original added back.
+  s4 = (s4 + ok4) >>> 0;
+  s5 = (s5 + ok5) >>> 0;
+  s6 = (s6 + ok6) >>> 0;
+  s7 = (s7 + ok7) >>> 0;
+  s8 = (s8 + ok8) >>> 0;
+  s9 = (s9 + ok9) >>> 0;
+  s10 = (s10 + ok10) >>> 0;
+  s11 = (s11 + ok11) >>> 0;
+
+  // The chacha8rand interleaved output layout is:
+  //   buf[2*i]   = block0[i] | block1[i] << 32    (blocks 0,1)
+  //   buf[2*i+1] = block2[i] | block3[i] << 32    (blocks 2,3)
+  //
+  // DeterministicSpanConfig reads 16 bytes (TraceID = buf[0..1]) then
+  // 8 bytes (SpanID = buf[2]).  buf[2] = buf[2*1] = block0[1] | block1[1] << 32.
+  // So the SpanID uses state word index 1 (s1) from both blocks.
+  // s1 is a constants position (no addition in chacha8rand).
+  const hi = chacha8randColumn1Row1(k);
+
+  return BigInt(s1 >>> 0) | (BigInt(hi >>> 0) << 32n);
+}
+
+/**
+ * Run chacha8rand for column 1 (counter = 1) and return row 1 (s1).
+ */
+function chacha8randColumn1Row1(k: Uint32Array): number {
+  let s0 = 0x61707865;
+  let s1 = 0x3320646e;
+  let s2 = 0x79622d32;
+  let s3 = 0x6b206574;
+  let s4 = k[0]!;
+  let s5 = k[1]!;
+  let s6 = k[2]!;
+  let s7 = k[3]!;
+  let s8 = k[4]!;
+  let s9 = k[5]!;
+  let s10 = k[6]!;
+  let s11 = k[7]!;
+  let s12 = 1; // counter = 1
+  let s13 = 0;
+  let s14 = 0;
+  let s15 = 0;
+
+  for (let i = 0; i < 4; i++) {
+    // Column rounds
+    s0 = (s0 + s4) >>> 0;
+    s12 ^= s0;
+    s12 = ((s12 << 16) | (s12 >>> 16)) >>> 0;
+    s8 = (s8 + s12) >>> 0;
+    s4 ^= s8;
+    s4 = ((s4 << 12) | (s4 >>> 20)) >>> 0;
+    s0 = (s0 + s4) >>> 0;
+    s12 ^= s0;
+    s12 = ((s12 << 8) | (s12 >>> 24)) >>> 0;
+    s8 = (s8 + s12) >>> 0;
+    s4 ^= s8;
+    s4 = ((s4 << 7) | (s4 >>> 25)) >>> 0;
+
+    s1 = (s1 + s5) >>> 0;
+    s13 ^= s1;
+    s13 = ((s13 << 16) | (s13 >>> 16)) >>> 0;
+    s9 = (s9 + s13) >>> 0;
+    s5 ^= s9;
+    s5 = ((s5 << 12) | (s5 >>> 20)) >>> 0;
+    s1 = (s1 + s5) >>> 0;
+    s13 ^= s1;
+    s13 = ((s13 << 8) | (s13 >>> 24)) >>> 0;
+    s9 = (s9 + s13) >>> 0;
+    s5 ^= s9;
+    s5 = ((s5 << 7) | (s5 >>> 25)) >>> 0;
+
+    s2 = (s2 + s6) >>> 0;
+    s14 ^= s2;
+    s14 = ((s14 << 16) | (s14 >>> 16)) >>> 0;
+    s10 = (s10 + s14) >>> 0;
+    s6 ^= s10;
+    s6 = ((s6 << 12) | (s6 >>> 20)) >>> 0;
+    s2 = (s2 + s6) >>> 0;
+    s14 ^= s2;
+    s14 = ((s14 << 8) | (s14 >>> 24)) >>> 0;
+    s10 = (s10 + s14) >>> 0;
+    s6 ^= s10;
+    s6 = ((s6 << 7) | (s6 >>> 25)) >>> 0;
+
+    s3 = (s3 + s7) >>> 0;
+    s15 ^= s3;
+    s15 = ((s15 << 16) | (s15 >>> 16)) >>> 0;
+    s11 = (s11 + s15) >>> 0;
+    s7 ^= s11;
+    s7 = ((s7 << 12) | (s7 >>> 20)) >>> 0;
+    s3 = (s3 + s7) >>> 0;
+    s15 ^= s3;
+    s15 = ((s15 << 8) | (s15 >>> 24)) >>> 0;
+    s11 = (s11 + s15) >>> 0;
+    s7 ^= s11;
+    s7 = ((s7 << 7) | (s7 >>> 25)) >>> 0;
+
+    // Diagonal rounds
+    s0 = (s0 + s5) >>> 0;
+    s15 ^= s0;
+    s15 = ((s15 << 16) | (s15 >>> 16)) >>> 0;
+    s10 = (s10 + s15) >>> 0;
+    s5 ^= s10;
+    s5 = ((s5 << 12) | (s5 >>> 20)) >>> 0;
+    s0 = (s0 + s5) >>> 0;
+    s15 ^= s0;
+    s15 = ((s15 << 8) | (s15 >>> 24)) >>> 0;
+    s10 = (s10 + s15) >>> 0;
+    s5 ^= s10;
+    s5 = ((s5 << 7) | (s5 >>> 25)) >>> 0;
+
+    s1 = (s1 + s6) >>> 0;
+    s12 ^= s1;
+    s12 = ((s12 << 16) | (s12 >>> 16)) >>> 0;
+    s11 = (s11 + s12) >>> 0;
+    s6 ^= s11;
+    s6 = ((s6 << 12) | (s6 >>> 20)) >>> 0;
+    s1 = (s1 + s6) >>> 0;
+    s12 ^= s1;
+    s12 = ((s12 << 8) | (s12 >>> 24)) >>> 0;
+    s11 = (s11 + s12) >>> 0;
+    s6 ^= s11;
+    s6 = ((s6 << 7) | (s6 >>> 25)) >>> 0;
+
+    s2 = (s2 + s7) >>> 0;
+    s13 ^= s2;
+    s13 = ((s13 << 16) | (s13 >>> 16)) >>> 0;
+    s8 = (s8 + s13) >>> 0;
+    s7 ^= s8;
+    s7 = ((s7 << 12) | (s7 >>> 20)) >>> 0;
+    s2 = (s2 + s7) >>> 0;
+    s13 ^= s2;
+    s13 = ((s13 << 8) | (s13 >>> 24)) >>> 0;
+    s8 = (s8 + s13) >>> 0;
+    s7 ^= s8;
+    s7 = ((s7 << 7) | (s7 >>> 25)) >>> 0;
+
+    s3 = (s3 + s4) >>> 0;
+    s14 ^= s3;
+    s14 = ((s14 << 16) | (s14 >>> 16)) >>> 0;
+    s9 = (s9 + s14) >>> 0;
+    s4 ^= s9;
+    s4 = ((s4 << 12) | (s4 >>> 20)) >>> 0;
+    s3 = (s3 + s4) >>> 0;
+    s14 ^= s3;
+    s14 = ((s14 << 8) | (s14 >>> 24)) >>> 0;
+    s9 = (s9 + s14) >>> 0;
+    s4 ^= s9;
+    s4 = ((s4 << 7) | (s4 >>> 25)) >>> 0;
+  }
+
+  // No addition for row 1 (constants row in chacha8rand).
+  return s1;
+}
+
+/** Convert a uint64 bigint to a 16-char little-endian hex string. */
+function uint64ToLEHex(v: bigint): string {
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += (Number((v >> BigInt(i * 8)) & 0xffn) | 0x100).toString(16).slice(1);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Userland OTel spans were orphaned across checkpoint boundaries because the SDK had no way to reference the step spans the executor creates server-side.

- Compute deterministic span IDs matching Go's ChaCha8-based generation _(thank you Claude 🙃)_
- Track active step context to attach inngest.step.parentSpanId to userland spans
- Filter infrastructure spans between checkpoint steps

## Checklist
- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
* https://linear.app/inngest/issue/EXE-1408/extended-traces-not-working
* https://github.com/inngest/inngest/pull/3804
