### PR TITLE
fix: wrap AssertNoTransform to prevent union distribution

### DIFF
--- a/.changeset/eighty-avocados-reply.md
+++ b/.changeset/eighty-avocados-reply.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix: wrap AssertNoTransform to prevent union distribution

--- a/packages/inngest/src/components/triggers/trigger.test.ts
+++ b/packages/inngest/src/components/triggers/trigger.test.ts
@@ -396,6 +396,32 @@ describe("eventType with schema", () => {
       schema: z.array(z.object({ a: z.string() })),
     });
   });
+
+  test("schema is union", () => {
+    const inngest = new Inngest({ id: "app" });
+    inngest.createFunction(
+      {
+        id: "fn",
+        triggers: [
+          eventType("event-1", {
+            schema: z.union([
+              z.object({ a: z.string() }),
+              z.object({ b: z.number() }),
+            ]),
+          }),
+        ],
+      },
+      ({ event }) => {
+        expectTypeOf(event.name).not.toBeAny();
+        expectTypeOf(event.name).toEqualTypeOf<
+          "event-1" | "inngest/function.invoked"
+        >();
+
+        expectTypeOf(event.data).not.toBeAny();
+        expectTypeOf(event.data).toEqualTypeOf<{ a: string } | { b: number }>();
+      },
+    );
+  });
 });
 
 test("eventType with version", () => {

--- a/packages/inngest/src/components/triggers/triggers.ts
+++ b/packages/inngest/src/components/triggers/triggers.ts
@@ -210,7 +210,8 @@ type AssertNoTransform<TSchema extends StandardSchemaV1 | undefined> =
     ? // Undefined schema is OK
       undefined
     : TSchema extends StandardSchemaV1<infer TInput, infer TOutput>
-      ? TInput extends TOutput
+      ? // Wrap in tuples to prevent distributive conditional over union types. This ensures that the schema can be a union.
+        [TInput] extends [TOutput]
         ? // Input and output schemas match, so we're good
           TSchema
         : // Return an error message since the input and output schemas don't match


### PR DESCRIPTION
## Summary

 Fixes `eventType()` rejecting discriminated union schemas (both `staticSchema<Union>()` and  `z.discriminatedUnion(...)`) by wrapping the `AssertNoTransform` conditional check in tuples  (`[TInput] extends [TOutput]`) to prevent TypeScript's distributive conditional type  behavior


## Checklist

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [x] Added changesets if applicable

## Related

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes `AssertNoTransform` incorrectly rejecting discriminated union schemas by wrapping the conditional check in tuples (`[TInput] extends [TOutput]`) to prevent TypeScript's distributive conditional type behavior. Adds a test case for union schemas and a changeset entry.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9b05c8eee79894601e8c33ca55b4708b9969cbba.</sup>
<!-- /MENDRAL_SUMMARY -->