### PR TITLE
Delete changeset files

### DIFF
--- a/.changeset/tender-cooks-battle.md
+++ b/.changeset/tender-cooks-battle.md
@@ -1,5 +1,0 @@
----
-"@inngest/middleware-sentry": major
----
-
-Drop support for TypeScript SDK <4

--- a/.changeset/wicked-vans-brake.md
+++ b/.changeset/wicked-vans-brake.md
@@ -1,5 +1,0 @@
----
-"@inngest/middleware-encryption": major
----
-
-Drop support for TypeScript SDK <4


### PR DESCRIPTION
Temporarily delete a couple changeset files to avoid releasing the middleware packages in the release PR

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Deletes two changeset files (`tender-cooks-battle.md` and `wicked-vans-brake.md`) that would have triggered major releases for `@inngest/middleware-sentry` and `@inngest/middleware-encryption` to prevent them from being included in the current release PR.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 70055194267cafd65abef81fc61f3683c7528a08.</sup>
<!-- /MENDRAL_SUMMARY -->