### PR TITLE
fix: empty body on Vercel serverless Node handlers

### DIFF
--- a/.changeset/twelve-bars-serve.md
+++ b/.changeset/twelve-bars-serve.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix empty body on Vercel serverless Node handlers

--- a/packages/inngest/src/node.test.ts
+++ b/packages/inngest/src/node.test.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer";
 import http from "node:http";
 import { Socket } from "node:net";
+import { PassThrough } from "node:stream";
+import httpMocks from "node-mocks-http";
+import { Inngest } from "./components/Inngest.ts";
 import * as NodeHandler from "./node.ts";
 import { testFramework } from "./test/helpers.ts";
 
@@ -32,4 +35,89 @@ testFramework("Node", NodeHandler, {
 
     return [nodeReq, res];
   },
+});
+
+/**
+ * Mimics `@vercel/node`'s `restoreBody()`: after Vercel drains the original
+ * request stream to populate `req.body`, it patches `req.on('data'|'end')` and
+ * `req.read` to replay the bytes from a `PassThrough` — but does NOT patch
+ * `Symbol.asyncIterator` or the `readable` event.
+ *
+ * Regression guard for EXE-1666: body readers that consume the stream via the
+ * async-iterator path (e.g. `node:stream/consumers.text`) read from the
+ * already-drained original stream and see an empty body.
+ *
+ * https://github.com/vercel/vercel/blob/main/packages/node/src/serverless-functions/helpers.ts
+ */
+function restoreBodyLikeVercel(req: http.IncomingMessage, body: Buffer) {
+  const replicate = new PassThrough();
+  const originalOn = req.on.bind(req);
+  const patched: typeof req.on = (name, cb) => {
+    if (name === "data" || name === "end") {
+      replicate.on(name, cb);
+    } else {
+      originalOn(name, cb);
+    }
+    return req;
+  };
+  req.on = patched;
+  req.addListener = patched;
+  req.read = replicate.read.bind(replicate);
+  replicate.write(body);
+  replicate.end();
+}
+
+describe("Node serve() under @vercel/node restoreBody()", () => {
+  test("reads the request body via the replayed event listeners", async () => {
+    const client = new Inngest({ id: "test", isDev: true });
+    const fn = client.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "ok",
+    );
+    const handler = NodeHandler.serve({ client, functions: [fn] });
+
+    const socket = new Socket();
+    const req = new http.IncomingMessage(socket);
+    req.method = "POST";
+    req.url = "/api/inngest?fnId=test-test&stepId=step";
+    req.headers.host = "localhost:3000";
+    req.headers["content-type"] = "application/json";
+
+    const body = Buffer.from(JSON.stringify({ event: {}, events: [{}] }));
+    req.push(body);
+    req.push(null);
+
+    // @vercel/node drains the underlying stream via `stream.on('data', ...)`
+    // (see build-utils `streamToBuffer`) before calling `restoreBody()`.
+    await new Promise<void>((resolve, reject) => {
+      req.on("data", () => {
+        /* drain */
+      });
+      req.on("end", resolve);
+      req.on("error", reject);
+    });
+
+    // Then it replays the bytes via the monkey-patched event listeners only.
+    restoreBodyLikeVercel(req, body);
+
+    const res = httpMocks.createResponse({ req });
+    await handler(req, res);
+
+    // Proof-positive that the body was read: the handler advances past the
+    // body-missing guard (which would 500 with "Missing request body when
+    // executing") into event validation, which fails with a 400 on our
+    // minimal fixture.
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("readRequestBody", () => {
+  test("decodes multi-byte UTF-8 chars split across chunks", async () => {
+    const req = new http.IncomingMessage(new Socket());
+    const bytes = Buffer.from("é", "utf8");
+    req.push(bytes.subarray(0, 1));
+    req.push(bytes.subarray(1));
+    req.push(null);
+    expect(await NodeHandler.readRequestBody(req)).toBe("é");
+  });
 });

--- a/packages/inngest/src/node.ts
+++ b/packages/inngest/src/node.ts
@@ -1,5 +1,4 @@
 import http from "node:http";
-import consumers from "node:stream/consumers";
 import type { TLSSocket } from "node:tls";
 import { URL } from "node:url";
 import { createWebApiCommHandler } from "./components/createWebApiCommHandler.ts";
@@ -19,6 +18,27 @@ import type { RegisterOptions, SupportedFrameworkName } from "./types.ts";
  */
 export const frameworkName: SupportedFrameworkName = "nodejs";
 
+/**
+ * Read the incoming message body as text.
+ *
+ * Collects Buffer chunks and decodes once with `Buffer.concat` so multi-byte
+ * UTF-8 characters aren't corrupted when split across chunk boundaries.
+ * Reads via `req.on('data'|'end')` so body-replay wrappers — notably
+ * `@vercel/node`'s `restoreBody()`, which patches only those two events —
+ * deliver the replayed bytes; async-iterator and `readable`-event readers
+ * see an empty body under that wrapper.
+ */
+export async function readRequestBody(
+  req: http.IncomingMessage,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
 function getURL(req: http.IncomingMessage, hostnameOption?: string): URL {
   const protocol =
     (req.headers["x-forwarded-proto"] as string) ||
@@ -33,7 +53,7 @@ const commHandler = (options: ServeHandlerOptions | SyncHandlerOptions) => {
     ...options,
     handler: (req: http.IncomingMessage, res: http.ServerResponse) => {
       return {
-        body: async () => consumers.text(req),
+        body: () => readRequestBody(req),
         headers: (key) => {
           return req.headers[key] && Array.isArray(req.headers[key])
             ? req.headers[key][0]
@@ -216,7 +236,7 @@ export const endpointAdapter = InngestEndpointAdapter.create((options) => {
  */
 export function serveEndpoint(handler: EndpointHandler): http.RequestListener {
   return async (req: http.IncomingMessage, res: http.ServerResponse) => {
-    const body = await consumers.text(req);
+    const body = await readRequestBody(req);
 
     const headers = new Headers();
     for (const [key, value] of Object.entries(req.headers)) {


### PR DESCRIPTION
## Summary

4.2.3 (#1460) switched `inngest/node`'s body reader to `consumers.text(req)`, which reads via the async-iterator path. `@vercel/node`'s `restoreBody()` only patches `req.on('data'|'end')` and `req.read`, so the reader sees the already-drained original stream and the handler returns `500 "Missing body when executing"` on every POST.

## Checklist
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

[EXE-1666: `inngest@4.2.3+` breaks Vercel serverless Node handlers](https://linear.app/inngest/issue/EXE-1666/inngest423-breaks-vercel-serverless-node-handlers)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces `node:stream/consumers.text()` (async-iterator path) with a manual `data`/`end` event listener in `readRequestBody`, fixing the empty-body regression on Vercel serverless Node handlers where `@vercel/node`'s `restoreBody()` only patches those two events. Both `commHandler` and `serveEndpoint` are updated, and a regression test that faithfully mimics Vercel's monkey-patching is added.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 63ec2ce7d5326b7ff6c9bd8c2a70e19ab28a04ce.</sup>
<!-- /MENDRAL_SUMMARY -->