### PR TITLE
fix: HMAC signature verification tweak

### DIFF
--- a/.changeset/timing-safe-signature-compare.md
+++ b/.changeset/timing-safe-signature-compare.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Improves HMAC signature verification by using a constant-time comparison, which mitigates a potential timing-based signature-recovery attack against the request signature. Also improves handling of timestamps in signatures, including malformed or future-dated values.

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -1,8 +1,11 @@
 import httpMocks from "node-mocks-http";
 import { ExecutionVersion, envKeys, headerKeys } from "../helpers/consts.ts";
+import { signDataWithKey } from "../helpers/net.ts";
+import { ConsoleLogger } from "../middleware/logger.ts";
 import { serve } from "../next.ts";
 import { createClient } from "../test/helpers.ts";
 import { internalLoggerSymbol } from "./Inngest.ts";
+import { RequestSignature } from "./InngestCommHandler.ts";
 
 /**
  * Helper to run a POST request through a Next.js serve handler and capture
@@ -428,5 +431,116 @@ describe("response version header", () => {
     expect(result.headers[headerKeys.RequestVersion]).toBe(
       ExecutionVersion.V2.toString(),
     );
+  });
+});
+
+describe("RequestSignature", () => {
+  const signingKey = "signkey-test-deadbeefcafef00d";
+  const body = { event: { name: "demo/event.sent", data: {} } };
+  const logger = new ConsoleLogger({ level: "silent" });
+
+  const fixedNowMs = new Date("2026-04-22T12:00:00Z").getTime();
+  const fixedNowSeconds = Math.round(fixedNowMs / 1000);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNowMs);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const verify = async (
+    ts: string,
+    { allowExpired = false }: { allowExpired?: boolean } = {},
+  ) => {
+    const mac = await signDataWithKey(body, signingKey, ts, logger);
+    return new RequestSignature(`t=${ts}&s=${mac}`).verifySignature({
+      body,
+      signingKey,
+      signingKeyFallback: undefined,
+      allowExpiredSignatures: allowExpired,
+      logger,
+    });
+  };
+
+  describe("constructor", () => {
+    test("throws when `t` is missing", () => {
+      expect(() => new RequestSignature("s=abc")).toThrow(/Invalid/);
+    });
+
+    test("throws when `s` is missing", () => {
+      expect(() => new RequestSignature("t=123")).toThrow(/Invalid/);
+    });
+  });
+
+  describe("verifySignature expiry", () => {
+    test("accepts a timestamp 60s in the future (tolerates clock skew)", async () => {
+      await expect(verify((fixedNowSeconds + 60).toString())).resolves.toBe(
+        signingKey,
+      );
+    });
+
+    test("accepts a timestamp exactly 5 minutes old (boundary)", async () => {
+      await expect(verify((fixedNowSeconds - 300).toString())).resolves.toBe(
+        signingKey,
+      );
+    });
+
+    test("rejects a timestamp older than 5 minutes", async () => {
+      await expect(verify((fixedNowSeconds - 301).toString())).rejects.toThrow(
+        "Signature has expired",
+      );
+    });
+
+    test("rejects a timestamp more than 5 minutes in the future", async () => {
+      await expect(verify((fixedNowSeconds + 301).toString())).rejects.toThrow(
+        "Signature has expired",
+      );
+    });
+
+    test("rejects an unparseable `t`", async () => {
+      await expect(verify("not-a-number")).rejects.toThrow(
+        "Signature has expired",
+      );
+    });
+
+    test("rejects a hex-prefixed `t` (parseInt radix guard)", async () => {
+      const hexTs = `0x${fixedNowSeconds.toString(16)}`;
+      await expect(verify(hexTs)).rejects.toThrow("Signature has expired");
+    });
+
+    test.each([
+      ["past", -3600],
+      ["future", 3600],
+    ])(
+      "accepts a %s expired timestamp when allowExpiredSignatures is true",
+      async (_label, offsetSeconds) => {
+        await expect(
+          verify((fixedNowSeconds + offsetSeconds).toString(), {
+            allowExpired: true,
+          }),
+        ).resolves.toBe(signingKey);
+      },
+    );
+  });
+
+  describe("verifySignature signature check", () => {
+    test("rejects a tampered signature", async () => {
+      const ts = fixedNowSeconds.toString();
+      const mac = await signDataWithKey(body, signingKey, ts, logger);
+      const tampered = (mac[0] === "0" ? "1" : "0") + mac.slice(1);
+
+      await expect(
+        new RequestSignature(`t=${ts}&s=${tampered}`).verifySignature({
+          body,
+          signingKey,
+          signingKeyFallback: undefined,
+          allowExpiredSignatures: false,
+          logger,
+        }),
+      ).rejects.toThrow("Invalid signature");
+    });
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -33,7 +33,12 @@ import { fetchWithAuthFallback, signDataWithKey } from "../helpers/net.ts";
 import { runAsPromise } from "../helpers/promises.ts";
 import { ServerTiming } from "../helpers/ServerTiming.ts";
 import { createStream } from "../helpers/stream.ts";
-import { hashEventKey, hashSigningKey, stringify } from "../helpers/strings.ts";
+import {
+  hashEventKey,
+  hashSigningKey,
+  stringify,
+  timingSafeEqual,
+} from "../helpers/strings.ts";
 import { isRecord, type MaybePromise } from "../helpers/types.ts";
 import type { Logger } from "../middleware/logger.ts";
 import {
@@ -2595,7 +2600,7 @@ export class InngestCommHandler<
     key: string,
     body: string,
   ): Promise<string> {
-    const now = Date.now();
+    const now = Math.round(Date.now() / 1000);
     const mac = await signDataWithKey(
       body,
       key,
@@ -2607,7 +2612,10 @@ export class InngestCommHandler<
   }
 }
 
-class RequestSignature {
+/**
+ * @internal Exported for testing; not part of the public API.
+ */
+export class RequestSignature {
   public timestamp: string;
   public signature: string;
 
@@ -2626,9 +2634,15 @@ class RequestSignature {
       return false;
     }
 
-    const delta =
-      Date.now() - new Date(Number.parseInt(this.timestamp) * 1000).valueOf();
-    return delta > 1000 * 60 * 5;
+    const ts = Number.parseInt(this.timestamp, 10);
+    if (!Number.isFinite(ts)) {
+      return true;
+    }
+
+    const delta = Date.now() - ts * 1000;
+    // Clamp both ends: negative delta (future-skewed `t`) would otherwise give
+    // captured requests an unbounded replay
+    return Math.abs(delta) > 1000 * 60 * 5;
   }
 
   async #verifySignature({
@@ -2647,7 +2661,7 @@ class RequestSignature {
     }
 
     const mac = await signDataWithKey(body, signingKey, this.timestamp, logger);
-    if (mac !== this.signature) {
+    if (!timingSafeEqual(mac, this.signature)) {
       throw new Error("Invalid signature");
     }
   }

--- a/packages/inngest/src/helpers/strings.test.ts
+++ b/packages/inngest/src/helpers/strings.test.ts
@@ -1,4 +1,8 @@
-import { slugify, stringify, timeStr } from "./strings.ts";
+import { ConsoleLogger } from "../middleware/logger.ts";
+import { signDataWithKey } from "./net.ts";
+import { slugify, stringify, timeStr, timingSafeEqual } from "./strings.ts";
+
+const logger = new ConsoleLogger({ level: "silent" });
 
 describe("slugify", () => {
   it("Generates a slug using hyphens", () => {
@@ -46,5 +50,57 @@ describe("timeStr", () => {
 describe("stringify", () => {
   test("removes BigInt", () => {
     expect(stringify({ a: BigInt(1), b: 2 })).toEqual(JSON.stringify({ b: 2 }));
+  });
+});
+
+describe("timingSafeEqual", () => {
+  it("returns true for identical strings", () => {
+    const a = "deadbeefcafef00d";
+    const b = "deadbeefcafef00d";
+    expect(timingSafeEqual(a, b)).toBe(true);
+  });
+
+  it("returns true for real signDataWithKey output compared to itself", async () => {
+    const mac = await signDataWithKey(
+      "payload",
+      "signkey-test-abc",
+      "1234567890",
+      logger,
+    );
+    expect(timingSafeEqual(mac, mac)).toBe(true);
+  });
+
+  it("returns false for equal-length strings that differ", () => {
+    expect(timingSafeEqual("abc123", "abc124")).toBe(false);
+  });
+
+  it("returns false when strings differ only in the first character", () => {
+    expect(timingSafeEqual("0bc123", "abc123")).toBe(false);
+  });
+
+  it("returns false when strings differ only in the last character", () => {
+    expect(timingSafeEqual("abc120", "abc123")).toBe(false);
+  });
+
+  it("returns false for differing-length strings (prefix match)", () => {
+    expect(timingSafeEqual("abc", "abc123")).toBe(false);
+  });
+
+  it("returns false for differing-length strings (empty vs non-empty)", () => {
+    expect(timingSafeEqual("", "a")).toBe(false);
+    expect(timingSafeEqual("a", "")).toBe(false);
+  });
+
+  it("returns true for two empty strings", () => {
+    expect(timingSafeEqual("", "")).toBe(true);
+  });
+
+  it("returns false for strings that differ in multi-byte characters", () => {
+    expect(timingSafeEqual("café", "cafe")).toBe(false);
+    expect(timingSafeEqual("🌍a", "🌍b")).toBe(false);
+  });
+
+  it("returns true for identical non-ASCII strings", () => {
+    expect(timingSafeEqual("世界 🌍", "世界 🌍")).toBe(true);
   });
 });

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -6,6 +6,26 @@ import type { TimeStr } from "../types.ts";
 const { sha256 } = hashjs;
 
 /**
+ * Constant-time equality check for two strings. Returns `false` immediately if
+ * lengths differ; otherwise XOR-accumulates every char code so the total time
+ * is independent of where (or whether) the strings diverge.
+ *
+ * Used for HMAC signature verification — `===`/`!==` short-circuit on the
+ * first mismatched character and leak the matching-prefix length via timing.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
  * Safely `JSON.stringify()` an `input`, handling circular refernences and
  * removing `BigInt` values.
  */

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -1250,7 +1250,7 @@ export const testFramework = (
             const edgeHandler = createEdgeHandler();
             const signingKey = "123";
             const body = { url: "https://example.com/api/inngest" };
-            const ts = Date.now().toString();
+            const ts = Math.round(Date.now() / 1000).toString();
 
             const signature = validSignature
               ? `t=${ts}&s=${await signDataWithKey(body, signingKey, ts, new ConsoleLogger({ level: "silent" }))}`


### PR DESCRIPTION
## Summary

Fix timing side-channel in HMAC signature verification and harden our signature timestamp verification.

## Checklist

- [x] Added changesets if applicable

## Related

[EXE-1652: Timing attack in HMAC signature comparison (InngestCommHandler)](https://linear.app/inngest/issue/EXE-1652/timing-attack-in-hmac-signature-comparison-inngestcommhandler)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a timing side-channel in HMAC signature verification by replacing `===` with a constant-time XOR accumulator (`timingSafeEqual`), and hardens timestamp validation with a radix-10 guard on `parseInt`, a `Number.isFinite` check for unparseable values, and `Math.abs` clamping to reject future-dated timestamps. Also fixes the `signDataWithKey` call site and test helper to pass seconds (not milliseconds) as the timestamp.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e14963712b01539c3848baf0326d7ed82c9e19df.</sup>
<!-- /MENDRAL_SUMMARY -->