### PR TITLE
EXE-266: Update sendSignal's return type

### DIFF
--- a/.changeset/fix-send-signal-return-type.md
+++ b/.changeset/fix-send-signal-return-type.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `step.sendSignal()` return type to match runtime: `Promise<InngestApi.SendSignalResponse>` (`{ runId: string | undefined }`) instead of `Promise<null>`

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -2,6 +2,7 @@ import { type AiAdapter, models } from "@inngest/ai";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { z } from "zod/v3";
 
+import type { InngestApi } from "../api/api.ts";
 import type { Jsonify } from "../helpers/jsonify.ts";
 import { timeStr } from "../helpers/strings.ts";
 import * as Temporal from "../helpers/temporal.ts";
@@ -585,7 +586,10 @@ export const createStepTools = <
      * Send a Signal to Inngest.
      */
     sendSignal: createTool<
-      (idOrOptions: StepOptionsOrId, opts: SendSignalOpts) => Promise<null>
+      (
+        idOrOptions: StepOptionsOrId,
+        opts: SendSignalOpts,
+      ) => Promise<InngestApi.SendSignalResponse>
     >(
       ({ id, name }, opts) => {
         return {


### PR DESCRIPTION
## Summary

- Update step.sendSignal's return type from `null` to match runtime: `InngestApi.SendSignalResponse`

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A we have no docs page with sendSignal typing
- [ ] ~Added unit/integration tests~ N/A additional testing not needed for typing change
- [x] Added changesets if applicable

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Corrects the return type of `step.sendSignal()` from `Promise<null>` to `Promise<InngestApi.SendSignalResponse>` (`{ runId: string | undefined }`), aligning the TypeScript type with the actual runtime behavior. Includes a changeset for a patch release.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9fa1a2a36093d01d3d77e78e58bd40557d60bf50.</sup>
<!-- /MENDRAL_SUMMARY -->