### PR TITLE
Reduce response info when unauthorized

### DIFF
--- a/.changeset/few-balloons-hear.md
+++ b/.changeset/few-balloons-hear.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Reduce response info when unauthorized

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -323,17 +323,10 @@ describe("introspection", () => {
       },
     });
     const res = await handler(req);
-    expect(res.status).toBe(200);
-
-    // Unauthenticated response body (since signature is not provided)
-    expect(await res.json()).toEqual({
-      extra: { is_mode_explicit: true },
-      function_count: 0,
-      has_event_key: false,
-      has_signing_key: false,
-      mode: "cloud",
-      schema_version: "2024-05-24",
-    });
+    // Cloud-mode GET without a signature is now treated as unauthorized —
+    // we no longer fall back to the unauthenticated introspection body.
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
   });
 
   test("wrong signature", async () => {

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -386,17 +386,10 @@ describe("introspection", () => {
       },
     });
     const res = await handler(req);
-    expect(res.status).toBe(200);
-
-    // Unauthenticated response body (since signature is wrong)
-    expect(await res.json()).toEqual({
-      extra: { is_mode_explicit: true },
-      function_count: 0,
-      has_event_key: false,
-      has_signing_key: true,
-      mode: "cloud",
-      schema_version: "2024-05-24",
-    });
+    // Cloud-mode GET with a wrong signature is now treated as unauthorized
+    // — we no longer fall back to the unauthenticated introspection body.
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ message: "Unauthorized" });
   });
 });
 

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1300,6 +1300,33 @@ export class InngestCommHandler<
         headers[headerKeys.Signature] = signature;
       }
 
+      // Unauthenticated responses must not leak SDK identification headers,
+      // so we strip every `x-inngest-*` header except `x-inngest-sdk-handled`
+      // (which the Inngest backend uses to know that the SDK produced the
+      // response, useful for troubleshooting). `User-Agent` is also stripped
+      // since it advertises the SDK and version. In dev mode, signature
+      // validation short-circuits to success so this branch is a no-op.
+      const validation = await signatureValidation;
+      if (!validation.success) {
+        const filteredHeaders: Record<string, string> = {};
+        for (const [k, v] of Object.entries(headers)) {
+          const lower = k.toLowerCase();
+          if (
+            lower === "user-agent" ||
+            (lower.startsWith("x-inngest-") &&
+              lower !== headerKeys.SdkHandled.toLowerCase())
+          ) {
+            continue;
+          }
+          filteredHeaders[k] = v;
+        }
+
+        return {
+          ...res,
+          headers: filteredHeaders,
+        };
+      }
+
       return {
         ...res,
         headers,
@@ -1524,29 +1551,29 @@ export class InngestCommHandler<
           );
 
           return {
-            status: 500,
+            status: 401,
             headers: {
               "Content-Type": "application/json",
             },
-            body: stringify(
-              serializeError(
-                new Error(
-                  "Missing request body when executing, possibly due to missing request body middleware",
-                ),
-              ),
-            ),
+            body: stringify({ message: "Unauthorized" }),
             version: undefined,
           };
         }
 
         const validationResult = await signatureValidation;
         if (!validationResult.success) {
+          this.log(
+            "error",
+            "Signature validation failed",
+            validationResult.err,
+          );
+
           return {
             status: 401,
             headers: {
               "Content-Type": "application/json",
             },
-            body: stringify(serializeError(validationResult.err)),
+            body: stringify({ message: "Unauthorized" }),
             version: undefined,
           };
         }
@@ -1863,6 +1890,29 @@ export class InngestCommHandler<
       const env = (await getHeaders())[headerKeys.Environment] ?? null;
 
       if (method === "GET") {
+        // In cloud mode, introspection requires a valid signature. We don't
+        // serve an unauthenticated introspection body to anonymous callers
+        // because it leaks deployment fingerprint (mode, function count,
+        // event/signing key presence). In dev mode, signature validation
+        // short-circuits to success so this branch is a no-op.
+        const validationResult = await signatureValidation;
+        if (!validationResult.success) {
+          this.log(
+            "error",
+            "Signature validation failed",
+            validationResult.err,
+          );
+
+          return {
+            status: 401,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: stringify({ message: "Unauthorized" }),
+            version: undefined,
+          };
+        }
+
         return {
           status: 200,
           body: stringify(
@@ -2027,9 +2077,7 @@ export class InngestCommHandler<
 
     return {
       status: 405,
-      body: JSON.stringify({
-        message: `No action found; expected POST, PUT, or GET but received "${method}"`,
-      }),
+      body: JSON.stringify({ message: "Method not allowed" }),
       headers: {},
       version: undefined,
     };

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -2078,7 +2078,9 @@ export class InngestCommHandler<
     return {
       status: 405,
       body: JSON.stringify({ message: "Method not allowed" }),
-      headers: {},
+      headers: {
+        "Content-Type": "application/json",
+      },
       version: undefined,
     };
   }

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -187,6 +187,7 @@ export enum headerKeys {
   InngestRunId = "x-run-id",
   InngestStepId = "x-inngest-step-id",
   InngestForceStepPlan = "x-inngest-force-step-plan",
+  SdkHandled = "x-inngest-sdk-handled",
 }
 
 /**

--- a/packages/inngest/src/helpers/env.ts
+++ b/packages/inngest/src/helpers/env.ts
@@ -415,6 +415,7 @@ export const inngestHeaders = (opts?: {
     "Content-Type": "application/json",
     "User-Agent": sdkVersion,
     [headerKeys.SdkVersion]: sdkVersion,
+    [headerKeys.SdkHandled]: "true",
   };
 
   if (opts?.framework) {

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -437,11 +437,28 @@ export const testFramework = (
         });
       });
 
+      const signGet = async (signingKey: string) => {
+        const ts = Math.round(Date.now() / 1000).toString();
+        return {
+          [headerKeys.Signature]: `t=${ts}&s=${await signDataWithKey(
+            "",
+            signingKey,
+            ts,
+          )}`,
+        };
+      };
+
       test("can pick up delayed event key from environment", async () => {
+        // Cloud mode (default) requires a signing key + a signed GET to
+        // return introspection.
+        const signingKey = "signing-key-123";
         const ret = await run(
           [{ client: createClient({ id: "test" }), functions: [] }],
-          [{ method: "GET" }],
-          { [envKeys.InngestEventKey]: "event-key-123" },
+          [{ method: "GET", headers: await signGet(signingKey) }],
+          {
+            [envKeys.InngestEventKey]: "event-key-123",
+            [envKeys.InngestSigningKey]: signingKey,
+          },
         );
 
         const body = JSON.parse(ret.body);
@@ -452,10 +469,11 @@ export const testFramework = (
       });
 
       test("can pick up delayed signing key from environment", async () => {
+        const signingKey = "signing-key-123";
         const ret = await run(
           [{ client: createClient({ id: "test" }), functions: [] }],
-          [{ method: "GET" }],
-          { [envKeys.InngestSigningKey]: "signing-key-123" },
+          [{ method: "GET", headers: await signGet(signingKey) }],
+          { [envKeys.InngestSigningKey]: signingKey },
         );
 
         expect(ret.status).toEqual(200);
@@ -467,7 +485,10 @@ export const testFramework = (
         });
       });
 
-      test("#690 returns 200 if signature validation fails", async () => {
+      test("returns 401 in cloud mode if signature validation fails", async () => {
+        // Counterpart of the dropped #690 test: cloud mode GET with no
+        // signature now returns 401 instead of an unauthenticated
+        // introspection body, so we don't fingerprint the deployment.
         const ret = await run(
           [
             {
@@ -479,13 +500,8 @@ export const testFramework = (
           { [envKeys.InngestSigningKey]: "signing-key-123" },
         );
 
-        expect(ret.status).toEqual(200);
-
-        const body = JSON.parse(ret.body);
-
-        expect(body).toMatchObject({
-          has_signing_key: true,
-        });
+        expect(ret.status).toEqual(401);
+        expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
       });
     });
 
@@ -1087,7 +1103,7 @@ export const testFramework = (
 
     describe("POST (run function)", () => {
       describe("#789 missing body", () => {
-        test("returns 500", async () => {
+        test("returns 401", async () => {
           const client = createClient({ id: "test" });
 
           const fn = client.createFunction(
@@ -1103,7 +1119,7 @@ export const testFramework = (
             { body: () => undefined },
           );
 
-          expect(ret.status).toEqual(500);
+          expect(ret.status).toEqual(401);
         });
       });
 
@@ -1129,11 +1145,7 @@ export const testFramework = (
             env,
           );
           expect(ret.status).toEqual(401);
-          expect(JSON.parse(ret.body)).toMatchObject({
-            message: expect.stringContaining(
-              `No ${headerKeys.Signature} provided`,
-            ),
-          });
+          expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
         });
         test("should throw an error with an invalid signature", async () => {
           const ret = await run(
@@ -1142,11 +1154,7 @@ export const testFramework = (
             env,
           );
           expect(ret.status).toEqual(401);
-          expect(JSON.parse(ret.body)).toMatchObject({
-            message: expect.stringContaining(
-              `Invalid ${headerKeys.Signature} provided`,
-            ),
-          });
+          expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
         });
         test("should throw an error with an expired signature", async () => {
           const yesterday = new Date();
@@ -1167,10 +1175,8 @@ export const testFramework = (
             ],
             env,
           );
-          expect(ret).toMatchObject({
-            status: 401,
-            body: expect.stringContaining("Signature has expired"),
-          });
+          expect(ret.status).toEqual(401);
+          expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
         });
         // These signatures are randomly generated within a local development environment, matching
         // what is sent from the cloud.
@@ -1323,10 +1329,8 @@ export const testFramework = (
               ],
               env,
             );
-            expect(ret).toMatchObject({
-              status: 401,
-              body: expect.stringContaining("Invalid signature"),
-            });
+            expect(ret.status).toEqual(401);
+            expect(JSON.parse(ret.body)).toEqual({ message: "Unauthorized" });
           });
         });
 

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -506,6 +506,35 @@ export const testFramework = (
     });
 
     describe("PUT (register)", () => {
+      // Tests that want the SDK to return its full identification headers
+      // (sdk version, framework, env, platform, expected-server-kind) need
+      // to send a properly-signed request — unsigned requests in cloud mode
+      // strip those headers to avoid fingerprinting. Defaults the signed
+      // body to `{}` because `node-mocks-http` materializes a missing body
+      // as an empty object, which the server canonicalizes to `"{}"` before
+      // HMACing.
+      const putSigningKey = "signkey-test-12345";
+      const signedPutHeaders = async (
+        body: unknown = {},
+      ): Promise<Record<string, string>> => {
+        const ts = Math.round(Date.now() / 1000).toString();
+        return {
+          [headerKeys.Signature]: `t=${ts}&s=${await signDataWithKey(
+            body,
+            putSigningKey,
+            ts,
+          )}`,
+        };
+      };
+
+      // Force cloud mode (so the SDK targets api.inngest.com where nock is
+      // mocking, not the dev server) and provide the signing key so the
+      // signature we're sending validates.
+      const putEnv = {
+        [envKeys.InngestSigningKey]: putSigningKey,
+        INNGEST_DEV: "0",
+      };
+
       describe("out-of-band (legacy)", () => {
         describe("prod env registration", () => {
           test("register with correct default URL from request", async () => {
@@ -528,10 +557,12 @@ export const testFramework = (
                   method: "PUT",
                   url: "/api/inngest",
                   headers: {
+                    ...(await signedPutHeaders()),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
               ],
+              putEnv,
             );
 
             const retBody = JSON.parse(ret.body);
@@ -568,11 +599,13 @@ export const testFramework = (
                 {
                   method: "PUT",
                   headers: {
+                    ...(await signedPutHeaders()),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
               ],
               {
+                ...putEnv,
                 [envKeys.IsNetlify]: "true",
               },
             );
@@ -606,10 +639,12 @@ export const testFramework = (
                   method: "PUT",
                   url: customUrl,
                   headers: {
+                    ...(await signedPutHeaders()),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
               ],
+              putEnv,
             );
 
             const retBody = JSON.parse(ret.body);
@@ -658,7 +693,13 @@ export const testFramework = (
 
             await run(
               [{ client: inngest, functions: [fn1], serveHost }],
-              [{ method: "PUT" }],
+              [
+                {
+                  method: "PUT",
+                  headers: { ...(await signedPutHeaders()) },
+                },
+              ],
+              putEnv,
             );
 
             expect(reqToMock).toMatchObject({
@@ -700,7 +741,13 @@ export const testFramework = (
 
             await run(
               [{ client: inngest, functions: [fn1], servePath }],
-              [{ method: "PUT" }],
+              [
+                {
+                  method: "PUT",
+                  headers: { ...(await signedPutHeaders()) },
+                },
+              ],
+              putEnv,
             );
 
             expect(reqToMock).toMatchObject({
@@ -735,10 +782,12 @@ export const testFramework = (
                 {
                   method: "PUT",
                   headers: {
+                    ...(await signedPutHeaders()),
                     [headerKeys.InngestServerKind]: serverKind.Dev,
                   },
                 },
               ],
+              putEnv,
             );
 
             expect(ret).toMatchObject({
@@ -775,7 +824,13 @@ export const testFramework = (
 
           await run(
             [{ client: inngest, functions: [fn1], serveHost, servePath }],
-            [{ method: "PUT" }],
+            [
+              {
+                method: "PUT",
+                headers: { ...(await signedPutHeaders()) },
+              },
+            ],
+            putEnv,
           );
 
           expect(reqToMock).toMatchObject({
@@ -821,14 +876,19 @@ export const testFramework = (
                   status: 200,
                 });
 
-              await run(serveHandler, [
-                {
-                  method: "PUT",
-                  url: `/api/inngest${
-                    deployId ? `?${queryKeys.DeployId}=${deployId}` : ""
-                  }`,
-                },
-              ]);
+              await run(
+                serveHandler,
+                [
+                  {
+                    method: "PUT",
+                    url: `/api/inngest${
+                      deployId ? `?${queryKeys.DeployId}=${deployId}` : ""
+                    }`,
+                    headers: { ...(await signedPutHeaders()) },
+                  },
+                ],
+                putEnv,
+              );
 
               // Asserts that the nock scope was used
               scope.done();
@@ -946,12 +1006,23 @@ export const testFramework = (
             if (typeof expectedResponse === "number") {
               expect(ret.status).toEqual(expectedResponse);
             } else {
-              expect(ret).toMatchObject({
-                status: 200,
-                headers: expect.objectContaining({
-                  [headerKeys.InngestSyncKind]: expectedResponse,
-                }),
-              });
+              // When the SDK is in cloud mode and the request was unsigned or
+              // had an invalid signature, all `x-inngest-*` headers other
+              // than `x-inngest-sdk-handled` are stripped to avoid
+              // fingerprinting an unauthenticated caller. We can still verify
+              // the sync succeeded (status 200), but the sync-kind header is
+              // unavailable.
+              const sigStripped =
+                sdkMode === serverKind.Cloud && validSignature !== true;
+
+              expect(ret.status).toEqual(200);
+              if (!sigStripped) {
+                expect(ret.headers).toEqual(
+                  expect.objectContaining({
+                    [headerKeys.InngestSyncKind]: expectedResponse,
+                  }),
+                );
+              }
             }
           });
         };


### PR DESCRIPTION
## Summary

Reduce response info when unauthorized:
- Body is only `{ "message": "Unauthorized" }`.
- No `X-Inngest` headers (except the new `X-Inngest-Sdk-Handled: true`).
- No `User-Agent` header, since it contains the SDK version.

Additionally, this PR removes the unauthenticated `GET` request (a.k.a. "unauthenticated introspection"). This was an intentional feature for troubleshooting. It did not return any sensitive info, but it's still a best practice to minimize response info to an unauthenticated client.

This PR does not remove the unauthenticated `PUT` request (a.k.a. "out-of-band sync"). This is an intentional feature that allows an unauthenticated caller to trigger an app sync. This is not a security vulnerability since the caller is unable to dictate anything besides telling the SDK to sync itself with Inngest. The caller cannot change any SDK configuration or change the Inngest API URL that the SDK sends its sync request to.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
https://linear.app/inngest/issue/EXE-1710

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR hardens the SDK's HTTP responses for unauthorized requests: strips `x-inngest-*` and `User-Agent` headers, removes the unauthenticated GET introspection body (returning 401 instead), and normalizes all auth-failure bodies to `{ message: "Unauthorized" }`. A new `x-inngest-sdk-handled` header is always preserved. Tests are updated throughout to send signed requests in cloud mode.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ca99b9f5fe8b2580fbe212c0cfd64e4574f00fc0.</sup>
<!-- /MENDRAL_SUMMARY -->