### PR TITLE
refactor: tighten SDK authentication

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -1,7 +1,7 @@
 import httpMocks from "node-mocks-http";
 import { ExecutionVersion, envKeys, headerKeys } from "../helpers/consts.ts";
 import { serve } from "../next.ts";
-import { createClient } from "../test/helpers.ts";
+import { createClient, makeTestSignature } from "../test/helpers.ts";
 import { internalLoggerSymbol } from "./Inngest.ts";
 
 /**
@@ -428,5 +428,174 @@ describe("response version header", () => {
     expect(result.headers[headerKeys.RequestVersion]).toBe(
       ExecutionVersion.V2.toString(),
     );
+  });
+});
+
+describe("GET introspection", () => {
+  const runGet = async (
+    handler: ReturnType<typeof serve>,
+    opts?: { signature?: string; env?: Record<string, string> },
+  ) => {
+    const headers: Record<string, string> = {
+      host: "localhost:3000",
+      "content-type": "application/json",
+    };
+    if (opts?.signature !== undefined) {
+      headers[headerKeys.Signature] = opts.signature;
+    }
+
+    const req = httpMocks.createRequest({
+      method: "GET",
+      url: "/api/inngest",
+      headers,
+    });
+    const res = httpMocks.createResponse();
+
+    const prevEnv = process.env;
+    if (opts?.env) {
+      process.env = { ...prevEnv, ...opts.env };
+    }
+
+    try {
+      await (handler as (...args: unknown[]) => Promise<unknown>)(req, res);
+      return {
+        status: res.statusCode,
+        body: JSON.parse(res._getData() || "{}") as Record<string, unknown>,
+        headers: res.getHeaders() as Record<string, string>,
+      };
+    } finally {
+      process.env = prevEnv;
+    }
+  };
+
+  test("dev mode returns unauthenticated introspection body", async () => {
+    const inngest = createClient({ id: "test", isDev: true });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runGet(handler);
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      function_count: 1,
+      has_event_key: expect.any(Boolean),
+      has_signing_key: expect.any(Boolean),
+      mode: "dev",
+      schema_version: "2024-05-24",
+    });
+    expect(result.body).not.toHaveProperty("authentication_succeeded");
+  });
+
+  test("cloud mode without a signature returns 401", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runGet(handler, {
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.body).toEqual({ code: "sig_verification_failed" });
+  });
+
+  test("cloud mode with an invalid signature returns 401", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runGet(handler, {
+      signature:
+        "t=1700000000&s=0000000000000000000000000000000000000000000000000000000000000000",
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.body).toEqual({ code: "sig_verification_failed" });
+  });
+
+  test("cloud mode 401 body does not leak introspection fields", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runGet(handler, {
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+    });
+
+    expect(result.body).not.toHaveProperty("function_count");
+    expect(result.body).not.toHaveProperty("has_event_key");
+    expect(result.body).not.toHaveProperty("has_signing_key");
+    expect(result.body).not.toHaveProperty("mode");
+    expect(result.body).not.toHaveProperty("schema_version");
+    expect(result.body).not.toHaveProperty("extra");
+  });
+
+  test("cloud mode 401 response does not leak SDK fingerprint headers", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runGet(handler, {
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+    });
+
+    expect(result.headers).not.toHaveProperty(
+      headerKeys.SdkVersion.toLowerCase(),
+    );
+    expect(result.headers).not.toHaveProperty(
+      headerKeys.Framework.toLowerCase(),
+    );
+    expect(result.headers).not.toHaveProperty(
+      headerKeys.Platform.toLowerCase(),
+    );
+    expect(result.headers).not.toHaveProperty(
+      headerKeys.Environment.toLowerCase(),
+    );
+    expect(result.headers).not.toHaveProperty(
+      headerKeys.InngestExpectedServerKind.toLowerCase(),
+    );
+    expect(result.headers).not.toHaveProperty(
+      headerKeys.RequestVersion.toLowerCase(),
+    );
+    expect(result.headers).not.toHaveProperty("user-agent");
+  });
+
+  test("cloud mode with a valid signature returns authenticated body", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const signingKey = "signkey-prod-12345";
+    const result = await runGet(handler, {
+      signature: await makeTestSignature("", signingKey),
+      env: { [envKeys.InngestSigningKey]: signingKey },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      authentication_succeeded: true,
+      mode: "cloud",
+      sdk_language: "js",
+      function_count: 1,
+    });
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -1,7 +1,16 @@
 import httpMocks from "node-mocks-http";
-import { ExecutionVersion, envKeys, headerKeys } from "../helpers/consts.ts";
+import {
+  ExecutionVersion,
+  envKeys,
+  headerKeys,
+  syncKind,
+} from "../helpers/consts.ts";
 import { serve } from "../next.ts";
-import { createClient, makeTestSignature } from "../test/helpers.ts";
+import {
+  createClient,
+  expectNoFingerprintHeaders,
+  makeTestSignature,
+} from "../test/helpers.ts";
 import { internalLoggerSymbol } from "./Inngest.ts";
 
 /**
@@ -555,25 +564,7 @@ describe("GET introspection", () => {
       env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
     });
 
-    expect(result.headers).not.toHaveProperty(
-      headerKeys.SdkVersion.toLowerCase(),
-    );
-    expect(result.headers).not.toHaveProperty(
-      headerKeys.Framework.toLowerCase(),
-    );
-    expect(result.headers).not.toHaveProperty(
-      headerKeys.Platform.toLowerCase(),
-    );
-    expect(result.headers).not.toHaveProperty(
-      headerKeys.Environment.toLowerCase(),
-    );
-    expect(result.headers).not.toHaveProperty(
-      headerKeys.InngestExpectedServerKind.toLowerCase(),
-    );
-    expect(result.headers).not.toHaveProperty(
-      headerKeys.RequestVersion.toLowerCase(),
-    );
-    expect(result.headers).not.toHaveProperty("user-agent");
+    expectNoFingerprintHeaders(result.headers);
   });
 
   test("cloud mode with a valid signature returns authenticated body", async () => {
@@ -597,5 +588,200 @@ describe("GET introspection", () => {
       sdk_language: "js",
       function_count: 1,
     });
+  });
+});
+
+describe("PUT sync auth", () => {
+  const runPut = async (
+    handler: ReturnType<typeof serve>,
+    opts?: {
+      signature?: string;
+      env?: Record<string, string>;
+      syncKindHeader?: string;
+      body?: Record<string, unknown>;
+    },
+  ) => {
+    const headers: Record<string, string> = {
+      host: "localhost:3000",
+      "content-type": "application/json",
+    };
+    if (opts?.signature !== undefined) {
+      headers[headerKeys.Signature] = opts.signature;
+    }
+    if (opts?.syncKindHeader !== undefined) {
+      headers[headerKeys.InngestSyncKind] = opts.syncKindHeader;
+    }
+
+    const req = httpMocks.createRequest({
+      method: "PUT",
+      url: "/api/inngest",
+      headers,
+      body: opts?.body,
+    });
+    const res = httpMocks.createResponse();
+
+    const prevEnv = process.env;
+    if (opts?.env) {
+      process.env = { ...prevEnv, ...opts.env };
+    }
+
+    try {
+      await (handler as (...args: unknown[]) => Promise<unknown>)(req, res);
+      return {
+        status: res.statusCode,
+        body: JSON.parse(res._getData() || "{}") as Record<string, unknown>,
+        headers: res.getHeaders() as Record<string, string>,
+      };
+    } finally {
+      process.env = prevEnv;
+    }
+  };
+
+  test("in-band PUT without a signature returns 401", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runPut(handler, {
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+      syncKindHeader: syncKind.InBand,
+      body: { url: "http://localhost:3000/api/inngest" },
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.body).toEqual({ code: "sig_verification_failed" });
+  });
+
+  test("in-band PUT with an invalid signature returns 401", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runPut(handler, {
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+      syncKindHeader: syncKind.InBand,
+      signature:
+        "t=1700000000&s=0000000000000000000000000000000000000000000000000000000000000000",
+      body: { url: "http://localhost:3000/api/inngest" },
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.body).toEqual({ code: "sig_verification_failed" });
+  });
+
+  test("in-band PUT 401 response does not leak SDK fingerprint headers", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runPut(handler, {
+      env: { [envKeys.InngestSigningKey]: "signkey-prod-12345" },
+      syncKindHeader: syncKind.InBand,
+      body: { url: "http://localhost:3000/api/inngest" },
+    });
+
+    expect(result.status).toBe(401);
+    expectNoFingerprintHeaders(result.headers);
+  });
+
+  test("out-of-band PUT 500 (no signing key) does not leak SDK fingerprint headers", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runPut(handler);
+
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({ code: "internal_server_error" });
+    expectNoFingerprintHeaders(result.headers);
+  });
+});
+
+describe("non-PUT methods are gated", () => {
+  test("DELETE without a signature returns 401", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const req = httpMocks.createRequest({
+      method: "DELETE",
+      url: "/api/inngest",
+      headers: {
+        host: "localhost:3000",
+        "content-type": "application/json",
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    const prevEnv = process.env;
+    process.env = {
+      ...prevEnv,
+      [envKeys.InngestSigningKey]: "signkey-prod-12345",
+    };
+
+    try {
+      await (handler as (...args: unknown[]) => Promise<unknown>)(req, res);
+      expect(res.statusCode).toBe(401);
+      expect(JSON.parse(res._getData() || "{}")).toEqual({
+        code: "sig_verification_failed",
+      });
+      expectNoFingerprintHeaders(res.getHeaders() as Record<string, string>);
+    } finally {
+      process.env = prevEnv;
+    }
+  });
+});
+
+describe("POST 401 fingerprint suppression", () => {
+  test("cloud-mode POST without a signature returns 401 and no fingerprint headers", async () => {
+    const inngest = createClient({ id: "test", isDev: false });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      url: "/api/inngest",
+      headers: {
+        host: "localhost:3000",
+        "content-type": "application/json",
+      },
+      body: { event: { name: "demo/event.sent", data: {} } },
+    });
+    const res = httpMocks.createResponse();
+
+    const prevEnv = process.env;
+    process.env = {
+      ...prevEnv,
+      [envKeys.InngestSigningKey]: "signkey-prod-12345",
+    };
+
+    try {
+      await (handler as (...args: unknown[]) => Promise<unknown>)(req, res);
+      expect(res.statusCode).toBe(401);
+      expect(JSON.parse(res._getData() || "{}")).toEqual({
+        code: "sig_verification_failed",
+      });
+      expectNoFingerprintHeaders(res.getHeaders() as Record<string, string>);
+    } finally {
+      process.env = prevEnv;
+    }
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -71,18 +71,16 @@ import {
 } from "./InngestFunction.ts";
 import { buildWrapRequestChain, type Middleware } from "./middleware/index.ts";
 
-// A response object for when an internal server error occurs. When that
-// happens, we don't to leak any internal details to the client.
+// Sent directly via `actions.transformResponse`, bypassing `prepareActionRes`
+// so unauthenticated/misconfigured responses don't pick up SDK-fingerprint
+// headers.
 const internalServerErrorResponse = {
   body: stringify({ code: "internal_server_error" }),
   headers: { "Content-Type": "application/json" },
   status: 500,
-  version: undefined,
+  version: null,
 } as const;
 
-// `version: null` suppresses the RequestVersion header. Returned directly
-// (without running through prepareActionRes) so no fingerprint headers are
-// attached on unauthenticated responses.
 const sigVerificationFailedResponse = {
   body: stringify({ code: "sig_verification_failed" }),
   headers: { "Content-Type": "application/json" },
@@ -685,6 +683,26 @@ export class InngestCommHandler<
   }
 
   /**
+   * Whether a PUT is requesting in-band sync. Out-of-band PUT is unsigned by design, so PUT auth depends on this.
+   */
+  private async isInBandSyncRequested(
+    actions: HandlerResponseWithErrors,
+  ): Promise<boolean> {
+    const allowInBandSync = parseAsBoolean(
+      this.env[envKeys.InngestAllowInBandSync],
+    );
+    if (allowInBandSync !== undefined && !allowInBandSync) {
+      return false;
+    }
+
+    const kind = await actions.headers(
+      "processing deployment request",
+      headerKeys.InngestSyncKind,
+    );
+    return kind === syncKind.InBand;
+  }
+
+  /**
    * Start handling a request, setting up environments, modes, and returning
    * some helpers.
    */
@@ -1158,9 +1176,8 @@ export class InngestCommHandler<
           // pre-parsed objects (req.body).
           const parsed =
             typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody;
-          // For PUT, normalize `{}` to `""` so the signing contract matches
-          // what the sender signs over an empty HTTP body. POST is left alone
-          // so downstream missing-body detection still fires.
+          // PUT-only: normalize `{}` to `""` to match the empty-body signing
+          // contract. POST falls through so missing-body detection still fires.
           if (
             method === "PUT" &&
             isRecord(parsed) &&
@@ -1177,17 +1194,26 @@ export class InngestCommHandler<
 
     const signatureValidation = this.validateSignature(signature, body);
 
-    // Single auth gate for the whole request. validateSignature short-circuits
-    // to success in dev mode, so local tooling is unaffected. Treat a thrown
-    // error the same as a resolved failure.
-    const validationResult = await signatureValidation.catch((err: Error) => ({
-      success: false as const,
-      err,
-    }));
+    const inBandSyncRequested =
+      method === "PUT" ? await this.isInBandSyncRequested(actions) : false;
+
+    // Out-of-band PUT is unsigned by design, so we only gate PUT when the caller asks for in-band sync.
+    const validationResult = await signatureValidation;
     if (!validationResult.success) {
+      if (method !== "PUT" || inBandSyncRequested) {
+        return actions.transformResponse(
+          "sending back response",
+          sigVerificationFailedResponse,
+        );
+      }
+    }
+
+    // Runs after the auth gate so GET/POST without a signing key still 401
+    // first; only out-of-band PUT can reach this without a key.
+    if (!this.checkModeConfiguration()) {
       return actions.transformResponse(
         "sending back response",
-        sigVerificationFailedResponse,
+        internalServerErrorResponse,
       );
     }
 
@@ -1256,6 +1282,7 @@ export class InngestCommHandler<
           forceExecution: Boolean(forceExecution),
           fns,
           mwInstances,
+          inBandSyncRequested,
         }),
       );
       actionResponseVersion = rawRes.version;
@@ -1537,6 +1564,7 @@ export class InngestCommHandler<
     forceExecution,
     fns,
     mwInstances,
+    inBandSyncRequested,
   }: {
     actions: HandlerResponseWithErrors;
     timer: ServerTiming;
@@ -1547,11 +1575,8 @@ export class InngestCommHandler<
     forceExecution: boolean;
     fns?: InngestFunction.Any[];
     mwInstances?: Middleware.BaseMiddleware[];
+    inBandSyncRequested: boolean;
   }): Promise<ActionResponse> {
-    if (!this.checkModeConfiguration()) {
-      return internalServerErrorResponse;
-    }
-
     // This is when the request body is completely missing. This commonly
     // happens when the HTTP framework doesn't have body parsing middleware,
     // or for PUT requests that don't require a body.
@@ -1924,33 +1949,14 @@ export class InngestCommHandler<
       }
 
       if (method === "PUT") {
-        const [deployId, inBandSyncRequested] = await Promise.all([
-          actions
-            .queryStringWithDefaults(
-              "processing deployment request",
-              queryKeys.DeployId,
-            )
-            .then((deployId) => {
-              return deployId === "undefined" ? undefined : deployId;
-            }),
-
-          Promise.resolve(
-            parseAsBoolean(this.env[envKeys.InngestAllowInBandSync]),
+        const deployId = await actions
+          .queryStringWithDefaults(
+            "processing deployment request",
+            queryKeys.DeployId,
           )
-            .then((allowInBandSync) => {
-              if (allowInBandSync !== undefined && !allowInBandSync) {
-                return syncKind.OutOfBand;
-              }
-
-              return actions.headers(
-                "processing deployment request",
-                headerKeys.InngestSyncKind,
-              );
-            })
-            .then((kind) => {
-              return kind === syncKind.InBand;
-            }),
-        ]);
+          .then((deployId) => {
+            return deployId === "undefined" ? undefined : deployId;
+          });
 
         if (inBandSyncRequested) {
           if (isMissingBody) {
@@ -2359,9 +2365,8 @@ export class InngestCommHandler<
       schema_version: "2024-05-24",
     } satisfies UnauthenticatedIntrospection;
 
-    // Only return an authenticated body in Cloud mode. Dev mode skips
-    // signature validation, so we return the unauthenticated shape for local
-    // tooling.
+    // Only return an authenticated body in cloud mode; dev mode skips
+    // signature validation.
     if (this.client.mode === "cloud") {
       introspection = {
         ...introspection,

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -80,6 +80,16 @@ const internalServerErrorResponse = {
   version: undefined,
 } as const;
 
+// `version: null` suppresses the RequestVersion header, and `prepareActionRes`
+// strips fingerprint headers from the final response so we don't leak
+// SDK/framework/platform info on unauthenticated responses.
+const sigVerificationFailedResponse = {
+  body: stringify({ code: "sig_verification_failed" }),
+  headers: { "Content-Type": "application/json" },
+  status: 401,
+  version: null,
+} as const;
+
 /**
  * A set of options that can be passed to a serve handler, intended to be used
  * by internal and custom serve handlers to provide a consistent interface.
@@ -1135,19 +1145,30 @@ export class InngestCommHandler<
       methodP,
       methodP.then(async (method) => {
         if (method === "POST" || method === "PUT") {
-          const body = await actions.body(
+          const rawBody = await actions.body(
             `checking body for request signing as method is ${method}`,
           );
-          if (!body) {
-            // Empty body can happen with PUT requests
+          if (
+            !rawBody ||
+            (typeof rawBody === "string" && rawBody.trim() === "")
+          ) {
             return "";
           }
           // Some adapters return strings (req.text()), others return
-          // pre-parsed objects (req.body). Handle both cases.
-          if (typeof body === "string") {
-            return JSON.parse(body);
+          // pre-parsed objects (req.body).
+          const parsed =
+            typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody;
+          // For PUT, normalize `{}` to `""` so the signing contract matches
+          // what the sender signs over an empty HTTP body. POST is left alone
+          // so downstream missing-body detection still fires.
+          if (
+            method === "PUT" &&
+            isRecord(parsed) &&
+            Object.keys(parsed).length === 0
+          ) {
+            return "";
           }
-          return body;
+          return parsed;
         }
 
         return "";
@@ -1155,6 +1176,13 @@ export class InngestCommHandler<
     ]);
 
     const signatureValidation = this.validateSignature(signature, body);
+
+    // Non-throwing view of the same memoized promise for paths that must not
+    // surface a validation error as an uncaught rejection.
+    const settledSignatureValidation = signatureValidation.then(
+      (result) => result,
+      (err: Error) => ({ success: false as const, err }),
+    );
 
     // Create middleware instances once; shared by wrapRequest and execution hooks.
     // Starts with client-level middleware; function-level middleware is appended
@@ -1173,40 +1201,42 @@ export class InngestCommHandler<
     const prepareActionRes = async (
       res: ActionResponse,
     ): Promise<ActionResponse> => {
-      const headers: Record<string, string> = {
-        ...(await getHeaders()),
-        ...res.headers,
-        ...(res.version === null
-          ? {}
-          : {
-              [headerKeys.RequestVersion]: (
-                res.version ?? PREFERRED_ASYNC_EXECUTION_VERSION
-              ).toString(),
-            }),
-      };
+      const sigResult = await settledSignatureValidation;
 
-      let signature: string | undefined;
-
-      try {
-        signature = await signatureValidation.then(async (result) => {
-          if (!result.success || !result.keyUsed) {
-            return undefined;
+      // On unauthenticated responses, strip SDK/framework/platform headers so
+      // we don't leak fingerprint info. Dev mode short-circuits
+      // validateSignature to success, so the full header set still attaches
+      // for local tooling.
+      const headers: Record<string, string> = sigResult.success
+        ? {
+            ...(await getHeaders()),
+            ...res.headers,
+            ...(res.version === null
+              ? {}
+              : {
+                  [headerKeys.RequestVersion]: (
+                    res.version ?? PREFERRED_ASYNC_EXECUTION_VERSION
+                  ).toString(),
+                }),
           }
+        : { ...res.headers };
 
-          return await this.getResponseSignature(result.keyUsed, res.body);
-        });
-      } catch (err) {
-        // If we fail to sign, retun a 500 with the error.
-        return {
-          ...res,
-          headers,
-          body: stringify(serializeError(err)),
-          status: 500,
-        };
-      }
-
-      if (signature) {
-        headers[headerKeys.Signature] = signature;
+      if (sigResult.success && sigResult.keyUsed) {
+        try {
+          const signature = await this.getResponseSignature(
+            sigResult.keyUsed,
+            res.body,
+          );
+          headers[headerKeys.Signature] = signature;
+        } catch (err) {
+          // If we fail to sign, return a 500 with the error.
+          return {
+            ...res,
+            headers,
+            body: stringify(serializeError(err)),
+            status: 500,
+          };
+        }
       }
 
       return {
@@ -1327,6 +1357,13 @@ export class InngestCommHandler<
         body: stringify(serializeError(err)),
         version: undefined,
       });
+    }
+
+    // Don't start a streaming response before confirming authentication —
+    // streaming commits headers before the body resolves, which would bypass
+    // the fingerprint-stripping in prepareActionRes.
+    if (shouldStream && !(await settledSignatureValidation).success) {
+      shouldStream = false;
     }
 
     if (shouldStream) {
@@ -1563,14 +1600,7 @@ export class InngestCommHandler<
 
         const validationResult = await signatureValidation;
         if (!validationResult.success) {
-          return {
-            status: 401,
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: stringify(serializeError(validationResult.err)),
-            version: undefined,
-          };
+          return sigVerificationFailedResponse;
         }
 
         let fn: { fn: InngestFunction.Any; onFailure: boolean } | undefined;
@@ -1897,6 +1927,16 @@ export class InngestCommHandler<
       const env = (await getHeaders())[headerKeys.Environment] ?? null;
 
       if (method === "GET") {
+        // Cloud mode must not return introspection data without a valid
+        // signature. Dev mode short-circuits validation, so local tooling
+        // still gets the full body.
+        if (this.client.mode === "cloud") {
+          const validationResult = await signatureValidation;
+          if (!validationResult.success) {
+            return sigVerificationFailedResponse;
+          }
+        }
+
         return {
           status: 200,
           body: stringify(
@@ -1915,6 +1955,11 @@ export class InngestCommHandler<
       }
 
       if (method === "PUT") {
+        const sigCheck = await signatureValidation;
+        if (!sigCheck.success) {
+          return sigVerificationFailedResponse;
+        }
+
         const [deployId, inBandSyncRequested] = await Promise.all([
           actions
             .queryStringWithDefaults(
@@ -1961,24 +2006,6 @@ export class InngestCommHandler<
                   ),
                 ),
               ),
-              version: undefined,
-            };
-          }
-
-          // Validation can be successful if we're in dev mode and did not
-          // actually validate a key. In this case, also check that we did indeed
-          // use a particular key to validate.
-          const sigCheck = await signatureValidation;
-
-          if (!sigCheck.success) {
-            return {
-              status: 401,
-              body: stringify({
-                code: "sig_verification_failed",
-              }),
-              headers: {
-                "Content-Type": "application/json",
-              },
               version: undefined,
             };
           }
@@ -2062,10 +2089,11 @@ export class InngestCommHandler<
       status: 405,
       body: JSON.stringify({
         message: `No action found; expected POST, PUT, or GET but received "${method}"`,
-        mode: this.client.mode,
       }),
-      headers: {},
-      version: undefined,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      version: null,
     };
   }
 
@@ -2373,47 +2401,41 @@ export class InngestCommHandler<
       schema_version: "2024-05-24",
     } satisfies UnauthenticatedIntrospection;
 
-    // Only allow authenticated introspection in Cloud mode, since Dev mode skips
-    // signature validation
+    // Only return an authenticated body in Cloud mode. Dev mode skips
+    // signature validation, so we return the unauthenticated shape for local
+    // tooling. Cloud-mode callers must have validated the signature before
+    // reaching here (see the GET handler's 401 short-circuit).
     if (this.client.mode === "cloud") {
-      try {
-        const validationResult = await signatureValidation;
-        if (!validationResult.success) {
-          throw new Error("Signature validation failed");
-        }
-
-        introspection = {
-          ...introspection,
-          authentication_succeeded: true,
-          api_origin: this.client.apiBaseUrl,
-          app_id: this.client.id,
-          capabilities: {
-            trust_probe: "v1",
-            connect: "v1",
-          },
-          env,
-          event_api_origin: this.client.eventBaseUrl,
-          event_key_hash: this.hashedEventKey ?? null,
-          extra: {
-            ...introspection.extra,
-            is_streaming: await this.shouldStream(actions),
-            native_crypto: globalThis.crypto?.subtle ? true : false,
-          },
-          framework: this.frameworkName,
-          sdk_language: "js",
-          sdk_version: version,
-          serve_origin: this.serveOrigin ?? null,
-          serve_path: this.servePath ?? null,
-          signing_key_fallback_hash: this.hashedSigningKeyFallback ?? null,
-          signing_key_hash: this.hashedSigningKey ?? null,
-        } satisfies AuthenticatedIntrospection;
-      } catch {
-        // Swallow signature validation error since we'll just return the
-        // unauthenticated introspection
-        introspection = {
-          ...introspection,
-        } satisfies UnauthenticatedIntrospection;
+      const validationResult = await signatureValidation;
+      if (!validationResult.success) {
+        throw new Error("Signature validation failed");
       }
+
+      introspection = {
+        ...introspection,
+        authentication_succeeded: true,
+        api_origin: this.client.apiBaseUrl,
+        app_id: this.client.id,
+        capabilities: {
+          trust_probe: "v1",
+          connect: "v1",
+        },
+        env,
+        event_api_origin: this.client.eventBaseUrl,
+        event_key_hash: this.hashedEventKey ?? null,
+        extra: {
+          ...introspection.extra,
+          is_streaming: await this.shouldStream(actions),
+          native_crypto: globalThis.crypto?.subtle ? true : false,
+        },
+        framework: this.frameworkName,
+        sdk_language: "js",
+        sdk_version: version,
+        serve_origin: this.serveOrigin ?? null,
+        serve_path: this.servePath ?? null,
+        signing_key_fallback_hash: this.hashedSigningKeyFallback ?? null,
+        signing_key_hash: this.hashedSigningKey ?? null,
+      } satisfies AuthenticatedIntrospection;
     }
 
     return introspection;

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -80,9 +80,9 @@ const internalServerErrorResponse = {
   version: undefined,
 } as const;
 
-// `version: null` suppresses the RequestVersion header, and `prepareActionRes`
-// strips fingerprint headers from the final response so we don't leak
-// SDK/framework/platform info on unauthenticated responses.
+// `version: null` suppresses the RequestVersion header. Returned directly
+// (without running through prepareActionRes) so no fingerprint headers are
+// attached on unauthenticated responses.
 const sigVerificationFailedResponse = {
   body: stringify({ code: "sig_verification_failed" }),
   headers: { "Content-Type": "application/json" },
@@ -1177,12 +1177,19 @@ export class InngestCommHandler<
 
     const signatureValidation = this.validateSignature(signature, body);
 
-    // Non-throwing view of the same memoized promise for paths that must not
-    // surface a validation error as an uncaught rejection.
-    const settledSignatureValidation = signatureValidation.then(
-      (result) => result,
-      (err: Error) => ({ success: false as const, err }),
-    );
+    // Single auth gate for the whole request. validateSignature short-circuits
+    // to success in dev mode, so local tooling is unaffected. Treat a thrown
+    // error the same as a resolved failure.
+    const validationResult = await signatureValidation.catch((err: Error) => ({
+      success: false as const,
+      err,
+    }));
+    if (!validationResult.success) {
+      return actions.transformResponse(
+        "sending back response",
+        sigVerificationFailedResponse,
+      );
+    }
 
     // Create middleware instances once; shared by wrapRequest and execution hooks.
     // Starts with client-level middleware; function-level middleware is appended
@@ -1201,35 +1208,26 @@ export class InngestCommHandler<
     const prepareActionRes = async (
       res: ActionResponse,
     ): Promise<ActionResponse> => {
-      const sigResult = await settledSignatureValidation;
+      const headers: Record<string, string> = {
+        ...(await getHeaders()),
+        ...res.headers,
+        ...(res.version === null
+          ? {}
+          : {
+              [headerKeys.RequestVersion]: (
+                res.version ?? PREFERRED_ASYNC_EXECUTION_VERSION
+              ).toString(),
+            }),
+      };
 
-      // On unauthenticated responses, strip SDK/framework/platform headers so
-      // we don't leak fingerprint info. Dev mode short-circuits
-      // validateSignature to success, so the full header set still attaches
-      // for local tooling.
-      const headers: Record<string, string> = sigResult.success
-        ? {
-            ...(await getHeaders()),
-            ...res.headers,
-            ...(res.version === null
-              ? {}
-              : {
-                  [headerKeys.RequestVersion]: (
-                    res.version ?? PREFERRED_ASYNC_EXECUTION_VERSION
-                  ).toString(),
-                }),
-          }
-        : { ...res.headers };
-
-      if (sigResult.success && sigResult.keyUsed) {
+      const validation = await signatureValidation;
+      if (validation.success && validation.keyUsed) {
         try {
-          const signature = await this.getResponseSignature(
-            sigResult.keyUsed,
+          headers[headerKeys.Signature] = await this.getResponseSignature(
+            validation.keyUsed,
             res.body,
           );
-          headers[headerKeys.Signature] = signature;
         } catch (err) {
-          // If we fail to sign, return a 500 with the error.
           return {
             ...res,
             headers,
@@ -1239,10 +1237,7 @@ export class InngestCommHandler<
         }
       }
 
-      return {
-        ...res,
-        headers,
-      };
+      return { ...res, headers };
     };
 
     // Build the inner handler that wraps handleAction + prepareActionRes.
@@ -1256,7 +1251,6 @@ export class InngestCommHandler<
           timer,
           getHeaders,
           reqArgs: args,
-          signatureValidation,
           body,
           method,
           forceExecution: Boolean(forceExecution),
@@ -1357,13 +1351,6 @@ export class InngestCommHandler<
         body: stringify(serializeError(err)),
         version: undefined,
       });
-    }
-
-    // Don't start a streaming response before confirming authentication —
-    // streaming commits headers before the body resolves, which would bypass
-    // the fingerprint-stripping in prepareActionRes.
-    if (shouldStream && !(await settledSignatureValidation).success) {
-      shouldStream = false;
     }
 
     if (shouldStream) {
@@ -1545,7 +1532,6 @@ export class InngestCommHandler<
     timer,
     getHeaders,
     reqArgs,
-    signatureValidation,
     body: rawBody,
     method,
     forceExecution,
@@ -1556,7 +1542,6 @@ export class InngestCommHandler<
     timer: ServerTiming;
     getHeaders: () => Promise<Record<string, string>>;
     reqArgs: unknown[];
-    signatureValidation: ReturnType<InngestCommHandler["validateSignature"]>;
     body: unknown;
     method: string;
     forceExecution: boolean;
@@ -1596,11 +1581,6 @@ export class InngestCommHandler<
             ),
             version: undefined,
           };
-        }
-
-        const validationResult = await signatureValidation;
-        if (!validationResult.success) {
-          return sigVerificationFailedResponse;
         }
 
         let fn: { fn: InngestFunction.Any; onFailure: boolean } | undefined;
@@ -1927,23 +1907,12 @@ export class InngestCommHandler<
       const env = (await getHeaders())[headerKeys.Environment] ?? null;
 
       if (method === "GET") {
-        // Cloud mode must not return introspection data without a valid
-        // signature. Dev mode short-circuits validation, so local tooling
-        // still gets the full body.
-        if (this.client.mode === "cloud") {
-          const validationResult = await signatureValidation;
-          if (!validationResult.success) {
-            return sigVerificationFailedResponse;
-          }
-        }
-
         return {
           status: 200,
           body: stringify(
             await this.introspectionBody({
               actions,
               env,
-              signatureValidation,
               url,
             }),
           ),
@@ -1955,11 +1924,6 @@ export class InngestCommHandler<
       }
 
       if (method === "PUT") {
-        const sigCheck = await signatureValidation;
-        if (!sigCheck.success) {
-          return sigVerificationFailedResponse;
-        }
-
         const [deployId, inBandSyncRequested] = await Promise.all([
           actions
             .queryStringWithDefaults(
@@ -2034,7 +1998,6 @@ export class InngestCommHandler<
             actions,
             deployId,
             env,
-            signatureValidation,
             url,
           });
 
@@ -2314,7 +2277,6 @@ export class InngestCommHandler<
     actions,
     deployId,
     env,
-    signatureValidation,
     url,
   }: {
     actions: HandlerResponseWithErrors;
@@ -2326,7 +2288,6 @@ export class InngestCommHandler<
     deployId: string | undefined | null;
 
     env: string | null;
-    signatureValidation: ReturnType<InngestCommHandler["validateSignature"]>;
 
     url: URL;
   }): Promise<InBandRegisterRequest> {
@@ -2334,7 +2295,6 @@ export class InngestCommHandler<
     const introspectionBody = await this.introspectionBody({
       actions,
       env,
-      signatureValidation,
       url,
     });
 
@@ -2371,12 +2331,10 @@ export class InngestCommHandler<
   protected async introspectionBody({
     actions,
     env,
-    signatureValidation,
     url,
   }: {
     actions: HandlerResponseWithErrors;
     env: string | null;
-    signatureValidation: ReturnType<InngestCommHandler["validateSignature"]>;
     url: URL;
   }): Promise<UnauthenticatedIntrospection | AuthenticatedIntrospection> {
     const registerBody = this.registerBody({
@@ -2403,14 +2361,8 @@ export class InngestCommHandler<
 
     // Only return an authenticated body in Cloud mode. Dev mode skips
     // signature validation, so we return the unauthenticated shape for local
-    // tooling. Cloud-mode callers must have validated the signature before
-    // reaching here (see the GET handler's 401 short-circuit).
+    // tooling.
     if (this.client.mode === "cloud") {
-      const validationResult = await signatureValidation;
-      if (!validationResult.success) {
-        throw new Error("Signature validation failed");
-      }
-
       introspection = {
         ...introspection,
         authentication_succeeded: true,

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -583,7 +583,7 @@ export const testFramework = (
         );
       });
 
-      test("returns 500 at request time without signing key", async () => {
+      test("returns 401 at request time without signing key", async () => {
         await withoutEnvVars(
           [envKeys.InngestSigningKey, envKeys.InngestDevMode],
           async () => {
@@ -603,9 +603,9 @@ export const testFramework = (
                   ]);
 
             const res = await run(serveHandler, [{ method: "GET" }], {});
-            expect(res.status).toBe(500);
+            expect(res.status).toBe(401);
             expect(JSON.parse(res.body)).toEqual({
-              code: "internal_server_error",
+              code: "sig_verification_failed",
             });
           },
         );

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -231,11 +231,7 @@ export function createFnRunner(fn: InngestFunction.Any, opts?: RunFnOpts) {
  */
 export const testSigningKey = "signkey-test-12345";
 
-/**
- * Build a valid `x-inngest-signature` header for a test request. Body
- * defaults to the empty-string form used by bodyless PUT/GET (see
- * `InngestCommHandler` body-for-signing logic).
- */
+/** Build an `x-inngest-signature` header value. Body defaults to `""`. */
 export const makeTestSignature = async (
   body: unknown = "",
   signingKey: string = testSigningKey,
@@ -248,6 +244,27 @@ export const makeTestSignature = async (
     new ConsoleLogger({ level: "silent" }),
   );
   return `t=${ts}&s=${sig}`;
+};
+
+const fingerprintHeaderKeys = [
+  headerKeys.SdkVersion,
+  headerKeys.Framework,
+  headerKeys.Platform,
+  headerKeys.Environment,
+  headerKeys.InngestExpectedServerKind,
+  headerKeys.RequestVersion,
+  "user-agent",
+] as const;
+
+/** Assert that no SDK-fingerprint headers leaked onto a response. */
+export const expectNoFingerprintHeaders = (
+  headers: Record<string, unknown> | Headers,
+): void => {
+  const get = (key: string) =>
+    headers instanceof Headers ? headers.get(key) : headers[key.toLowerCase()];
+  for (const key of fingerprintHeaderKeys) {
+    expect(get(key)).toBeFalsy();
+  }
 };
 
 /**
@@ -716,8 +733,6 @@ export const testFramework = (
       });
 
       test("returns 401 if signature validation fails", async () => {
-        // Cloud-mode GET without a valid signature must not leak
-        // introspection data.
         const ret = await run(
           [
             {
@@ -1397,15 +1412,10 @@ export const testFramework = (
           nock.cleanAll();
         });
 
-        // Cloud-mode PUT requires a valid signature; dev-mode
-        // short-circuits validation, so out-of-band sync still runs there.
-        const expectedOutOfBand = (
-          sdkMode: serverKind,
-          validSignature: boolean | undefined,
-        ): syncKind | 401 =>
-          sdkMode === serverKind.Cloud && validSignature !== true
-            ? 401
-            : syncKind.OutOfBand;
+        // Out-of-band PUT bypasses the auth gate so unsigned CI/CD callers
+        // can still sync; security comes from the outgoing register POST.
+        // Every case in this block resolves to OutOfBand regardless of
+        // signature or mode.
 
         // Always perform out-of-band syncs if the env var is falsey
         describe("env var disallow", () => {
@@ -1414,7 +1424,7 @@ export const testFramework = (
               [undefined, ...Object.values(syncKind)].forEach(
                 (requestedSyncKind) => {
                   [undefined, false, true].forEach((validSignature) => {
-                    expectResponse(expectedOutOfBand(sdkMode, validSignature), {
+                    expectResponse(syncKind.OutOfBand, {
                       serverMode,
                       sdkMode,
                       requestedSyncKind,
@@ -1433,7 +1443,7 @@ export const testFramework = (
             Object.values(serverKind).forEach((sdkMode) => {
               [undefined, false, true].forEach((validSignature) => {
                 [undefined, true].forEach((allowInBandSync) => {
-                  expectResponse(expectedOutOfBand(sdkMode, validSignature), {
+                  expectResponse(syncKind.OutOfBand, {
                     serverMode,
                     sdkMode,
                     requestedSyncKind: undefined,
@@ -1452,7 +1462,7 @@ export const testFramework = (
             Object.values(serverKind).forEach((sdkMode) => {
               [undefined, false, true].forEach((validSignature) => {
                 [undefined, true].forEach((allowInBandSync) => {
-                  expectResponse(expectedOutOfBand(sdkMode, validSignature), {
+                  expectResponse(syncKind.OutOfBand, {
                     serverMode,
                     sdkMode,
                     requestedSyncKind: syncKind.OutOfBand,
@@ -1525,10 +1535,8 @@ export const testFramework = (
             Object.values(serverKind).forEach((serverMode) => {
               Object.values(serverKind).forEach((sdkMode) => {
                 [undefined, true].forEach((allowInBandSync) => {
-                  // Cloud-mode runs signature validation before the
-                  // missing-body check, so a forced empty body fails sig (401)
-                  // before reaching the 500 missing-body path. Dev-mode
-                  // short-circuits validation, so the 500 path still fires.
+                  // Cloud auth runs before the missing-body check, so an
+                  // empty body 401s before reaching the 500. Dev skips auth.
                   expectResponse(sdkMode === serverKind.Dev ? 500 : 401, {
                     actionOverrides: { body: () => undefined },
                     serverMode,

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -232,6 +232,25 @@ export function createFnRunner(fn: InngestFunction.Any, opts?: RunFnOpts) {
 export const testSigningKey = "signkey-test-12345";
 
 /**
+ * Build a valid `x-inngest-signature` header for a test request. Body
+ * defaults to the empty-string form used by bodyless PUT/GET (see
+ * `InngestCommHandler` body-for-signing logic).
+ */
+export const makeTestSignature = async (
+  body: unknown = "",
+  signingKey: string = testSigningKey,
+  ts: string = Date.now().toString(),
+): Promise<string> => {
+  const sig = await signDataWithKey(
+    body,
+    signingKey,
+    ts,
+    new ConsoleLogger({ level: "silent" }),
+  );
+  return `t=${ts}&s=${sig}`;
+};
+
+/**
  * Dev mode test client for most tests.
  * Uses isDev: true so no signing key is required.
  */
@@ -638,10 +657,24 @@ export const testFramework = (
 
           // At request time, env vars become available
           // Cloud mode (default) requires signing key at request time
-          const ret = await run(edgeHandler, [{ method: "GET" }], {
-            [envKeys.InngestEventKey]: "event-key-123",
-            [envKeys.InngestSigningKey]: "signing-key-123",
-          });
+          const ret = await run(
+            edgeHandler,
+            [
+              {
+                method: "GET",
+                headers: {
+                  [headerKeys.Signature]: await makeTestSignature(
+                    "",
+                    "signing-key-123",
+                  ),
+                },
+              },
+            ],
+            {
+              [envKeys.InngestEventKey]: "event-key-123",
+              [envKeys.InngestSigningKey]: "signing-key-123",
+            },
+          );
 
           const body = JSON.parse(ret.body);
 
@@ -654,9 +687,23 @@ export const testFramework = (
           // Simulate edge: handler created with empty process.env
           const edgeHandler = createEdgeHandler();
 
-          const ret = await run(edgeHandler, [{ method: "GET" }], {
-            [envKeys.InngestSigningKey]: "signing-key-123",
-          });
+          const ret = await run(
+            edgeHandler,
+            [
+              {
+                method: "GET",
+                headers: {
+                  [headerKeys.Signature]: await makeTestSignature(
+                    "",
+                    "signing-key-123",
+                  ),
+                },
+              },
+            ],
+            {
+              [envKeys.InngestSigningKey]: "signing-key-123",
+            },
+          );
 
           expect(ret.status).toEqual(200);
 
@@ -668,8 +715,9 @@ export const testFramework = (
         });
       });
 
-      test("#690 returns 200 if signature validation fails", async () => {
-        // Pass signingKey via env for cloud mode
+      test("returns 401 if signature validation fails", async () => {
+        // Cloud-mode GET without a valid signature must not leak
+        // introspection data.
         const ret = await run(
           [
             {
@@ -681,12 +729,9 @@ export const testFramework = (
           { [envKeys.InngestSigningKey]: "signing-key-123" },
         );
 
-        expect(ret.status).toEqual(200);
-
-        const body = JSON.parse(ret.body);
-
-        expect(body).toMatchObject({
-          has_signing_key: true,
+        expect(ret.status).toEqual(401);
+        expect(JSON.parse(ret.body)).toEqual({
+          code: "sig_verification_failed",
         });
       });
     });
@@ -720,6 +765,7 @@ export const testFramework = (
                   url: "/api/inngest",
                   headers: {
                     [headerKeys.InngestServerKind]: serverKind.Dev,
+                    [headerKeys.Signature]: await makeTestSignature(),
                   },
                 },
               ],
@@ -766,6 +812,7 @@ export const testFramework = (
                   method: "PUT",
                   headers: {
                     [headerKeys.InngestServerKind]: serverKind.Dev,
+                    [headerKeys.Signature]: await makeTestSignature(),
                   },
                 },
               ],
@@ -810,6 +857,7 @@ export const testFramework = (
                   url: customUrl,
                   headers: {
                     [headerKeys.InngestServerKind]: serverKind.Dev,
+                    [headerKeys.Signature]: await makeTestSignature(),
                   },
                 },
               ],
@@ -867,7 +915,14 @@ export const testFramework = (
                   serveOrigin,
                 },
               ],
-              [{ method: "PUT" }],
+              [
+                {
+                  method: "PUT",
+                  headers: {
+                    [headerKeys.Signature]: await makeTestSignature(),
+                  },
+                },
+              ],
               { [envKeys.InngestSigningKey]: testSigningKey },
             );
 
@@ -915,7 +970,14 @@ export const testFramework = (
                   servePath,
                 },
               ],
-              [{ method: "PUT" }],
+              [
+                {
+                  method: "PUT",
+                  headers: {
+                    [headerKeys.Signature]: await makeTestSignature(),
+                  },
+                },
+              ],
               { [envKeys.InngestSigningKey]: testSigningKey },
             );
 
@@ -957,6 +1019,7 @@ export const testFramework = (
                   method: "PUT",
                   headers: {
                     [headerKeys.InngestServerKind]: serverKind.Dev,
+                    [headerKeys.Signature]: await makeTestSignature(),
                   },
                 },
               ],
@@ -1003,7 +1066,14 @@ export const testFramework = (
                 servePath,
               },
             ],
-            [{ method: "PUT" }],
+            [
+              {
+                method: "PUT",
+                headers: {
+                  [headerKeys.Signature]: await makeTestSignature(),
+                },
+              },
+            ],
             { [envKeys.InngestSigningKey]: testSigningKey },
           );
 
@@ -1051,7 +1121,14 @@ export const testFramework = (
                 functions: [fn1],
               },
             ],
-            [{ method: "PUT" }],
+            [
+              {
+                method: "PUT",
+                headers: {
+                  [headerKeys.Signature]: await makeTestSignature(),
+                },
+              },
+            ],
             {
               [envKeys.InngestSigningKey]: testSigningKey,
               [envKeys.InngestServeOrigin]: serveOrigin,
@@ -1102,7 +1179,14 @@ export const testFramework = (
                 functions: [fn1],
               },
             ],
-            [{ method: "PUT" }],
+            [
+              {
+                method: "PUT",
+                headers: {
+                  [headerKeys.Signature]: await makeTestSignature(),
+                },
+              },
+            ],
             {
               [envKeys.InngestSigningKey]: testSigningKey,
               [envKeys.InngestServeHost]: serveHost,
@@ -1170,6 +1254,9 @@ export const testFramework = (
                   url: `/api/inngest${
                     deployId ? `?${queryKeys.DeployId}=${deployId}` : ""
                   }`,
+                  headers: {
+                    [headerKeys.Signature]: await makeTestSignature(),
+                  },
                 },
               ]);
 
@@ -1250,10 +1337,9 @@ export const testFramework = (
             const edgeHandler = createEdgeHandler();
             const signingKey = "123";
             const body = { url: "https://example.com/api/inngest" };
-            const ts = Date.now().toString();
 
             const signature = validSignature
-              ? `t=${ts}&s=${await signDataWithKey(body, signingKey, ts, new ConsoleLogger({ level: "silent" }))}`
+              ? await makeTestSignature(body, signingKey)
               : validSignature === false
                 ? "INVALID"
                 : undefined;
@@ -1311,6 +1397,16 @@ export const testFramework = (
           nock.cleanAll();
         });
 
+        // Cloud-mode PUT requires a valid signature; dev-mode
+        // short-circuits validation, so out-of-band sync still runs there.
+        const expectedOutOfBand = (
+          sdkMode: serverKind,
+          validSignature: boolean | undefined,
+        ): syncKind | 401 =>
+          sdkMode === serverKind.Cloud && validSignature !== true
+            ? 401
+            : syncKind.OutOfBand;
+
         // Always perform out-of-band syncs if the env var is falsey
         describe("env var disallow", () => {
           Object.values(serverKind).forEach((serverMode) => {
@@ -1318,7 +1414,7 @@ export const testFramework = (
               [undefined, ...Object.values(syncKind)].forEach(
                 (requestedSyncKind) => {
                   [undefined, false, true].forEach((validSignature) => {
-                    expectResponse(syncKind.OutOfBand, {
+                    expectResponse(expectedOutOfBand(sdkMode, validSignature), {
                       serverMode,
                       sdkMode,
                       requestedSyncKind,
@@ -1337,7 +1433,7 @@ export const testFramework = (
             Object.values(serverKind).forEach((sdkMode) => {
               [undefined, false, true].forEach((validSignature) => {
                 [undefined, true].forEach((allowInBandSync) => {
-                  expectResponse(syncKind.OutOfBand, {
+                  expectResponse(expectedOutOfBand(sdkMode, validSignature), {
                     serverMode,
                     sdkMode,
                     requestedSyncKind: undefined,
@@ -1356,7 +1452,7 @@ export const testFramework = (
             Object.values(serverKind).forEach((sdkMode) => {
               [undefined, false, true].forEach((validSignature) => {
                 [undefined, true].forEach((allowInBandSync) => {
-                  expectResponse(syncKind.OutOfBand, {
+                  expectResponse(expectedOutOfBand(sdkMode, validSignature), {
                     serverMode,
                     sdkMode,
                     requestedSyncKind: syncKind.OutOfBand,
@@ -1429,7 +1525,11 @@ export const testFramework = (
             Object.values(serverKind).forEach((serverMode) => {
               Object.values(serverKind).forEach((sdkMode) => {
                 [undefined, true].forEach((allowInBandSync) => {
-                  expectResponse(500, {
+                  // Cloud-mode runs signature validation before the
+                  // missing-body check, so a forced empty body fails sig (401)
+                  // before reaching the 500 missing-body path. Dev-mode
+                  // short-circuits validation, so the 500 path still fires.
+                  expectResponse(sdkMode === serverKind.Dev ? 500 : 401, {
                     actionOverrides: { body: () => undefined },
                     serverMode,
                     sdkMode,
@@ -1487,33 +1587,29 @@ export const testFramework = (
           ENVIRONMENT: "production",
           INNGEST_DEV: "0",
         };
-        test("should throw an error in prod with no signature", async () => {
+        test("should return 401 in prod with no signature", async () => {
           const ret = await run(
             [{ client, functions: [fn] }],
             [{ method: "POST", headers: {} }],
             { ...env, [envKeys.InngestSigningKey]: "test" },
           );
           expect(ret.status).toEqual(401);
-          expect(JSON.parse(ret.body)).toMatchObject({
-            message: expect.stringContaining(
-              `No ${headerKeys.Signature} provided`,
-            ),
+          expect(JSON.parse(ret.body)).toEqual({
+            code: "sig_verification_failed",
           });
         });
-        test("should throw an error with an invalid signature", async () => {
+        test("should return 401 with an invalid signature", async () => {
           const ret = await run(
             [{ client, functions: [fn] }],
             [{ method: "POST", headers: { [headerKeys.Signature]: "t=&s=" } }],
             { ...env, [envKeys.InngestSigningKey]: "test" },
           );
           expect(ret.status).toEqual(401);
-          expect(JSON.parse(ret.body)).toMatchObject({
-            message: expect.stringContaining(
-              `Invalid ${headerKeys.Signature} provided`,
-            ),
+          expect(JSON.parse(ret.body)).toEqual({
+            code: "sig_verification_failed",
           });
         });
-        test("should throw an error with an expired signature", async () => {
+        test("should return 401 with an expired signature", async () => {
           const yesterday = new Date();
           yesterday.setDate(yesterday.getDate() - 1);
           const ret = await run(
@@ -1532,9 +1628,9 @@ export const testFramework = (
             ],
             { ...env, [envKeys.InngestSigningKey]: testSigningKey },
           );
-          expect(ret).toMatchObject({
-            status: 401,
-            body: expect.stringContaining("Signature has expired"),
+          expect(ret.status).toEqual(401);
+          expect(JSON.parse(ret.body)).toEqual({
+            code: "sig_verification_failed",
           });
         });
         // These signatures are randomly generated within a local development environment, matching
@@ -1703,9 +1799,9 @@ export const testFramework = (
                 [envKeys.InngestSigningKeyFallback]: "another-fake",
               },
             );
-            expect(ret).toMatchObject({
-              status: 401,
-              body: expect.stringContaining("Invalid signature"),
+            expect(ret.status).toEqual(401);
+            expect(JSON.parse(ret.body)).toEqual({
+              code: "sig_verification_failed",
             });
           });
         });

--- a/packages/inngest/src/test/integration/noSigningKey.test.ts
+++ b/packages/inngest/src/test/integration/noSigningKey.test.ts
@@ -3,6 +3,7 @@ import { randomSuffix, testNameFromFileUrl } from "@inngest/test-harness";
 import { afterEach, expect, test } from "vitest";
 import { Inngest } from "../../index.ts";
 import { createServer } from "../../node.ts";
+import { expectNoFingerprintHeaders } from "../helpers.ts";
 
 const testFileName = testNameFromFileUrl(import.meta.url);
 
@@ -59,17 +60,18 @@ test("serve() does not throw without a signing key in cloud mode", async () => {
   expect(url).toBeDefined();
 });
 
-test("GET returns 500 without a signing key in cloud mode", async () => {
+test("GET returns 401 without a signing key in cloud mode", async () => {
   const url = await startCloudServerWithoutSigningKey();
 
   const res = await fetch(url);
 
-  expect(res.status).toBe(500);
+  expect(res.status).toBe(401);
   const body = await res.json();
-  expect(body).toEqual({ code: "internal_server_error" });
+  expect(body).toEqual({ code: "sig_verification_failed" });
+  expectNoFingerprintHeaders(res.headers);
 });
 
-test("POST returns 500 without a signing key in cloud mode", async () => {
+test("POST returns 401 without a signing key in cloud mode", async () => {
   const url = await startCloudServerWithoutSigningKey();
 
   const res = await fetch(url, {
@@ -78,12 +80,15 @@ test("POST returns 500 without a signing key in cloud mode", async () => {
     body: JSON.stringify({}),
   });
 
-  expect(res.status).toBe(500);
+  expect(res.status).toBe(401);
   const body = await res.json();
-  expect(body).toEqual({ code: "internal_server_error" });
+  expect(body).toEqual({ code: "sig_verification_failed" });
+  expectNoFingerprintHeaders(res.headers);
 });
 
 test("PUT returns 500 without a signing key in cloud mode", async () => {
+  // Out-of-band PUT bypasses auth and hits the misconfig 500. Must not
+  // leak fingerprint headers either.
   const url = await startCloudServerWithoutSigningKey();
 
   const res = await fetch(url, { method: "PUT" });
@@ -91,4 +96,5 @@ test("PUT returns 500 without a signing key in cloud mode", async () => {
   expect(res.status).toBe(500);
   const body = await res.json();
   expect(body).toEqual({ code: "internal_server_error" });
+  expectNoFingerprintHeaders(res.headers);
 });


### PR DESCRIPTION
## Summary
Make every request in the SDK authenticated

## Checklist

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
[EXE-1677: Make every request in the SDK authenticated](https://linear.app/inngest/issue/EXE-1677/make-every-request-in-the-sdk-authenticated)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Centralizes SDK authentication into a single gate at the top of `handleAsyncRequest`, applied uniformly to GET/POST/PUT (with an exception for out-of-band PUT which is unsigned by design). Tightens 401 responses to suppress SDK fingerprint headers and introspection fields. Extracts `isInBandSyncRequested` as a reusable private method.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 660f09cd713a01e9622492236addecf0b9fc6a9a.</sup>
<!-- /MENDRAL_SUMMARY -->