### PR TITLE
Error when function config is v3-style

### DIFF
--- a/.changeset/nasty-sheep-beam.md
+++ b/.changeset/nasty-sheep-beam.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Error when function config is v3-style

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -670,6 +670,23 @@ describe("send", () => {
 });
 
 describe("createFunction", () => {
+  test("throws if handler is not a function (v3-style 3-arg call)", () => {
+    const inngest = createClient({ id: "test" });
+
+    expect(() => {
+      // Simulate v3 signature: `createFunction(config, trigger, handler)`
+      // The trigger object lands in the handler parameter.
+      inngest.createFunction(
+        { id: "fn-1" },
+        { event: "event-1" },
+        // @ts-expect-error - Intentional
+        async () => {},
+      );
+    }).toThrow(
+      `"createFunction" expected a handler function as the second argument`,
+    );
+  });
+
   describe("types", () => {
     describe("function input", () => {
       const inngest = createClient({ id: "test" });

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -954,6 +954,12 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     rawOptions,
     handler,
   ) => {
+    if (typeof handler !== "function") {
+      throw new Error(
+        `"createFunction" expected a handler function as the second argument. Triggers belong in the first argument: createFunction({ id, triggers: { event: "..." } }, handler)`,
+      );
+    }
+
     const options = {
       ...rawOptions,
       triggers: this.sanitizeTriggers(rawOptions.triggers),


### PR DESCRIPTION
Throw an error when a function is defined using v3-style (triggers in 2nd arg)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a runtime guard in `createFunction` to detect v3-style 3-argument calls (where the trigger object is passed as the handler) and throws a descriptive error with migration guidance. Includes a matching test and changeset entry.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 21152869ef71926e7c050d53868f55ee2e9ac205.</sup>
<!-- /MENDRAL_SUMMARY -->