### PR TITLE
fix: use encodeURIComponent for runIDs

### DIFF
--- a/.changeset/lazy-horses-kiss.md
+++ b/.changeset/lazy-horses-kiss.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix run IDs not URL encoded in Durable Endpoints

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -152,7 +152,9 @@ export class InngestApi {
   async getRunSteps(
     runId: string,
   ): Promise<Result<StepsResponse, ErrorResponse>> {
-    const result = await this.req(`/v0/runs/${runId}/actions`);
+    const result = await this.req(
+      `/v0/runs/${encodeURIComponent(runId)}/actions`,
+    );
     if (result.ok) {
       const res = result.value;
       const data: unknown = await res.json();
@@ -176,7 +178,9 @@ export class InngestApi {
   async getRunBatch(
     runId: string,
   ): Promise<Result<BatchResponse, ErrorResponse>> {
-    const result = await this.req(`/v0/runs/${runId}/batch`);
+    const result = await this.req(
+      `/v0/runs/${encodeURIComponent(runId)}/batch`,
+    );
     if (result.ok) {
       const res = result.value;
       const data: unknown = await res.json();
@@ -395,11 +399,14 @@ export class InngestApi {
   ): Promise<Result<void, ErrorResponse>> {
     const payload = { target: args.target, metadata: args.metadata };
 
-    const result = await this.req(`/v1/runs/${args.target.run_id}/metadata`, {
-      method: "POST",
-      body: JSON.stringify(payload),
-      headers: options?.headers,
-    });
+    const result = await this.req(
+      `/v1/runs/${encodeURIComponent(args.target.run_id)}/metadata`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: options?.headers,
+      },
+    );
 
     if (!result.ok) {
       return err({
@@ -500,10 +507,13 @@ export class InngestApi {
       ts: new Date().valueOf(),
     });
 
-    const result = await this.req(`/v1/checkpoint/${args.runId}/steps`, {
-      method: "POST",
-      body,
-    });
+    const result = await this.req(
+      `/v1/checkpoint/${encodeURIComponent(args.runId)}/steps`,
+      {
+        method: "POST",
+        body,
+      },
+    );
 
     if (!result.ok) {
       throw new Error(
@@ -538,10 +548,13 @@ export class InngestApi {
       ts: new Date().valueOf(),
     });
 
-    const result = await this.req(`/v1/checkpoint/${args.runId}/async`, {
-      method: "POST",
-      body,
-    });
+    const result = await this.req(
+      `/v1/checkpoint/${encodeURIComponent(args.runId)}/async`,
+      {
+        method: "POST",
+        body,
+      },
+    );
 
     if (!result.ok) {
       throw new Error(
@@ -618,7 +631,9 @@ export class InngestApi {
    * @returns The raw Response from the API
    */
   async getRunOutput(runId: string, token: string): Promise<Response> {
-    const url = await this.getTargetUrl(`/v1/http/runs/${runId}/output`);
+    const url = await this.getTargetUrl(
+      `/v1/http/runs/${encodeURIComponent(runId)}/output`,
+    );
     url.searchParams.set("token", token);
 
     return this._fetch()(url.toString(), {


### PR DESCRIPTION
## Summary

use encodeURIComponent for runIDs


## Checklist

- [x] Added changesets if applicable

## Related

[EXE-1657: \[Security\] Unvalidated/unencoded `runId` in API client URLs → path traversal (inngest-js)](https://linear.app/inngest/issue/EXE-1657/security-unvalidatedunencoded-runid-in-api-client-urls-path-traversal)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Applies `encodeURIComponent` to `runId` in all six URL-building call sites in `api.ts` to prevent path traversal via malformed run IDs. Adds a changeset entry marking the fix as a patch.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ae08226cbd7fd625fa3981fb5d1939c49491a1dd.</sup>
<!-- /MENDRAL_SUMMARY -->