### PR TITLE
Add default checkpointing maxRuntime

### DIFF
--- a/.changeset/four-lemons-grab.md
+++ b/.changeset/four-lemons-grab.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add default checkpointing maxRuntime

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -41,6 +41,7 @@ import {
   AsyncResponseType,
   type AsyncResponseValue,
   type AuthenticatedIntrospection,
+  DefaultMaxRuntime,
   type EventPayload,
   type FunctionConfig,
   functionConfigSchema,
@@ -272,6 +273,14 @@ interface InngestCommHandlerOptions<
   skipSignatureValidation?: boolean;
 
   /**
+   * The default `maxRuntime` in milliseconds to use for checkpointing when the
+   * user hasn't explicitly configured one at the function or client level.
+   *
+   * Defaults to {@link DefaultMaxRuntime.serve} (10 seconds).
+   */
+  defaultMaxRuntime?: DefaultMaxRuntime;
+
+  /**
    * Options for when this comm handler executes a synchronous (API) function.
    */
   syncOptions?: SyncHandlerOptions;
@@ -420,6 +429,8 @@ export class InngestCommHandler<
 
   private readonly skipSignatureValidation: boolean;
 
+  private readonly defaultMaxRuntime: DefaultMaxRuntime;
+
   constructor(options: InngestCommHandlerOptions<Input, Output, StreamOutput>) {
     // Set input options directly so we can reference them later
     this._options = options;
@@ -440,6 +451,8 @@ export class InngestCommHandler<
 
     this.frameworkName = options.frameworkName;
     this.client = options.client as Inngest.Any;
+    this.defaultMaxRuntime =
+      options.defaultMaxRuntime ?? DefaultMaxRuntime.serve;
 
     this.handler = options.handler as Handler;
 
@@ -2152,6 +2165,7 @@ export class InngestCommHandler<
         requestedRunStep,
         ctx?.fn_id,
         Boolean(ctx?.disable_immediate_execution),
+        this.defaultMaxRuntime,
       );
 
       const executionOptions: CreateExecutionOptions = {

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -5,6 +5,7 @@ import {
   type Cancellation,
   type CheckpointingOptions,
   type ConcurrencyOption,
+  type DefaultMaxRuntime,
   defaultCheckpointingOptions,
   type FunctionConfig,
   type Handler,
@@ -293,6 +294,7 @@ export class InngestFunction<
     requestedRunStep: string | undefined,
     internalFnId: string | undefined,
     disableImmediateExecution: boolean,
+    defaultMaxRuntime: DefaultMaxRuntime,
   ): InternalCheckpointingOptions | undefined {
     if (requestedRunStep || !internalFnId || disableImmediateExecution) {
       return;
@@ -312,13 +314,16 @@ export class InngestFunction<
     }
 
     if (userCfg === true) {
-      return defaultCheckpointingOptions;
+      return {
+        ...defaultCheckpointingOptions,
+        maxRuntime: defaultMaxRuntime,
+      };
     }
 
     return {
       bufferedSteps:
         userCfg.bufferedSteps ?? defaultCheckpointingOptions.bufferedSteps,
-      maxRuntime: userCfg.maxRuntime ?? defaultCheckpointingOptions.maxRuntime,
+      maxRuntime: userCfg.maxRuntime ?? defaultMaxRuntime,
       maxInterval:
         userCfg.maxInterval ?? defaultCheckpointingOptions.maxInterval,
     };

--- a/packages/inngest/src/components/connect/config.ts
+++ b/packages/inngest/src/components/connect/config.ts
@@ -15,7 +15,11 @@ import {
   SDKResponse,
   SDKResponseStatus,
 } from "../../proto/src/components/connect/protobuf/connect.ts";
-import type { Capabilities, FunctionConfig } from "../../types.ts";
+import {
+  type Capabilities,
+  DefaultMaxRuntime,
+  type FunctionConfig,
+} from "../../types.ts";
 import { version } from "../../version.ts";
 import { PREFERRED_ASYNC_EXECUTION_VERSION } from "../execution/InngestExecution.ts";
 import { type Inngest, internalLoggerSymbol } from "../Inngest.ts";
@@ -161,6 +165,7 @@ export function prepareConnectionConfig(
       client: client,
       functions: fns,
       frameworkName: "connect",
+      defaultMaxRuntime: DefaultMaxRuntime.connect,
       skipSignatureValidation: true,
       handler: (msg: GatewayExecutorRequestData) => {
         const asString = new TextDecoder().decode(msg.requestPayload);

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1077,7 +1077,8 @@ export type CheckpointingOptions =
        *
        * Set to `0` to disable maximum runtime.
        *
-       * @default 0
+       * If not set, defaults to 10 seconds for "serve" (HTTP-based) and 5
+       * minutes for "connect" (WebSocket-based).
        */
       maxRuntime?: number | string | Temporal.DurationLike;
 
@@ -1109,13 +1110,28 @@ export type InternalCheckpointingOptions = Exclude<
 >;
 
 /**
- * Default config options if `true` has been passed by a user.
+ * Default config options if `true` has been passed by a user. Does not include
+ * `maxRuntime`, which is supplied per-request by the handler via
+ * {@link DefaultMaxRuntime}.
  */
-export const defaultCheckpointingOptions: InternalCheckpointingOptions = {
+export const defaultCheckpointingOptions: Omit<
+  InternalCheckpointingOptions,
+  "maxRuntime"
+> = {
   bufferedSteps: 1,
-  maxRuntime: 0,
   maxInterval: 0,
 };
+
+/**
+ * Default `maxRuntime` values for checkpointing. A higher value is safer for
+ * Connect since it doesn't have the HTTP request timeout constraint.
+ */
+export const DefaultMaxRuntime = {
+  connect: 5 * 60 * 1000, // 5 minutes
+  serve: 10_000, // 10 seconds
+};
+export type DefaultMaxRuntime =
+  (typeof DefaultMaxRuntime)[keyof typeof DefaultMaxRuntime];
 
 /**
  * A set of log levels that can be used to control the amount of logging output


### PR DESCRIPTION
Default `maxRuntime` to 10 seconds for serve and 5 minutes for connect. User-explicit `maxRuntime` at the function or client level still takes priority.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds transport-aware default `maxRuntime` for checkpointing: 10 seconds for HTTP-based `serve` and 5 minutes for WebSocket-based `connect`. Previously `checkpointing: true` defaulted to `maxRuntime: 0` (disabled). The `defaultMaxRuntime` is threaded from `InngestCommHandler` → `InngestFunction.shouldAsyncCheckpoint`, with `connect/config.ts` explicitly passing `DefaultMaxRuntime.connect`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e32403cdf8d40e2b690717ff2d020301f0d200d9.</sup>
<!-- /MENDRAL_SUMMARY -->