### PR TITLE
OTel Improvements

### DIFF
--- a/.changeset/fix-otel-v2-extend-provider.md
+++ b/.changeset/fix-otel-v2-extend-provider.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `extendProvider()` for OTel SDK v2 where `addSpanProcessor()` was removed

--- a/.changeset/fix-otel-v2-extend-provider.md
+++ b/.changeset/fix-otel-v2-extend-provider.md
@@ -2,4 +2,6 @@
 "inngest": patch
 ---
 
-Fix `extendProvider()` for OTel SDK v2 where `addSpanProcessor()` was removed
+Fix `extendProvider()` for OTel SDK v2 where `addSpanProcessor()` was removed.
+
+Move `@opentelemetry/auto-instrumentations-node` and related imports from static top-level to dynamic `await import()` inside `createProvider()`. This prevents module-level monkey-patching side effects that broke `inngest.send()` when combined with host app OTel setups (e.g. Sentry). See #1324.

--- a/packages/inngest/scripts/checkDependencies.ts
+++ b/packages/inngest/scripts/checkDependencies.ts
@@ -225,7 +225,12 @@ function checkDependencies(
   });
 
   // Packages that are dynamically imported and should not be flagged as unused
-  const dynamicallyImportedPackages = ["ulid"];
+  const dynamicallyImportedPackages = [
+    "ulid",
+    "@opentelemetry/auto-instrumentations-node",
+    "@opentelemetry/context-async-hooks",
+    "@traceloop/instrumentation-anthropic",
+  ];
 
   // Check for unused packages in dependencies
   // biome-ignore lint/complexity/noForEach: intentional

--- a/packages/inngest/src/components/execution/otel/middleware.ts
+++ b/packages/inngest/src/components/execution/otel/middleware.ts
@@ -1,6 +1,5 @@
 import { type DiagLogger, DiagLogLevel, diag, trace } from "@opentelemetry/api";
 import Debug from "debug";
-import type { Logger } from "../../../middleware/logger.ts";
 import { version } from "../../../version.ts";
 import { Middleware } from "../../middleware/middleware.ts";
 import { clientProcessorMap } from "./access.ts";
@@ -76,6 +75,7 @@ export const extendedTracesMiddleware = ({
   devDebug("behaviour:", behaviour);
 
   let processor: InngestSpanProcessor | undefined;
+  let processorReady: Promise<void> | undefined;
 
   switch (behaviour) {
     case "auto": {
@@ -86,27 +86,35 @@ export const extendedTracesMiddleware = ({
         break;
       }
 
-      const created = createProvider(behaviour, instrumentations);
-      if (created.success) {
-        devDebug("created new provider");
-        processor = created.processor;
-        break;
-      }
-
-      console.warn("no provider found to extend and unable to create one");
+      processorReady = createProvider(behaviour, instrumentations).then(
+        (created) => {
+          if (created.success) {
+            devDebug("created new provider");
+            processor = created.processor;
+          } else {
+            console.warn(
+              "no provider found to extend and unable to create one",
+              created.error ?? "",
+            );
+          }
+        },
+      );
 
       break;
     }
     case "createProvider": {
-      const created = createProvider(behaviour, instrumentations);
-      if (created.success) {
-        devDebug("created new provider");
-        processor = created.processor;
-        break;
-      }
-
-      console.warn(
-        "unable to create provider, Extended Traces middleware will not work",
+      processorReady = createProvider(behaviour, instrumentations).then(
+        (created) => {
+          if (created.success) {
+            devDebug("created new provider");
+            processor = created.processor;
+          } else {
+            console.warn(
+              "unable to create provider, Extended Traces middleware will not work",
+              created.error ?? "",
+            );
+          }
+        },
       );
 
       break;
@@ -153,6 +161,13 @@ export const extendedTracesMiddleware = ({
 
       if (processor) {
         clientProcessorMap.set(client, processor);
+      } else if (processorReady) {
+        // createProvider is async; register the processor once it resolves.
+        processorReady.then(() => {
+          if (processor) {
+            clientProcessorMap.set(client, processor);
+          }
+        });
       }
     }
 
@@ -168,7 +183,8 @@ export const extendedTracesMiddleware = ({
       };
     }
 
-    override wrapRequest({ next }: Middleware.WrapRequestArgs) {
+    override async wrapRequest({ next }: Middleware.WrapRequestArgs) {
+      await processorReady;
       return next().finally(() => processor?.forceFlush());
     }
   }

--- a/packages/inngest/src/components/execution/otel/middleware.ts
+++ b/packages/inngest/src/components/execution/otel/middleware.ts
@@ -163,11 +163,15 @@ export const extendedTracesMiddleware = ({
         clientProcessorMap.set(client, processor);
       } else if (processorReady) {
         // createProvider is async; register the processor once it resolves.
-        processorReady.then(() => {
-          if (processor) {
-            clientProcessorMap.set(client, processor);
-          }
-        });
+        processorReady
+          .then(() => {
+            if (processor) {
+              clientProcessorMap.set(client, processor);
+            }
+          })
+          .catch((err) => {
+            devDebug("failed to register processor for client:", err);
+          });
       }
     }
 
@@ -184,7 +188,6 @@ export const extendedTracesMiddleware = ({
     }
 
     override async wrapRequest({ next }: Middleware.WrapRequestArgs) {
-      await processorReady;
       return next().finally(() => processor?.forceFlush());
     }
   }

--- a/packages/inngest/src/components/execution/otel/util.test.ts
+++ b/packages/inngest/src/components/execution/otel/util.test.ts
@@ -1,4 +1,4 @@
-import { trace } from "@opentelemetry/api";
+import { type TracerProvider, trace } from "@opentelemetry/api";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { InngestSpanProcessor } from "./processor.ts";
 import { extendProvider } from "./util.ts";
@@ -60,7 +60,7 @@ describe("extendProvider", () => {
     warnSpy.mockRestore();
   });
 
-  test("should call addSpanProcessor on the underlying provider", () => {
+  test("should call addSpanProcessor on the underlying provider (v1 path)", () => {
     const { provider, addSpanProcessor } = createProviderWithAddSpanProcessor();
     trace.setGlobalTracerProvider(provider);
 
@@ -71,5 +71,69 @@ describe("extendProvider", () => {
     expect(addSpanProcessor).toHaveBeenCalledWith(
       expect.any(InngestSpanProcessor),
     );
+  });
+
+  test("should push into _activeSpanProcessor._spanProcessors when addSpanProcessor is missing (v2 path)", () => {
+    // OTel SDK v2 BasicTracerProvider has no addSpanProcessor method.
+    // Simulate by creating a plain provider (v2 BasicTracerProvider) which
+    // exposes _activeSpanProcessor._spanProcessors at runtime.
+    const provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+
+    const result = extendProvider("auto");
+
+    expect(result.success).toBe(true);
+    expect((result as { processor: unknown }).processor).toBeInstanceOf(
+      InngestSpanProcessor,
+    );
+
+    // Verify the processor was pushed into the internal array
+    // biome-ignore lint/suspicious/noExplicitAny: accessing OTel internals for test assertion
+    const spanProcessors = (provider as any)._activeSpanProcessor
+      ._spanProcessors;
+    expect(spanProcessors).toContainEqual(expect.any(InngestSpanProcessor));
+  });
+
+  test("should succeed with behaviour 'extendProvider' via v2 path", () => {
+    const provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+
+    const result = extendProvider("extendProvider");
+
+    expect(result.success).toBe(true);
+  });
+
+  test("should warn and fail when provider has neither addSpanProcessor nor _activeSpanProcessor", () => {
+    const mockProvider = {
+      getTracer: vi.fn(),
+    };
+    trace.setGlobalTracerProvider(mockProvider as unknown as TracerProvider);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = extendProvider("extendProvider");
+
+    expect(result.success).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unable to add InngestSpanProcessor"),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test("should not warn on unknown provider when behaviour is 'auto'", () => {
+    const mockProvider = {
+      getTracer: vi.fn(),
+    };
+    trace.setGlobalTracerProvider(mockProvider as unknown as TracerProvider);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = extendProvider("auto");
+
+    expect(result.success).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -66,14 +66,7 @@ export const extendProvider = (
       ? globalProvider.getDelegate()
       : globalProvider;
 
-  if (
-    !existingProvider ||
-    !("addSpanProcessor" in existingProvider) ||
-    typeof existingProvider.addSpanProcessor !== "function"
-  ) {
-    // TODO Could we also add a function the user can provide that takes the
-    // processor and adds it? That way they could support many different
-    // providers.
+  if (!existingProvider) {
     if (behaviour !== "auto") {
       console.warn(
         "Existing OTel provider is not a BasicTracerProvider. Inngest's OTel middleware will not work, as it can only extend an existing processor if it's a BasicTracerProvider.",
@@ -84,7 +77,59 @@ export const extendProvider = (
   }
 
   const processor = new InngestSpanProcessor();
-  existingProvider.addSpanProcessor(processor);
 
-  return { success: true, processor };
+  // OTel SDK v1 exposes addSpanProcessor() on BasicTracerProvider.
+  if (
+    "addSpanProcessor" in existingProvider &&
+    typeof existingProvider.addSpanProcessor === "function"
+  ) {
+    existingProvider.addSpanProcessor(processor);
+    return { success: true, processor };
+  }
+
+  // OTel SDK v2 removed addSpanProcessor() — span processors are constructor-only.
+  // No public API exists to add processors post-construction (OTel issue #5299),
+  // so push into the internal _spanProcessors array.
+  // These fields are TypeScript `private` (not #private), so accessible at runtime.
+  const spanProcessors = getInternalSpanProcessors(existingProvider);
+  if (spanProcessors) {
+    spanProcessors.push(processor);
+    return { success: true, processor };
+  }
+
+  if (behaviour !== "auto") {
+    console.warn(
+      "Unable to add InngestSpanProcessor to existing OTel provider. " +
+        "The provider does not support addSpanProcessor() (OTel SDK v1) " +
+        "or expose _activeSpanProcessor._spanProcessors (OTel SDK v2).",
+    );
+  }
+
+  return { success: false };
 };
+
+/**
+ * Extract the internal span processors array from a BasicTracerProvider.
+ * Returns the mutable array if accessible, undefined otherwise.
+ *
+ * BasicTracerProvider._activeSpanProcessor is a MultiSpanProcessor,
+ * which holds a _spanProcessors: SpanProcessor[] array.
+ * Both are TypeScript `private` (not ES #private), so accessible at runtime.
+ *
+ * Wrapped in try/catch because this accesses internal OTel fields that may
+ * change — must never crash the host app.
+ */
+function getInternalSpanProcessors(
+  provider: unknown,
+): unknown[] | undefined {
+  try {
+    const active = (provider as Record<string, unknown>)
+      ?._activeSpanProcessor;
+    if (typeof active !== "object" || active === null) return undefined;
+
+    const arr = (active as Record<string, unknown>)._spanProcessors;
+    return Array.isArray(arr) ? arr : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -119,12 +119,9 @@ export const extendProvider = (
  * Wrapped in try/catch because this accesses internal OTel fields that may
  * change — must never crash the host app.
  */
-function getInternalSpanProcessors(
-  provider: unknown,
-): unknown[] | undefined {
+function getInternalSpanProcessors(provider: unknown): unknown[] | undefined {
   try {
-    const active = (provider as Record<string, unknown>)
-      ?._activeSpanProcessor;
+    const active = (provider as Record<string, unknown>)?._activeSpanProcessor;
     if (typeof active !== "object" || active === null) return undefined;
 
     const arr = (active as Record<string, unknown>)._spanProcessors;

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -1,42 +1,66 @@
 import { context, trace } from "@opentelemetry/api";
-import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
-import {
-  type Instrumentation,
-  registerInstrumentations,
-} from "@opentelemetry/instrumentation";
+import type { Instrumentation } from "@opentelemetry/instrumentation";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
-import { AnthropicInstrumentation } from "@traceloop/instrumentation-anthropic";
+import Debug from "debug";
+import { debugPrefix } from "./consts.ts";
 import { InngestSpanProcessor } from "./processor.ts";
+
+const debug = Debug(`${debugPrefix}:createProvider`);
 
 export type Behaviour = "createProvider" | "extendProvider" | "off" | "auto";
 export type Instrumentations = (Instrumentation | Instrumentation[])[];
 
-export const createProvider = (
+export const createProvider = async (
   _behaviour: Behaviour,
   instrumentations: Instrumentations | undefined = [],
-): { success: true; processor: InngestSpanProcessor } | { success: false } => {
-  // TODO Check if there's an existing provider
-  const processor = new InngestSpanProcessor();
+): Promise<
+  | { success: true; processor: InngestSpanProcessor }
+  | { success: false; error?: unknown }
+> => {
+  try {
+    // TODO Check if there's an existing provider
+    const processor = new InngestSpanProcessor();
 
-  const p = new BasicTracerProvider({
-    spanProcessors: [processor],
-  });
+    const p = new BasicTracerProvider({
+      spanProcessors: [processor],
+    });
 
-  const instrList: Instrumentations = [
-    ...instrumentations,
-    ...getNodeAutoInstrumentations(),
-    new AnthropicInstrumentation(),
-  ];
+    // Dynamic imports to avoid loading the full auto-instrumentation suite at
+    // module evaluation time. These are only needed when creating a new provider,
+    // not when extending an existing one. Static imports here caused version
+    // conflicts with host app OTel setups (e.g. Sentry) and silently broke
+    // inngest.send(). See #1324.
+    const { getNodeAutoInstrumentations } = await import(
+      "@opentelemetry/auto-instrumentations-node"
+    );
+    const { registerInstrumentations } = await import(
+      "@opentelemetry/instrumentation"
+    );
+    const { AnthropicInstrumentation } = await import(
+      "@traceloop/instrumentation-anthropic"
+    );
+    const { AsyncHooksContextManager } = await import(
+      "@opentelemetry/context-async-hooks"
+    );
 
-  registerInstrumentations({
-    instrumentations: instrList,
-  });
+    const instrList: Instrumentations = [
+      ...instrumentations,
+      ...getNodeAutoInstrumentations(),
+      new AnthropicInstrumentation(),
+    ];
 
-  trace.setGlobalTracerProvider(p);
-  context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+    registerInstrumentations({
+      instrumentations: instrList,
+    });
 
-  return { success: true, processor };
+    trace.setGlobalTracerProvider(p);
+    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+
+    return { success: true, processor };
+  } catch (err) {
+    debug("failed to create provider:", err);
+    return { success: false, error: err };
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary
Pulls in @ptts's changes from https://github.com/inngest/inngest-js/pull/1325 along with the suggestion from @arobison in 
https://github.com/inngest/inngest-js/issues/1324#issuecomment-4009588121


## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
https://github.com/inngest/inngest-js/issues/1324#issuecomment-4009588121
https://github.com/inngest/inngest-js/pull/1325

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes `extendProvider()` compatibility with OTel SDK v2 (which removed `addSpanProcessor()`) by falling back to the internal `_activeSpanProcessor._spanProcessors` array. It also converts `createProvider()` to async and moves `@opentelemetry/auto-instrumentations-node` and related imports to dynamic `await import()` to prevent module-level monkey-patching side effects that broke `inngest.send()` with host app OTel setups.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 22f3692a1fffbee7efeed69b516d7540e156b383.</sup>
<!-- /MENDRAL_SUMMARY -->