### PR TITLE
Skip a flaky test

### DIFF
--- a/packages/inngest/src/components/connect/strategies/core/integration.test.ts
+++ b/packages/inngest/src/components/connect/strategies/core/integration.test.ts
@@ -553,7 +553,8 @@ describe.skipIf(!hasNativeWebSocket)("ConnectionCore integration", () => {
       await gateway.start();
     });
 
-    it(
+    // Skipping because it's flaky. Needs to be fixed
+    it.skip(
       "server-side WS close triggers reconnection",
       { timeout: 15000 },
       async () => {


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Skips a flaky integration test for server-side WebSocket close triggering reconnection, with a comment noting it needs to be fixed.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0e663b078ddae13b5644f75cfecd65cd15a41c5f.</sup>
<!-- /MENDRAL_SUMMARY -->