### PR TITLE
Whitelist env vars that are stored in memory

### DIFF
--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -16,6 +16,7 @@ import {
   type Mode,
   normalizeUrl,
   parseAsBoolean,
+  protectEnv,
 } from "../helpers/env.ts";
 import { type ErrCode, fixEventKeyMissingSteps } from "../helpers/errors.ts";
 import type { Jsonify } from "../helpers/jsonify.ts";
@@ -324,7 +325,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     }
 
     this.id = id;
-    this._env = { ...getProcessEnv() };
+    this._env = protectEnv({ ...getProcessEnv() });
     this._userProvidedFetch = options.fetch;
 
     this.inngestApi = new InngestApi({
@@ -368,7 +369,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
   public setEnvVars(
     env: Record<string, string | undefined> = getProcessEnv(),
   ): this {
-    this._env = { ...this._env, ...env };
+    this._env = protectEnv({ ...this._env, ...env });
 
     return this;
   }

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -9,9 +9,9 @@ import {
 } from "../helpers/consts.ts";
 import { createEntropy } from "../helpers/crypto.ts";
 import {
-  allProcessEnv,
   type Env,
   getFetch,
+  getProcessEnv,
   inngestHeaders,
   type Mode,
   normalizeUrl,
@@ -324,7 +324,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     }
 
     this.id = id;
-    this._env = { ...allProcessEnv() };
+    this._env = { ...getProcessEnv() };
     this._userProvidedFetch = options.fetch;
 
     this.inngestApi = new InngestApi({
@@ -366,7 +366,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
    * update the client with those values as requests come in.
    */
   public setEnvVars(
-    env: Record<string, string | undefined> = allProcessEnv(),
+    env: Record<string, string | undefined> = getProcessEnv(),
   ): this {
     this._env = { ...this._env, ...env };
 

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -13,12 +13,13 @@ import {
 } from "../helpers/consts.ts";
 import { enumFromValue } from "../helpers/enum.ts";
 import {
-  allProcessEnv,
   checkModeConfiguration,
   type Env,
   getPlatformName,
+  getProcessEnv,
   inngestHeaders,
   parseAsBoolean,
+  protectEnv,
 } from "../helpers/env.ts";
 import { rethrowError, serializeError } from "../helpers/errors.ts";
 import {
@@ -422,7 +423,7 @@ export class InngestCommHandler<
     { fn: InngestFunction.Any; onFailure: boolean }
   > = {};
 
-  private env: Env = allProcessEnv();
+  private env: Env = getProcessEnv();
 
   private allowExpiredSignatures: boolean;
 
@@ -703,7 +704,7 @@ export class InngestCommHandler<
     // `process.env`; some platforms may not provide all the necessary
     // environment variables or may use two sources.
     // Update both handler's env and client's env to ensure consistency.
-    this.env = { ...allProcessEnv(), ...env };
+    this.env = protectEnv({ ...getProcessEnv(), ...env });
     this.client.setEnvVars(this.env);
 
     const headerPromises = forwardedHeaders.map(async (header) => {
@@ -2324,7 +2325,7 @@ export class InngestCommHandler<
       functions: registerBody.functions,
       inspection: introspectionBody,
       platform: getPlatformName({
-        ...allProcessEnv(),
+        ...getProcessEnv(),
         ...this.env,
       }),
       sdk_author: "inngest",

--- a/packages/inngest/src/components/connect/config.ts
+++ b/packages/inngest/src/components/connect/config.ts
@@ -7,7 +7,7 @@
  */
 
 import { envKeys, headerKeys, queryKeys } from "../../helpers/consts.ts";
-import { allProcessEnv, getEnvironmentName } from "../../helpers/env.ts";
+import { getEnvironmentName } from "../../helpers/env.ts";
 import { parseFnData } from "../../helpers/functions.ts";
 import { hashSigningKey } from "../../helpers/strings.ts";
 import {

--- a/packages/inngest/src/components/connect/index.ts
+++ b/packages/inngest/src/components/connect/index.ts
@@ -1,5 +1,5 @@
 import { envKeys } from "../../helpers/consts.ts";
-import { allProcessEnv } from "../../helpers/env.ts";
+import { getProcessEnv } from "../../helpers/env.ts";
 import { type Inngest, internalLoggerSymbol } from "../Inngest.ts";
 import { prepareConnectionConfig } from "./config.ts";
 import { type ConnectionStrategy, createStrategy } from "./strategies/index.ts";
@@ -54,7 +54,7 @@ class WebSocketWorkerConnection implements WorkerConnection {
       options.handleShutdownSignals = DEFAULT_SHUTDOWN_SIGNALS;
     }
 
-    const env = allProcessEnv();
+    const env = getProcessEnv();
 
     if (options.maxWorkerConcurrency === undefined) {
       const envValue = env[envKeys.InngestConnectMaxWorkerConcurrency];

--- a/packages/inngest/src/components/connect/strategies/core/handshake.ts
+++ b/packages/inngest/src/components/connect/strategies/core/handshake.ts
@@ -8,7 +8,7 @@
 
 import ms from "ms";
 import { headerKeys } from "../../../../helpers/consts.ts";
-import { allProcessEnv, getPlatformName } from "../../../../helpers/env.ts";
+import { getPlatformName, getProcessEnv } from "../../../../helpers/env.ts";
 import { resolveApiBaseUrl } from "../../../../helpers/url.ts";
 import type { Logger } from "../../../../middleware/logger.ts";
 import {
@@ -243,7 +243,7 @@ export async function establishConnection(
       const workerConnectRequestMsg = WorkerConnectRequestData.create({
         connectionId: startResp.connectionId,
         environment: config.envName,
-        platform: getPlatformName({ ...allProcessEnv() }),
+        platform: getPlatformName({ ...getProcessEnv() }),
         sdkVersion: `v${version}`,
         sdkLanguage: "typescript",
         framework: "connect",

--- a/packages/inngest/src/h3.ts
+++ b/packages/inngest/src/h3.ts
@@ -40,6 +40,7 @@ import {
   InngestCommHandler,
   type ServeHandlerOptions,
 } from "./components/InngestCommHandler.ts";
+import { envKeys } from "./helpers/consts.ts";
 import { processEnv } from "./helpers/env.ts";
 import type { SupportedFrameworkName } from "./types.ts";
 
@@ -91,7 +92,7 @@ export const serve = (
         method: () => event.method,
         url: () => {
           let scheme = "https";
-          if ((processEnv("NODE_ENV") ?? "dev").startsWith("dev")) {
+          if ((processEnv(envKeys.NodeEnv) ?? "dev").startsWith("dev")) {
             scheme = "http";
           }
 

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -113,6 +113,35 @@ export enum envKeys {
 
   VercelEnvKey = "VERCEL_ENV",
 
+  /**
+   * Standard Node.js environment indicator (e.g. `"production"`, `"development"`,
+   * `"test"`). Read by some framework adapters to choose the request scheme,
+   * and by prod-mode inference.
+   */
+  NodeEnv = "NODE_ENV",
+
+  /**
+   * Netlify's deploy context (e.g. `"production"`, `"deploy-preview"`). Used
+   * for prod-mode inference.
+   *
+   * {@link https://docs.netlify.com/configure-builds/environment-variables/#build-metadata}
+   */
+  Context = "CONTEXT",
+
+  /**
+   * Generic environment name used by some platforms to indicate prod vs
+   * non-prod (e.g. `"production"`).
+   */
+  Environment = "ENVIRONMENT",
+
+  /**
+   * Set by Deno Deploy. Its presence indicates a Deno Deploy environment,
+   * which we treat as prod.
+   *
+   * {@link https://docs.deno.com/deploy/manual/environment-variables/}
+   */
+  DenoDeployment = "DENO_DEPLOYMENT_ID",
+
   OpenAiApiKey = "OPENAI_API_KEY",
   GeminiApiKey = "GEMINI_API_KEY",
   AnthropicApiKey = "ANTHROPIC_API_KEY",

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -145,6 +145,16 @@ export enum envKeys {
   OpenAiApiKey = "OPENAI_API_KEY",
   GeminiApiKey = "GEMINI_API_KEY",
   AnthropicApiKey = "ANTHROPIC_API_KEY",
+
+  /**
+   * Framework-prefixed variants of Inngest env vars. CRA's `REACT_APP_` and
+   * Next's `NEXT_PUBLIC_` prefixes expose env vars to bundled client code, so
+   * we accept the prefixed forms in addition to the canonical names.
+   */
+  ReactAppInngestBaseUrl = "REACT_APP_INNGEST_BASE_URL",
+  ReactAppInngestDevMode = "REACT_APP_INNGEST_DEV",
+  NextPublicInngestBaseUrl = "NEXT_PUBLIC_INNGEST_BASE_URL",
+  NextPublicInngestDevMode = "NEXT_PUBLIC_INNGEST_DEV",
 }
 
 /**

--- a/packages/inngest/src/helpers/env.test.ts
+++ b/packages/inngest/src/helpers/env.test.ts
@@ -1,4 +1,41 @@
-import { parseAsBoolean } from "./env.ts";
+import { afterEach, vi } from "vitest";
+import { getProcessEnv, parseAsBoolean, processEnv } from "./env.ts";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test("getProcessEnv", () => {
+  vi.stubEnv("FOO", "bar");
+  vi.stubEnv("INNGEST_SIGNING_KEY", "test");
+  const env = getProcessEnv();
+
+  // Included a whitelisted env var
+  expect(env.INNGEST_SIGNING_KEY).toBe("test");
+
+  // Did not include a non-whitelisted env var
+  expect(env.FOO).toBeUndefined();
+});
+
+test("getProcessEnv result does not leak values via JSON.stringify", () => {
+  vi.stubEnv("INNGEST_SIGNING_KEY", "signkey-test");
+  const env = getProcessEnv();
+
+  expect(env.INNGEST_SIGNING_KEY).toBe("signkey-test");
+  expect(JSON.stringify(env)).toBe("{}");
+  expect(JSON.stringify({ env })).toBe('{"env":{}}');
+
+  // Protection carries through spreading since the `toJSON` method is
+  // enumerable
+  expect(JSON.stringify({ ...env })).toBe("{}");
+});
+
+test("processEnv errors on unknown key", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: intentional
+  expect(() => processEnv("UNKNOWN_KEY" as any)).toThrow(
+    "Unknown env var: UNKNOWN_KEY",
+  );
+});
 
 describe("parseAsBoolean", () => {
   const specs: { input: unknown; expected: boolean | undefined }[] = [

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -27,7 +27,7 @@ export type EnvValue = string | undefined;
  *
  * @example devServerHost()
  */
-export const devServerHost = (env: Env = allProcessEnv()): EnvValue => {
+export const devServerHost = (env: Env = getProcessEnv()): EnvValue => {
   // devServerKeys are the env keys we search for to discover the dev server
   // URL.  This includes the standard key first, then includes prefixed keys
   // for use within common frameworks (eg. CRA, next).
@@ -103,7 +103,7 @@ export const normalizeUrl = (
  * This could be used to determine if we're on a branch deploy or not, though it
  * should be noted that we don't know if this is the default branch or not.
  */
-export const getEnvironmentName = (env: Env = allProcessEnv()): EnvValue => {
+export const getEnvironmentName = (env: Env = getProcessEnv()): EnvValue => {
   /**
    * Order is important; more than one of these env vars may be set, so ensure
    * that we check the most specific, most reliable env vars first.
@@ -119,8 +119,12 @@ export const getEnvironmentName = (env: Env = allProcessEnv()): EnvValue => {
   );
 };
 
-export const processEnv = (key: string): EnvValue => {
-  return allProcessEnv()[key];
+export const processEnv = (key: envKeys): EnvValue => {
+  if (!Object.values(envKeys).includes(key)) {
+    throw new Error(`Unknown env var: ${key}`);
+  }
+
+  return getProcessEnv()[key];
 };
 
 /**
@@ -138,6 +142,45 @@ declare const Netlify: {
 };
 
 /**
+ * Get the current process env vars. Only includes env vars that we care about.
+ *
+ * Returns an empty object if they can't be read.
+ */
+export function getProcessEnv(): Env {
+  const env: Env = {};
+  const whitelist: string[] = Object.values(envKeys);
+
+  for (const [k, v] of Object.entries(allProcessEnv())) {
+    if (!whitelist.includes(k)) {
+      continue;
+    }
+    env[k] = v;
+  }
+
+  return protectEnv(env);
+}
+
+/**
+ * Install a `toJSON` that returns `{}` so env var values can't leak via
+ * `JSON.stringify`, regardless of where the object is reachable from. The
+ * property is enumerable so it survives spreads (e.g. `{...env}`) which carries
+ * the protection into the new object. But note that the enumerability also
+ * means the static type is technically incorrect.
+ *
+ * Callers still read values via normal `env[key]` access.
+ */
+export function protectEnv(env: Env): Env {
+  return {
+    ...env,
+
+    // @ts-expect-error - intentional
+    toJSON: () => {
+      return {};
+    },
+  };
+}
+
+/**
  * allProcessEnv returns the current process environment variables, or an empty
  * object if they cannot be read, making sure we support environments other than
  * Node such as Deno, too.
@@ -145,7 +188,7 @@ declare const Netlify: {
  * Using this ensures we don't dangerously access `process.env` in environments
  * where it may not be defined, such as Deno or the browser.
  */
-export const allProcessEnv = (): Env => {
+const allProcessEnv = (): Env => {
   // Node, or Node-like environments
   try {
     if (process.env) {
@@ -241,7 +284,7 @@ export const inngestHeaders = (opts?: {
   }
 
   const env = {
-    ...allProcessEnv(),
+    ...getProcessEnv(),
     ...opts?.env,
   };
 
@@ -329,7 +372,7 @@ export const getPlatformName = (env: Env) => {
  */
 export const platformSupportsStreaming = (
   framework: SupportedFrameworkName,
-  env: Env = allProcessEnv(),
+  env: Env = getProcessEnv(),
 ): boolean => {
   return (
     streamingChecks[getPlatformName(env) as keyof typeof streamingChecks]?.(

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -28,21 +28,17 @@ export type EnvValue = string | undefined;
  * @example devServerHost()
  */
 export const devServerHost = (env: Env = getProcessEnv()): EnvValue => {
-  // devServerKeys are the env keys we search for to discover the dev server
-  // URL.  This includes the standard key first, then includes prefixed keys
-  // for use within common frameworks (eg. CRA, next).
-  //
-  // We have to fully write these using process.env as they're typically
-  // processed using webpack's DefinePlugin, which is dumb and does a straight
-  // text replacement instead of actually understanding the AST, despite webpack
-  // being fully capable of understanding the AST.
-  const prefixes = ["REACT_APP_", "NEXT_PUBLIC_"];
-  const keys = [envKeys.InngestBaseUrl, envKeys.InngestDevMode];
-
-  const values = keys.flatMap((key) => {
-    return prefixes.map((prefix) => {
-      return env[prefix + key];
-    });
+  // The prefixed keys we look up for common frameworks (CRA, Next). The
+  // unprefixed `INNGEST_BASE_URL` / `INNGEST_DEV` are read directly by the
+  // Inngest client elsewhere, so we only check the prefixed variants here.
+  const keys = [
+    envKeys.ReactAppInngestBaseUrl,
+    envKeys.NextPublicInngestBaseUrl,
+    envKeys.ReactAppInngestDevMode,
+    envKeys.NextPublicInngestDevMode,
+  ];
+  const values = keys.map((key) => {
+    return env[key];
   });
 
   return values.find((v) => {

--- a/packages/inngest/src/redwood.ts
+++ b/packages/inngest/src/redwood.ts
@@ -26,6 +26,7 @@ import {
   InngestCommHandler,
   type ServeHandlerOptions,
 } from "./components/InngestCommHandler.ts";
+import { envKeys } from "./helpers/consts.ts";
 import { processEnv } from "./helpers/env.ts";
 import type { SupportedFrameworkName } from "./types.ts";
 
@@ -85,7 +86,7 @@ export const serve = (
         method: () => event.httpMethod,
         url: () => {
           const scheme =
-            processEnv("NODE_ENV") === "development" ? "http" : "https";
+            processEnv(envKeys.NodeEnv) === "development" ? "http" : "https";
           const url = new URL(
             event.path,
             `${scheme}://${event.headers.host || ""}`,

--- a/packages/inngest/src/sveltekit.ts
+++ b/packages/inngest/src/sveltekit.ts
@@ -26,6 +26,7 @@ import {
   InngestCommHandler,
   type ServeHandlerOptions,
 } from "./components/InngestCommHandler.ts";
+import { envKeys } from "./helpers/consts.ts";
 import { processEnv } from "./helpers/env.ts";
 import type { SupportedFrameworkName } from "./types.ts";
 
@@ -78,7 +79,7 @@ export const serve = (
         headers: (key) => event.request.headers.get(key),
         url: () => {
           const protocol =
-            processEnv("NODE_ENV") === "development" ? "http" : "https";
+            processEnv(envKeys.NodeEnv) === "development" ? "http" : "https";
 
           return new URL(
             event.request.url,


### PR DESCRIPTION
When storing env vars in memory, run them through a whitelist (only include env vars we care about).

This is merely defense-in-depth: it isn't related to any vulns

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a whitelist to `getProcessEnv()` so only `envKeys`-enumerated variables are stored in memory, and installs a `toJSON: () => ({})` guard on the resulting object to prevent env var values from leaking through `JSON.stringify` (including after spreads, since `toJSON` is enumerable).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cecae701b192838a50300fbeabf6d53010a4a32f.</sup>
<!-- /MENDRAL_SUMMARY -->