### PR TITLE
Fix dependencyInjection not working statically at function level

### DIFF
--- a/.changeset/wild-tools-dress.md
+++ b/.changeset/wild-tools-dress.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix dependencyInjection not working statically at function level

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -1196,11 +1196,13 @@ export namespace Inngest {
       > &
         ApplyAllMiddlewareCtxExtensions<
           ClientOptionsFromInngest<TClient>["middleware"]
-        > & {
+        > &
+        ApplyAllMiddlewareCtxExtensions<TFnMiddleware> & {
           step: ReturnType<typeof createStepTools<TClient, TFnMiddleware>> &
             ApplyAllMiddlewareStepExtensions<
               ClientOptionsFromInngest<TClient>["middleware"]
-            >;
+            > &
+            ApplyAllMiddlewareStepExtensions<TFnMiddleware>;
         }
     >,
     TFailureHandler extends Handler.Any = HandlerWithTriggers<
@@ -1212,11 +1214,13 @@ export namespace Inngest {
         FailureEventArgs<EventPayload> &
         ApplyAllMiddlewareCtxExtensions<
           ClientOptionsFromInngest<TClient>["middleware"]
-        > & {
+        > &
+        ApplyAllMiddlewareCtxExtensions<TFnMiddleware> & {
           step: ReturnType<typeof createStepTools<TClient, TFnMiddleware>> &
             ApplyAllMiddlewareStepExtensions<
               ClientOptionsFromInngest<TClient>["middleware"]
-            >;
+            > &
+            ApplyAllMiddlewareStepExtensions<TFnMiddleware>;
         }
     >,
   >(

--- a/packages/inngest/src/middleware/dependencyInjection.test.ts
+++ b/packages/inngest/src/middleware/dependencyInjection.test.ts
@@ -1,7 +1,9 @@
 import { Inngest } from "../components/Inngest.ts";
 import { dependencyInjectionMiddleware } from "./dependencyInjection.ts";
 
-describe("Mutates ctx", () => {
+describe("client level", () => {
+  // Injections at the client level apply to all of the client's functions
+
   test("ctx is injected into the function input", () => {
     const inngest = new Inngest({
       id: "test",
@@ -30,5 +32,51 @@ describe("Mutates ctx", () => {
     inngest.createFunction({ id: "test", triggers: [{ event: "" }] }, (ctx) => {
       assertType<"bar">(ctx.foo);
     });
+  });
+});
+
+describe("function level", () => {
+  // Injections at the function level apply only to that function
+
+  test("ctx is injected into the function input", () => {
+    const inngest = new Inngest({ id: "test" });
+    inngest.createFunction(
+      {
+        id: "test",
+        middleware: [
+          dependencyInjectionMiddleware({
+            foo: "bar",
+          }),
+        ],
+        triggers: [{ event: "" }],
+      },
+      (ctx) => {
+        assertType<string>(ctx.foo);
+      },
+    );
+
+    // Doesn't leak to other functions
+    inngest.createFunction({ id: "test", triggers: [{ event: "" }] }, (ctx) => {
+      // @ts-expect-error foo is not in the context
+      ctx.foo;
+    });
+  });
+
+  test("can infer const ctx type", () => {
+    const inngest = new Inngest({ id: "test" });
+    inngest.createFunction(
+      {
+        id: "test",
+        middleware: [
+          dependencyInjectionMiddleware({
+            foo: "bar",
+          } as const),
+        ],
+        triggers: [{ event: "" }],
+      },
+      (ctx) => {
+        assertType<"bar">(ctx.foo);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary
Fix `dependencyInjection` not applying to static types when set at the function level

## Checklist
- [x] Added unit/integration tests
- [x] Added changesets if applicable

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a TypeScript type-level bug where function-level middleware (e.g. `dependencyInjectionMiddleware`) was not reflected in the handler's `ctx` type. The fix adds `ApplyAllMiddlewareCtxExtensions<TFnMiddleware>` and `ApplyAllMiddlewareStepExtensions<TFnMiddleware>` to both `THandler` and `TFailureHandler` type definitions in `createFunction`, mirroring how client-level middleware extensions are already applied.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit bee3441fb26d9caf018f75854734500013319492.</sup>
<!-- /MENDRAL_SUMMARY -->