### PR TITLE
Fix metadata loss when step errors propagate to function level

### DIFF
--- a/packages/inngest/src/components/execution/engine-error-metadata.test.ts
+++ b/packages/inngest/src/components/execution/engine-error-metadata.test.ts
@@ -25,13 +25,17 @@ describe("Error path metadata propagation", () => {
    */
   function createAsyncExecution(
     client: ReturnType<typeof createClient>,
-    fn: InngestFunction<any, any, any, any, any>,
+    fn: InstanceType<typeof InngestFunction>,
     overrides?: Record<string, unknown>,
   ) {
     return fn["createExecution"]({
       partialOptions: {
         client,
-        data: fromPartial({ event: mockEvent, runId: "test-run-id", ...overrides }),
+        data: fromPartial({
+          event: mockEvent,
+          runId: "test-run-id",
+          ...overrides,
+        }),
         runId: "test-run-id",
         stepState: {},
         stepCompletionOrder: [],
@@ -93,8 +97,9 @@ describe("Error path metadata propagation", () => {
 
     // Mock the updateMetadata API call
     const mockUpdateMetadata = vi.fn().mockResolvedValue(undefined);
-    (client as unknown as { updateMetadata: typeof mockUpdateMetadata })
-      .updateMetadata = mockUpdateMetadata;
+    (
+      client as unknown as { updateMetadata: typeof mockUpdateMetadata }
+    ).updateMetadata = mockUpdateMetadata;
 
     // Function throws outside of step.run — metadata set in an earlier step
     // is still in state.metadata when the function rejects
@@ -150,8 +155,9 @@ describe("Error path metadata propagation", () => {
     const client = createClient({ id: "test" });
 
     const mockUpdateMetadata = vi.fn().mockResolvedValue(undefined);
-    (client as unknown as { updateMetadata: typeof mockUpdateMetadata })
-      .updateMetadata = mockUpdateMetadata;
+    (
+      client as unknown as { updateMetadata: typeof mockUpdateMetadata }
+    ).updateMetadata = mockUpdateMetadata;
 
     const fn = new InngestFunction(
       client,

--- a/packages/inngest/src/components/execution/engine-error-metadata.test.ts
+++ b/packages/inngest/src/components/execution/engine-error-metadata.test.ts
@@ -1,0 +1,194 @@
+import { fromPartial } from "@total-typescript/shoehorn";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ExecutionVersion } from "../../helpers/consts.ts";
+import { createClient } from "../../test/helpers.ts";
+import { StepMode } from "../../types.ts";
+import { InngestFunction } from "../InngestFunction.ts";
+import type { MetadataUpdate } from "../InngestMetadata.ts";
+
+describe("Error path metadata propagation", () => {
+  const mockEvent = { name: "test/event", data: {} };
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Helper: create an execution in Async (non-checkpoint) mode.
+   * In this mode, step errors produce "step-ran" with an error opcode.
+   */
+  function createAsyncExecution(
+    client: ReturnType<typeof createClient>,
+    fn: InngestFunction<any, any, any, any, any>,
+    overrides?: Record<string, unknown>,
+  ) {
+    return fn["createExecution"]({
+      partialOptions: {
+        client,
+        data: fromPartial({ event: mockEvent, runId: "test-run-id", ...overrides }),
+        runId: "test-run-id",
+        stepState: {},
+        stepCompletionOrder: [],
+        reqArgs: [],
+        headers: {},
+        stepMode: StepMode.Async,
+      },
+    });
+  }
+
+  test("retriable step error includes metadata in the step-ran result", async () => {
+    const client = createClient({ id: "test" });
+
+    const fn = new InngestFunction(
+      client,
+      {
+        id: "test-fn",
+        triggers: [{ event: "test/event" }],
+        retries: 3,
+      },
+      async ({ step }) => {
+        await step.run("failing-step", () => {
+          throw new Error("test error");
+        });
+      },
+    );
+
+    const execution = createAsyncExecution(client, fn, { attempt: 0 });
+
+    // Pre-populate metadata for the step (keyed by unhashed display name)
+    const metadataUpdates: MetadataUpdate[] = [
+      {
+        kind: "userland.test",
+        scope: "step",
+        op: "merge",
+        values: { error_context: "before-throw" },
+      },
+    ];
+    (
+      execution as unknown as {
+        state: { metadata: Map<string, MetadataUpdate[]> };
+      }
+    ).state.metadata = new Map([["failing-step", metadataUpdates]]);
+
+    const result = await execution.start();
+
+    // With retries > 0 and attempt 0, the step error produces "step-ran"
+    // with the error opcode, and metadata should be included.
+    expect(result.type).toBe("step-ran");
+    if (result.type === "step-ran") {
+      expect(result.step.error).toBeDefined();
+      expect(result.step.metadata).toBeDefined();
+      expect(result.step.metadata).toEqual(metadataUpdates);
+    }
+  });
+
+  test("function-level error flushes metadata via API", async () => {
+    const client = createClient({ id: "test" });
+
+    // Mock the updateMetadata API call
+    const mockUpdateMetadata = vi.fn().mockResolvedValue(undefined);
+    (client as unknown as { updateMetadata: typeof mockUpdateMetadata })
+      .updateMetadata = mockUpdateMetadata;
+
+    // Function throws outside of step.run — metadata set in an earlier step
+    // is still in state.metadata when the function rejects
+    const fn = new InngestFunction(
+      client,
+      { id: "test-fn", triggers: [{ event: "test/event" }] },
+      async () => {
+        throw new Error("function-level error");
+      },
+    );
+
+    const execution = createAsyncExecution(client, fn);
+
+    // Pre-populate metadata (simulating metadata from a prior step that completed)
+    const metadataUpdates: MetadataUpdate[] = [
+      {
+        kind: "userland.test",
+        scope: "step",
+        op: "merge",
+        values: { error_context: "before-throw" },
+      },
+    ];
+    (
+      execution as unknown as {
+        state: { metadata: Map<string, MetadataUpdate[]> };
+      }
+    ).state.metadata = new Map([["prior-step", metadataUpdates]]);
+
+    const result = await execution.start();
+
+    // Function-level throw produces function-rejected
+    expect(result.type).toBe("function-rejected");
+
+    // The metadata should have been flushed via the API
+    expect(mockUpdateMetadata).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          run_id: "test-run-id",
+          step_id: "prior-step",
+        }),
+        metadata: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "userland.test",
+            values: { error_context: "before-throw" },
+          }),
+        ]),
+      }),
+    );
+  });
+
+  test("metadata is cleared after flush so it is not sent twice", async () => {
+    const client = createClient({ id: "test" });
+
+    const mockUpdateMetadata = vi.fn().mockResolvedValue(undefined);
+    (client as unknown as { updateMetadata: typeof mockUpdateMetadata })
+      .updateMetadata = mockUpdateMetadata;
+
+    const fn = new InngestFunction(
+      client,
+      { id: "test-fn", triggers: [{ event: "test/event" }] },
+      async () => {
+        throw new Error("function-level error");
+      },
+    );
+
+    const execution = createAsyncExecution(client, fn);
+
+    (
+      execution as unknown as {
+        state: { metadata: Map<string, MetadataUpdate[]> };
+      }
+    ).state.metadata = new Map([
+      [
+        "some-step",
+        [
+          {
+            kind: "userland.test" as const,
+            scope: "step" as const,
+            op: "merge" as const,
+            values: { key: "value" },
+          },
+        ],
+      ],
+    ]);
+
+    await execution.start();
+
+    // Verify the metadata map is cleared after flush
+    const stateMetadata = (
+      execution as unknown as {
+        state: { metadata: Map<string, MetadataUpdate[]> };
+      }
+    ).state.metadata;
+    expect(stateMetadata.size).toBe(0);
+  });
+});

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -50,6 +50,7 @@ import type {
   MetadataScope,
   MetadataUpdate,
 } from "../InngestMetadata.ts";
+import { sendMetadataViaAPI } from "../InngestMetadata.ts";
 import {
   createStepTools,
   type ExperimentStepTools,
@@ -248,6 +249,57 @@ class InngestExecutionEngine
     this.state.metadata.set(stepId, updates);
 
     return true;
+  }
+
+  /**
+   * Flush any pending metadata entries via the metadata REST API.
+   *
+   * This is used when the normal batching path (sending metadata alongside
+   * step opcodes) won't work — specifically when a step error propagates to
+   * the function level as a `function-rejected` result. In that case, the
+   * error response doesn't include step opcodes, so any metadata batched
+   * during the step's execution would be silently lost.
+   *
+   * Each entry is sent as a best-effort fire-and-forget call. Failures are
+   * logged but don't block the error response.
+   */
+  private async flushPendingMetadata(): Promise<void> {
+    const metadata = this.state.metadata;
+    if (!metadata || metadata.size === 0) return;
+
+    const runId = this.options.runId;
+    if (!runId) return;
+
+    const client = this.options.client;
+    const headers = this.options.headers;
+
+    const promises: Promise<void>[] = [];
+
+    for (const [stepId, updates] of metadata) {
+      for (const update of updates) {
+        promises.push(
+          sendMetadataViaAPI(
+            client,
+            { run_id: runId, step_id: stepId },
+            update.kind,
+            update.op,
+            update.values,
+            headers,
+          ).catch((err) => {
+            client[internalLoggerSymbol].warn(
+              { err, stepId, kind: update.kind },
+              "failed to flush pending metadata on function rejection",
+            );
+          }),
+        );
+      }
+    }
+
+    // Wait for all sends to complete (or fail silently)
+    await Promise.allSettled(promises);
+
+    // Clear flushed metadata so it isn't sent again
+    metadata.clear();
   }
 
   /**
@@ -555,6 +607,10 @@ class InngestExecutionEngine
       },
 
       "function-rejected": async (checkpoint) => {
+        // Flush any metadata batched during the step that threw — the error
+        // response won't include step opcodes, so batched metadata would be lost.
+        await this.flushPendingMetadata();
+
         // If the function throws during sync execution, we want to switch to
         // async mode so that we can retry. The exception is that we're already
         // at max attempts, in which case we do actually want to reject.
@@ -679,6 +735,7 @@ class InngestExecutionEngine
        * The user's function has thrown an error.
        */
       "function-rejected": async (checkpoint) => {
+        await this.flushPendingMetadata();
         return await this.transformOutput({ error: checkpoint.error });
       },
 
@@ -764,6 +821,7 @@ class InngestExecutionEngine
             }
           }
 
+          await this.flushPendingMetadata();
           return await this.transformOutput({ error: checkpoint.error });
         },
         "step-not-found": asyncHandlers["step-not-found"],


### PR DESCRIPTION
## Summary

When `client.metadata.update()` is called inside a `step.run()` callback that subsequently throws, the userland metadata is silently lost in both checkpoint and non-checkpoint modes. This happens because metadata is batched in `state.metadata` during step execution, but when the error propagates to the function level as a `function-rejected` result, the error response contains only the error — no step opcodes, no metadata. The batched metadata is discarded.

This PR adds a `flushPendingMetadata()` method to the execution engine that sends any accumulated metadata entries via the metadata REST API (`sendMetadataViaAPI`) before the function-rejected response is returned. This is called in all three `function-rejected` checkpoint handlers (sync checkpoint, non-checkpoint async, and async checkpoint).

Key behaviors:
- Each metadata entry is sent as a best-effort call; failures are logged but don't block the error response
- The metadata map is cleared after flush to prevent duplicate sends
- Retriable step errors (which go through the `step-ran` path) are unaffected — they already include metadata on the step opcode

## Checklist

- [x] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A No docs changes needed
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- Investigated as part of the checkpointing metadata audit (see `projects/checkpointing-metadata/step-metadata-findings.md` in inngest-mono)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `flushPendingMetadata()` to `InngestExecutionEngine` to prevent metadata loss when step errors propagate to the function level as `function-rejected`. The method is wired into all three `function-rejected` checkpoint handlers and sends accumulated metadata via the REST API as a best-effort fire-and-forget before returning the error response. A new test file covers the retriable step error path, flush-on-rejection, and post-flush clear behavior.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit eba90fb32a68a7ba26fb78e90ebfb3741b5afb3c.</sup>
<!-- /MENDRAL_SUMMARY -->