### PR TITLE
Add `experimentScoreMiddleware()` that adds `step.score()`

### DIFF
--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -97,6 +97,7 @@ export type {
   UnionKeys,
 } from "./helpers/types";
 export { dependencyInjectionMiddleware } from "./middleware/dependencyInjection.ts";
+export { experimentScoreMiddleware } from "./middleware/experimentScore.ts";
 export type { LogArg, Logger } from "./middleware/logger";
 export { ConsoleLogger, ProxyLogger } from "./middleware/logger.ts";
 export type {

--- a/packages/inngest/src/middleware/experimentScore.ts
+++ b/packages/inngest/src/middleware/experimentScore.ts
@@ -1,0 +1,69 @@
+import { metadataSymbol } from "../components/InngestMetadata";
+import type { ExperimentalStepTools } from "../components/InngestStepTools";
+import { Middleware } from "../components/middleware/middleware.ts";
+import type { MaybePromise } from "../helpers/types";
+
+/**
+ * Adds `step.score` to the function input. Used to score variants in
+ * experiments created via `group.experiment()`.
+ *
+ * `step.score` is currently a no-op stub — the implementation will be filled in
+ * later.
+ */
+export const experimentScoreMiddleware = () => {
+  class ExperimentScoreMiddleware extends Middleware.BaseMiddleware {
+    readonly id = "inngest:experiment-score";
+
+    override transformFunctionInput(
+      arg: Middleware.TransformFunctionInputArgs,
+    ): Middleware.TransformFunctionInputArgs & {
+      ctx: {
+        step: {
+          /**
+           * EXPERIMENTAL
+           *
+           * An initial scoring implementation that just uses `step.run()` to
+           * execute the scoring inline; it MUST be awaited in this form.
+           *
+           * This will be replaced with a more robust, ergonomic implemenetation
+           * in the future, but this allows us to start testing and iterating on
+           * the API now.
+           *
+           * @deprecated Experimental - use at your own risk.
+           */
+          score: (
+            key: string,
+            handler:
+              | MaybePromise<number | boolean>
+              | (() => MaybePromise<number | boolean>),
+          ) => Promise<void>;
+        };
+      };
+    } {
+      return {
+        ...arg,
+        ctx: {
+          ...arg.ctx,
+          step: {
+            ...arg.ctx.step,
+            score: async (key, handler) => {
+              const stepMetadata = (
+                arg.ctx.step as unknown as ExperimentalStepTools
+              )[metadataSymbol];
+
+              const value = await (typeof handler === "function"
+                ? handler()
+                : handler);
+
+              return stepMetadata(key).update({
+                [`score::${key}`]: value,
+              });
+            },
+          },
+        },
+      };
+    }
+  }
+
+  return ExperimentScoreMiddleware;
+};


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Adds `experimentalScoreMiddleware()` which gives access to `step.score()`, allowing us to start testing scoring with experimentation dashboards.

```ts
import { experimentScoreMiddleware, Inngest } from "inngest";

const inngest = new Inngest({
  id: "test",
  middleware: [experimentScoreMiddleware()],
});

inngest.createFunction(
  { id: "test-fn", triggers: [{ event: "test/event" }] },
  async ({ step }) => {
    await step.score("accuracy", 0.9);

    await step.score("performance", async () => {
      // some expensive scoring logic

      return 52352;
    });
  },
);
```

Temporal scoring can be dogfooded using some grim code:

```ts
const scoreP = (async () => {
  const gotAThing = await step.waitForEvent();
  return step.score("got-it", Boolean(gotAThing)); 
})();

// ... rest of the fn ...

await scoreP;
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Experiment
- [ ] ~Added unit/integration tests~ N/A Experiment
- [x] Added changesets if applicable
