### PR TITLE
fix: set onRunError isFinalAttempt for final StepError failures

### DIFF
--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1165,6 +1165,14 @@ class InngestExecutionEngine
       return true;
     }
 
+    if (
+      error instanceof StepError ||
+      // biome-ignore lint/suspicious/noExplicitAny: instanceof fails across module boundaries
+      (error as any)?.name === "StepError"
+    ) {
+      return true;
+    }
+
     return Boolean(
       this.fnArg.maxAttempts &&
         this.fnArg.maxAttempts - 1 === this.fnArg.attempt,

--- a/packages/inngest/src/test/integration/middleware/hooks/onRunError.test.ts
+++ b/packages/inngest/src/test/integration/middleware/hooks/onRunError.test.ts
@@ -207,6 +207,45 @@ test("fires when function throws after steps complete", async () => {
   expect(state.calls[0]!.isFinalAttempt).toBe(true);
 });
 
+test("marks onRunError as final after final step retry", async () => {
+  const state = createState({
+    calls: [] as Middleware.OnRunErrorArgs[],
+  });
+
+  class TestMiddleware extends Middleware.BaseMiddleware {
+    readonly id = "test";
+    override onRunError(args: Middleware.OnRunErrorArgs) {
+      state.calls.push(args);
+    }
+  }
+
+  const eventName = randomSuffix("evt");
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [TestMiddleware],
+  });
+
+  const fn = client.createFunction(
+    { id: "fn", retries: 1, triggers: [{ event: eventName }] },
+    async ({ step, runId }) => {
+      state.runId = runId;
+      await step.run("my-step", () => {
+        throw new MyError("step failure");
+      });
+    },
+  );
+
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  await state.waitForRunFailed();
+
+  expect(state.calls).toHaveLength(1);
+  expect(state.calls[0]!.error.name).toBe("StepError");
+  expect(state.calls[0]!.isFinalAttempt).toBe(true);
+});
+
 test("throws", async () => {
   const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 


### PR DESCRIPTION
## Bug
Fixes #1393 — onRunError received isFinalAttempt: false when a run failed after step retries were exhausted.

## Fix
Treat StepError as a final-attempt error in the execution engine final-attempt detection. This aligns onRunError with the final retry state already reported by step-level hooks.

Also added an integration test that reproduces a step retry exhaustion flow and asserts onRunError.isFinalAttempt is true.

## Testing
- Added integration coverage in packages/inngest/src/test/integration/middleware/hooks/onRunError.test.ts for final step retry exhaustion.
- Could not run tests locally in this environment because repository dependencies are not installed (node_modules missing).

Happy to address any feedback.

Greetings, saschabuehrle

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes `isFinalAttempt` in the execution engine to return `true` when the error is a `StepError`, ensuring `onRunError` middleware receives `isFinalAttempt: true` after step retry exhaustion. Adds an integration test reproducing the scenario.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9b16dffa122bacf1bd8e0f3ff0aa027ed57f1185.</sup>
<!-- /MENDRAL_SUMMARY -->