### PR TITLE
(v3) Do not touch `@latest` when backporting

### DIFF
--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -11,13 +11,17 @@ console.log("branch:", branch);
 
 const name = process.env.npm_package_name;
 const version = process.env.npm_package_version;
-const registry = process.env.npm_package_publishConfig_registry;
 console.log("version:", version);
 const tag = `${name}@${version}`;
 console.log("tag:", tag);
 
 const [, tagEnd = ""] = version.split("-");
-const distTag = tagEnd.split(".")[0] || "latest";
+let distTag = tagEnd.split(".")[0] || "latest";
+// Backport branches publish under their own dist-tag (e.g. `v3-lts`) so they
+// never touch `latest`.
+if (branch !== "main") {
+  distTag = `${branch}-lts`;
+}
 console.log("distTag:", distTag);
 
 console.log("process.cwd()", process.cwd());
@@ -59,52 +63,6 @@ const exec = async (...args) => {
     throw new Error(`git ls-remote exited with ${exitCode}:\n${stderr}`);
   }
 
-  // Get current latest version
-  let latestVersion;
-
-  const {
-    exitCode: latestCode,
-    stdout: latestStdout,
-    stderr: latestStderr,
-  } = await getExecOutput("npm", ["dist-tag", "ls"]);
-
-  if (latestCode !== 0) {
-    // It could be a non-zero code if the package was never published before
-    const notFoundMsg = "is not in this registry";
-
-    if (
-      latestStdout.includes(notFoundMsg) ||
-      latestStderr.includes(notFoundMsg)
-    ) {
-      console.log(
-        "npm dist-tag ls failed but it's okay; package hasn't been published yet"
-      );
-    } else {
-      throw new Error(
-        `npm dist-tag ls exited with ${latestCode}:\n${latestStderr}`
-      );
-    }
-  } else {
-    latestVersion = latestStdout
-      ?.split("\n")
-      ?.find((line) => line.startsWith("latest: "))
-      ?.split(" ")[1];
-
-    if (!latestVersion) {
-      throw new Error(`Could not find "latest" dist-tag in:\n${latestStdout}`);
-    }
-  }
-
-  console.log("latestVersion:", latestVersion);
-
-  // If this is going to be backport release, don't allow us to continue if we
-  // have no latest version to reset to
-  if (branch !== "main" && !latestVersion) {
-    throw new Error(
-      "Cannot continue with backport release; no latest version found"
-    );
-  }
-
   // Release to npm
   await exec("npm", ["config", "set", "git-tag-version", "false"], {
     cwd: distDir,
@@ -144,23 +102,4 @@ const exec = async (...args) => {
   }
 
   console.log("Publish successful");
-
-  // If this was a backport release, republish the "latest" tag at the actual latest version
-  if (branch !== "main" && distTag === "latest") {
-    console.log(
-      'is backport release; updating "latest" tag to:',
-      latestVersion
-    );
-
-    // `npm dist-tag` doesn't obey `publishConfig.registry`, so we must
-    // explicitly pass the registry URL here
-    await exec("npm", [
-      "dist-tag",
-      "add",
-      `inngest@${latestVersion}`,
-      "latest",
-      "--registry",
-      registry,
-    ]);
-  }
 })();


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Do not touch `@latest` when backporting fixes.

We needed this a long time ago, but no longer.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~Added a [docs PR](https://github.com/inngest/website) that references this PR~ N/A KTLO
- [ ] ~Added unit/integration tests~ N/A CI
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- #230 
- `v3` version of #1501

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Simplifies the backport release flow by assigning a branch-specific dist-tag (e.g. `v3-lts`) for non-main branches instead of publishing under `latest` and then resetting it. Removes ~60 lines of `npm dist-tag ls` + re-tagging logic that was needed to restore `latest` after a backport publish.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 65080cee598b580614bcc10d811a230ae88ceeea.</sup>
<!-- /MENDRAL_SUMMARY -->