### PR TITLE
Authed introspection sends partial signing key hash

### DIFF
--- a/.changeset/four-seas-tell.md
+++ b/.changeset/four-seas-tell.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Authed introspection returns partial signing key hash

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -5,7 +5,7 @@ import { ConsoleLogger } from "../middleware/logger.ts";
 import { serve } from "../next.ts";
 import { createClient } from "../test/helpers.ts";
 import { internalLoggerSymbol } from "./Inngest.ts";
-import { RequestSignature } from "./InngestCommHandler.ts";
+import { InngestCommHandler, RequestSignature } from "./InngestCommHandler.ts";
 
 /**
  * Helper to run a POST request through a Next.js serve handler and capture
@@ -541,6 +541,162 @@ describe("RequestSignature", () => {
           logger,
         }),
       ).rejects.toThrow("Invalid signature");
+    });
+  });
+});
+
+describe("introspection", () => {
+  const logger = new ConsoleLogger({ level: "silent" });
+
+  test("authenticated", async () => {
+    const signingKey =
+      "signkey-test-0000000000000000000000000000000000000000000000000000000000000000";
+    const signingKeyFallback =
+      "signkey-test-1111111111111111111111111111111111111111111111111111111111111111";
+
+    const client = createClient({
+      id: "test",
+      isDev: false,
+      signingKey,
+      signingKeyFallback,
+    });
+    const commHandler = new InngestCommHandler({
+      client,
+      frameworkName: "test",
+      functions: [],
+      handler: (req: Request) => {
+        return {
+          body: () => req.text(),
+          headers: (key: string) => req.headers.get(key),
+          method: () => req.method,
+          url: () => new URL(req.url),
+          transformResponse: ({
+            body,
+            headers,
+            status,
+          }: {
+            body: string;
+            headers: Record<string, string>;
+            status: number;
+          }) => {
+            return new Response(body, { status, headers });
+          },
+        };
+      },
+    });
+    const handler = commHandler["createHandler"]();
+
+    const timestamp = Math.round(Date.now() / 1000).toString();
+    const signature = await signDataWithKey("", signingKey, timestamp, logger);
+    const req = new Request("https://localhost:3000/api/inngest", {
+      method: "GET",
+      headers: {
+        host: "localhost:3000",
+
+        // Request signature is used to authenticate the request
+        [headerKeys.Signature]: `t=${timestamp}&s=${signature}`,
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // Authenticated response body (since signature is valid)
+    expect(await res.json()).toEqual({
+      api_origin: "https://api.inngest.com/",
+      app_id: "test",
+      authentication_succeeded: true,
+      capabilities: { trust_probe: "v1", connect: "v1" },
+      env: null,
+      event_api_origin: "https://inn.gs/",
+      event_key_hash: null,
+      extra: {
+        is_streaming: false,
+        native_crypto: true,
+      },
+      framework: "test",
+      function_count: 0,
+      has_event_key: false,
+      has_signing_key: true,
+      mode: "cloud",
+      schema_version: "2024-05-24",
+      sdk_language: "js",
+      sdk_version: expect.any(String),
+      serve_origin: null,
+      serve_path: null,
+
+      // IMPORTANT: Only the first 12 characters of the hash are included
+      signing_key_fallback_hash: "02d449a31fbb",
+      signing_key_hash: "66687aadf862",
+    });
+  });
+
+  test("wrong signature", async () => {
+    const signingKey =
+      "signkey-test-0000000000000000000000000000000000000000000000000000000000000000";
+    const signingKeyFallback =
+      "signkey-test-1111111111111111111111111111111111111111111111111111111111111111";
+    const wrongSigningKey =
+      "signkey-test-wrong-2222222222222222222222222222222222222222222222222222222222222222";
+
+    const client = createClient({
+      id: "test",
+      isDev: false,
+      signingKey,
+      signingKeyFallback,
+    });
+    const commHandler = new InngestCommHandler({
+      client,
+      frameworkName: "test",
+      functions: [],
+      handler: (req: Request) => {
+        return {
+          body: () => req.text(),
+          headers: (key: string) => req.headers.get(key),
+          method: () => req.method,
+          url: () => new URL(req.url),
+          transformResponse: ({
+            body,
+            headers,
+            status,
+          }: {
+            body: string;
+            headers: Record<string, string>;
+            status: number;
+          }) => {
+            return new Response(body, { status, headers });
+          },
+        };
+      },
+    });
+    const handler = commHandler["createHandler"]();
+
+    const timestamp = Math.round(Date.now() / 1000).toString();
+    const signature = await signDataWithKey(
+      "",
+      wrongSigningKey,
+      timestamp,
+      logger,
+    );
+    const req = new Request("https://localhost:3000/api/inngest", {
+      method: "GET",
+      headers: {
+        host: "localhost:3000",
+
+        // Request signature is used to authenticate the request
+        [headerKeys.Signature]: `t=${timestamp}&s=${signature}`,
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    // Unauthenticated response body (since signature is wrong)
+    expect(await res.json()).toEqual({
+      extra: { native_crypto: true },
+      function_count: 0,
+      has_event_key: false,
+      has_signing_key: true,
+      mode: "cloud",
+      schema_version: "2024-05-24",
     });
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -37,6 +37,7 @@ import { createStream } from "../helpers/stream.ts";
 import {
   hashEventKey,
   hashSigningKey,
+  removeSigningKeyPrefix,
   stringify,
   timingSafeEqual,
 } from "../helpers/strings.ts";
@@ -2388,6 +2389,25 @@ export class InngestCommHandler<
           throw new Error("Signature validation failed");
         }
 
+        // For the signing keys, only send the first 12 characters of the hash.
+        // It's technically safe to send the full hash since the request was
+        // authenticated, but we'll play it safe and only send the first 12
+        // characters. 12 characters is enough to uniquely identify the key
+        // without revealing the full hash.
+        let signingKeyHash: string | null = null;
+        if (this.hashedSigningKey) {
+          signingKeyHash = removeSigningKeyPrefix(this.hashedSigningKey).slice(
+            0,
+            12,
+          );
+        }
+        let signingKeyFallbackHash: string | null = null;
+        if (this.hashedSigningKeyFallback) {
+          signingKeyFallbackHash = removeSigningKeyPrefix(
+            this.hashedSigningKeyFallback,
+          ).slice(0, 12);
+        }
+
         introspection = {
           ...introspection,
           authentication_succeeded: true,
@@ -2410,8 +2430,8 @@ export class InngestCommHandler<
           sdk_version: version,
           serve_origin: this.serveOrigin ?? null,
           serve_path: this.servePath ?? null,
-          signing_key_fallback_hash: this.hashedSigningKeyFallback ?? null,
-          signing_key_hash: this.hashedSigningKey ?? null,
+          signing_key_fallback_hash: signingKeyFallbackHash,
+          signing_key_hash: signingKeyHash,
         } satisfies AuthenticatedIntrospection;
       } catch {
         // Swallow signature validation error since we'll just return the

--- a/packages/inngest/src/helpers/net.ts
+++ b/packages/inngest/src/helpers/net.ts
@@ -2,6 +2,7 @@ import canonicalize from "canonicalize";
 import hashjs from "hash.js";
 import type { Logger } from "../middleware/logger.ts";
 import { logOnce } from "./log.ts";
+import { removeSigningKeyPrefix } from "./strings.ts";
 
 const { hmac, sha256 } = hashjs;
 
@@ -53,10 +54,8 @@ export function signWithHashJs(
   // raw bytes; it may be pertinent in the future to always parse, then
   // canonicalize the body to ensure it's consistent.
   const encoded = typeof data === "string" ? data : canonicalize(data);
-  // Remove the `/signkey-[test|prod]-/` prefix from our signing key to calculate the HMAC.
-  const key = signingKey.replace(/signkey-\w+-/, "");
   // biome-ignore lint/suspicious/noExplicitAny: intentional
-  const mac = hmac(sha256 as any, key)
+  const mac = hmac(sha256 as any, removeSigningKeyPrefix(signingKey))
     .update(encoded)
     .update(ts)
     .digest("hex");
@@ -74,7 +73,7 @@ async function signWithNative(
   ts: string,
 ): Promise<string> {
   const encoded = typeof data === "string" ? data : canonicalize(data);
-  const key = signingKey.replace(/signkey-\w+-/, "");
+  const key = removeSigningKeyPrefix(signingKey);
 
   let cryptoKey = cryptoKeyCache.get(key);
   if (!cryptoKey) {

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -138,8 +138,12 @@ export const hashSigningKey = (signingKey: string | undefined): string => {
   }
 
   const prefix = signingKey.match(/^signkey-[\w]+-/)?.shift() || "";
-  const key = signingKey.replace(/^signkey-[\w]+-/, "");
+  const key = removeSigningKeyPrefix(signingKey);
 
   // Decode the key from its hex representation into a bytestream
   return `${prefix}${sha256().update(key, "hex").digest("hex")}`;
 };
+
+export function removeSigningKeyPrefix(signingKey: string): string {
+  return signingKey.replace(/^signkey-[\w]+-/, "");
+}


### PR DESCRIPTION
## Summary

Change authed introspection response to return part of the signing key hash, rather than the whole signing key hash.

This is NOT related to a security vulnerability: it's just a defense-in-depth change. It isn't a vulnerability because the SDK only returns the signing key hash when the request was signed, and signing the request requires knowing the entire unhashed signing key.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR changes the authenticated introspection response to return only the first 12 characters of the signing key hash (and fallback hash), rather than the full 64-character hex hash. It also extracts the repeated `signkey-\w+-` prefix-stripping regex into a shared `removeSigningKeyPrefix` helper used in both `net.ts` and `strings.ts`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a88ac6179ddedbe66354f0c51ba1bdcbdba856e3.</sup>
<!-- /MENDRAL_SUMMARY -->