### PR TITLE
Fix checkpointing maxRuntime causing duplicate execution

### DIFF
--- a/.changeset/wicked-seals-greet.md
+++ b/.changeset/wicked-seals-greet.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix checkpointing maxRuntime causing duplicate execution

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1287,6 +1287,24 @@ class InngestExecutionEngine
 
           // Got new steps? Exit early.
           if (!this.options.requestedRunStep && newSteps.length) {
+            // If the checkpointing runtime has been exceeded, don't execute new
+            // steps in-process. Flush any buffered steps and return the new
+            // steps to the executor so it can schedule them.
+            if (this.state.checkpointingRuntimeExceeded) {
+              if (this.state.checkpointingStepBuffer.length) {
+                const fallback = await attemptCheckpointAndResume(
+                  undefined,
+                  false,
+                  true,
+                );
+                if (fallback) {
+                  return fallback;
+                }
+              }
+
+              return maybeReturnNewSteps();
+            }
+
             const stepResult = await this.tryExecuteStep(newSteps);
             if (stepResult) {
               this.devDebug(`executed step "${stepResult.id}" successfully`);
@@ -1352,25 +1370,14 @@ class InngestExecutionEngine
           return;
         },
         "checkpointing-runtime-reached": async () => {
-          this.options.client[internalLoggerSymbol].debug(
-            "Checkpointing runtime reached; sending discovery request",
-          );
-
-          return {
-            type: "steps-found",
-            ctx: this.fnArg,
-            ops: this.ops,
-            steps: [
-              {
-                op: StepOpCode.DiscoveryRequest,
-
-                // Append with time because we don't want Executor-side
-                // idempotency to dedupe. There may have been a previous
-                // discovery request.
-                id: _internals.hashId(`discovery-request-${Date.now()}`),
-              },
-            ],
-          };
+          // Don't return a DiscoveryRequest immediately. Instead, set a flag so
+          // that the next "steps-found" checkpoint returns the step to the
+          // executor rather than executing it in-process. This lets user code
+          // between steps run to completion and avoids re-entering the function
+          // from scratch for stepless functions. In other words, it avoids
+          // duplicate execution requests.
+          this.state.checkpointingRuntimeExceeded = true;
+          return undefined;
         },
 
         "checkpointing-buffer-interval-reached": () => {
@@ -2714,6 +2721,14 @@ export interface ExecutionState {
     token?: string;
     realtimeToken: string;
   };
+
+  /**
+   * Set when the checkpointing max runtime has been reached. Rather than
+   * immediately returning a DiscoveryRequest (which re-invokes user code
+   * between steps), we defer until the next step boundary so the user's code
+   * between steps can complete.
+   */
+  checkpointingRuntimeExceeded?: boolean;
 
   /**
    * A buffer of steps that are currently queued to be checkpointed.

--- a/packages/inngest/src/test/integration/checkpointing/maxRuntime.test.ts
+++ b/packages/inngest/src/test/integration/checkpointing/maxRuntime.test.ts
@@ -1,0 +1,129 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { expect, test } from "vitest";
+import { Inngest } from "../../../index.ts";
+import { createServer } from "../../../node.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("hit maxRuntime in stepless function", async () => {
+  // We created this test after discovering a bug. The SDK returned a response
+  // but kept processing the function, resulting in duplicate execution
+  // requests.
+
+  const state = createState({ enterCount: 0 });
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+      checkpointing: {
+        maxRuntime: 1,
+      },
+    },
+    async ({ runId }) => {
+      state.runId = runId;
+      state.enterCount++;
+      await sleep(2000);
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  expect(result).toBe("done");
+  expect(state.enterCount).toBe(1);
+});
+
+test("hit maxRuntime between steps", async () => {
+  // We created this test after discovering a bug. The SDK returned a response
+  // but kept processing the function, resulting in duplicate execution
+  // requests.
+
+  const state = createState({ enterCount: 0 });
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+      checkpointing: {
+        maxRuntime: 1,
+      },
+    },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      state.enterCount++;
+      await step.run("before", async () => {});
+      await sleep(2000);
+      await step.run("after", async () => {});
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  expect(result).toBe("done");
+  expect(state.enterCount).toBe(3);
+});
+
+test("hit maxRuntime after step", async () => {
+  // We created this test after discovering a bug. The SDK returned a response
+  // but kept processing the function, resulting in duplicate execution
+  // requests.
+
+  const state = createState({ enterCount: 0 });
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+      checkpointing: {
+        maxRuntime: 1,
+      },
+    },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      state.enterCount++;
+      await step.run("before", async () => {});
+      await sleep(2000);
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  expect(result).toBe("done");
+  expect(state.enterCount).toBe(1);
+});


### PR DESCRIPTION
## Summary

Fix checkpointing `maxRuntime` causing duplicate execution. This happened when `maxRuntime` was reached while _not_ in a step.

The `checkpointing-runtime-reached` handler was immediately returning a `DiscoveryRequest`, which re-invoked the function from scratch. For stepless functions this looped forever. This also happened when hitting `maxRuntime` between steps or after the last step.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a duplicate execution bug where the `checkpointing-runtime-reached` handler was immediately returning a `DiscoveryRequest`, causing the function to be re-invoked from scratch. The fix defers the checkpoint boundary to the next step boundary by setting a flag, allowing user code between steps to complete before returning steps to the executor.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit abcfa64b12256c44c01273cd97c69df20e62f1a7.</sup>
<!-- /MENDRAL_SUMMARY -->