### PR TITLE
[e13n phase 2] propagate selectionStrategy and fix replay-path gap

### DIFF
--- a/packages/inngest/src/components/InngestGroupTools.ts
+++ b/packages/inngest/src/components/InngestGroupTools.ts
@@ -377,16 +377,21 @@ export const createGroupTools = (deps?: GroupToolsDeps): GroupTools => {
     }
 
     // Propagate experiment context via ALS so variant sub-steps include
-    // experiment fields in their OutgoingOp.opts. Also track whether any
-    // step tool is invoked to detect zero-step variants.
+    // experiment fields in their OutgoingOp.opts. The executor reads these
+    // fields from opts and emits the step-scoped `inngest.experiment`
+    // metadata span itself — the SDK does not need to call addMetadata()
+    // for variant steps. See the companion executor change in inngest/inngest
+    // for the server-side emission path.
     //
-    // TODO: On replay, experimentStepHashedId is undefined because it's
-    // captured inside the selection step callback, which doesn't run when
-    // memoized. This means sub-steps discovered during replay won't carry
-    // experimentContext in their OutgoingOp.opts. Fixing this requires an
-    // engine-level change to expose the hashed step ID outside the callback
-    // (e.g. via ALS before the callback runs, or returned alongside the
-    // memoized result). Tracked in EXE-1330.
+    // Also track whether any step tool is invoked to detect zero-step
+    // variants.
+    //
+    // NOTE: experimentStepHashedId may be undefined on replay because it
+    // is captured inside the selection step callback, which doesn't run
+    // when memoized. We still set experimentContext (with an empty string
+    // for the hashed ID fallback) so that variant sub-steps discovered on
+    // replay still carry experiment fields in their opts and the executor
+    // can attach metadata to their ClickHouse rows.
     const currentCtx = getAsyncCtxSync();
     const stepTracker = { found: false };
     let result: unknown;
@@ -397,13 +402,12 @@ export const createGroupTools = (deps?: GroupToolsDeps): GroupTools => {
         ...currentCtx,
         execution: {
           ...currentCtx.execution,
-          ...(experimentStepHashedId && {
-            experimentContext: {
-              experimentStepID: experimentStepHashedId,
-              experimentName: stepOpts.id,
-              variant: selectedVariant,
-            },
-          }),
+          experimentContext: {
+            experimentStepID: experimentStepHashedId ?? "",
+            experimentName: stepOpts.id,
+            variant: selectedVariant,
+            selectionStrategy: select.__experimentConfig.strategy,
+          },
           experimentStepTracker: stepTracker,
         },
       };

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -59,6 +59,7 @@ export interface AsyncContext {
       experimentStepID: string;
       experimentName: string;
       variant: string;
+      selectionStrategy: string;
     };
 
     /**

--- a/packages/inngest/src/components/experiment.test.ts
+++ b/packages/inngest/src/components/experiment.test.ts
@@ -658,6 +658,7 @@ describe("group.experiment() ALS propagation", () => {
       experimentStepID: HASHED_STEP_ID,
       experimentName: "my-exp",
       variant: "alpha",
+      selectionStrategy: "fixed",
     });
   });
 
@@ -682,12 +683,97 @@ describe("group.experiment() ALS propagation", () => {
       }),
     );
 
-    // Verify the fields that wrappedMatchOp would spread into OutgoingOp.opts
+    // Verify the fields that wrappedMatchOp would spread into OutgoingOp.opts.
+    // These become GeneratorOpcode.Opts on the executor side, where an
+    // ExtractExperimentOptsMetadata extractor emits the inngest.experiment
+    // metadata span (see the companion inngest/inngest executor change).
     expect(capturedExperimentContext).toEqual({
       experimentStepID: HASHED_STEP_ID,
       experimentName: "my-exp",
       variant: "alpha",
+      selectionStrategy: "fixed",
     });
+  });
+
+  test("experimentContext is set on replay even without hashed step ID", async () => {
+    // On replay, the selection callback is memoized and never re-executes, so
+    // `experimentStepHashedId` stays undefined. Prior to this change we would
+    // skip setting `experimentContext` entirely in that case, meaning variant
+    // sub-steps discovered on replay lost their experiment fields in opts.
+    //
+    // With the executor now emitting metadata from opts (see the companion
+    // inngest/inngest executor change), we cannot afford to drop the
+    // context — so we set it with an empty experimentStepID fallback.
+    const exec = mockExecution();
+    const ctx: AsyncContext = {
+      app: {} as AsyncContext["app"],
+      execution: {
+        instance: exec,
+        ctx: { runId: "run-id-replay" } as never,
+      },
+    };
+
+    // experimentStepRun that never sets executingStep.id — simulates the
+    // memoized selection step on replay.
+    const experimentStepRun = vi.fn(
+      async (
+        _idOrOptions: string | { id: string },
+        callback: () => unknown,
+      ) => {
+        return als.run(ctx, () => callback());
+      },
+    );
+
+    const group = createGroupTools({ experimentStepRun });
+    let capturedCtx: AsyncContext["execution"] | undefined;
+
+    await expect(
+      als.run(ctx, () =>
+        group.experiment("my-exp", {
+          variants: {
+            alpha: () => {
+              capturedCtx = als.getStore()?.execution;
+              return "val";
+            },
+          },
+          select: experiment.fixed("alpha"),
+        }),
+      ),
+    ).rejects.toThrow(); // zero-step detection still fires
+
+    expect(capturedCtx?.experimentContext).toEqual({
+      experimentStepID: "",
+      experimentName: "my-exp",
+      variant: "alpha",
+      selectionStrategy: "fixed",
+    });
+  });
+
+  test("experimentContext carries selectionStrategy for weighted strategy", async () => {
+    const { group, run } = createHarness();
+    let capturedCtx: AsyncContext["execution"] | undefined;
+
+    await expect(
+      run(() =>
+        group.experiment("weighted-ctx", {
+          variants: {
+            a: () => {
+              capturedCtx = als.getStore()?.execution;
+              return 1;
+            },
+            b: () => {
+              capturedCtx = als.getStore()?.execution;
+              return 2;
+            },
+          },
+          select: experiment.weighted({ a: 70, b: 30 }),
+        }),
+      ),
+    ).rejects.toThrow(); // zero-step
+
+    expect(capturedCtx?.experimentContext?.selectionStrategy).toBe("weighted");
+    expect(capturedCtx?.experimentContext?.experimentName).toBe("weighted-ctx");
+    expect(["a", "b"]).toContain(capturedCtx?.experimentContext?.variant);
   });
 
   test("step tool invocation flips experimentStepTracker via ALS", async () => {


### PR DESCRIPTION
## Summary

Slim successor to #1458. Two focused changes to `group.experiment()` ALS propagation that complete the companion executor-side metadata emission in [inngest/inngest#4000](https://github.com/inngest/inngest/pull/4000):

1. **Add `selectionStrategy` to the ALS `experimentContext` shape** so the strategy (`"fixed"` / `"weighted"` / `"bucket"`) flows into variant sub-steps' `OutgoingOp.opts`. The executor reads this from opts and writes it to the `inngest.experiment` metadata row on the variant step's ClickHouse record.
2. **Drop the `experimentStepHashedId && {...}` guard.** On replay the selector step is memoized, so its callback never runs and the hashed ID stays undefined. Previously the whole `experimentContext` was skipped in that case, which meant variant sub-steps discovered on replay lost their experiment fields in opts. We now always set the context with an empty-string fallback for `experimentStepID`, letting the executor still attach metadata to those steps' ClickHouse rows.

Both changes are small (~40 lines of production code). Tests added for both the strategy field and the replay-path fallback. No `addMetadata()` call is introduced in `InngestStepTools.ts` — that's now the executor's job.

## Why this shape (vs. #1458)

#1458 implemented the single-row ClickHouse layout entirely in the SDK, by adding an explicit `addMetadata()` call inside `wrappedMatchOp`. That works, but has two downsides we wanted to avoid:

- **End users must upgrade their SDK** to get experiment observability.
- **Every SDK language (JS, Python, Go) needs to implement the same metadata call.**

Moving the emission to the executor (the companion PR) achieves the same single-row layout while fixing both of those. All this PR needs to do is make sure the right fields reach `op.opts` — which is already how the SDK propagated `experimentName` and `variant` before #1458. We're just adding one more field (`selectionStrategy`) and ensuring the propagation survives replay.

## What changed

| File | Change |
|------|--------|
| [packages/inngest/src/components/execution/als.ts](packages/inngest/src/components/execution/als.ts) | Add `selectionStrategy: string` to `experimentContext` type. |
| [packages/inngest/src/components/InngestGroupTools.ts](packages/inngest/src/components/InngestGroupTools.ts) | Pass `select.__experimentConfig.strategy` into `experimentContext`. Replace the `experimentStepHashedId && {...}` guard with `experimentStepHashedId ?? ""`. Update the companion comment. |
| [packages/inngest/src/components/experiment.test.ts](packages/inngest/src/components/experiment.test.ts) | Update two existing assertions to include `selectionStrategy`. Add a test for the replay path (context is set even with empty hashed ID) and a test for the weighted strategy field. |

## What this PR does NOT do (vs. #1458)

- **No `addMetadata()` call in `wrappedMatchOp`.** That's now the executor's job — see the companion PR. This is what trims ~200 lines off #1458's scope.
- **No new tests exercising `createStepTools` + `matchOp` to assert metadata calls.** Those validated SDK behaviour that no longer exists; removed alongside the production change.

The SDK still emits the selector-step metadata (`available_variants`, `variant_weights`, bucket warnings) because those values live in the SDK — only the variant sub-step metadata is moving to the server.

## Testing

- `pnpm test -- --run src/components/experiment.test.ts` — 52 tests pass (4 pre-existing unrelated test-suite failures in `react.runtime.test.ts`, `react.test.ts`, `connect/strategies/core/integration.test.ts` confirmed to also fail on clean `main`).
- `pnpm lint` — clean.
- `pnpm test:types` — no errors on changed files.
- **End-to-end** — ran the modified SDK against the modified dev server from [inngest/inngest#4000](https://github.com/inngest/inngest/pull/4000). A function with `group.experiment()` produced the expected trace:

```
  my-exp      [inngest.experiment, inngest.http.timing, inngest.timing]   // selector (SDK-side addMetadata, unchanged)
  alpha-step  [inngest.experiment]                                        // variant sub-step (new executor emission)
```

The variant-step metadata carried `experiment_name`, `variant`, and `selection_strategy` as expected.

## Compatibility

| Scenario | Behaviour |
|----------|-----------|
| This SDK + modern executor | Full fidelity: `experiment_name` + `variant` + `selection_strategy` on every variant step, including replay-discovered ones. |
| Older SDK + modern executor | Partial fidelity: `experiment_name` + `variant` only (missing `selection_strategy`). Replay-discovery still leaks on the older SDK. |
| This SDK + older executor | No variant-step metadata at all — the executor isn't looking at opts yet. Selector-step metadata continues to work (SDK-side). |

## Checklist

- [x] Added tests for the new behaviour
- [ ] ~~Added changesets~~ N/A — no public API surface change for consumers
- [x] Ran the combined stack end-to-end against the companion executor PR

## Related

- Companion executor PR: inngest/inngest#4000
- Supersedes: #1458
- EXE-1617

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `selectionStrategy` to the ALS `experimentContext` shape and drops the `experimentStepHashedId && {...}` guard so that variant sub-steps discovered on replay still carry experiment fields in their `OutgoingOp.opts`. The executor (companion PR inngest/inngest#4000) reads these opts to emit the `inngest.experiment` metadata row, removing the need for SDK-side `addMetadata()` calls on variant steps.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fb55b68fb20532357f90c197cde2547adc6bd8b6.</sup>
<!-- /MENDRAL_SUMMARY -->