### PR TITLE
refactor: SSE Frame -> SSE Event

### DIFF
--- a/packages/inngest/src/components/InngestStreamTools.test.ts
+++ b/packages/inngest/src/components/InngestStreamTools.test.ts
@@ -81,7 +81,7 @@ describe("InngestStream.pipe", () => {
 });
 
 describe("InngestStream.stepLifecycle", () => {
-  test("emits step lifecycle frames", async () => {
+  test("emits step lifecycle events", async () => {
     const s = new InngestStream();
 
     s.stepLifecycle("my-step", "running");

--- a/packages/inngest/src/components/InngestStreamTools.ts
+++ b/packages/inngest/src/components/InngestStreamTools.ts
@@ -1,11 +1,11 @@
 import { getAsyncCtx, getAsyncCtxSync } from "./execution/als.ts";
 import {
-  buildSseFailedFrame,
-  buildSseRedirectFrame,
-  buildSseStepFrame,
-  buildSseStreamFrame,
-  buildSseSucceededFrame,
-  type SseStepFrame,
+  buildSseFailedEvent,
+  buildSseRedirectEvent,
+  buildSseStepEvent,
+  buildSseStreamEvent,
+  buildSseSucceededEvent,
+  type SseStepEvent,
   type StepErrorData,
 } from "./execution/streaming.ts";
 
@@ -26,7 +26,7 @@ export type PipeSource =
  */
 export interface StreamTools {
   /**
-   * Push data to the client as an SSE stream frame. Fire-and-forget from the
+   * Push data to the client as an SSE stream event. Fire-and-forget from the
    * caller's perspective.
    *
    * Outside of an Inngest execution context this is a silent no-op (graceful
@@ -35,7 +35,7 @@ export interface StreamTools {
   push(data: unknown): void;
 
   /**
-   * Pipe a source to the client, writing each chunk as an SSE stream frame.
+   * Pipe a source to the client, writing each chunk as an SSE stream event.
    * Resolves with the concatenated content of all chunks when the source is
    * fully consumed.
    *
@@ -98,14 +98,14 @@ export class InngestStream {
 
   /**
    * The readable side of the underlying transform stream. Consumers (i.e. the
-   * HTTP response) read SSE frames from here.
+   * HTTP response) read SSE events from here.
    */
   get readable(): ReadableStream<Uint8Array> {
     return this.transform.readable;
   }
 
   /**
-   * Resolve the current step ID for stream frames. Returns the executing
+   * Resolve the current step ID for stream events. Returns the executing
    * step's hashed ID (read from ALS), or undefined if outside a step.
    */
   private currentStepId(): string | undefined {
@@ -120,11 +120,11 @@ export class InngestStream {
   }
 
   /**
-   * Enqueue a pre-built SSE frame string onto the write chain.
+   * Enqueue a pre-built SSE event string onto the write chain.
    */
-  private enqueue(frame: string): void {
+  private enqueue(sseEvent: string): void {
     this.writeChain = this.writeChain
-      .then(() => this.writer.write(this.encoder.encode(frame)))
+      .then(() => this.writer.write(this.encoder.encode(sseEvent)))
       .catch((err) => {
         // Writer errored (e.g. stream closed) — swallow so the chain
         // doesn't break and subsequent writes fail gracefully.
@@ -133,19 +133,19 @@ export class InngestStream {
   }
 
   /**
-   * Emit a step lifecycle SSE frame (`step:running`, `step:completed`,
+   * Emit a step lifecycle SSE event (`step:running`, `step:completed`,
    * `step:errored`). Internal use only — called by the execution engine.
    */
   stepLifecycle(
     stepId: string,
-    status: SseStepFrame["status"],
+    status: SseStepEvent["status"],
     data?: StepErrorData,
   ): void {
-    this.enqueue(buildSseStepFrame(stepId, status, data));
+    this.enqueue(buildSseStepEvent(stepId, status, data));
   }
 
   /**
-   * Write a single SSE stream frame containing `data`. The current step's
+   * Write a single SSE stream event containing `data`. The current step's
    * hashed ID is automatically included as stepId for rollback tracking.
    */
   push(data: unknown): void {
@@ -153,19 +153,19 @@ export class InngestStream {
 
     const stepId = this.currentStepId();
 
-    let frame: string;
+    let sseEvent: string;
     try {
-      frame = buildSseStreamFrame(data, stepId);
+      sseEvent = buildSseStreamEvent(data, stepId);
     } catch {
       // data is not JSON-serializable (e.g. circular reference) — skip
       return;
     }
 
-    this.enqueue(frame);
+    this.enqueue(sseEvent);
   }
 
   /**
-   * Pipe a source to the client, writing each chunk as an SSE stream frame.
+   * Pipe a source to the client, writing each chunk as an SSE stream event.
    * Returns the concatenated content of all chunks.
    */
   async pipe(source: PipeSource): Promise<string> {
@@ -208,7 +208,7 @@ export class InngestStream {
 
   /**
    * Core pipe loop: iterate an async iterable, writing each chunk as an SSE
-   * stream frame and collecting the concatenated result.
+   * stream event and collecting the concatenated result.
    */
   private async pipeIterable(source: AsyncIterable<string>): Promise<string> {
     const stepId = this.currentStepId();
@@ -217,14 +217,14 @@ export class InngestStream {
     for await (const chunk of source) {
       chunks.push(chunk);
 
-      let frame: string;
+      let sseEvent: string;
       try {
-        frame = buildSseStreamFrame(chunk, stepId);
+        sseEvent = buildSseStreamEvent(chunk, stepId);
       } catch {
         continue;
       }
 
-      this.enqueue(frame);
+      this.enqueue(sseEvent);
       await this.writeChain;
     }
 
@@ -232,38 +232,38 @@ export class InngestStream {
   }
 
   /**
-   * Write a redirect info frame. Tells the client where to reconnect if the
+   * Write a redirect info event. Tells the client where to reconnect if the
    * durable endpoint goes async. Does NOT close the writer — more stream
-   * frames may follow before the durable endpoint actually switches to async
+   * events may follow before the durable endpoint actually switches to async
    * mode. Internal use only.
    */
   sendRedirectInfo(data: { runId: string; url: string }): void {
-    this.enqueue(buildSseRedirectFrame(data));
+    this.enqueue(buildSseRedirectEvent(data));
   }
 
   /**
-   * Write a succeeded result frame and close the writer. Internal use only.
+   * Write a succeeded result event and close the writer. Internal use only.
    */
   closeSucceeded(data?: unknown): void {
-    let frame: string;
+    let sseEvent: string;
     try {
-      frame = buildSseSucceededFrame(data);
+      sseEvent = buildSseSucceededEvent(data);
     } catch {
-      frame = buildSseFailedFrame("Failed to serialize result");
+      sseEvent = buildSseFailedEvent("Failed to serialize result");
     }
-    this.closeWithFrame(frame);
+    this.closeWithEvent(sseEvent);
   }
 
   /**
-   * Write a failed result frame and close the writer. Internal use only.
+   * Write a failed result event and close the writer. Internal use only.
    */
   closeFailed(error: string): void {
-    this.closeWithFrame(buildSseFailedFrame(error));
+    this.closeWithEvent(buildSseFailedEvent(error));
   }
 
-  private closeWithFrame(frame: string): void {
+  private closeWithEvent(sseEvent: string): void {
     this.writeChain = this.writeChain
-      .then(() => this.writer.write(this.encoder.encode(frame)))
+      .then(() => this.writer.write(this.encoder.encode(sseEvent)))
       .then(() => this.writer.close())
       .catch((err) => {
         // Writer already errored/closed — nothing to do.
@@ -272,7 +272,7 @@ export class InngestStream {
   }
 
   /**
-   * Close the writer without writing a result frame. Used when the durable endpoint goes
+   * Close the writer without writing a result event. Used when the durable endpoint goes
    * async and the real result will arrive on the redirected stream.
    */
   end(): void {

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -784,7 +784,7 @@ describe("Sync mode function-resolved response handling", () => {
     expect(resolved.data).toBeInstanceOf(Response);
 
     // When acceptsSse is true, the Response body is extracted and wrapped
-    // in SSE format (metadata + result frames)
+    // in SSE format (metadata + result events)
     const body = await (resolved.data as Response).text();
     expect(body).toContain("event: inngest.metadata");
     expect(body).toContain("event: inngest.result");
@@ -804,7 +804,7 @@ describe("Sync mode function-resolved response handling", () => {
     const resolved = result as ExecutionResult & { data: unknown };
     expect(resolved.data).toBeInstanceOf(Response);
 
-    // Should be an SSE response with event frames
+    // Should be an SSE response with events
     const res = resolved.data as Response;
     expect(res.headers.get("Content-Type")).toBe("text/event-stream");
     const body = await res.text();

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -79,7 +79,7 @@ import {
   type MemoizedOp,
 } from "./InngestExecution.ts";
 import { clientProcessorMap } from "./otel/access.ts";
-import { buildSseMetadataFrame, prependToStream } from "./streaming.ts";
+import { buildSseMetadataEvent, prependToStream } from "./streaming.ts";
 
 const { sha1 } = hashjs;
 
@@ -133,13 +133,13 @@ class InngestExecutionEngine
     | undefined;
 
   /**
-   * Whether the `inngest.redirect_info` SSE frame has already been sent.
-   * Prevents duplicate redirect frames.
+   * Whether the `inngest.redirect_info` SSE event has already been sent.
+   * Prevents duplicate redirect events.
    */
   private redirectSent = false;
 
   /**
-   * Promise that resolves once the redirect frame has been written (or the
+   * Promise that resolves once the redirect event has been written (or the
    * attempt completes). Stored so that `checkpointAndSwitchToAsync` can
    * await it before closing the writer.
    */
@@ -342,7 +342,7 @@ class InngestExecutionEngine
         }
       }
     } catch (error) {
-      // If earlyStreamResponse was set up, close the stream with an error frame.
+      // If earlyStreamResponse was set up, close the stream with an error event.
       if (this.earlyStreamResponse) {
         this.streamTools.closeFailed("Internal execution error");
       }
@@ -439,17 +439,17 @@ class InngestExecutionEngine
 
     const token = this.state.checkpointedRun.token;
 
-    // Wait for the redirect_info frame to flush — sendRedirectIfReady
+    // Wait for the redirect_info event to flush — sendRedirectIfReady
     // fetches the redirect URL asynchronously.
     await this.redirectPromise;
 
     if (this.streamTools.activated) {
       if (stepError && !this.retriability(stepError)) {
-        // Permanent failure — close with a failed frame so the client
+        // Permanent failure — close with a failed event so the client
         // gets onFunctionFailed instead of silence.
         this.streamTools.closeFailed(errorMessage(stepError));
       } else {
-        // End stream without a result frame — client uses redirect_info
+        // End stream without a result event — client uses redirect_info
         // to reconnect.
         this.streamTools.end();
       }
@@ -465,7 +465,7 @@ class InngestExecutionEngine
   }
 
   /**
-   * Prepend the `inngest.metadata` SSE frame to the stream's readable side.
+   * Prepend the `inngest.metadata` SSE event to the stream's readable side.
    * The returned stream can be used as a fetch body or Response body.
    *
    * NOTE: `this.streamTools.readable` can only be consumed once, so only one
@@ -473,16 +473,16 @@ class InngestExecutionEngine
    * execution.
    */
   private buildMetadataPrefixedStream(): ReadableStream<Uint8Array> {
-    const metadataFrame = buildSseMetadataFrame(this.fnArg.runId);
+    const metadataEvent = buildSseMetadataEvent(this.fnArg.runId);
     return prependToStream(
-      new TextEncoder().encode(metadataFrame),
+      new TextEncoder().encode(metadataEvent),
       this.streamTools.readable,
     );
   }
 
   /**
    * Build a complete SSE `Response` backed by the stream's readable side,
-   * prefixed with the metadata frame.
+   * prefixed with the metadata event.
    */
   private buildSseResponse(): Response {
     return new Response(this.buildMetadataPrefixedStream(), {
@@ -499,7 +499,7 @@ class InngestExecutionEngine
    *
    * Used when the client sent `Accept: text/event-stream` but
    * `stream.push()`/`pipe()` was NOT called during execution. The
-   * checkpointable data is the function's return value — the SSE frames are
+   * checkpointable data is the function's return value — the SSE events are
    * just a delivery mechanism.
    */
   private wrapResultAsSse(
@@ -509,7 +509,7 @@ class InngestExecutionEngine
   ): ExecutionResult {
     const resultData: unknown = checkpoint.data;
 
-    // Close the stream with a terminal succeeded frame
+    // Close the stream with a terminal succeeded event
     this.streamTools.closeSucceeded(resultData);
 
     const clientResponse = this.buildSseResponse();
@@ -558,8 +558,8 @@ class InngestExecutionEngine
   }
 
   /**
-   * Sends the `inngest.redirect_info` SSE frame when both conditions are met:
-   * 1. The client accepts SSE (so there's a stream to write the frame to)
+   * Sends the `inngest.redirect_info` SSE event when both conditions are met:
+   * 1. The client accepts SSE (so there's a stream to write the event to)
    * 2. We have a realtime token (first checkpoint has completed)
    *
    * Called after the first checkpoint AND on stream activation, whichever
@@ -831,7 +831,7 @@ class InngestExecutionEngine
           }
 
           // Always close the stream — either the SSE client or the
-          // server-side checkpoint POST needs the terminal result frame.
+          // server-side checkpoint POST needs the terminal result event.
           this.streamTools.closeSucceeded(resultData);
 
           if (sseDeliveredToClient) {
@@ -892,7 +892,7 @@ class InngestExecutionEngine
           if (isFinal) {
             this.streamTools.closeFailed(errorMessage(checkpoint.error));
           } else {
-            // Retryable error — suppress the result frame; the run will retry.
+            // Retryable error — suppress the result event; the run will retry.
             this.streamTools.end();
           }
 
@@ -1029,17 +1029,17 @@ class InngestExecutionEngine
 
         // Check for unreported new steps (e.g. from `Promise.race` where
         // the winning branch completed before losing branches reported)
-        // before closing the stream — once closed, no more frames can be sent.
+        // before closing the stream — once closed, no more events can be sent.
         const newStepsResult = await maybeReturnNewSteps();
         if (newStepsResult) {
           return newStepsResult;
         }
 
-        // Close the stream with a terminal succeeded frame.
+        // Close the stream with a terminal succeeded event.
         this.streamTools.closeSucceeded(resultData);
 
         // If stream was never activated, start the POST now so the
-        // client waiting at the GET endpoint gets the result frame.
+        // client waiting at the GET endpoint gets the result event.
         if (!this.streamTools.activated) {
           this.postCheckpointStream();
         }
@@ -1066,7 +1066,7 @@ class InngestExecutionEngine
         if (isFinal) {
           this.streamTools.closeFailed(errorMessage(checkpoint.error));
         } else {
-          // Retryable error — suppress the result frame; the run will retry.
+          // Retryable error — suppress the result event; the run will retry.
           this.streamTools.end();
         }
 
@@ -1418,7 +1418,7 @@ class InngestExecutionEngine
 
     this.devDebug(`executing step "${id}"`);
 
-    // Emit step:running lifecycle frame
+    // Emit step:running lifecycle event
     this.streamTools.stepLifecycle(hashedId, "running");
 
     if (this.rootSpanId && this.options.checkpointingConfig) {
@@ -1482,7 +1482,7 @@ class InngestExecutionEngine
         // with confirmed data from the server). handle() resolves it.
         await this.middlewareManager.onStepComplete(stepInfo, serverData);
 
-        // Emit step:completed lifecycle frame
+        // Emit step:completed lifecycle event
         this.streamTools.stepLifecycle(hashedId, "completed");
 
         return {
@@ -1631,7 +1631,7 @@ class InngestExecutionEngine
       isFinal,
     );
 
-    // Emit step:errored lifecycle frame
+    // Emit step:errored lifecycle event
     this.streamTools.stepLifecycle(hashedId, "errored", {
       willRetry: !isFinal,
       error: error instanceof Error ? error.message : String(error),

--- a/packages/inngest/src/components/execution/streaming.ts
+++ b/packages/inngest/src/components/execution/streaming.ts
@@ -79,32 +79,32 @@ const sseRedirectSchema = z.object({
 // Types derived from schemas
 // ---------------------------------------------------------------------------
 
-export type SseMetadataFrame = z.infer<typeof sseMetadataSchema>;
-export type SseStreamFrame = z.infer<typeof sseStreamSchema>;
-export type SseResultSucceededFrame = z.infer<typeof sseResultSucceededSchema>;
-export type SseResultFailedFrame = z.infer<typeof sseResultFailedSchema>;
-export type SseResultFrame = z.infer<typeof sseResultSchema>;
+export type SseMetadataEvent = z.infer<typeof sseMetadataSchema>;
+export type SseStreamEvent = z.infer<typeof sseStreamSchema>;
+export type SseResultSucceededEvent = z.infer<typeof sseResultSucceededSchema>;
+export type SseResultFailedEvent = z.infer<typeof sseResultFailedSchema>;
+export type SseResultEvent = z.infer<typeof sseResultSchema>;
 
 /**
- * Payload included with every `inngest.step` errored frame. Describes the
+ * Payload included with every `inngest.step` errored event. Describes the
  * failure so the client can decide whether to show an error or wait for a
  * retry.
  */
 export type StepErrorData = z.infer<typeof stepErrorDataSchema>;
 
-export type SseStepRunningFrame = z.infer<typeof sseStepRunningSchema>;
-export type SseStepCompletedFrame = z.infer<typeof sseStepCompletedSchema>;
-export type SseStepErroredFrame = z.infer<typeof sseStepErroredSchema>;
-export type SseStepFrame = z.infer<typeof sseStepSchema>;
+export type SseStepRunningEvent = z.infer<typeof sseStepRunningSchema>;
+export type SseStepCompletedEvent = z.infer<typeof sseStepCompletedSchema>;
+export type SseStepErroredEvent = z.infer<typeof sseStepErroredSchema>;
+export type SseStepEvent = z.infer<typeof sseStepSchema>;
 
-export type SseRedirectFrame = z.infer<typeof sseRedirectSchema>;
+export type SseRedirectEvent = z.infer<typeof sseRedirectSchema>;
 
-export type SseFrame =
-  | SseMetadataFrame
-  | SseStreamFrame
-  | SseResultFrame
-  | SseStepFrame
-  | SseRedirectFrame;
+export type SseEvent =
+  | SseMetadataEvent
+  | SseStreamEvent
+  | SseResultEvent
+  | SseStepEvent
+  | SseRedirectEvent;
 
 export interface RawSseEvent {
   event: string;
@@ -112,70 +112,70 @@ export interface RawSseEvent {
 }
 
 // ---------------------------------------------------------------------------
-// Frame builders
+// SSE event builders
 // ---------------------------------------------------------------------------
 
 /**
- * Builds a single SSE frame with the given event name and JSON-serialized data.
+ * Builds a single SSE event with the given event name and JSON-serialized data.
  *
  * `undefined` is normalized to `null` so that the `data:` field is always valid
  * JSON (since `JSON.stringify(undefined)` returns the JS primitive `undefined`,
  * not the string `"null"`).
  */
-function buildSseFrame(event: string, data: unknown): string {
+function buildSseEvent(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data ?? null)}\n\n`;
 }
 
 /**
- * Builds an SSE metadata frame string for a streaming response.
+ * Builds an SSE metadata event string for a streaming response.
  *
- * The frame follows the Server-Sent Events format and provides run context
+ * The event follows the Server-Sent Events format and provides run context
  * (run ID) to consumers of the stream.
  */
-export function buildSseMetadataFrame(runId: string): string {
-  return buildSseFrame("inngest.metadata", { runId });
+export function buildSseMetadataEvent(runId: string): string {
+  return buildSseEvent("inngest.metadata", { runId });
 }
 
 /**
- * Builds an SSE stream frame string for user-pushed data.
+ * Builds an SSE stream event string for user-pushed data.
  *
  * Used by `stream.push()` and `stream.pipe()` to send arbitrary data to
  * clients as part of a streaming response.
  */
-export function buildSseStreamFrame(data: unknown, stepId?: string): string {
+export function buildSseStreamEvent(data: unknown, stepId?: string): string {
   const payload: Record<string, unknown> = { data };
   if (stepId) payload.stepId = stepId;
-  return buildSseFrame("stream", payload);
+  return buildSseEvent("stream", payload);
 }
 
 /**
- * Builds an SSE result frame for a successfully completed function.
- * This is the last frame sent before the stream closes.
+ * Builds an SSE result event for a successfully completed function.
+ * This is the last event sent before the stream closes.
  */
-export function buildSseSucceededFrame(data: unknown): string {
-  return buildSseFrame("inngest.result", { status: "succeeded", data });
+export function buildSseSucceededEvent(data: unknown): string {
+  return buildSseEvent("inngest.result", { status: "succeeded", data });
 }
 
 /**
- * Builds an SSE result frame for a permanently failed function.
- * This is the last frame sent before the stream closes.
+ * Builds an SSE result event for a permanently failed function.
+ * This is the last event sent before the stream closes.
  */
-export function buildSseFailedFrame(error: string): string {
-  return buildSseFrame("inngest.result", { status: "failed", error });
+export function buildSseFailedEvent(error: string): string {
+  return buildSseEvent("inngest.result", { status: "failed", error });
 }
 
 /**
- * Builds an SSE redirect frame telling the client that execution has switched
+ * Builds an SSE redirect event telling the client that execution has switched
  * to async mode and it should reconnect elsewhere to get remaining output.
  *
  * The `url` already contains the realtime JWT as a query parameter, so no
  * separate token field is needed.
  */
-export function buildSseRedirectFrame(data: {
+export function buildSseRedirectEvent(data: {
   runId: string;
   url: string;
 }): string {
-  return buildSseFrame("inngest.redirect_info", data);
+  return buildSseEvent("inngest.redirect_info", data);
 }
 
 /**
@@ -316,22 +316,22 @@ export async function drainStreamWithTimeout(
 }
 
 // ---------------------------------------------------------------------------
-// Step frame builder
+// Step event builder
 // ---------------------------------------------------------------------------
 
 /**
- * Builds an SSE step lifecycle frame.
+ * Builds an SSE step lifecycle event.
  */
-export function buildSseStepFrame(
+export function buildSseStepEvent(
   stepId: string,
-  status: SseStepFrame["status"],
+  status: SseStepEvent["status"],
   data?: unknown,
 ): string {
   const payload: Record<string, unknown> = { stepId, status };
   if (data !== undefined) {
     payload.data = data;
   }
-  return buildSseFrame("inngest.step", payload);
+  return buildSseEvent("inngest.step", payload);
 }
 
 // ---------------------------------------------------------------------------
@@ -386,10 +386,10 @@ export async function* iterSse(
 }
 
 // ---------------------------------------------------------------------------
-// Raw SSE event -> typed SSE frame
+// Raw SSE event -> typed SseEvent
 // ---------------------------------------------------------------------------
 
-const sseSchemasByEvent: Record<string, z.ZodType<SseFrame>> = {
+const sseSchemasByEvent: Record<string, z.ZodType<SseEvent>> = {
   "inngest.metadata": sseMetadataSchema,
   stream: sseStreamSchema,
   "inngest.result": sseResultSchema,
@@ -398,10 +398,10 @@ const sseSchemasByEvent: Record<string, z.ZodType<SseFrame>> = {
 };
 
 /**
- * Converts a `RawSseEvent` into a typed `SseFrame`, or returns `undefined`
+ * Converts a `RawSseEvent` into a typed `SseEvent`, or returns `undefined`
  * if the event type is unrecognised or fails validation.
  */
-export function parseSseFrame(raw: RawSseEvent): SseFrame | undefined {
+export function parseSseEvent(raw: RawSseEvent): SseEvent | undefined {
   const schema = sseSchemasByEvent[raw.event];
   if (!schema) {
     return undefined;

--- a/packages/inngest/src/stream.test.ts
+++ b/packages/inngest/src/stream.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test, vi } from "vitest";
-import type { SseFrame } from "./components/execution/streaming.ts";
+import type { SseEvent } from "./components/execution/streaming.ts";
 import { streamRun } from "./stream.ts";
 
 /**
- * Helper: create an async iterable from an array of SseFrames.
+ * Helper: create an async iterable from an array of SseEvents.
  */
-async function* framesFrom(frames: SseFrame[]): AsyncGenerator<SseFrame> {
-  for (const frame of frames) {
-    yield frame;
+async function* eventsFrom(events: SseEvent[]): AsyncGenerator<SseEvent> {
+  for (const sseEvent of events) {
+    yield sseEvent;
   }
 }
 
@@ -19,7 +19,7 @@ describe("streamRun", () => {
       onData: (d) => collected.push(d),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "stream", data: "hello" },
         { type: "stream", data: " world" },
       ]),
@@ -34,14 +34,14 @@ describe("streamRun", () => {
     expect(rs.chunks).toEqual(["hello", " world"]);
   });
 
-  test("calls onFunctionCompleted when succeeded result frame arrives", async () => {
+  test("calls onFunctionCompleted when succeeded result event arrives", async () => {
     const results: { data: unknown }[] = [];
 
     const rs = streamRun("http://test", {
       onFunctionCompleted: (info) => results.push(info),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "stream", data: "chunk" },
         { type: "inngest.result", status: "succeeded", data: "final" },
       ]),
@@ -52,14 +52,14 @@ describe("streamRun", () => {
     expect(results).toEqual([{ data: "final" }]);
   });
 
-  test("calls onFunctionFailed when failed result frame arrives", async () => {
+  test("calls onFunctionFailed when failed result event arrives", async () => {
     const errors: string[] = [];
 
     const rs = streamRun("http://test", {
       onFunctionFailed: (e) => errors.push(e),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "stream", data: "chunk" },
         {
           type: "inngest.result",
@@ -81,7 +81,7 @@ describe("streamRun", () => {
       onRollback: (count) => rolledBack.push(count),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "inngest.step", stepId: "s1", status: "running" },
         { type: "stream", data: "a", stepId: "s1" },
         { type: "stream", data: "b", stepId: "s1" },
@@ -112,7 +112,7 @@ describe("streamRun", () => {
       onStepErrored: (id) => errored.push(id),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "inngest.step", stepId: "s1", status: "running" },
         { type: "inngest.step", stepId: "s1", status: "completed" },
         { type: "inngest.step", stepId: "s2", status: "running" },
@@ -138,7 +138,7 @@ describe("streamRun", () => {
       parse: (d) => Number(d),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "stream", data: "42" },
         { type: "stream", data: "7" },
       ]),
@@ -161,7 +161,7 @@ describe("streamRun", () => {
       onStepErrored: (id, info) => errored.push({ id, info }),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "inngest.step", stepId: "s1", status: "running" },
         { type: "stream", data: "partial", stepId: "s1" },
         // Stream ends without step:completed or step:errored
@@ -180,21 +180,21 @@ describe("streamRun", () => {
 
   test("throws if consumed twice", async () => {
     const rs = streamRun("http://test");
-    rs._fromSource(framesFrom([]));
+    rs._fromSource(eventsFrom([]));
 
     await rs;
 
     await expect(rs).rejects.toThrow("already been consumed");
   });
 
-  test("calls onMetadata when metadata frame arrives", async () => {
+  test("calls onMetadata when metadata event arrives", async () => {
     const metadata: Array<{ runId: string }> = [];
 
     const rs = streamRun("http://test", {
       onMetadata: (info) => metadata.push(info),
     });
     rs._fromSource(
-      framesFrom([{ type: "inngest.metadata", runId: "run-123" }]),
+      eventsFrom([{ type: "inngest.metadata", runId: "run-123" }]),
     );
 
     await rs;
@@ -202,21 +202,21 @@ describe("streamRun", () => {
     expect(metadata).toEqual([{ runId: "run-123" }]);
   });
 
-  test("stops consuming after inngest.result frame", async () => {
+  test("stops consuming after inngest.result event", async () => {
     const collected: string[] = [];
     const done = vi.fn();
 
     // Simulate a source that sends a result then keeps sending (server
     // didn't close the connection). The stream should stop after result.
-    async function* neverEnding(): AsyncGenerator<SseFrame> {
-      yield { type: "stream", data: "a" } as SseFrame;
+    async function* neverEnding(): AsyncGenerator<SseEvent> {
+      yield { type: "stream", data: "a" } as SseEvent;
       yield {
         type: "inngest.result",
         status: "succeeded",
         data: "done",
-      } as SseFrame;
+      } as SseEvent;
       // These should never be reached:
-      yield { type: "stream", data: "SHOULD NOT APPEAR" } as SseFrame;
+      yield { type: "stream", data: "SHOULD NOT APPEAR" } as SseEvent;
     }
 
     const rs = streamRun<string>("http://test", {
@@ -240,7 +240,7 @@ describe("streamRun", () => {
       onDone: done,
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "stream", data: "x" },
         { type: "stream", data: "y" },
       ]),
@@ -256,8 +256,8 @@ describe("streamRun", () => {
     const onError = vi.fn();
     const onDone = vi.fn();
 
-    async function* exploding(): AsyncGenerator<SseFrame> {
-      yield { type: "stream", data: "ok" } as SseFrame;
+    async function* exploding(): AsyncGenerator<SseEvent> {
+      yield { type: "stream", data: "ok" } as SseEvent;
       throw new Error("network failure");
     }
 
@@ -281,8 +281,8 @@ describe("streamRun", () => {
     const onDone = vi.fn();
     const controller = new AbortController();
 
-    async function* abortable(): AsyncGenerator<SseFrame> {
-      yield { type: "stream", data: "a" } as SseFrame;
+    async function* abortable(): AsyncGenerator<SseEvent> {
+      yield { type: "stream", data: "a" } as SseEvent;
       controller.abort();
       // Simulate abort by throwing AbortError
       throw new DOMException("The operation was aborted.", "AbortError");
@@ -306,7 +306,7 @@ describe("streamRun", () => {
       onRollback: (count) => rolledBack.push(count),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "inngest.step", stepId: "s1", status: "running" },
         { type: "stream", data: "a", stepId: "s1" },
         { type: "inngest.step", stepId: "s1", status: "completed" },
@@ -330,7 +330,7 @@ describe("streamRun", () => {
       onStepRunning: (info) => running.push(info),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         {
           type: "inngest.step",
           stepId: "s1",
@@ -352,7 +352,7 @@ describe("streamRun", () => {
       onRollback: (count) => rolledBack.push(count),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "inngest.step", stepId: "A", status: "running" },
         { type: "inngest.step", stepId: "B", status: "running" },
         { type: "stream", data: "A1", stepId: "A" },
@@ -383,7 +383,7 @@ describe("streamRun", () => {
       onRollback: (count) => rolledBack.push(count),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         { type: "inngest.step", stepId: "s1", status: "running" },
         {
           type: "inngest.step",
@@ -408,7 +408,7 @@ describe("streamRun", () => {
       onRollback: (count) => rolledBack.push(count),
     });
     rs._fromSource(
-      framesFrom([
+      eventsFrom([
         // Step "A" runs and completes — its chunks are committed
         { type: "inngest.step", stepId: "A", status: "running" },
         { type: "stream", data: "first-A", stepId: "A" },

--- a/packages/inngest/src/stream.ts
+++ b/packages/inngest/src/stream.ts
@@ -8,8 +8,8 @@
 
 import {
   iterSse,
-  parseSseFrame,
-  type SseFrame,
+  parseSseEvent,
+  type SseEvent,
 } from "./components/execution/streaming.ts";
 
 // ---------------------------------------------------------------------------
@@ -26,12 +26,12 @@ export interface SubscribeToRunOptions {
 }
 
 /**
- * Low-level async generator that fetches an SSE endpoint, parses frames,
- * and follows `inngest.redirect_info` frames transparently.
+ * Low-level async generator that fetches an SSE endpoint, parses SSE events,
+ * and follows `inngest.redirect_info` events transparently.
  */
 export async function* subscribeToRun(
   opts: SubscribeToRunOptions,
-): AsyncGenerator<SseFrame> {
+): AsyncGenerator<SseEvent> {
   const fetchFn = opts.fetch ?? globalThis.fetch;
   let currentUrl: string | undefined = opts.url;
 
@@ -52,17 +52,17 @@ export async function* subscribeToRun(
     let redirectUrl: string | undefined;
 
     for await (const raw of iterSse(res.body)) {
-      const frame = parseSseFrame(raw);
-      if (!frame) continue;
+      const sseEvent = parseSseEvent(raw);
+      if (!sseEvent) continue;
 
-      if (frame.type === "inngest.redirect_info") {
-        redirectUrl = frame.url;
-        yield frame;
-        // Don't break — keep consuming remaining frames from this response
+      if (sseEvent.type === "inngest.redirect_info") {
+        redirectUrl = sseEvent.url;
+        yield sseEvent;
+        // Don't break — keep consuming remaining events from this response
         continue;
       }
 
-      yield frame;
+      yield sseEvent;
     }
 
     // Follow redirect if we got one; otherwise we're done
@@ -108,7 +108,7 @@ export interface RunStreamOptions<TData = unknown> {
   /**
    * Called when the function fails permanently (NonRetriableError or final
    * attempt). Will not fire for retryable errors — those simply end the
-   * stream without a result frame.
+   * stream without a result event.
    */
   onFunctionFailed?: (error: string) => void;
   /** Called when a step begins running. */
@@ -169,7 +169,7 @@ export class RunStream<TData = unknown> {
   private _tagged: Array<{ data: TData; stepId?: string }> = [];
   private _chunks: TData[] = [];
   private _consumed = false;
-  private _source: AsyncIterable<SseFrame> | undefined;
+  private _source: AsyncIterable<SseEvent> | undefined;
 
   private _parseFn: (data: unknown) => TData;
 
@@ -217,7 +217,7 @@ export class RunStream<TData = unknown> {
    * Inject a pre-built source for testing. Skips the real fetch.
    * @internal
    */
-  _fromSource(source: AsyncIterable<SseFrame>): this {
+  _fromSource(source: AsyncIterable<SseEvent>): this {
     this._source = source;
     return this;
   }
@@ -252,7 +252,7 @@ export class RunStream<TData = unknown> {
     yield* this._consume();
   }
 
-  private _resolveSource(): AsyncIterable<SseFrame> {
+  private _resolveSource(): AsyncIterable<SseEvent> {
     return (
       this._source ??
       subscribeToRun({
@@ -264,7 +264,7 @@ export class RunStream<TData = unknown> {
   }
 
   /**
-   * Core processing loop. Processes SSE frames, fires hooks, yields parsed
+   * Core processing loop. Processes SSE events, fires hooks, yields parsed
    * data chunks, and handles rollback on step errors / disconnects.
    */
   private async *_consume(): AsyncGenerator<TData> {
@@ -284,47 +284,47 @@ export class RunStream<TData = unknown> {
       // switch, and after receiving `inngest.result` the underlying SSE
       // connection may stay open — meaning `source.next()` would block forever
       // if we relied on the loop's next iteration to check a flag.
-      outer: for await (const frame of source) {
-        switch (frame.type) {
+      outer: for await (const sseEvent of source) {
+        switch (sseEvent.type) {
           case "stream": {
-            const parsed = this._parseFn(frame.data);
-            this._pushChunk(parsed, frame.stepId);
-            this.opts.onData?.({ data: parsed, hashedStepId: frame.stepId });
+            const parsed = this._parseFn(sseEvent.data);
+            this._pushChunk(parsed, sseEvent.stepId);
+            this.opts.onData?.({ data: parsed, hashedStepId: sseEvent.stepId });
             yield parsed;
             break;
           }
           case "inngest.step": {
-            if (frame.status === "running") {
-              inFlightSteps.add(frame.stepId);
-              this.opts.onStepRunning?.({ hashedStepId: frame.stepId });
-            } else if (frame.status === "completed") {
-              inFlightSteps.delete(frame.stepId);
-              this._commitStepId(frame.stepId);
+            if (sseEvent.status === "running") {
+              inFlightSteps.add(sseEvent.stepId);
+              this.opts.onStepRunning?.({ hashedStepId: sseEvent.stepId });
+            } else if (sseEvent.status === "completed") {
+              inFlightSteps.delete(sseEvent.stepId);
+              this._commitStepId(sseEvent.stepId);
               this.opts.onStepCompleted?.({
-                hashedStepId: frame.stepId,
+                hashedStepId: sseEvent.stepId,
               });
-            } else if (frame.status === "errored") {
-              inFlightSteps.delete(frame.stepId);
-              const count = this._rollbackStepId(frame.stepId);
+            } else if (sseEvent.status === "errored") {
+              inFlightSteps.delete(sseEvent.stepId);
+              const count = this._rollbackStepId(sseEvent.stepId);
               if (count > 0) {
                 this.opts.onRollback?.(count);
               }
-              this.opts.onStepErrored?.(frame.stepId, {
-                willRetry: frame.willRetry,
-                error: frame.error,
+              this.opts.onStepErrored?.(sseEvent.stepId, {
+                willRetry: sseEvent.willRetry,
+                error: sseEvent.error,
               });
             }
             break;
           }
           case "inngest.result":
-            if (frame.status === "succeeded") {
-              this.opts.onFunctionCompleted?.({ data: frame.data });
+            if (sseEvent.status === "succeeded") {
+              this.opts.onFunctionCompleted?.({ data: sseEvent.data });
             } else {
-              this.opts.onFunctionFailed?.(frame.error);
+              this.opts.onFunctionFailed?.(sseEvent.error);
             }
             break outer;
           case "inngest.metadata":
-            this.opts.onMetadata?.({ runId: frame.runId });
+            this.opts.onMetadata?.({ runId: sseEvent.runId });
             break;
           default:
             break;

--- a/packages/inngest/src/test/integration/durableEndpoints/streaming.test.ts
+++ b/packages/inngest/src/test/integration/durableEndpoints/streaming.test.ts
@@ -163,7 +163,7 @@ describe("header negotiation", () => {
       );
 
       test(
-        "async: returns SSE stream with redirect frame for async handoff",
+        "async: returns SSE stream with redirect event for async handoff",
         { timeout: 60000 },
         async () => {
           const { port } = await setupEndpoint(testFileName, async () => {
@@ -190,7 +190,7 @@ describe("header negotiation", () => {
           const streamData = getStreamData(events);
           expect(streamData).toContain("sync-data");
 
-          // Redirect frame tells the client where to reconnect
+          // Redirect event tells the client where to reconnect
           const redirects = events.filter(
             (e) => e.event === "inngest.redirect_info",
           );
@@ -231,8 +231,8 @@ describe("header negotiation", () => {
             data: "computed",
           });
 
-          const streamFrames = events.filter((e) => e.event === "stream");
-          expect(streamFrames.length).toBe(0);
+          const streamEvents = events.filter((e) => e.event === "stream");
+          expect(streamEvents.length).toBe(0);
         },
       );
 
@@ -416,10 +416,10 @@ describe("streaming functionality", () => {
     const { events } = await readSseStream(res, 15_000);
     const streamData = getStreamData(events);
 
-    // All frames arrive in order
+    // All events arrive in order
     expect(streamData).toEqual(["Starting...", "a", "b", "Done"]);
 
-    // Result frame present
+    // Result event present
     const results = events.filter((e) => e.event === "inngest.result");
     expect(results.length).toBe(1);
   });
@@ -455,7 +455,7 @@ describe("streaming functionality", () => {
         streamData.indexOf("from-step-2"),
       );
 
-      // Result frame
+      // Result event
       const results = events.filter((e) => e.event === "inngest.result");
       expect(results.length).toBe(1);
       expect(JSON.parse(results[0]!.data)).toEqual({
@@ -465,7 +465,7 @@ describe("streaming functionality", () => {
 
       // redirect_info is always sent once checkpoint creates the run
 
-      // Step lifecycle frames present
+      // Step lifecycle events present
       const stepEvents = events.filter((e) => e.event === "inngest.step");
       expect(stepEvents.length).toBeGreaterThanOrEqual(2);
     },
@@ -478,7 +478,7 @@ describe("streaming functionality", () => {
 
 describe("error and rollback", () => {
   test(
-    "step error emits errored frame with streamed data",
+    "step error emits errored event with streamed data",
     { timeout: 60000 },
     async () => {
       const { port } = await setupEndpoint(testFileName, async () => {
@@ -501,9 +501,9 @@ describe("error and rollback", () => {
       // The partial data was streamed before the error
       expect(streamData).toContain("partial");
 
-      // Step errored frame present
+      // Step errored event present
       const stepEvents = events.filter((e) => e.event === "inngest.step");
-      const erroredFrames = stepEvents.filter((e) => {
+      const erroredEvents = stepEvents.filter((e) => {
         try {
           const parsed = JSON.parse(e.data);
           return parsed.status === "errored";
@@ -511,10 +511,10 @@ describe("error and rollback", () => {
           return false;
         }
       });
-      expect(erroredFrames.length).toBeGreaterThanOrEqual(1);
+      expect(erroredEvents.length).toBeGreaterThanOrEqual(1);
 
-      const errorData = JSON.parse(erroredFrames[0]!.data);
-      // willRetry is nested inside the data field of the step frame
+      const errorData = JSON.parse(erroredEvents[0]!.data);
+      // willRetry is nested inside the data field of the step event
       const willRetry = errorData.data?.willRetry ?? errorData.willRetry;
       expect(willRetry).toBe(false);
     },
@@ -542,9 +542,9 @@ describe("error and rollback", () => {
 
     const { events } = await readSseStream(res, 15_000);
 
-    // Find the "between" stream frame and verify it has no stepId
+    // Find the "between" stream event and verify it has no stepId
     const streamEvents = events.filter((e) => e.event === "stream");
-    const betweenFrame = streamEvents.find((e) => {
+    const betweenEvent = streamEvents.find((e) => {
       try {
         const parsed = JSON.parse(e.data);
         return (parsed?.data ?? parsed) === "between";
@@ -553,16 +553,16 @@ describe("error and rollback", () => {
       }
     });
 
-    expect(betweenFrame).toBeDefined();
+    expect(betweenEvent).toBeDefined();
 
-    // Parse the frame data and check for absence of stepId
-    const parsedBetween = JSON.parse(betweenFrame!.data);
+    // Parse the event data and check for absence of stepId
+    const parsedBetween = JSON.parse(betweenEvent!.data);
     if (typeof parsedBetween === "object" && parsedBetween !== null) {
       expect(parsedBetween.stepId).toBeUndefined();
     }
 
-    // The inside-step frame should have a stepId
-    const insideFrame = streamEvents.find((e) => {
+    // The inside-step event should have a stepId
+    const insideEvent = streamEvents.find((e) => {
       try {
         const parsed = JSON.parse(e.data);
         return (parsed?.data ?? parsed) === "inside-step";
@@ -570,8 +570,8 @@ describe("error and rollback", () => {
         return e.data === "inside-step";
       }
     });
-    expect(insideFrame).toBeDefined();
-    const parsedInside = JSON.parse(insideFrame!.data);
+    expect(insideEvent).toBeDefined();
+    const parsedInside = JSON.parse(insideEvent!.data);
     if (typeof parsedInside === "object" && parsedInside !== null) {
       expect(parsedInside.stepId).toBeDefined();
     }
@@ -579,7 +579,7 @@ describe("error and rollback", () => {
 
   // Fails
   test.skip(
-    "NonRetriableError after async mode sends inngest.result failed frame",
+    "NonRetriableError after async mode sends inngest.result failed event",
     { timeout: 60000 },
     async () => {
       const state = createState({});
@@ -629,8 +629,8 @@ describe("error and rollback", () => {
         readTimeoutMs: 15_000,
       });
 
-      // inngest.result failed frame must be present — this is the bug fix.
-      // Before the fix, the stream closed without a terminal result frame,
+      // inngest.result failed event must be present — this is the bug fix.
+      // Before the fix, the stream closed without a terminal result event,
       // so onFunctionFailed never fired on the client.
       const resultEvents = asyncEvents.filter(
         (e) => e.event === "inngest.result",


### PR DESCRIPTION
## Summary
To help make our code more understandable, this refactor from our usage of "SSE Frame" to "SseEvent" to mean a "single Server Side Event chunk".

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Pure rename refactor replacing "SSE Frame" terminology with "SSE Event" across the streaming subsystem — types, builder functions, local variables, comments, and test descriptions are all updated consistently. No logic changes.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f8dfc94a377f1760b569a6d35298f3aeed8be038.</sup>
<!-- /MENDRAL_SUMMARY -->