### PR TITLE
Add optional jitter field to cron triggers

### DIFF
--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -160,7 +160,11 @@ export class InngestFunction<
     const triggers: FunctionConfig["triggers"] = [];
     for (const trigger of this.opts.triggers ?? []) {
       if (trigger.cron) {
-        triggers.push({ cron: trigger.cron });
+        const cronTrigger = trigger as { cron: string; jitter?: string };
+        triggers.push({
+          cron: cronTrigger.cron,
+          ...(cronTrigger.jitter ? { jitter: cronTrigger.jitter } : {}),
+        });
         continue;
       }
 

--- a/packages/inngest/src/components/triggers/trigger.test.ts
+++ b/packages/inngest/src/components/triggers/trigger.test.ts
@@ -14,6 +14,26 @@ describe("cron", () => {
     expectTypeOf(c.cron).toEqualTypeOf<"* * * * *">();
   });
 
+  test("cron trigger with jitter", () => {
+    const inngest = new Inngest({ id: "app" });
+    inngest.createFunction(
+      { id: "fn", triggers: [{ cron: "* * * * *", jitter: "30s" }] },
+      ({ event }) => {
+        expectTypeOf(event.name).not.toBeAny();
+      },
+    );
+  });
+
+  test("cron trigger without jitter", () => {
+    const inngest = new Inngest({ id: "app" });
+    inngest.createFunction(
+      { id: "fn", triggers: [{ cron: "* * * * *" }] },
+      ({ event }) => {
+        expectTypeOf(event.name).not.toBeAny();
+      },
+    );
+  });
+
   test("createFunction", () => {
     const inngest = new Inngest({ id: "app" });
     inngest.createFunction(

--- a/packages/inngest/src/components/triggers/triggers.ts
+++ b/packages/inngest/src/components/triggers/triggers.ts
@@ -7,6 +7,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
  */
 type CronTrigger = {
   cron: string;
+  jitter?: string;
 };
 
 /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1483,6 +1483,7 @@ export const functionConfigSchema = z.strictObject({
       }),
       z.strictObject({
         cron: z.string(),
+        jitter: z.string().optional(),
       }),
     ]),
   ),


### PR DESCRIPTION
## Summary

Allows cron triggers to specify a jitter duration that delays execution by a random amount after the cron boundary. Ran trigger unit tests which have new tests for cron triggers with and without jitter. 

## Checklist

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [X] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
see SYS-711

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an optional `jitter` field to cron triggers, allowing users to delay execution by a random amount after the cron boundary. The change touches the `CronTrigger` type, the `functionConfigSchema` Zod validator, the serialization path in `InngestFunction.ts`, and adds two unit tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4f9056137027b2fa45715e62e61cebfe0530d9a3.</sup>
<!-- /MENDRAL_SUMMARY -->