### PR TITLE
v3 private backport

### DIFF
--- a/.changeset/lazy-horses-kiss.md
+++ b/.changeset/lazy-horses-kiss.md
@@ -1,5 +1,5 @@
 ---
-"inngest": minor
+"inngest": patch
 ---
 
-Ensure runIds are properly URI encoded across the board
+Ensure runIds are properly URI encoded in Durable Endpoints

--- a/.changeset/lazy-horses-kiss.md
+++ b/.changeset/lazy-horses-kiss.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Ensure runIds are properly URI encoded across the board

--- a/.changeset/timing-safe-signature-compare.md
+++ b/.changeset/timing-safe-signature-compare.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Improves HMAC signature verification by using a constant-time comparison, which mitigates a potential timing-based signature-recovery attack against the request signature. Also improves handling of timestamps in signatures, including malformed or future-dated values.

--- a/.changeset/timing-safe-signature-compare.md
+++ b/.changeset/timing-safe-signature-compare.md
@@ -1,5 +1,5 @@
 ---
-"inngest": minor
+"inngest": patch
 ---
 
 Improves HMAC signature verification by using a constant-time comparison, which mitigates a potential timing-based signature-recovery attack against the request signature. Also improves handling of timestamps in signatures, including malformed or future-dated values.

--- a/.changeset/wild-grapes-sink.md
+++ b/.changeset/wild-grapes-sink.md
@@ -1,5 +1,5 @@
 ---
-"inngest": minor
+"inngest": patch
 ---
 
 Hash the signing key used when exporting OTel traces

--- a/.changeset/wild-grapes-sink.md
+++ b/.changeset/wild-grapes-sink.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Hash the signing key used when exporting OTel traces

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -165,7 +165,9 @@ export class InngestApi {
     runId: string,
     version: ExecutionVersion,
   ): Promise<Result<StepsResponse, ErrorResponse>> {
-    const result = await this.req(`/v0/runs/${runId}/actions`);
+    const result = await this.req(
+      `/v0/runs/${encodeURIComponent(runId)}/actions`,
+    );
     if (result.ok) {
       const res = result.value;
       const data: unknown = await res.json();
@@ -189,7 +191,9 @@ export class InngestApi {
   async getRunBatch(
     runId: string,
   ): Promise<Result<BatchResponse, ErrorResponse>> {
-    const result = await this.req(`/v0/runs/${runId}/batch`);
+    const result = await this.req(
+      `/v0/runs/${encodeURIComponent(runId)}/batch`,
+    );
     if (result.ok) {
       const res = result.value;
       const data: unknown = await res.json();
@@ -408,11 +412,14 @@ export class InngestApi {
   ): Promise<Result<void, ErrorResponse>> {
     const payload = { target: args.target, metadata: args.metadata };
 
-    const result = await this.req(`/v1/runs/${args.target.run_id}/metadata`, {
-      method: "POST",
-      body: JSON.stringify(payload),
-      headers: options?.headers,
-    });
+    const result = await this.req(
+      `/v1/runs/${encodeURIComponent(args.target.run_id)}/metadata`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: options?.headers,
+      },
+    );
 
     if (!result.ok) {
       return err({
@@ -513,10 +520,13 @@ export class InngestApi {
       ts: new Date().valueOf(),
     });
 
-    const result = await this.req(`/v1/checkpoint/${args.runId}/steps`, {
-      method: "POST",
-      body,
-    });
+    const result = await this.req(
+      `/v1/checkpoint/${encodeURIComponent(args.runId)}/steps`,
+      {
+        method: "POST",
+        body,
+      },
+    );
 
     if (!result.ok) {
       throw new Error(
@@ -551,10 +561,13 @@ export class InngestApi {
       ts: new Date().valueOf(),
     });
 
-    const result = await this.req(`/v1/checkpoint/${args.runId}/async`, {
-      method: "POST",
-      body,
-    });
+    const result = await this.req(
+      `/v1/checkpoint/${encodeURIComponent(args.runId)}/async`,
+      {
+        method: "POST",
+        body,
+      },
+    );
 
     if (!result.ok) {
       throw new Error(
@@ -583,7 +596,9 @@ export class InngestApi {
    * @returns The raw Response from the API
    */
   async getRunOutput(runId: string, token: string): Promise<Response> {
-    const url = await this.getTargetUrl(`/v1/http/runs/${runId}/output`);
+    const url = await this.getTargetUrl(
+      `/v1/http/runs/${encodeURIComponent(runId)}/output`,
+    );
     url.searchParams.set("token", token);
 
     return this.fetch(url.toString(), {

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -3,10 +3,12 @@ import { z } from "zod/v3";
 import { EventSchemas } from "../components/EventSchemas.ts";
 import { InngestCommHandler } from "../components/InngestCommHandler.ts";
 import type { InngestFunction } from "../components/InngestFunction.ts";
-import { envKeys } from "../helpers/consts.ts";
+import { envKeys, headerKeys } from "../helpers/consts.ts";
+import { signDataWithKey } from "../helpers/net.ts";
 import { hashSigningKey } from "../helpers/strings.ts";
 import { serve } from "../next.ts";
 import { createClient } from "../test/helpers.ts";
+import { RequestSignature } from "./InngestCommHandler.ts";
 
 /**
  * When signingKey is provided via serve() options but NOT via
@@ -193,5 +195,308 @@ describe("#597", () => {
     });
 
     expect(commHandler["fetch"]).toBe(inngest["fetch"]);
+  });
+});
+
+describe("introspection", () => {
+  test("authenticated", async () => {
+    const signingKey =
+      "signkey-test-0000000000000000000000000000000000000000000000000000000000000000";
+    const signingKeyFallback =
+      "signkey-test-1111111111111111111111111111111111111111111111111111111111111111";
+
+    const client = createClient({ id: "test", isDev: false });
+    const commHandler = new InngestCommHandler({
+      client,
+      frameworkName: "test",
+      functions: [],
+      fetch,
+      signingKey,
+      signingKeyFallback,
+      handler: (req: Request) => {
+        return {
+          body: () => req.text(),
+          headers: (key: string) => req.headers.get(key),
+          method: () => req.method,
+          url: () => new URL(req.url),
+          transformResponse: ({
+            body,
+            headers,
+            status,
+          }: {
+            body: string;
+            headers: Record<string, string>;
+            status: number;
+          }) => {
+            return new Response(body, { status, headers });
+          },
+        };
+      },
+    });
+    const handler = commHandler["createHandler"]();
+
+    const timestamp = Math.round(Date.now() / 1000).toString();
+    const signature = await signDataWithKey("", signingKey, timestamp);
+    const req = new Request("https://localhost:3000/api/inngest", {
+      method: "GET",
+      headers: {
+        host: "localhost:3000",
+
+        // Request signature is used to authenticate the request
+        [headerKeys.Signature]: `t=${timestamp}&s=${signature}`,
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // Authenticated response body (since signature is valid)
+    expect(await res.json()).toEqual({
+      api_origin: "https://api.inngest.com/",
+      app_id: "test",
+      authentication_succeeded: true,
+      capabilities: { trust_probe: "v1", connect: "v1" },
+      env: null,
+      event_api_origin: "https://inn.gs/",
+      event_key_hash: null,
+      extra: {
+        is_mode_explicit: true,
+        native_crypto: true,
+        is_streaming: false,
+      },
+      framework: "test",
+      function_count: 0,
+      has_event_key: false,
+      has_signing_key: true,
+      mode: "cloud",
+      schema_version: "2024-05-24",
+      sdk_language: "js",
+      sdk_version: expect.any(String),
+      serve_origin: null,
+      serve_path: null,
+
+      // IMPORTANT: Only the first 12 characters of the hash are included
+      signing_key_fallback_hash: "02d449a31fbb",
+      signing_key_hash: "66687aadf862",
+    });
+  });
+
+  test("unauthenticated", async () => {
+    const client = createClient({ id: "test", isDev: false });
+    const commHandler = new InngestCommHandler({
+      client,
+      frameworkName: "test",
+      functions: [],
+      fetch,
+      handler: (req: Request) => {
+        return {
+          body: () => req.text(),
+          headers: (key: string) => req.headers.get(key),
+          method: () => req.method,
+          url: () => new URL(req.url),
+          transformResponse: ({
+            body,
+            headers,
+            status,
+          }: {
+            body: string;
+            headers: Record<string, string>;
+            status: number;
+          }) => {
+            return new Response(body, { status, headers });
+          },
+        };
+      },
+    });
+    const handler = commHandler["createHandler"]();
+
+    const req = new Request("https://localhost:3000/api/inngest", {
+      method: "GET",
+      headers: {
+        host: "localhost:3000",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // Unauthenticated response body (since signature is not provided)
+    expect(await res.json()).toEqual({
+      extra: { is_mode_explicit: true },
+      function_count: 0,
+      has_event_key: false,
+      has_signing_key: false,
+      mode: "cloud",
+      schema_version: "2024-05-24",
+    });
+  });
+
+  test("wrong signature", async () => {
+    const signingKey =
+      "signkey-test-0000000000000000000000000000000000000000000000000000000000000000";
+    const signingKeyFallback =
+      "signkey-test-1111111111111111111111111111111111111111111111111111111111111111";
+    const wrongSigningKey =
+      "signkey-test-wrong-2222222222222222222222222222222222222222222222222222222222222222";
+
+    const client = createClient({ id: "test", isDev: false });
+    const commHandler = new InngestCommHandler({
+      client,
+      frameworkName: "test",
+      functions: [],
+      fetch,
+      signingKey,
+      signingKeyFallback,
+      handler: (req: Request) => {
+        return {
+          body: () => req.text(),
+          headers: (key: string) => req.headers.get(key),
+          method: () => req.method,
+          url: () => new URL(req.url),
+          transformResponse: ({
+            body,
+            headers,
+            status,
+          }: {
+            body: string;
+            headers: Record<string, string>;
+            status: number;
+          }) => {
+            return new Response(body, { status, headers });
+          },
+        };
+      },
+    });
+    const handler = commHandler["createHandler"]();
+
+    const timestamp = Math.round(Date.now() / 1000).toString();
+    const signature = await signDataWithKey("", wrongSigningKey, timestamp);
+    const req = new Request("https://localhost:3000/api/inngest", {
+      method: "GET",
+      headers: {
+        host: "localhost:3000",
+
+        // Request signature is used to authenticate the request
+        [headerKeys.Signature]: `t=${timestamp}&s=${signature}`,
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // Unauthenticated response body (since signature is wrong)
+    expect(await res.json()).toEqual({
+      extra: { is_mode_explicit: true },
+      function_count: 0,
+      has_event_key: false,
+      has_signing_key: true,
+      mode: "cloud",
+      schema_version: "2024-05-24",
+    });
+  });
+});
+
+describe("RequestSignature", () => {
+  const signingKey = "signkey-test-deadbeefcafef00d";
+  const body = { event: { name: "demo/event.sent", data: {} } };
+
+  const fixedNowMs = new Date("2026-04-22T12:00:00Z").getTime();
+  const fixedNowSeconds = Math.round(fixedNowMs / 1000);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNowMs);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const verify = async (
+    ts: string,
+    { allowExpired = false }: { allowExpired?: boolean } = {},
+  ) => {
+    const mac = await signDataWithKey(body, signingKey, ts);
+    return new RequestSignature(`t=${ts}&s=${mac}`).verifySignature({
+      body,
+      signingKey,
+      signingKeyFallback: undefined,
+      allowExpiredSignatures: allowExpired,
+    });
+  };
+
+  describe("constructor", () => {
+    test("throws when `t` is missing", () => {
+      expect(() => new RequestSignature("s=abc")).toThrow(/Invalid/);
+    });
+
+    test("throws when `s` is missing", () => {
+      expect(() => new RequestSignature("t=123")).toThrow(/Invalid/);
+    });
+  });
+
+  describe("verifySignature expiry", () => {
+    test("accepts a timestamp 60s in the future (tolerates clock skew)", async () => {
+      await expect(verify((fixedNowSeconds + 60).toString())).resolves.toBe(
+        signingKey,
+      );
+    });
+
+    test("accepts a timestamp exactly 5 minutes old (boundary)", async () => {
+      await expect(verify((fixedNowSeconds - 300).toString())).resolves.toBe(
+        signingKey,
+      );
+    });
+
+    test("rejects a timestamp older than 5 minutes", async () => {
+      await expect(verify((fixedNowSeconds - 301).toString())).rejects.toThrow(
+        "Signature has expired",
+      );
+    });
+
+    test("rejects a timestamp more than 5 minutes in the future", async () => {
+      await expect(verify((fixedNowSeconds + 301).toString())).rejects.toThrow(
+        "Signature has expired",
+      );
+    });
+
+    test("rejects an unparseable `t`", async () => {
+      await expect(verify("not-a-number")).rejects.toThrow(
+        "Signature has expired",
+      );
+    });
+
+    test("rejects a hex-prefixed `t` (parseInt radix guard)", async () => {
+      const hexTs = `0x${fixedNowSeconds.toString(16)}`;
+      await expect(verify(hexTs)).rejects.toThrow("Signature has expired");
+    });
+
+    test.each([
+      ["past", -3600],
+      ["future", 3600],
+    ])(
+      "accepts a %s expired timestamp when allowExpiredSignatures is true",
+      async (_label, offsetSeconds) => {
+        await expect(
+          verify((fixedNowSeconds + offsetSeconds).toString(), {
+            allowExpired: true,
+          }),
+        ).resolves.toBe(signingKey);
+      },
+    );
+  });
+
+  describe("verifySignature signature check", () => {
+    test("rejects a tampered signature", async () => {
+      const ts = fixedNowSeconds.toString();
+      const mac = await signDataWithKey(body, signingKey, ts);
+      const tampered = (mac[0] === "0" ? "1" : "0") + mac.slice(1);
+
+      await expect(
+        new RequestSignature(`t=${ts}&s=${tampered}`).verifySignature({
+          body,
+          signingKey,
+          signingKeyFallback: undefined,
+          allowExpiredSignatures: false,
+        }),
+      ).rejects.toThrow("Invalid signature");
+    });
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -43,7 +43,13 @@ import { fetchWithAuthFallback, signDataWithKey } from "../helpers/net.ts";
 import { runAsPromise } from "../helpers/promises.ts";
 import { ServerTiming } from "../helpers/ServerTiming.ts";
 import { createStream } from "../helpers/stream.ts";
-import { hashEventKey, hashSigningKey, stringify } from "../helpers/strings.ts";
+import {
+  hashEventKey,
+  hashSigningKey,
+  removeSigningKeyPrefix,
+  stringify,
+  timingSafeEqual,
+} from "../helpers/strings.ts";
 import type { MaybePromise } from "../helpers/types.ts";
 import {
   type APIStepPayload,
@@ -2428,7 +2434,6 @@ export class InngestCommHandler<
       | AuthenticatedIntrospection = {
       extra: {
         is_mode_explicit: this._mode.isExplicit,
-        native_crypto: globalThis.crypto?.subtle ? true : false,
       },
       has_event_key: this.client["eventKeySet"](),
       has_signing_key: Boolean(this.signingKey),
@@ -2444,6 +2449,25 @@ export class InngestCommHandler<
         const validationResult = await signatureValidation;
         if (!validationResult.success) {
           throw new Error("Signature validation failed");
+        }
+
+        // For the signing keys, only send the first 12 characters of the hash.
+        // It's technically safe to send the full hash since the request was
+        // authenticated, but we'll play it safe and only send the first 12
+        // characters. 12 characters is enough to uniquely identify the key
+        // without revealing the full hash.
+        let signingKeyHash: string | null = null;
+        if (this.hashedSigningKey) {
+          signingKeyHash = removeSigningKeyPrefix(this.hashedSigningKey).slice(
+            0,
+            12,
+          );
+        }
+        let signingKeyFallbackHash: string | null = null;
+        if (this.hashedSigningKeyFallback) {
+          signingKeyFallbackHash = removeSigningKeyPrefix(
+            this.hashedSigningKeyFallback,
+          ).slice(0, 12);
         }
 
         introspection = {
@@ -2468,8 +2492,8 @@ export class InngestCommHandler<
           sdk_version: version,
           serve_origin: this.serveHost ?? null,
           serve_path: this.servePath ?? null,
-          signing_key_fallback_hash: this.hashedSigningKeyFallback ?? null,
-          signing_key_hash: this.hashedSigningKey ?? null,
+          signing_key_fallback_hash: signingKeyFallbackHash,
+          signing_key_hash: signingKeyHash,
         } satisfies AuthenticatedIntrospection;
       } catch {
         // Swallow signature validation error since we'll just return the
@@ -2710,7 +2734,7 @@ export class InngestCommHandler<
     key: string,
     body: string,
   ): Promise<string> {
-    const now = Date.now();
+    const now = Math.round(Date.now() / 1000);
     const mac = await signDataWithKey(body, key, now.toString());
 
     return `t=${now}&s=${mac}`;
@@ -2749,7 +2773,10 @@ export class InngestCommHandler<
   }
 }
 
-class RequestSignature {
+/**
+ * @internal Exported for testing; not part of the public API.
+ */
+export class RequestSignature {
   public timestamp: string;
   public signature: string;
 
@@ -2769,9 +2796,15 @@ class RequestSignature {
       return false;
     }
 
-    const delta =
-      Date.now() - new Date(Number.parseInt(this.timestamp) * 1000).valueOf();
-    return delta > 1000 * 60 * 5;
+    const ts = Number.parseInt(this.timestamp, 10);
+    if (!Number.isFinite(ts)) {
+      return true;
+    }
+
+    const delta = Date.now() - ts * 1000;
+    // Clamp both ends: negative delta (future-skewed `t`) would otherwise give
+    // captured requests an unbounded replay
+    return Math.abs(delta) > 1000 * 60 * 5;
   }
 
   async #verifySignature({
@@ -2789,7 +2822,7 @@ class RequestSignature {
     }
 
     const mac = await signDataWithKey(body, signingKey, this.timestamp);
-    if (mac !== this.signature) {
+    if (!timingSafeEqual(mac, this.signature)) {
       // TODO PrettyError
       throw new Error("Invalid signature");
     }

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -22,6 +22,7 @@ import {
 import { deterministicSpanID } from "../../../helpers/deterministicId.ts";
 import { devServerAvailable } from "../../../helpers/devserver.ts";
 import { devServerHost } from "../../../helpers/env.ts";
+import { hashSigningKey } from "../../../helpers/strings.ts";
 import type { Inngest } from "../../Inngest.ts";
 import { getAsyncCtx } from "../als.ts";
 import { clientProcessorMap } from "./access.ts";
@@ -340,7 +341,7 @@ export class InngestSpanProcessor implements SpanProcessor {
 
             headers: {
               ...app["headers"],
-              Authorization: `Bearer ${app["inngestApi"]["signingKey"]}`,
+              Authorization: `Bearer ${hashSigningKey(app["inngestApi"]["signingKey"])}`,
             },
           });
 

--- a/packages/inngest/src/helpers/net.ts
+++ b/packages/inngest/src/helpers/net.ts
@@ -1,5 +1,6 @@
 import canonicalize from "canonicalize";
 import hashjs from "hash.js";
+import { removeSigningKeyPrefix } from "./strings";
 
 const { hmac, sha256 } = hashjs;
 
@@ -53,10 +54,8 @@ export function signWithHashJs(
   // raw bytes; it may be pertinent in the future to always parse, then
   // canonicalize the body to ensure it's consistent.
   const encoded = typeof data === "string" ? data : canonicalize(data);
-  // Remove the `/signkey-[test|prod]-/` prefix from our signing key to calculate the HMAC.
-  const key = signingKey.replace(/signkey-\w+-/, "");
   // biome-ignore lint/suspicious/noExplicitAny: intentional
-  const mac = hmac(sha256 as any, key)
+  const mac = hmac(sha256 as any, removeSigningKeyPrefix(signingKey))
     .update(encoded)
     .update(ts)
     .digest("hex");
@@ -74,7 +73,7 @@ async function signWithNative(
   ts: string,
 ): Promise<string> {
   const encoded = typeof data === "string" ? data : canonicalize(data);
-  const key = signingKey.replace(/signkey-\w+-/, "");
+  const key = removeSigningKeyPrefix(signingKey);
 
   let cryptoKey = cryptoKeyCache.get(key);
   if (!cryptoKey) {

--- a/packages/inngest/src/helpers/strings.test.ts
+++ b/packages/inngest/src/helpers/strings.test.ts
@@ -1,4 +1,5 @@
-import { slugify, stringify, timeStr } from "./strings.ts";
+import { signDataWithKey } from "./net.ts";
+import { slugify, stringify, timeStr, timingSafeEqual } from "./strings.ts";
 
 describe("slugify", () => {
   it("Generates a slug using hyphens", () => {
@@ -46,5 +47,56 @@ describe("timeStr", () => {
 describe("stringify", () => {
   test("removes BigInt", () => {
     expect(stringify({ a: BigInt(1), b: 2 })).toEqual(JSON.stringify({ b: 2 }));
+  });
+});
+
+describe("timingSafeEqual", () => {
+  it("returns true for identical strings", () => {
+    const a = "deadbeefcafef00d";
+    const b = "deadbeefcafef00d";
+    expect(timingSafeEqual(a, b)).toBe(true);
+  });
+
+  it("returns true for real signDataWithKey output compared to itself", async () => {
+    const mac = await signDataWithKey(
+      "payload",
+      "signkey-test-abc",
+      "1234567890",
+    );
+    expect(timingSafeEqual(mac, mac)).toBe(true);
+  });
+
+  it("returns false for equal-length strings that differ", () => {
+    expect(timingSafeEqual("abc123", "abc124")).toBe(false);
+  });
+
+  it("returns false when strings differ only in the first character", () => {
+    expect(timingSafeEqual("0bc123", "abc123")).toBe(false);
+  });
+
+  it("returns false when strings differ only in the last character", () => {
+    expect(timingSafeEqual("abc120", "abc123")).toBe(false);
+  });
+
+  it("returns false for differing-length strings (prefix match)", () => {
+    expect(timingSafeEqual("abc", "abc123")).toBe(false);
+  });
+
+  it("returns false for differing-length strings (empty vs non-empty)", () => {
+    expect(timingSafeEqual("", "a")).toBe(false);
+    expect(timingSafeEqual("a", "")).toBe(false);
+  });
+
+  it("returns true for two empty strings", () => {
+    expect(timingSafeEqual("", "")).toBe(true);
+  });
+
+  it("returns false for strings that differ in multi-byte characters", () => {
+    expect(timingSafeEqual("café", "cafe")).toBe(false);
+    expect(timingSafeEqual("🌍a", "🌍b")).toBe(false);
+  });
+
+  it("returns true for identical non-ASCII strings", () => {
+    expect(timingSafeEqual("世界 🌍", "世界 🌍")).toBe(true);
   });
 });

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -6,6 +6,26 @@ import type { TimeStr } from "../types.ts";
 const { sha256 } = hashjs;
 
 /**
+ * Constant-time equality check for two strings. Returns `false` immediately if
+ * lengths differ; otherwise XOR-accumulates every char code so the total time
+ * is independent of where (or whether) the strings diverge.
+ *
+ * Used for HMAC signature verification — `===`/`!==` short-circuit on the
+ * first mismatched character and leak the matching-prefix length via timing.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
  * Safely `JSON.stringify()` an `input`, handling circular refernences and
  * removing `BigInt` values.
  */
@@ -118,8 +138,12 @@ export const hashSigningKey = (signingKey: string | undefined): string => {
   }
 
   const prefix = signingKey.match(/^signkey-[\w]+-/)?.shift() || "";
-  const key = signingKey.replace(/^signkey-[\w]+-/, "");
+  const key = removeSigningKeyPrefix(signingKey);
 
   // Decode the key from its hex representation into a bytestream
   return `${prefix}${sha256().update(key, "hex").digest("hex")}`;
 };
+
+export function removeSigningKeyPrefix(signingKey: string): string {
+  return signingKey.replace(/^signkey-[\w]+-/, "");
+}

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -890,7 +890,7 @@ export const testFramework = (
           test(name, async () => {
             const signingKey = "123";
             const body = { url: "https://example.com/api/inngest" };
-            const ts = Date.now().toString();
+            const ts = Math.round(Date.now() / 1000).toString();
 
             const signature = validSignature
               ? `t=${ts}&s=${await signDataWithKey(body, signingKey, ts)}`

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1380,7 +1380,6 @@ export interface InBandRegisterRequest
 export interface UnauthenticatedIntrospection {
   extra: {
     is_mode_explicit: boolean;
-    native_crypto: boolean;
   };
   function_count: number;
   has_event_key: boolean;


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR backports three security/correctness fixes from v3: (1) URI-encodes `runId` in all Durable Endpoint API paths, (2) hardens HMAC signature verification with constant-time comparison, radix-10 timestamp parsing, bidirectional expiry clamping, and correct seconds-based timestamps, and (3) hashes the signing key before using it as a Bearer token in the OTel trace exporter.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 77e6d3f5480145cbee343fbfa80bc8f7cf62d7fe.</sup>
<!-- /MENDRAL_SUMMARY -->