### PR TITLE
Reduce response info when unauthorized

### DIFF
--- a/.changeset/few-balloons-hear.md
+++ b/.changeset/few-balloons-hear.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Reduce response info when unauthorized

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -306,7 +306,7 @@ describe("error responses", () => {
     const result = await runHandler(handler, {
       actionOverrides: { body: () => undefined },
     });
-    expect(result.status).toBe(500);
+    expect(result.status).toBe(401);
     const parsed = JSON.parse(result.body) as Record<string, unknown>;
     expect(parsed).toEqual({ message: "Unauthorized" });
   });
@@ -762,16 +762,9 @@ describe("introspection", () => {
       },
     });
     const res = await handler(req);
-    expect(res.status).toBe(200);
-
-    // Unauthenticated response body (since signature is wrong)
-    expect(await res.json()).toEqual({
-      extra: { native_crypto: true },
-      function_count: 0,
-      has_event_key: false,
-      has_signing_key: true,
-      mode: "cloud",
-      schema_version: "2024-05-24",
-    });
+    // Cloud-mode GET with a wrong signature is now treated as unauthorized
+    // — we no longer fall back to the unauthenticated introspection body.
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
   });
 });

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -294,6 +294,81 @@ describe("ServeHandler", () => {
   });
 });
 
+describe("error responses", () => {
+  test("missing body", async () => {
+    const inngest = createClient({ id: "test", isDev: true });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runHandler(handler, {
+      actionOverrides: { body: () => undefined },
+    });
+    expect(result.status).toBe(500);
+    const parsed = JSON.parse(result.body) as Record<string, unknown>;
+    expect(parsed).toEqual({ message: "Unauthorized" });
+  });
+
+  test("missing signature header in cloud mode", async () => {
+    const inngest = createClient({
+      id: "test",
+      isDev: false,
+      eventKey: "event-key-123",
+      signingKey: "signkey-test-1234567890",
+    });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    const result = await runHandler(handler, {
+      actionOverrides: {
+        headers: async (_reason: string, key: string) =>
+          key.toLowerCase() === headerKeys.Signature.toLowerCase()
+            ? null
+            : undefined,
+      },
+    });
+    expect(result.status).toBe(401);
+    const parsed = JSON.parse(result.body) as Record<string, unknown>;
+    expect(parsed).toEqual({ message: "Unauthorized" });
+  });
+
+  test("incorrect signature in cloud mode", async () => {
+    const inngest = createClient({
+      id: "test",
+      isDev: false,
+      eventKey: "event-key-123",
+      signingKey: "signkey-test-1234567890",
+    });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => "test",
+    );
+    const handler = serve({ client: inngest, functions: [fn] });
+
+    // Well-formed but wrong: current timestamp (so it doesn't trip the
+    // expiry check) paired with an HMAC that doesn't match the body.
+    const ts = Math.round(Date.now() / 1000);
+    const badSig = `t=${ts}&s=${"0".repeat(64)}`;
+
+    const result = await runHandler(handler, {
+      actionOverrides: {
+        headers: async (_reason: string, key: string) =>
+          key.toLowerCase() === headerKeys.Signature.toLowerCase()
+            ? badSig
+            : undefined,
+      },
+    });
+    expect(result.status).toBe(401);
+    const parsed = JSON.parse(result.body) as Record<string, unknown>;
+    expect(parsed).toEqual({ message: "Unauthorized" });
+  });
+});
+
 describe("response version header", () => {
   const inngest = createClient({ id: "test", isDev: true });
 

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1244,16 +1244,21 @@ export class InngestCommHandler<
       actionResponseVersion = rawRes.version;
       const prepared = await prepareActionRes(rawRes);
 
-      // Unauthenticated responses must not leak SDK identification headers, so
-      // we strip every `x-inngest-*` header except `x-inngest-sdk-handled`
+      // Unauthenticated responses must not leak SDK identification headers,
+      // so we strip every `x-inngest-*` header except `x-inngest-sdk-handled`
       // (which the Inngest backend uses to know that the SDK produced the
-      // response, useful for troubleshooting). In dev mode, signature
+      // response, useful for troubleshooting). `User-Agent` is also stripped
+      // since it advertises the SDK and version. In dev mode, signature
       // validation short-circuits to success so this branch is a no-op.
       const validation = await signatureValidation;
       if (!validation.success) {
         const filteredHeaders: Record<string, string> = {};
         for (const [k, v] of Object.entries(prepared.headers)) {
           const lower = k.toLowerCase();
+          if (lower === "user-agent") {
+            // User-Agent contains the SDK version
+            continue;
+          }
           if (
             lower.startsWith("x-inngest-") &&
             lower !== headerKeys.SdkHandled.toLowerCase()

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1242,7 +1242,31 @@ export class InngestCommHandler<
         }),
       );
       actionResponseVersion = rawRes.version;
-      return prepareActionRes(rawRes);
+      const prepared = await prepareActionRes(rawRes);
+
+      // Unauthenticated responses must not leak SDK identification headers, so
+      // we strip every `x-inngest-*` header except `x-inngest-sdk-handled`
+      // (which the Inngest backend uses to know that the SDK produced the
+      // response, useful for troubleshooting). In dev mode, signature
+      // validation short-circuits to success so this branch is a no-op.
+      const validation = await signatureValidation;
+      if (!validation.success) {
+        const filteredHeaders: Record<string, string> = {};
+        for (const [k, v] of Object.entries(prepared.headers)) {
+          const lower = k.toLowerCase();
+          if (
+            lower.startsWith("x-inngest-") &&
+            lower !== headerKeys.SdkHandled.toLowerCase()
+          ) {
+            continue;
+          }
+          filteredHeaders[k] = v;
+        }
+
+        return { ...prepared, headers: filteredHeaders };
+      }
+
+      return prepared;
     };
 
     // Only wrap POST requests with the wrapRequest middleware chain.
@@ -1553,29 +1577,28 @@ export class InngestCommHandler<
           );
 
           return {
-            status: 500,
+            status: 401,
             headers: {
               "Content-Type": "application/json",
             },
-            body: stringify(
-              serializeError(
-                new Error(
-                  "Missing request body when executing, possibly due to missing request body middleware",
-                ),
-              ),
-            ),
+            body: stringify({ message: "Unauthorized" }),
             version: undefined,
           };
         }
 
         const validationResult = await signatureValidation;
         if (!validationResult.success) {
+          this.client[internalLoggerSymbol].error(
+            { err: validationResult.err },
+            "Signature validation failed",
+          );
+
           return {
             status: 401,
             headers: {
               "Content-Type": "application/json",
             },
-            body: stringify(serializeError(validationResult.err)),
+            body: stringify({ message: "Unauthorized" }),
             version: undefined,
           };
         }
@@ -1904,6 +1927,29 @@ export class InngestCommHandler<
       const env = (await getHeaders())[headerKeys.Environment] ?? null;
 
       if (method === "GET") {
+        // In cloud mode, introspection requires a valid signature. We don't
+        // serve an unauthenticated introspection body to anonymous callers
+        // because it leaks deployment fingerprint (mode, function count,
+        // event/signing key presence).
+        if (this.client.mode === "cloud") {
+          const validationResult = await signatureValidation;
+          if (!validationResult.success) {
+            this.client[internalLoggerSymbol].error(
+              { err: validationResult.err },
+              "Signature validation failed",
+            );
+
+            return {
+              status: 401,
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: stringify({ message: "Unauthorized" }),
+              version: undefined,
+            };
+          }
+        }
+
         return {
           status: 200,
           body: stringify(
@@ -2067,10 +2113,7 @@ export class InngestCommHandler<
 
     return {
       status: 405,
-      body: JSON.stringify({
-        message: `No action found; expected POST, PUT, or GET but received "${method}"`,
-        mode: this.client.mode,
-      }),
+      body: JSON.stringify({ message: "Method not allowed" }),
       headers: {},
       version: undefined,
     };

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -2119,7 +2119,9 @@ export class InngestCommHandler<
     return {
       status: 405,
       body: JSON.stringify({ message: "Method not allowed" }),
-      headers: {},
+      headers: {
+        "Content-Type": "application/json",
+      },
       version: undefined,
     };
   }

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -190,6 +190,7 @@ export enum headerKeys {
   InngestRunId = "x-run-id",
   InngestStepId = "x-inngest-step-id",
   InngestForceStepPlan = "x-inngest-force-step-plan",
+  SdkHandled = "x-inngest-sdk-handled",
 }
 
 /**

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -269,6 +269,7 @@ export const inngestHeaders = (opts?: {
     "Content-Type": "application/json",
     "User-Agent": sdkVersion,
     [headerKeys.SdkVersion]: sdkVersion,
+    [headerKeys.SdkHandled]: "true",
   };
 
   if (opts?.framework) {

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -632,16 +632,32 @@ export const testFramework = (
       });
 
       describe("edge environment (delayed env vars)", () => {
+        const signGet = async (signingKey: string) => {
+          const ts = Math.round(Date.now() / 1000).toString();
+          const sig = `t=${ts}&s=${await signDataWithKey(
+            "",
+            signingKey,
+            ts,
+            new ConsoleLogger({ level: "silent" }),
+          )}`;
+          return { [headerKeys.Signature]: sig };
+        };
+
         test("can pick up delayed event key from environment", async () => {
           // Simulate edge: handler created with empty process.env
           const edgeHandler = createEdgeHandler();
 
           // At request time, env vars become available
           // Cloud mode (default) requires signing key at request time
-          const ret = await run(edgeHandler, [{ method: "GET" }], {
-            [envKeys.InngestEventKey]: "event-key-123",
-            [envKeys.InngestSigningKey]: "signing-key-123",
-          });
+          const signingKey = "signing-key-123";
+          const ret = await run(
+            edgeHandler,
+            [{ method: "GET", headers: await signGet(signingKey) }],
+            {
+              [envKeys.InngestEventKey]: "event-key-123",
+              [envKeys.InngestSigningKey]: signingKey,
+            },
+          );
 
           const body = JSON.parse(ret.body);
 
@@ -654,9 +670,12 @@ export const testFramework = (
           // Simulate edge: handler created with empty process.env
           const edgeHandler = createEdgeHandler();
 
-          const ret = await run(edgeHandler, [{ method: "GET" }], {
-            [envKeys.InngestSigningKey]: "signing-key-123",
-          });
+          const signingKey = "signing-key-123";
+          const ret = await run(
+            edgeHandler,
+            [{ method: "GET", headers: await signGet(signingKey) }],
+            { [envKeys.InngestSigningKey]: signingKey },
+          );
 
           expect(ret.status).toEqual(200);
 
@@ -668,8 +687,10 @@ export const testFramework = (
         });
       });
 
-      test("#690 returns 200 if signature validation fails", async () => {
-        // Pass signingKey via env for cloud mode
+      test("returns 401 in cloud mode if signature validation fails", async () => {
+        // Counterpart of the dropped #690 test: cloud mode GET with no
+        // signature now returns 401 instead of an unauthenticated
+        // introspection body, so we don't fingerprint the deployment.
         const ret = await run(
           [
             {
@@ -681,17 +702,36 @@ export const testFramework = (
           { [envKeys.InngestSigningKey]: "signing-key-123" },
         );
 
-        expect(ret.status).toEqual(200);
-
-        const body = JSON.parse(ret.body);
-
-        expect(body).toMatchObject({
-          has_signing_key: true,
-        });
+        expect(ret.status).toEqual(401);
+        expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
       });
     });
 
     describe("PUT (register)", () => {
+      // Tests that want the SDK to return its full identification headers
+      // (sdk version, framework, env, platform, expected-server-kind) need
+      // to send a properly-signed request — unsigned requests in cloud mode
+      // strip those headers to avoid fingerprinting.
+      // Sign a PUT request so cloud-mode validation succeeds and we can
+      // assert the full SDK identification headers in the response.
+      // Defaults the signed body to `{}` because `node-mocks-http` (used by
+      // the run helper) materializes a missing body as an empty object,
+      // which the server canonicalizes to `"{}"` before HMACing.
+      const signedPutHeaders = async (
+        signingKey: string,
+        body: unknown = {},
+      ): Promise<Record<string, string>> => {
+        const ts = Math.round(Date.now() / 1000).toString();
+        return {
+          [headerKeys.Signature]: `t=${ts}&s=${await signDataWithKey(
+            body,
+            signingKey,
+            ts,
+            new ConsoleLogger({ level: "silent" }),
+          )}`,
+        };
+      };
+
       describe("out-of-band (legacy)", () => {
         describe("prod env registration", () => {
           test("register with correct default URL from request", async () => {
@@ -719,6 +759,7 @@ export const testFramework = (
                   method: "PUT",
                   url: "/api/inngest",
                   headers: {
+                    ...(await signedPutHeaders(testSigningKey)),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
@@ -765,6 +806,7 @@ export const testFramework = (
                 {
                   method: "PUT",
                   headers: {
+                    ...(await signedPutHeaders(testSigningKey)),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
@@ -809,6 +851,7 @@ export const testFramework = (
                   method: "PUT",
                   url: customUrl,
                   headers: {
+                    ...(await signedPutHeaders(testSigningKey)),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
@@ -956,6 +999,7 @@ export const testFramework = (
                 {
                   method: "PUT",
                   headers: {
+                    ...(await signedPutHeaders(testSigningKey)),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
@@ -1290,12 +1334,23 @@ export const testFramework = (
             if (typeof expectedResponse === "number") {
               expect(ret.status).toEqual(expectedResponse);
             } else {
-              expect(ret).toMatchObject({
-                status: 200,
-                headers: expect.objectContaining({
-                  [headerKeys.InngestSyncKind]: expectedResponse,
-                }),
-              });
+              // When the SDK is in cloud mode and the request was unsigned or
+              // had an invalid signature, all `x-inngest-*` headers other
+              // than `x-inngest-sdk-handled` are stripped to avoid
+              // fingerprinting an unauthenticated caller. We can still verify
+              // the sync succeeded (status 200), but the sync-kind header is
+              // unavailable.
+              const sigStripped =
+                sdkMode === serverKind.Cloud && validSignature !== true;
+
+              expect(ret.status).toEqual(200);
+              if (!sigStripped) {
+                expect(ret.headers).toEqual(
+                  expect.objectContaining({
+                    [headerKeys.InngestSyncKind]: expectedResponse,
+                  }),
+                );
+              }
             }
           });
         };
@@ -1447,7 +1502,7 @@ export const testFramework = (
 
     describe("POST (run function)", () => {
       describe("#789 missing body", () => {
-        test("returns 500", async () => {
+        test("returns 401", async () => {
           const client = createClient({ id: "test", isDev: true });
 
           const fn = client.createFunction(
@@ -1466,7 +1521,7 @@ export const testFramework = (
             { body: () => undefined },
           );
 
-          expect(ret.status).toEqual(500);
+          expect(ret.status).toEqual(401);
         });
       });
 
@@ -1494,11 +1549,7 @@ export const testFramework = (
             { ...env, [envKeys.InngestSigningKey]: "test" },
           );
           expect(ret.status).toEqual(401);
-          expect(JSON.parse(ret.body)).toMatchObject({
-            message: expect.stringContaining(
-              `No ${headerKeys.Signature} provided`,
-            ),
-          });
+          expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
         });
         test("should throw an error with an invalid signature", async () => {
           const ret = await run(
@@ -1507,11 +1558,7 @@ export const testFramework = (
             { ...env, [envKeys.InngestSigningKey]: "test" },
           );
           expect(ret.status).toEqual(401);
-          expect(JSON.parse(ret.body)).toMatchObject({
-            message: expect.stringContaining(
-              `Invalid ${headerKeys.Signature} provided`,
-            ),
-          });
+          expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
         });
         test("should throw an error with an expired signature", async () => {
           const yesterday = new Date();
@@ -1532,10 +1579,8 @@ export const testFramework = (
             ],
             { ...env, [envKeys.InngestSigningKey]: testSigningKey },
           );
-          expect(ret).toMatchObject({
-            status: 401,
-            body: expect.stringContaining("Signature has expired"),
-          });
+          expect(ret.status).toEqual(401);
+          expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
         });
         // These signatures are randomly generated within a local development environment, matching
         // what is sent from the cloud.
@@ -1703,10 +1748,8 @@ export const testFramework = (
                 [envKeys.InngestSigningKeyFallback]: "another-fake",
               },
             );
-            expect(ret).toMatchObject({
-              status: 401,
-              body: expect.stringContaining("Invalid signature"),
-            });
+            expect(ret.status).toEqual(401);
+            expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
           });
         });
 

--- a/packages/inngest/src/test/integration/auth.test.ts
+++ b/packages/inngest/src/test/integration/auth.test.ts
@@ -1,7 +1,7 @@
 import type { AddressInfo } from "node:net";
 import { randomSuffix, testNameFromFileUrl } from "@inngest/test-harness";
 import { afterEach, expect, test } from "vitest";
-import { headerKeys } from "../../helpers/consts.ts";
+import { headerKeys, syncKind } from "../../helpers/consts.ts";
 import { signWithHashJs } from "../../helpers/net.ts";
 import { Inngest } from "../../index.ts";
 import { createServer } from "../../node.ts";
@@ -111,6 +111,7 @@ describe("GET", () => {
     expect(getInngestHeaders(res.headers)).toEqual({
       [headerKeys.SdkHandled]: "true",
     });
+    expect(res.headers.get("user-agent")).toBeNull();
   });
 });
 
@@ -128,6 +129,7 @@ describe("POST", () => {
     expect(getInngestHeaders(res.headers)).toEqual({
       [headerKeys.SdkHandled]: "true",
     });
+    expect(res.headers.get("user-agent")).toBeNull();
   });
 
   test("no signature", async () => {
@@ -144,6 +146,7 @@ describe("POST", () => {
     expect(getInngestHeaders(res.headers)).toEqual({
       [headerKeys.SdkHandled]: "true",
     });
+    expect(res.headers.get("user-agent")).toBeNull();
   });
 
   test("incorrect signature", async () => {
@@ -168,6 +171,7 @@ describe("POST", () => {
     expect(getInngestHeaders(res.headers)).toEqual({
       [headerKeys.SdkHandled]: "true",
     });
+    expect(res.headers.get("user-agent")).toBeNull();
   });
 });
 
@@ -185,24 +189,65 @@ test("PATCH with no signature", async () => {
   expect(getInngestHeaders(res.headers)).toEqual({
     [headerKeys.SdkHandled]: "true",
   });
+  expect(res.headers.get("user-agent")).toBeNull();
 });
 
-test("PUT with no signature", async () => {
-  // This is an "out-of-band" sync. It's OK to allow the unauthenticated request
-  // because the SDK reaches out to the Inngest API on its own, and does not
-  // return any sensitive info to the unauthenticated caller. An attacker is
-  // unable to dictate anything besides telling the SDK to sync itself
+describe("PUT", () => {
+  test("correct signature", async () => {
+    // In-band sync.
 
-  const url = await startCloudServer();
-  const res = await fetch(url, {
-    method: "PUT",
+    const url = await startCloudServer();
+
+    // PUT register with no body: server reads body as "".
+    const body = JSON.stringify({
+      url: "http://localhost:1234/api/inngest",
+    });
+    const ts = Math.round(Date.now() / 1000).toString();
+    const sig = `t=${ts}&s=${signWithHashJs(body, signingKey, ts)}`;
+
+    const res = await fetch(url, {
+      method: "PUT",
+      headers: {
+        [headerKeys.InngestSyncKind]: syncKind.InBand,
+        [headerKeys.Signature]: sig,
+      },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      url: "http://localhost:1234/api/inngest",
+    });
+    // Validation succeeded → no strip, so the full SDK fingerprint headers,
+    // the out-of-band sync-kind marker, and a signed response come through.
+    expect(getInngestHeaders(res.headers)).toEqual({
+      "x-inngest-framework": "nodejs",
+      "x-inngest-req-version": "2",
+      "x-inngest-sdk": expect.any(String),
+      "x-inngest-sdk-handled": "true",
+      "x-inngest-signature": expect.any(String),
+      "x-inngest-sync-kind": "in_band",
+    });
   });
-  expect(res.status).toBe(200);
-  expect(await res.json()).toEqual({
-    message: "Successfully registered",
-    modified: true,
-  });
-  expect(getInngestHeaders(res.headers)).toEqual({
-    [headerKeys.SdkHandled]: "true",
+
+  test("no signature", async () => {
+    // This is an "out-of-band" sync. It's OK to allow the unauthenticated request
+    // because the SDK reaches out to the Inngest API on its own, and does not
+    // return any sensitive info to the unauthenticated caller. An attacker is
+    // unable to dictate anything besides telling the SDK to sync itself
+
+    const url = await startCloudServer();
+    const res = await fetch(url, {
+      method: "PUT",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      message: "Successfully registered",
+      modified: true,
+    });
+    expect(getInngestHeaders(res.headers)).toEqual({
+      [headerKeys.SdkHandled]: "true",
+    });
+    expect(res.headers.get("user-agent")).toBeNull();
   });
 });

--- a/packages/inngest/src/test/integration/auth.test.ts
+++ b/packages/inngest/src/test/integration/auth.test.ts
@@ -1,0 +1,189 @@
+import type { AddressInfo } from "node:net";
+import { randomSuffix, testNameFromFileUrl } from "@inngest/test-harness";
+import { afterEach, expect, test } from "vitest";
+import { headerKeys } from "../../helpers/consts.ts";
+import { signWithHashJs } from "../../helpers/net.ts";
+import { Inngest } from "../../index.ts";
+import { createServer } from "../../node.ts";
+
+const signingKey = "signkey-test-1234567890";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+let cleanup: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await cleanup?.();
+  cleanup = undefined;
+});
+
+/**
+ * Start a server in cloud mode (isDev: false) with a signing key configured,
+ * then return the URL. This bypasses the no-signing-key 500 path so we can
+ * exercise the body and signature checks.
+ */
+async function startCloudServer(): Promise<string> {
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: false,
+    eventKey: "event-key-123",
+    signingKey,
+  });
+
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: "test/event" }] },
+    async () => "ok",
+  );
+
+  const servePath = "/api/inngest";
+  const server = createServer({
+    client,
+    functions: [fn],
+    servePath,
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, () => {
+      server.removeListener("error", reject);
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+
+  cleanup = () =>
+    new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+
+  return `http://localhost:${port}${servePath}`;
+}
+
+describe("GET", () => {
+  test("correct signature", async () => {
+    const url = await startCloudServer();
+
+    // GETs sign over an empty body.
+    const ts = Math.round(Date.now() / 1000).toString();
+    const sig = `t=${ts}&s=${signWithHashJs("", signingKey, ts)}`;
+
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        [headerKeys.Signature]: sig,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      authentication_succeeded: true,
+      mode: "cloud",
+    });
+    expect(getInngestHeaders(res.headers)).toEqual({
+      'x-inngest-framework': 'nodejs',
+      'x-inngest-req-version': '2',
+      'x-inngest-sdk': expect.any(String),
+      'x-inngest-sdk-handled': 'true',
+      'x-inngest-signature': expect.any(String),
+    });
+  });
+
+test("no signature", async () => {
+  const url = await startCloudServer();
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  expect(res.status).toBe(401);
+  expect(await res.json()).toEqual({ message: "Unauthorized" });
+  expect(getInngestHeaders(res.headers)).toEqual({
+    [headerKeys.SdkHandled]: "true",
+  });
+});
+});
+
+describe("POST", () => {
+  test("no body", async () => {
+    const url = await startCloudServer();
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
+    expect(getInngestHeaders(res.headers)).toEqual({
+      [headerKeys.SdkHandled]: "true",
+    });
+  });
+
+  test("no signature", async () => {
+    const url = await startCloudServer();
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
+    expect(getInngestHeaders(res.headers)).toEqual({
+      [headerKeys.SdkHandled]: "true",
+    });
+  });
+
+  test("incorrect signature", async () => {
+    const url = await startCloudServer();
+
+    // Well-formed but wrong: current timestamp (so it doesn't trip the
+    // expiry check) paired with an HMAC that doesn't match the body.
+    const ts = Math.round(Date.now() / 1000);
+    const badSig = `t=${ts}&s=${"0".repeat(64)}`;
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [headerKeys.Signature]: badSig,
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
+    expect(getInngestHeaders(res.headers)).toEqual({
+      [headerKeys.SdkHandled]: "true",
+    });
+  });
+});
+
+test("PATCH with no signature", async () => {
+  const url = await startCloudServer();
+
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+
+  expect(res.status).toBe(405);
+  expect(await res.json()).toEqual({ message: "Method not allowed" });
+  expect(getInngestHeaders(res.headers)).toEqual({
+    [headerKeys.SdkHandled]: "true",
+  });
+});
+
+
+function getInngestHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((v, k) => {
+    if (k.toLowerCase().startsWith("x-inngest-")) {
+      out[k] = v;
+    }
+  });
+  return out;
+}

--- a/packages/inngest/src/test/integration/auth.test.ts
+++ b/packages/inngest/src/test/integration/auth.test.ts
@@ -24,9 +24,9 @@ afterEach(async () => {
  */
 async function startCloudServer(): Promise<string> {
   const client = new Inngest({
+    baseUrl: "http://localhost:8288",
     id: randomSuffix(testFileName),
     isDev: false,
-    eventKey: "event-key-123",
     signingKey,
   });
 
@@ -58,6 +58,16 @@ async function startCloudServer(): Promise<string> {
   return `http://localhost:${port}${servePath}`;
 }
 
+function getInngestHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((v, k) => {
+    if (k.toLowerCase().startsWith("x-inngest-")) {
+      out[k] = v;
+    }
+  });
+  return out;
+}
+
 describe("GET", () => {
   test("correct signature", async () => {
     const url = await startCloudServer();
@@ -80,28 +90,28 @@ describe("GET", () => {
       mode: "cloud",
     });
     expect(getInngestHeaders(res.headers)).toEqual({
-      'x-inngest-framework': 'nodejs',
-      'x-inngest-req-version': '2',
-      'x-inngest-sdk': expect.any(String),
-      'x-inngest-sdk-handled': 'true',
-      'x-inngest-signature': expect.any(String),
+      "x-inngest-framework": "nodejs",
+      "x-inngest-req-version": "2",
+      "x-inngest-sdk": expect.any(String),
+      "x-inngest-sdk-handled": "true",
+      "x-inngest-signature": expect.any(String),
     });
   });
 
-test("no signature", async () => {
-  const url = await startCloudServer();
+  test("no signature", async () => {
+    const url = await startCloudServer();
 
-  const res = await fetch(url, {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-  });
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
 
-  expect(res.status).toBe(401);
-  expect(await res.json()).toEqual({ message: "Unauthorized" });
-  expect(getInngestHeaders(res.headers)).toEqual({
-    [headerKeys.SdkHandled]: "true",
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
+    expect(getInngestHeaders(res.headers)).toEqual({
+      [headerKeys.SdkHandled]: "true",
+    });
   });
-});
 });
 
 describe("POST", () => {
@@ -177,13 +187,22 @@ test("PATCH with no signature", async () => {
   });
 });
 
+test("PUT with no signature", async () => {
+  // This is an "out-of-band" sync. It's OK to allow the unauthenticated request
+  // because the SDK reaches out to the Inngest API on its own, and does not
+  // return any sensitive info to the unauthenticated caller. An attacker is
+  // unable to dictate anything besides telling the SDK to sync itself
 
-function getInngestHeaders(headers: Headers): Record<string, string> {
-  const out: Record<string, string> = {};
-  headers.forEach((v, k) => {
-    if (k.toLowerCase().startsWith("x-inngest-")) {
-      out[k] = v;
-    }
+  const url = await startCloudServer();
+  const res = await fetch(url, {
+    method: "PUT",
   });
-  return out;
-}
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    message: "Successfully registered",
+    modified: true,
+  });
+  expect(getInngestHeaders(res.headers)).toEqual({
+    [headerKeys.SdkHandled]: "true",
+  });
+});


### PR DESCRIPTION
## Summary

Reduce response info when unauthorized:
- Body is only `{ "message": "Unauthorized" }`.
- No `X-Inngest` headers (except the new `X-Inngest-Sdk-Handled: true`).
- No `User-Agent` header, since it contains the SDK version.

Additionally, this PR removes the unauthenticated `GET` request (a.k.a. "unauthenticated introspection"). This was an intentional feature for troubleshooting. It did not return any sensitive info, but it's still a best practice to minimize response info to an unauthenticated client.

This PR does not remove the unauthenticated `PUT` request (a.k.a. "out-of-band sync"). This is an intentional feature that allows an unauthenticated caller to trigger an app sync. This is not a security vulnerability since the caller is unable to dictate anything besides telling the SDK to sync itself with Inngest. The caller cannot change any SDK configuration or change the Inngest API URL that the SDK sends its sync request to.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
https://linear.app/inngest/issue/EXE-1710

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR hardens unauthorized response behavior across the SDK: replaces verbose error bodies with a generic `{ message: "Unauthorized" }`, strips all `x-inngest-*` headers (except the new `x-inngest-sdk-handled: true`) and `User-Agent` from 401 responses, gates GET introspection behind signature validation in cloud mode, and adds unit + integration test coverage for all auth failure paths.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 02c5f5ae62b0fe3ad050c6afcacc538ffc7a7e06.</sup>
<!-- /MENDRAL_SUMMARY -->