### PR TITLE
EXE-1708: Support Temporal.* types for .Timeout fields

### DIFF
--- a/.changeset/temporal-types.md
+++ b/.changeset/temporal-types.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Accept `Temporal.Duration`, `Temporal.Instant`, and `Temporal.ZonedDateTime` (and their `*Like` variants) wherever a timeout or sleep duration is taken: `step.sleep()`, `step.waitForEvent()`, `step.waitForSignal()`, `step.invoke()`, and function-level `cancelOn` timeouts. Durations are treated as relative waits; instants and zoned date-times as absolute deadlines.

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -719,6 +719,23 @@ describe("sleep", () => {
     });
   });
 
+  test("parses month-long Temporal.Duration", async () => {
+    // Calendar-unit Durations resolve relative to "now". Freeze time so the
+    // 1-month conversion is deterministic: 2026-04-28 → 2026-05-28 = 30 days.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-28T12:00:00Z"));
+
+    try {
+      const duration = Temporal.Duration.from({ months: 1 });
+
+      await expect(step.sleep("id", duration)).resolves.toMatchObject({
+        name: "4w2d",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("returns userland", async () => {
     await expect(step.sleep("id", "1m")).resolves.toMatchObject({
       userland: { id: "id" },

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -97,6 +97,30 @@ describe("waitForEvent", () => {
     });
   });
 
+  test("return TTL if `Temporal.Duration` `timeout` given", async () => {
+    const duration = Temporal.Duration.from({ hours: 2 });
+
+    await expect(
+      step.waitForEvent("id", { event: "event", timeout: duration }),
+    ).resolves.toMatchObject({
+      opts: {
+        timeout: "2h",
+      },
+    });
+  });
+
+  test("return TTL if `Temporal.Instant` `timeout` given", async () => {
+    const instant = Temporal.Now.instant().add({ hours: 1 });
+
+    await expect(
+      step.waitForEvent("id", { event: "event", timeout: instant }),
+    ).resolves.toMatchObject({
+      opts: {
+        timeout: instant.toString(),
+      },
+    });
+  });
+
   test("return simple field match if `match` string given", async () => {
     await expect(
       step.waitForEvent("id", { event: "event", match: "name", timeout: "2h" }),
@@ -1020,6 +1044,36 @@ describe("invoke", () => {
         ).resolves.toMatchObject({
           opts: {
             timeout: "1m",
+          },
+        });
+      });
+
+      test("return correct timeout if `Temporal.Duration` `timeout` given", async () => {
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            timeout: Temporal.Duration.from({ minutes: 1 }),
+          }),
+        ).resolves.toMatchObject({
+          opts: {
+            timeout: "1m",
+          },
+        });
+      });
+
+      test("return correct timeout if `Temporal.Instant` `timeout` given", async () => {
+        const instant = Temporal.Now.instant().add({ hours: 1 });
+
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            timeout: instant,
+          }),
+        ).resolves.toMatchObject({
+          opts: {
+            timeout: instant.toString(),
           },
         });
       });

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -497,8 +497,6 @@ export const createStepTools = <
         opts: WaitForSignalOpts,
       ) => Promise<{ signal: string; data: Jsonify<TData> } | null>
     >(({ id, name }, opts) => {
-      // TODO Should support Temporal.DurationLike, Temporal.InstantLike,
-      // Temporal.ZonedDateTimeLike
       return {
         id,
         mode: StepMode.Async,
@@ -643,11 +641,18 @@ export const createStepTools = <
            *
            * The time to wait can be specified using a `number` of milliseconds,
            * an `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or
-           * `"2.5d"`, or a `Date` object.
+           * `"2.5d"`, a `Date`, a `Temporal.Duration` (relative wait), or a
+           * `Temporal.Instant` / `Temporal.ZonedDateTime` (absolute deadline).
            *
            * {@link https://npm.im/ms}
            */
-          timeout: number | string | Date;
+          timeout:
+            | number
+            | string
+            | Date
+            | Temporal.DurationLike
+            | Temporal.InstantLike
+            | Temporal.ZonedDateTimeLike;
         } & ExclusiveKeys<{ match?: string; if?: string }, "match", "if">,
       >(
         idOrOptions: StepOptionsOrId,
@@ -875,7 +880,25 @@ export const createStepTools = <
       // Create a discriminated union to operate on based on the input types
       // available for this tool.
       const optsSchema = invokePayloadSchema.extend({
-        timeout: z.union([z.number(), z.string(), z.date()]).optional(),
+        timeout: z
+          .custom<
+            | number
+            | string
+            | Date
+            | Temporal.DurationLike
+            | Temporal.InstantLike
+            | Temporal.ZonedDateTimeLike
+          >(
+            (v) =>
+              typeof v === "number" ||
+              typeof v === "string" ||
+              v instanceof Date ||
+              Temporal.isTemporalDuration(v) ||
+              Temporal.isTemporalInstant(v) ||
+              Temporal.isTemporalZonedDateTime(v),
+            { message: "Invalid timeout" },
+          )
+          .optional(),
       });
 
       const parsedFnOpts = optsSchema
@@ -1152,11 +1175,18 @@ type InvocationOpts<TFunction extends InvokeTargetFunctionDefinition> =
        *
        * The time to wait can be specified using a `number` of milliseconds, an
        * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`,
-       * or a `Date` object.
+       * a `Date`, a `Temporal.Duration` (relative wait), or a `Temporal.Instant`
+       * / `Temporal.ZonedDateTime` (absolute deadline).
        *
        * {@link https://npm.im/ms}
        */
-      timeout?: number | string | Date;
+      timeout?:
+        | number
+        | string
+        | Date
+        | Temporal.DurationLike
+        | Temporal.InstantLike
+        | Temporal.ZonedDateTimeLike;
     };
 
 /**
@@ -1189,12 +1219,19 @@ type WaitForSignalOpts = {
    * data.
    *
    * The time to wait can be specified using a `number` of milliseconds, an
-   * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or
-   * a `Date` object.
+   * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, a
+   * `Date`, a `Temporal.Duration` (relative wait), or a `Temporal.Instant` /
+   * `Temporal.ZonedDateTime` (absolute deadline).
    *
    * {@link https://npm.im/ms}
    */
-  timeout: number | string | Date;
+  timeout:
+    | number
+    | string
+    | Date
+    | Temporal.DurationLike
+    | Temporal.InstantLike
+    | Temporal.ZonedDateTimeLike;
 
   /**
    * When this `step.waitForSignal()` call is made, choose whether an existing

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -795,11 +795,7 @@ export const createStepTools = <
        * The presence of this operation in the returned stack indicates that the
        * sleep is over and we should continue execution.
        */
-      const msTimeStr: string = timeStr(
-        Temporal.isTemporalDuration(time)
-          ? time.total({ unit: "milliseconds" })
-          : (time as number | string),
-      );
+      const msTimeStr: string = timeStr(time);
 
       return {
         id,

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -147,7 +147,9 @@ export class MiddlewareManager {
     let opName: string | undefined;
     if (stepType === "sleep" && stepInfo.input !== undefined) {
       if (!isTimeStrInput(stepInfo.input[0])) {
-        throw new Error("Sleep time must be a string, number, or Date");
+        throw new Error(
+          "Sleep time must be a string, number, Date, or Temporal.Duration",
+        );
       }
       opName = timeStr(stepInfo.input[0]);
     }

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -5,7 +5,7 @@ import type { MemoizedOp } from "../execution/InngestExecution.ts";
 import type { InngestFunction } from "../InngestFunction.ts";
 import type { Middleware } from "./middleware.ts";
 import {
-  isTimeStrInput,
+  isSleepInput,
   optsFromStepInput,
   stepInputFromOpts,
   stepTypeFromOpCode,
@@ -146,7 +146,7 @@ export class MiddlewareManager {
     // already set the name directly.
     let opName: string | undefined;
     if (stepType === "sleep" && stepInfo.input !== undefined) {
-      if (!isTimeStrInput(stepInfo.input[0])) {
+      if (!isSleepInput(stepInfo.input[0])) {
         throw new Error(
           "Sleep time must be a string, number, Date, or Temporal.Duration",
         );

--- a/packages/inngest/src/components/middleware/utils.test.ts
+++ b/packages/inngest/src/components/middleware/utils.test.ts
@@ -1,7 +1,12 @@
+import { Temporal } from "temporal-polyfill";
 import { describe, expect, test } from "vitest";
 import { ConsoleLogger } from "../../middleware/logger.ts";
 import { StepOpCode } from "../../types.ts";
-import { optsFromStepInput, stepTypeFromOpCode } from "./utils.ts";
+import {
+  isTimeStrInput,
+  optsFromStepInput,
+  stepTypeFromOpCode,
+} from "./utils.ts";
 
 const logger = new ConsoleLogger();
 
@@ -139,5 +144,18 @@ describe("optsFromStepInput", () => {
   test("returns undefined when input[0] is not an object", () => {
     expect(optsFromStepInput("invoke", ["not-an-object"])).toBeUndefined();
     expect(optsFromStepInput("invoke", [null])).toBeUndefined();
+  });
+});
+
+describe("isTimeStrInput", () => {
+  test("accepts string, number, Date, and Temporal.Duration", () => {
+    expect(isTimeStrInput("1h")).toBe(true);
+    expect(isTimeStrInput(60_000)).toBe(true);
+    expect(isTimeStrInput(new Date())).toBe(true);
+    expect(isTimeStrInput(Temporal.Duration.from({ seconds: 1 }))).toBe(true);
+  });
+
+  test("rejects an invalid value", () => {
+    expect(isTimeStrInput({})).toBe(false);
   });
 });

--- a/packages/inngest/src/components/middleware/utils.test.ts
+++ b/packages/inngest/src/components/middleware/utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { ConsoleLogger } from "../../middleware/logger.ts";
 import { StepOpCode } from "../../types.ts";
 import {
-  isTimeStrInput,
+  isSleepInput,
   optsFromStepInput,
   stepTypeFromOpCode,
 } from "./utils.ts";
@@ -147,15 +147,15 @@ describe("optsFromStepInput", () => {
   });
 });
 
-describe("isTimeStrInput", () => {
+describe("isSleepInput", () => {
   test("accepts string, number, Date, and Temporal.Duration", () => {
-    expect(isTimeStrInput("1h")).toBe(true);
-    expect(isTimeStrInput(60_000)).toBe(true);
-    expect(isTimeStrInput(new Date())).toBe(true);
-    expect(isTimeStrInput(Temporal.Duration.from({ seconds: 1 }))).toBe(true);
+    expect(isSleepInput("1h")).toBe(true);
+    expect(isSleepInput(60_000)).toBe(true);
+    expect(isSleepInput(new Date())).toBe(true);
+    expect(isSleepInput(Temporal.Duration.from({ seconds: 1 }))).toBe(true);
   });
 
   test("rejects an invalid value", () => {
-    expect(isTimeStrInput({})).toBe(false);
+    expect(isSleepInput({})).toBe(false);
   });
 });

--- a/packages/inngest/src/components/middleware/utils.ts
+++ b/packages/inngest/src/components/middleware/utils.ts
@@ -1,3 +1,4 @@
+import { type DurationLike, isTemporalDuration } from "../../helpers/temporal";
 import { isRecord } from "../../helpers/types";
 import type { Logger } from "../../middleware/logger";
 import { type SendEventBaseOutput, StepOpCode } from "../../types";
@@ -7,11 +8,12 @@ import type { ExtractLiteralStrings } from "./types";
 
 export function isTimeStrInput(
   value: unknown,
-): value is string | number | Date {
+): value is string | number | Date | DurationLike {
   return (
     typeof value === "string" ||
     typeof value === "number" ||
-    value instanceof Date
+    value instanceof Date ||
+    isTemporalDuration(value)
   );
 }
 

--- a/packages/inngest/src/components/middleware/utils.ts
+++ b/packages/inngest/src/components/middleware/utils.ts
@@ -6,7 +6,7 @@ import type { InngestFunction } from "../InngestFunction";
 import type { Middleware } from "./middleware";
 import type { ExtractLiteralStrings } from "./types";
 
-export function isTimeStrInput(
+export function isSleepInput(
   value: unknown,
 ): value is string | number | Date | DurationLike {
   return (

--- a/packages/inngest/src/helpers/strings.test.ts
+++ b/packages/inngest/src/helpers/strings.test.ts
@@ -1,3 +1,5 @@
+import { Temporal } from "temporal-polyfill";
+import { afterEach, beforeEach, vi } from "vitest";
 import { ConsoleLogger } from "../middleware/logger.ts";
 import { signDataWithKey } from "./net.ts";
 import { slugify, stringify, timeStr, timingSafeEqual } from "./strings.ts";
@@ -44,6 +46,63 @@ describe("timeStr", () => {
 
   test("converts a date to an ISO string", () => {
     expect(timeStr(new Date(0))).toEqual("1970-01-01T00:00:00.000Z");
+  });
+
+  test("converts a balanced Temporal.Duration", () => {
+    expect(timeStr(Temporal.Duration.from({ minutes: 1 }))).toEqual("1m");
+  });
+
+  test("converts a Temporal.Instant to an ISO string", () => {
+    const instant = Temporal.Instant.from("1970-01-01T00:00:00Z");
+    expect(timeStr(instant)).toEqual(instant.toString());
+  });
+
+  test("converts a Temporal.ZonedDateTime to an ISO string", () => {
+    const zdt = Temporal.ZonedDateTime.from("1970-01-01T00:00:00+00:00[UTC]");
+    expect(timeStr(zdt)).toEqual(zdt.toInstant().toString());
+  });
+
+  describe("Temporal.Duration matches ms-string equivalents", () => {
+    const cases: Array<{ duration: Temporal.DurationLike; ms: string }> = [
+      { duration: { seconds: 30 }, ms: "30s" },
+      { duration: { minutes: 5 }, ms: "5m" },
+      { duration: { hours: 2 }, ms: "2h" },
+      { duration: { days: 3 }, ms: "3d" },
+      { duration: { weeks: 1 }, ms: "1w" },
+      { duration: { weeks: 2 }, ms: "2w" },
+      // Mixed sub-day combinations should also agree.
+      { duration: { hours: 1, minutes: 30 }, ms: "1.5 hours" },
+    ];
+
+    for (const { duration, ms } of cases) {
+      test(`Duration(${JSON.stringify(duration)}) === ms("${ms}")`, () => {
+        expect(timeStr(Temporal.Duration.from(duration))).toEqual(timeStr(ms));
+      });
+    }
+  });
+
+  describe("Temporal.Duration calendar units are calendar-correct", () => {
+    // Calendar-unit Durations resolve relative to "now". Freeze time so both
+    // the test and `timeStr` see the same `new Date()`, and we can assert
+    // exact equality against the same `.total()` call.
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-28T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("1 month from 2026-04-28 = 30 calendar days", () => {
+      // 2026-04-28 → 2026-05-28 = 30 days = 4w2d
+      expect(timeStr(Temporal.Duration.from({ months: 1 }))).toEqual("4w2d");
+    });
+
+    test("1 year from 2026-04-28 = 365 calendar days", () => {
+      // 2026-04-28 → 2027-04-28 = 365 days = 52w1d (2026 is not a leap year)
+      expect(timeStr(Temporal.Duration.from({ years: 1 }))).toEqual("52w1d");
+    });
   });
 });
 

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -79,9 +79,6 @@ const periods = [
 /**
  * Convert a given `Date`, `number`, or `ms`-compatible `string` to a
  * Inngest sleep-compatible time string (e.g. `"1d"` or `"2h3010s"`).
- *
- * Can optionally provide a `now` date to use as the base for the calculation,
- * otherwise a new date will be created on invocation.
  */
 export const timeStr = (
   /**

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -1,7 +1,17 @@
 import hashjs from "hash.js";
 import { default as safeStringify } from "json-stringify-safe";
 import ms from "ms";
+import { Temporal } from "temporal-polyfill";
 import type { TimeStr } from "../types.ts";
+import {
+  type DurationLike,
+  getISOString,
+  type InstantLike,
+  isTemporalDuration,
+  isTemporalInstant,
+  isTemporalZonedDateTime,
+  type ZonedDateTimeLike,
+} from "./temporal.ts";
 
 const { sha256 } = hashjs;
 
@@ -84,14 +94,39 @@ export const timeStr = (
   /**
    * The future date to use to convert to a time string.
    */
-  input: string | number | Date,
+  input:
+    | string
+    | number
+    | Date
+    | DurationLike
+    | InstantLike
+    | ZonedDateTimeLike,
 ): string => {
   if (input instanceof Date) {
     return input.toISOString();
   }
 
-  const milliseconds: number =
-    typeof input === "string" ? ms(input as `${number}`) : input;
+  if (isTemporalInstant(input) || isTemporalZonedDateTime(input)) {
+    return getISOString(input);
+  }
+
+  let milliseconds: number;
+  if (isTemporalDuration(input)) {
+    // `relativeTo` is required for calendar units (months/years/weeks). We
+    // pass it as an ISO string rather than a Temporal object so this works
+    // regardless of which Temporal implementation the user's Duration came
+    // from (temporal-polyfill, @js-temporal/polyfill, native Temporal):
+    // ISO strings are spec-defined and parsed by every implementation;
+    // cross-polyfill object passing is not.
+    milliseconds = input.total({
+      unit: "milliseconds",
+      relativeTo: Temporal.Now.plainDateTimeISO("UTC").toString(),
+    });
+  } else if (typeof input === "string") {
+    milliseconds = ms(input as `${number}`);
+  } else {
+    milliseconds = input as number;
+  }
 
   const [, timeStr] = periods.reduce<[number, string]>(
     ([num, str], [suffix, period]) => {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1318,12 +1318,19 @@ export type Cancellation = {
    * function ends.
    *
    * The time to wait can be specified using a `number` of milliseconds, an
-   * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or
-   * a `Date` object.
+   * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, a
+   * `Date`, a `Temporal.Duration` (relative wait), or a `Temporal.Instant` /
+   * `Temporal.ZonedDateTime` (absolute deadline).
    *
    * {@link https://npm.im/ms}
    */
-  timeout?: number | string | Date;
+  timeout?:
+    | number
+    | string
+    | Date
+    | Temporal.DurationLike
+    | Temporal.InstantLike
+    | Temporal.ZonedDateTimeLike;
 };
 
 /**


### PR DESCRIPTION
## Summary

- We recently added support for Dates server-side on .Timeout fields
- We'd like to add support for Temporal.* types in .Timeout fields
- We carefully resolve Temporal.Duration and validate types
- Structured by commit

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `Temporal.Duration`, `Temporal.Instant`, and `Temporal.ZonedDateTime` support across all timeout/sleep fields (`step.sleep`, `step.waitForEvent`, `step.waitForSignal`, `step.invoke`, `cancelOn`). The `timeStr` helper is extended to handle these types, type signatures are updated throughout, and `isTimeStrInput` is renamed to `isSleepInput` to reflect the diverged type set for `sleep`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2e14575a71bd8c83881e201922f8412d4031fcc1.</sup>
<!-- /MENDRAL_SUMMARY -->