### PR TITLE
chore: improve DE cloud mode error

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -914,6 +914,15 @@ export class InngestCommHandler<
       );
     }
 
+    // Fail early if we're in cloud mode without a signing key, rather than
+    // letting the checkpoint API call fail with a confusing 401.
+    if (!this.checkModeConfiguration()) {
+      return actions.transformResponse(
+        "creating signing key error response",
+        internalServerErrorResponse,
+      );
+    }
+
     // Check we're not in a context already...
     const ctx = await getAsyncCtx();
     if (ctx) {


### PR DESCRIPTION
## Summary

Improve the user experience if they're trying to run durable endpoints in cloud mode and haven't configured a signing key.

Before:
<img width="1705" height="366" alt="Screenshot 2026-03-19 at 3 08 08 PM" src="https://github.com/user-attachments/assets/0da0ab63-ead5-4475-be88-8be85a67fb2b" />
After:
<img width="1005" height="265" alt="Screenshot 2026-03-19 at 3 08 49 PM" src="https://github.com/user-attachments/assets/3bf73b3e-85cc-40e4-8e23-33195a9c9b5b" />

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an early `checkModeConfiguration()` guard in `handleSyncRequest()` to return a 500 before reaching the checkpoint API when running in cloud mode without a signing key, improving the error UX over a confusing 401.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 625a4a49299c132bffa5ed40c788f90aa0146511.</sup>
<!-- /MENDRAL_SUMMARY -->