### PR TITLE
Fix test

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -621,9 +621,16 @@ describe("RequestSignature", () => {
 });
 
 describe("introspection", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   const logger = new ConsoleLogger({ level: "silent" });
 
   test("authenticated", async () => {
+    const fakeEnv = "v10";
+    vi.stubEnv(envKeys.InngestEnvironment, fakeEnv);
+
     const signingKey =
       "signkey-test-0000000000000000000000000000000000000000000000000000000000000000";
     const signingKeyFallback =
@@ -681,7 +688,7 @@ describe("introspection", () => {
       app_id: "test",
       authentication_succeeded: true,
       capabilities: { trust_probe: "v1", connect: "v1" },
-      env: null,
+      env: fakeEnv,
       event_api_origin: "https://inn.gs/",
       event_key_hash: null,
       extra: {


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes the "authenticated" introspection test by stubbing `INNGEST_ENV` to a known value (`"v10"`) before the test runs, then asserting `env: fakeEnv` instead of `env: null`. An `afterEach` cleanup hook is added to restore env stubs between tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 5b313db1e1a2d50eae8f9384eb82677cdad81bd2.</sup>
<!-- /MENDRAL_SUMMARY -->