### PR TITLE
fix: export JsonifyObject type from inngest/types

### DIFF
--- a/packages/inngest/src/helpers/jsonify.ts
+++ b/packages/inngest/src/helpers/jsonify.ts
@@ -44,7 +44,7 @@ type FilterJsonableKeys<T extends object> = {
 /**
 JSON serialize objects (not including arrays) and classes.
 */
-type JsonifyObject<T extends object> = {
+export type JsonifyObject<T extends object> = {
   [Key in keyof Pick<T, FilterJsonableKeys<T>>]: Jsonify<T[Key]>;
 };
 

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -35,7 +35,7 @@ import type {
 } from "./helpers/types.ts";
 import type { Logger } from "./middleware/logger.ts";
 
-export type { Jsonify } from "./helpers/jsonify.ts";
+export type { Jsonify, JsonifyObject } from "./helpers/jsonify.ts";
 export type { SimplifyDeep } from "./helpers/types.ts";
 
 const baseJsonErrorSchema = z.object({


### PR DESCRIPTION
## Problem

When `step.run()` returns a type with recursive or nested object structures (e.g., Drizzle ORM `json().$type<TreeNode>()`), TypeScript emits **TS4058**:

```
error TS4058: Return type of exported function has or is using name 'JsonifyObject'
from external module "inngest/types" but cannot be named.
```

This happens because `Jsonify<T>` is exported from `inngest/types`, but `JsonifyObject<T>` (which `Jsonify` resolves to internally for object types) is not. TypeScript needs all types in the resolution chain to be exported when generating declaration files.

### Reproduction

```typescript
import { Inngest } from "inngest";

type TreeNode = {
  id: string;
  children: TreeNode[]; // recursive
};

const inngest = new Inngest({ id: "app" });

export const fn = inngest.createFunction(
  { id: "test" },
  { event: "test/run" },
  async ({ step }) => {
    const result = await step.run("get-tree", (): TreeNode => ({
      id: "root",
      children: [],
    }));
    return result; // TS4058: cannot name 'JsonifyObject'
  }
);
```

## Solution

Export `JsonifyObject` from `helpers/jsonify.ts` and re-export it from `types.ts` alongside the existing `Jsonify` export.

## Changes

| File | Change |
|------|--------|
| `packages/inngest/src/helpers/jsonify.ts` | Added `export` to `JsonifyObject` type (line 47) |
| `packages/inngest/src/types.ts` | Added `JsonifyObject` to the re-export from `./helpers/jsonify.ts` |

## Notes

- This is backwards-compatible. Adding an export does not affect existing code.
- The type constraint `JsonifyObject<T extends object>` is unchanged.
- Previous PR #972 attempted a broader change. This PR is scoped to just the missing export.
- Tracked as EXE-1211 in Linear.

Closes #1273

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Exports `JsonifyObject` from `helpers/jsonify.ts` and re-exports it from `types.ts` to fix TS4058 errors when `step.run()` returns recursive/nested object types. The type was already used internally but not publicly accessible, causing TypeScript to fail when generating declaration files.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7c0ff64d33a07944724e2bf050ed797ba5d24164.</sup>
<!-- /MENDRAL_SUMMARY -->