### PR TITLE
Fix eventType can't be combined with if expression in triggers

### DIFF
--- a/.changeset/young-items-attack.md
+++ b/.changeset/young-items-attack.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix eventType can't be combined with if expression

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -20,7 +20,7 @@ import type {
 
 import type { Inngest } from "./Inngest.ts";
 import type { Middleware } from "./middleware/middleware.ts";
-import type { EventTypeWithAnySchema } from "./triggers/triggers.ts";
+import { EventType, type EventTypeWithAnySchema } from "./triggers/triggers.ts";
 
 /**
  * A stateless Inngest function, wrapping up function configuration and any
@@ -156,28 +156,35 @@ export class InngestFunction<
      */
     const retries = typeof attempts === "undefined" ? undefined : { attempts };
 
+    const triggers: FunctionConfig["triggers"] = [];
+    for (const trigger of this.opts.triggers ?? []) {
+      if (trigger.cron) {
+        triggers.push({ cron: trigger.cron });
+        continue;
+      }
+
+      if (!trigger.event) {
+        continue;
+      }
+
+      // The invoke event is in the triggers if they used the `invoke` trigger
+      // helper. But we need to remove it in the config, or else the function
+      // will be triggered by any invoke.
+      let eventName = trigger.event;
+      if (eventName instanceof EventType) {
+        eventName = eventName.name;
+      }
+      if (eventName === internalEvents.FunctionInvoked) {
+        continue;
+      }
+
+      triggers.push({ event: eventName, expression: trigger.if });
+    }
+
     const fn: FunctionConfig = {
       id: fnId,
       name: this.name,
-      triggers: (this.opts.triggers ?? [])
-        .filter((trigger) => {
-          // The invoke event is in the triggers if they used the `invoke`
-          // trigger helper. But we need to remove it in the config, or else the
-          // function will be triggered by any invoke
-          return trigger.event !== internalEvents.FunctionInvoked;
-        })
-        .map((trigger) => {
-          if ("event" in trigger) {
-            return {
-              event: trigger.event as string,
-              expression: trigger.if,
-            };
-          }
-
-          return {
-            cron: trigger.cron,
-          };
-        }),
+      triggers,
       steps: {
         [InngestFunction.stepId]: {
           id: InngestFunction.stepId,

--- a/packages/inngest/src/components/triggers/trigger.test.ts
+++ b/packages/inngest/src/components/triggers/trigger.test.ts
@@ -131,6 +131,34 @@ describe("eventType without options", () => {
     );
   });
 
+  test("function config serializes event name as string", () => {
+    const inngest = new Inngest({ id: "app" });
+
+    // Direct EventType trigger
+    const fn1 = inngest.createFunction({ id: "fn1", triggers: [et] }, () => {});
+    const config1 = fn1["getConfig"]({
+      baseUrl: new URL("http://localhost:3000"),
+      appPrefix: "app",
+    });
+    expect(config1[0]!.triggers).toEqual([{ event: "event-1" }]);
+
+    // EventType in object trigger with 'if' condition
+    const fn2 = inngest.createFunction(
+      {
+        id: "fn2",
+        triggers: [{ event: et, if: "event.data.foo == 'bar'" }],
+      },
+      () => {},
+    );
+    const config2 = fn2["getConfig"]({
+      baseUrl: new URL("http://localhost:3000"),
+      appPrefix: "app",
+    });
+    expect(config2[0]!.triggers).toEqual([
+      { event: "event-1", expression: "event.data.foo == 'bar'" },
+    ]);
+  });
+
   test("function options", () => {
     const inngest = new Inngest({ id: "app" });
 
@@ -503,6 +531,21 @@ describe("invoke", () => {
     const inngest = new Inngest({ id: "app" });
     const fn = inngest.createFunction(
       { id: "fn", triggers: [invoke(z.object({ msg: z.string() }))] },
+      () => {},
+    );
+    const config = fn["getConfig"]({
+      baseUrl: new URL("http://localhost:3000"),
+      appPrefix: "app",
+    });
+    expect(config).toHaveLength(1);
+    expect(config[0]!.triggers).toEqual([]);
+  });
+
+  test("invoke trigger with EventType is also filtered", () => {
+    const inngest = new Inngest({ id: "app" });
+    const inv = invoke(z.object({ msg: z.string() }));
+    const fn = inngest.createFunction(
+      { id: "fn", triggers: [{ event: inv, if: "event.data.msg == 'hi'" }] },
       () => {},
     );
     const config = fn["getConfig"]({


### PR DESCRIPTION
Fix `eventType` can't be combined with `if` expression in `triggers`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes a bug where an `EventType` object used as a trigger event couldn't be combined with an `if` expression. The old code cast `trigger.event` directly to `string`, which broke when it was an `EventType` instance. The fix replaces the filter+map chain with an explicit loop that unwraps `EventType` instances via `instanceof` before building the config.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ff0f84b36a224196e177e607aed4aca3a4083dc2.</sup>
<!-- /MENDRAL_SUMMARY -->