### PR TITLE
Add rollback test

### DIFF
--- a/packages/inngest/src/components/execution/streaming.ts
+++ b/packages/inngest/src/components/execution/streaming.ts
@@ -42,8 +42,10 @@ const sseStepErroredSchema = z.object({
   type: z.literal("inngest.step"),
   stepId: z.string(),
   status: z.literal("errored"),
-  willRetry: z.boolean(),
-  error: z.string(),
+  data: z.object({
+    willRetry: z.boolean(),
+    error: z.string(),
+  }),
 });
 
 const sseStepSchema = z.discriminatedUnion("status", [
@@ -419,6 +421,7 @@ export function parseSseEvent(raw: RawSseEvent): SseEvent | undefined {
 
   const result = schema.safeParse({ ...parsed, type: raw.event });
   if (!result.success) {
+    console.log(raw);
     throw new Error("Unknown SSE event", { cause: result.error });
   }
 

--- a/packages/inngest/src/stream.test.ts
+++ b/packages/inngest/src/stream.test.ts
@@ -89,8 +89,7 @@ describe("streamRun", () => {
           type: "inngest.step",
           stepId: "s1",
           status: "errored",
-          willRetry: true,
-          error: "boom",
+          data: { willRetry: true, error: "boom" },
         },
       ]),
     );
@@ -104,12 +103,12 @@ describe("streamRun", () => {
   test("emits step lifecycle hooks", async () => {
     const running: { hashedStepId: string }[] = [];
     const completed: string[] = [];
-    const errored: string[] = [];
+    const errored: { hashedStepId: string }[] = [];
 
     const rs = streamRun("http://test", {
       onStepRunning: (info) => running.push(info),
       onStepCompleted: (info) => completed.push(info.hashedStepId),
-      onStepErrored: (id) => errored.push(id),
+      onStepErrored: (info) => errored.push(info),
     });
     rs._fromSource(
       eventsFrom([
@@ -120,8 +119,7 @@ describe("streamRun", () => {
           type: "inngest.step",
           stepId: "s2",
           status: "errored",
-          willRetry: false,
-          error: "fail",
+          data: { willRetry: false, error: "fail" },
         },
       ]),
     );
@@ -130,7 +128,7 @@ describe("streamRun", () => {
 
     expect(running).toEqual([{ hashedStepId: "s1" }, { hashedStepId: "s2" }]);
     expect(completed).toEqual(["s1"]);
-    expect(errored).toEqual(["s2"]);
+    expect(errored).toEqual([{ hashedStepId: "s2" }]);
   });
 
   test("yields parsed chunks via async iteration", async () => {
@@ -154,11 +152,11 @@ describe("streamRun", () => {
 
   test("synthesizes rollback on mid-step disconnect", async () => {
     const rolledBack: number[] = [];
-    const errored: Array<{ id: string; info: unknown }> = [];
+    const errored: { hashedStepId: string }[] = [];
 
     const rs = streamRun<string>("http://test", {
       onRollback: (count) => rolledBack.push(count),
-      onStepErrored: (id, info) => errored.push({ id, info }),
+      onStepErrored: (info) => errored.push(info),
     });
     rs._fromSource(
       eventsFrom([
@@ -171,11 +169,7 @@ describe("streamRun", () => {
     await rs;
 
     expect(rolledBack).toEqual([1]);
-    expect(errored[0]?.id).toBe("s1");
-    expect(errored[0]?.info).toMatchObject({
-      willRetry: false,
-      error: "stream disconnected",
-    });
+    expect(errored).toEqual([{ hashedStepId: "s1" }]);
   });
 
   test("throws if consumed twice", async () => {
@@ -362,8 +356,7 @@ describe("streamRun", () => {
           type: "inngest.step",
           stepId: "B",
           status: "errored",
-          willRetry: true,
-          error: "fail",
+          data: { willRetry: true, error: "fail" },
         },
         { type: "inngest.step", stepId: "A", status: "completed" },
       ]),
@@ -389,8 +382,7 @@ describe("streamRun", () => {
           type: "inngest.step",
           stepId: "s1",
           status: "errored",
-          willRetry: true,
-          error: "boom",
+          data: { willRetry: true, error: "boom" },
         },
       ]),
     );
@@ -420,8 +412,7 @@ describe("streamRun", () => {
           type: "inngest.step",
           stepId: "A",
           status: "errored",
-          willRetry: true,
-          error: "retry fail",
+          data: { willRetry: true, error: "retry fail" },
         },
       ]),
     );

--- a/packages/inngest/src/stream.ts
+++ b/packages/inngest/src/stream.ts
@@ -119,7 +119,7 @@ export interface RunStreamOptions<TData = unknown> {
    */
   onStepCompleted?: (args: { hashedStepId: string }) => void;
   /** Called when a step errors. */
-  onStepErrored?: (stepId: string, info: StepErrorInfo) => void;
+  onStepErrored?: (args: { hashedStepId: string }) => void;
   /** Called when run metadata is received. */
   onMetadata?: (args: { runId: string }) => void;
   /** Called when the stream is fully consumed (including on abort or error). */
@@ -174,7 +174,6 @@ export class RunStream<TData = unknown> {
   private _parseFn: (data: unknown) => TData;
 
   constructor(private opts: RunStreamOptions<TData>) {
-    console.log("RunStream constructor");
     this._parseFn = opts.parse ?? ((d: unknown) => d as TData);
   }
 
@@ -309,9 +308,8 @@ export class RunStream<TData = unknown> {
               if (count > 0) {
                 this.opts.onRollback?.(count);
               }
-              this.opts.onStepErrored?.(sseEvent.stepId, {
-                willRetry: sseEvent.willRetry,
-                error: sseEvent.error,
+              this.opts.onStepErrored?.({
+                hashedStepId: sseEvent.stepId,
               });
             }
             break;
@@ -337,9 +335,8 @@ export class RunStream<TData = unknown> {
         if (count > 0) {
           this.opts.onRollback?.(count);
         }
-        this.opts.onStepErrored?.(stepId, {
-          willRetry: false,
-          error: "stream disconnected",
+        this.opts.onStepErrored?.({
+          hashedStepId: stepId,
         });
       }
     } catch (error) {

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -2232,3 +2232,5 @@ export const nodeVersion = process.version
       return { major, minor, patch };
     })()
   : undefined;
+
+export const silencedLogger = new ConsoleLogger({ level: "silent" });

--- a/packages/inngest/src/test/integration/durableEndpoints/helpers.ts
+++ b/packages/inngest/src/test/integration/durableEndpoints/helpers.ts
@@ -2,7 +2,7 @@ import http from "node:http";
 import { randomSuffix } from "@inngest/test-harness";
 import { onTestFinished } from "vitest";
 import { stream } from "../../../experimental/durable-endpoints.ts";
-import { Inngest } from "../../../index.ts";
+import { Inngest, type Logger } from "../../../index.ts";
 import type { EndpointHandler } from "../../../node.ts";
 import {
   createEndpointServer as createNodeEndpointServer,
@@ -67,11 +67,15 @@ export async function createEndpointServer(
 export async function setupEndpoint(
   testFileName: string,
   handler: (req: Request) => Promise<Response>,
+  opts?: {
+    logger?: Logger;
+  },
 ): Promise<{ port: number; server: http.Server }> {
   const client = new Inngest({
     id: randomSuffix(testFileName),
     isDev: true,
     endpointAdapter,
+    logger: opts?.logger,
   });
 
   const endpointHandler = client.endpoint(handler);

--- a/packages/inngest/src/test/integration/durableEndpoints/streamRun.test.ts
+++ b/packages/inngest/src/test/integration/durableEndpoints/streamRun.test.ts
@@ -3,12 +3,12 @@ import { expect, test } from "vitest";
 import { stream } from "../../../experimental/durable-endpoints.ts";
 import { step } from "../../../index.ts";
 import { streamRun } from "../../../stream.ts";
-
+import { silencedLogger } from "../../helpers.ts";
 import { setupEndpoint } from "./helpers.ts";
 
 const testFileName = testNameFromFileUrl(import.meta.url);
 
-test("async mode", async (method) => {
+test("async mode", async () => {
   const state = createState({});
   const { port } = await setupEndpoint(testFileName, async () => {
     await step.run("a", async () => {
@@ -23,53 +23,10 @@ test("async mode", async (method) => {
     return Response.json("fn output");
   });
 
-  const calls = {
-    onData: [] as { data: unknown; hashedStepId?: string }[],
-    onDone: [] as undefined[],
-    onError: [] as undefined[],
-    onFunctionCompleted: [] as { data: unknown }[],
-    onFunctionFailed: [] as undefined[],
-    onMetadata: [] as { runId: string }[],
-    onRollback: [] as undefined[],
-    onStepCompleted: [] as { hashedStepId: string }[],
-    onStepErrored: [] as undefined[],
-    onStepRunning: [] as { hashedStepId: string }[],
-  };
-
-  const rs = streamRun(`http://localhost:${port}/api/demo`, {
-    onData: (args) => {
-      calls.onData.push(args);
-    },
-    onDone: () => {
-      calls.onDone.push(undefined);
-    },
-    onError: () => {
-      calls.onError.push(undefined);
-    },
-    onFunctionCompleted: (args) => {
-      calls.onFunctionCompleted.push(args);
-    },
-    onFunctionFailed: () => {
-      calls.onFunctionFailed.push(undefined);
-    },
-    onMetadata: (args) => {
-      calls.onMetadata.push(args);
-      state.runId = args.runId;
-    },
-    onRollback: () => {
-      calls.onRollback.push(undefined);
-    },
-    onStepCompleted: (args) => {
-      calls.onStepCompleted.push(args);
-    },
-    onStepErrored: () => {
-      calls.onStepErrored.push(undefined);
-    },
-    onStepRunning: (args) => {
-      calls.onStepRunning.push(args);
-    },
-  });
-  await rs;
+  const { calls, runId } = await collectCalls(
+    `http://localhost:${port}/api/demo`,
+  );
+  state.runId = runId;
 
   expect(calls).toEqual({
     onData: [
@@ -108,3 +65,227 @@ test("async mode", async (method) => {
 
   await state.waitForRunComplete();
 });
+
+test("retries", async () => {
+  const state = createState({});
+  let shouldError = true;
+  const { port } = await setupEndpoint(
+    testFileName,
+    async () => {
+      await step.run("a", async () => {
+        stream.push("sync-data");
+        if (shouldError) {
+          shouldError = false;
+          throw new Error("oh no");
+        }
+        shouldError = true;
+        return "a output";
+      });
+      await step.sleep("go-async", "1s");
+      await step.run("b", async () => {
+        stream.push("async-data");
+        if (shouldError) {
+          shouldError = false;
+          throw new Error("oh no");
+        }
+        shouldError = true;
+        return "b output";
+      });
+      return Response.json("fn output");
+    },
+    { logger: silencedLogger },
+  );
+
+  const { calls, runId } = await collectCalls(
+    `http://localhost:${port}/api/demo`,
+  );
+  state.runId = runId;
+
+  expect(calls).toEqual({
+    onData: [
+      {
+        data: "sync-data",
+        hashedStepId: "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8",
+      },
+      {
+        data: "sync-data",
+        hashedStepId: "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8",
+      },
+      {
+        data: "async-data",
+        hashedStepId: "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98",
+      },
+      {
+        data: "async-data",
+        hashedStepId: "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98",
+      },
+    ],
+    onDone: [undefined],
+    onError: [],
+
+    // FIXME: Should we parse this as JSON?
+    onFunctionCompleted: [{ data: '"fn output"' }],
+
+    onFunctionFailed: [],
+    onMetadata: [
+      { runId: expect.any(String) },
+      { runId: expect.any(String) },
+      { runId: expect.any(String) },
+      { runId: expect.any(String) },
+      { runId: expect.any(String) },
+    ],
+    onRollback: [undefined, undefined],
+    onStepCompleted: [
+      { hashedStepId: "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8" },
+      { hashedStepId: "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98" },
+    ],
+    onStepErrored: [
+      { hashedStepId: "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8" },
+      { hashedStepId: "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98" },
+    ],
+    onStepRunning: [
+      { hashedStepId: "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8" },
+      { hashedStepId: "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8" },
+      { hashedStepId: "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98" },
+      { hashedStepId: "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98" },
+    ],
+  });
+
+  await state.waitForRunComplete();
+});
+
+test("rollback", async () => {
+  // Test an abstraction that automatically rolls back retried stream items
+
+  const state = createState({});
+  let shouldError = true;
+  const { port } = await setupEndpoint(
+    testFileName,
+    async () => {
+      await step.run("a", async () => {
+        stream.push("sync-data");
+        if (shouldError) {
+          shouldError = false;
+          throw new Error("oh no");
+        }
+        shouldError = true;
+        return "a output";
+      });
+      await step.sleep("go-async", "1s");
+      await step.run("b", async () => {
+        stream.push("async-data");
+        if (shouldError) {
+          shouldError = false;
+          throw new Error("oh no");
+        }
+        shouldError = true;
+        return "b output";
+      });
+      return Response.json("fn output");
+    },
+    { logger: silencedLogger },
+  );
+
+  const { chunks, rawChunks, runId } = await rollbacker(
+    `http://localhost:${port}/api/demo`,
+  );
+  state.runId = runId;
+
+  // After rollback: errored attempts' chunks are removed
+  expect(chunks).toEqual(["sync-data", "async-data"]);
+
+  // Raw: every chunk received, including ones later rolled back
+  expect(rawChunks).toEqual([
+    "sync-data",
+    "sync-data",
+    "async-data",
+    "async-data",
+  ]);
+
+  await state.waitForRunComplete();
+});
+
+async function collectCalls(url: string) {
+  const calls = {
+    onData: [] as { data: unknown; hashedStepId?: string }[],
+    onDone: [] as undefined[],
+    onError: [] as undefined[],
+    onFunctionCompleted: [] as { data: unknown }[],
+    onFunctionFailed: [] as undefined[],
+    onMetadata: [] as { runId: string }[],
+    onRollback: [] as undefined[],
+    onStepCompleted: [] as { hashedStepId: string }[],
+    onStepErrored: [] as { hashedStepId: string }[],
+    onStepRunning: [] as { hashedStepId: string }[],
+  };
+  let runId = "";
+
+  const rs = streamRun(url, {
+    onData: (args) => {
+      calls.onData.push(args);
+    },
+    onDone: () => {
+      calls.onDone.push(undefined);
+    },
+    onError: () => {
+      calls.onError.push(undefined);
+    },
+    onFunctionCompleted: (args) => {
+      calls.onFunctionCompleted.push(args);
+    },
+    onFunctionFailed: () => {
+      calls.onFunctionFailed.push(undefined);
+    },
+    onMetadata: (args) => {
+      calls.onMetadata.push(args);
+      runId = args.runId;
+    },
+    onRollback: () => {
+      calls.onRollback.push(undefined);
+    },
+    onStepCompleted: (args) => {
+      calls.onStepCompleted.push(args);
+    },
+    onStepErrored: (args) => {
+      calls.onStepErrored.push(args);
+    },
+    onStepRunning: (args) => {
+      calls.onStepRunning.push(args);
+    },
+  });
+  await rs;
+
+  return { calls, runId };
+}
+
+/**
+ * Handle rollbacks due to step retries
+ */
+async function rollbacker(
+  url: string,
+): Promise<{ chunks: string[]; rawChunks: string[]; runId: string }> {
+  const rawChunks: string[] = [];
+  const committed: string[] = [];
+  let inProgress: string[] = [];
+  let runId = "";
+
+  const rs = streamRun<string>(url, {
+    onMetadata: (args) => {
+      runId = args.runId;
+    },
+    onData: ({ data }) => {
+      rawChunks.push(data);
+      inProgress.push(data);
+    },
+    onStepCompleted: () => {
+      committed.push(...inProgress);
+      inProgress = [];
+    },
+    onStepErrored: () => {
+      inProgress = [];
+    },
+  });
+  await rs;
+
+  return { chunks: committed, rawChunks, runId };
+}


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a rollback integration test and refactors the `onStepErrored` callback signature to use a named-args object, aligning it with other callbacks. Also nests `willRetry`/`error` under a `data` field in the SSE schema for errored steps.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ba7dc977366a8a88201e271c09c71c086f24e46a.</sup>
<!-- /MENDRAL_SUMMARY -->