### PR TITLE
an attempt to handle empry matrix on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_packages: ${{ steps.set-matrix.outputs.has_packages }}
     steps:
       - id: set-matrix
         run: |
@@ -70,10 +71,12 @@ jobs:
             ] | map(. as $pkg | select($labelList | index("prerelease/" + $pkg.package)))
           ')
 
+          echo "has_packages=$(jq -n --argjson data "$MATRIX" '$data | length > 0')" >> $GITHUB_OUTPUT
           echo "matrix=$(jq -cn --argjson data "$MATRIX" '{include: $data}')" >> $GITHUB_OUTPUT
 
   prereleases:
     needs: generate-prerelease-matrix
+    if: needs.generate-prerelease-matrix.outputs.has_packages == 'true'
     concurrency: prerelease-${{ github.ref }}
     continue-on-error: true
     strategy:


### PR DESCRIPTION
## Summary
Not sure what changed recently, but when a PR has no `prerelease` labels, the matrix filter produces `[]` and fail the job. This is an attempt to handle that.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `has_packages` output to the `generate-prerelease-matrix` job and gates the `prereleases` job behind an `if` condition that skips execution when no `prerelease/*` labels are present on the PR, preventing a matrix-with-empty-include failure.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6b3163d0b24c0d6eb910f1feb1c5b4c485600b41.</sup>
<!-- /MENDRAL_SUMMARY -->