### PR TITLE
Fix CountQueuingStrategy erroring when stubbed in edge runtimes

### DIFF
--- a/.changeset/smart-lobsters-bake.md
+++ b/.changeset/smart-lobsters-bake.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix CountQueuingStrategy erroring when stubbed in edge runtimes

--- a/packages/inngest/src/components/StreamTools.ts
+++ b/packages/inngest/src/components/StreamTools.ts
@@ -86,13 +86,16 @@ export class Stream implements StreamTools {
     let readableStrategy: QueuingStrategy<Uint8Array> | undefined;
 
     // `CountQueuingStrategy` is not available in some runtimes (e.g. Next.js
-    // Edge), so fall back to a plain `TransformStream` when missing.
-    if (typeof CountQueuingStrategy !== "undefined") {
+    // Edge), where it may exist as a stub that throws on instantiation. Fall
+    // back to a plain `TransformStream` when it's missing or broken.
+    try {
       readableStrategy = new CountQueuingStrategy({
         // Use a generous high water mark so that writes don't block due to
         // backpressure before the consumer reads.
         highWaterMark: 1024,
       });
+    } catch {
+      // Leave `readableStrategy` undefined
     }
 
     this.transform = new TransformStream<Uint8Array, Uint8Array>(


### PR DESCRIPTION
`CountQueuingStrategy` exists but is a function that throws when runtime is Next.js edge

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces a `typeof CountQueuingStrategy !== "undefined"` guard with a `try/catch` to handle edge runtimes (e.g. Next.js Edge) where `CountQueuingStrategy` exists as a stub that throws on instantiation rather than being absent entirely.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 100ab9ce528ecb526e0e3da0413753af310beb5b.</sup>
<!-- /MENDRAL_SUMMARY -->