### PR TITLE
Update language server Nix references

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,9 @@
             bun
 
             # LSPs
-            nodePackages.typescript-language-server
-            nodePackages.vscode-json-languageserver
-            nodePackages.yaml-language-server
+            typescript-language-server
+            vscode-json-languageserver
+            yaml-language-server
 
             # Tools
             protobuf_29


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->
- Currently, loading the nix shell will lead to this error: `error: nodePackages has been removed.`
- The language servers have been moved out of nodePackages
- Let's update them to their new home, matching with the flake.lock, so that the shell successfully loads



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A Nix tools bump, no user-facing change
- [ ] ~Added unit/integration tests~ N/A loads locally
- [ ] ~Added changesets if applicable~ N/A Nix tools bump, no user-facing change

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a broken Nix dev shell by moving three LSP packages (`typescript-language-server`, `vscode-json-languageserver`, `yaml-language-server`) out of the removed `nodePackages` namespace to their new top-level locations in nixpkgs.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a0b827e8049c5e22349a76f309ed132560d7fc63.</sup>
<!-- /MENDRAL_SUMMARY -->