### PR TITLE
fix: hash otel exporter signing key

### DIFF
--- a/.changeset/wild-grapes-sink.md
+++ b/.changeset/wild-grapes-sink.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Hash the signing key used when exporting OTel traces

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -16,6 +16,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import Debug from "debug";
 import { deterministicSpanID } from "../../../helpers/deterministicId.ts";
+import { hashSigningKey } from "../../../helpers/strings.ts";
 import type { Inngest } from "../../Inngest.ts";
 import { getAsyncCtx } from "../als.ts";
 import { clientProcessorMap } from "./access.ts";
@@ -321,7 +322,7 @@ export class InngestSpanProcessor implements SpanProcessor {
             url: url.href,
             headers: {
               ...app.headers,
-              Authorization: `Bearer ${app.signingKey}`,
+              Authorization: `Bearer ${hashSigningKey(app.signingKey)}`,
             },
           });
 


### PR DESCRIPTION
## Summary
Hash the otelExporter's signing key


## Checklist

- [x] Added changesets if applicable

## Related
[EXE-1649: Raw (unhashed) signing key sent as Bearer token by OTel exporter](https://linear.app/inngest/issue/EXE-1649/raw-unhashed-signing-key-sent-as-bearer-token-by-otel-exporter)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes a security issue where the raw (unhashed) signing key was being sent as a Bearer token in the OTel exporter's Authorization header. The fix applies `hashSigningKey` to hash the key before transmission, consistent with how signing keys are handled elsewhere in the codebase.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b13976d7ca96ca777c023b64176b04dfb2727238.</sup>
<!-- /MENDRAL_SUMMARY -->