### PR TITLE
Conditionally instantiate CountQueuingStrategy

### DIFF
--- a/.changeset/itchy-suns-listen.md
+++ b/.changeset/itchy-suns-listen.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix using CountQueuingStrategy when not available

--- a/packages/inngest/src/components/StreamTools.ts
+++ b/packages/inngest/src/components/StreamTools.ts
@@ -91,7 +91,7 @@ export class Stream implements StreamTools {
       readableStrategy = new CountQueuingStrategy({
         // Use a generous high water mark so that writes don't block due to
         // backpressure before the consumer reads.
-        highWaterMark: 1024
+        highWaterMark: 1024,
       });
     }
 

--- a/packages/inngest/src/components/StreamTools.ts
+++ b/packages/inngest/src/components/StreamTools.ts
@@ -82,12 +82,23 @@ export class Stream implements StreamTools {
   }) {
     this.onActivated = opts?.onActivated;
     this.onWriteError = opts?.onWriteError;
+
+    let readableStrategy: QueuingStrategy<Uint8Array> | undefined;
+
+    // `CountQueuingStrategy` is not available in some runtimes (e.g. Next.js
+    // Edge), so fall back to a plain `TransformStream` when missing.
+    if (typeof CountQueuingStrategy !== "undefined") {
+      readableStrategy = new CountQueuingStrategy({
+        // Use a generous high water mark so that writes don't block due to
+        // backpressure before the consumer reads.
+        highWaterMark: 1024
+      });
+    }
+
     this.transform = new TransformStream<Uint8Array, Uint8Array>(
       undefined,
       undefined,
-      // Use a generous high water mark on the readable side so that writes
-      // don't block due to backpressure before the consumer reads.
-      new CountQueuingStrategy({ highWaterMark: 1024 }),
+      readableStrategy,
     );
     this.writer = this.transform.writable.getWriter();
   }


### PR DESCRIPTION
## Summary

Only instantiate `CountQueuingStrategy` when it exists

## Checklist

- [x] Added changesets if applicable

## Related

https://linear.app/inngest/issue/EXE-1611

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Guards `CountQueuingStrategy` instantiation behind a `typeof` check so the `Stream` class doesn't throw in runtimes (e.g. Next.js Edge) where the Web Streams API is partially implemented. Falls back to `undefined`, letting `TransformStream` use its default backpressure strategy.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1a5700694605b929b924f2443486f18ee008c9b3.</sup>
<!-- /MENDRAL_SUMMARY -->