### PR TITLE
fix: use proper URL construction for Vercel protection bypass parameter

### DIFF
--- a/.changeset/fix-vercel-bypass-url.md
+++ b/.changeset/fix-vercel-bypass-url.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix: use proper URL construction for Vercel protection bypass parameter

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -775,3 +775,95 @@ describe("introspection", () => {
     expect(await res.json()).toEqual({ message: "Unauthorized" });
   });
 });
+
+describe("reqUrl (Vercel deployment protection bypass)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const createReqUrlProbe = (options: {
+    servePath?: string;
+    serveOrigin?: string;
+  }): InngestCommHandler & { exposeReqUrl: (url: URL) => URL } => {
+    class ReqUrlProbe extends InngestCommHandler {
+      public exposeReqUrl(url: URL): URL {
+        return this.reqUrl(url);
+      }
+    }
+
+    const client = createClient({ id: "test", isDev: true });
+    return new ReqUrlProbe({
+      client,
+      frameworkName: "test",
+      functions: [],
+      ...options,
+      handler: () => ({
+        body: async () => "",
+        headers: () => null,
+        method: () => "GET",
+        url: () => new URL("https://localhost:3000/api/inngest"),
+        transformResponse: ({
+          body,
+          headers,
+          status,
+        }: {
+          body: string;
+          headers: Record<string, string>;
+          status: number;
+        }) => new Response(body, { status, headers }),
+      }),
+    }) as InngestCommHandler & { exposeReqUrl: (url: URL) => URL };
+  };
+
+  test("parses query strings in INNGEST_SERVE_PATH instead of encoding ? into pathname", () => {
+    vi.stubEnv(
+      envKeys.InngestServePath,
+      "/api/inngest?x-vercel-protection-bypass=mysecret",
+    );
+
+    const probe = createReqUrlProbe({});
+    const incoming = new URL(
+      "https://localhost:3000/original/path?fnId=my-fn&stepId=step",
+    );
+    const result = probe.exposeReqUrl(incoming);
+
+    expect(result.pathname).toBe("/api/inngest");
+    expect(result.searchParams.get("x-vercel-protection-bypass")).toBe(
+      "mysecret",
+    );
+    expect(result.searchParams.get("fnId")).toBe("my-fn");
+    expect(result.href).not.toContain("%3F");
+  });
+
+  test("sets x-vercel-protection-bypass from VERCEL_AUTOMATION_BYPASS_SECRET", () => {
+    vi.stubEnv(envKeys.VercelAutomationBypassSecret, "auto-secret");
+
+    const probe = createReqUrlProbe({ servePath: "/api/inngest" });
+    const incoming = new URL("https://localhost:3000/api/inngest?fnId=f1");
+    const result = probe.exposeReqUrl(incoming);
+
+    expect(result.pathname).toBe("/api/inngest");
+    expect(result.searchParams.get("x-vercel-protection-bypass")).toBe(
+      "auto-secret",
+    );
+    expect(result.searchParams.get("fnId")).toBe("f1");
+    expect(result.href).not.toContain("%3F");
+  });
+
+  test("combines serveOrigin with bypass query without encoding ? into pathname", () => {
+    vi.stubEnv(envKeys.VercelAutomationBypassSecret, "tok");
+
+    const probe = createReqUrlProbe({
+      servePath: "/api/inngest",
+      serveOrigin: "https://myapp.vercel.app",
+    });
+    const incoming = new URL("https://localhost:3000/api/inngest?fnId=fn");
+    const result = probe.exposeReqUrl(incoming);
+
+    expect(result.origin).toBe("https://myapp.vercel.app");
+    expect(result.pathname).toBe("/api/inngest");
+    expect(result.searchParams.get("fnId")).toBe("fn");
+    expect(result.searchParams.get("x-vercel-protection-bypass")).toBe("tok");
+    expect(result.href).not.toContain("%3F");
+  });
+});

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -2298,7 +2298,21 @@ export class InngestCommHandler<
     const servePath = this.servePath || this.env[envKeys.InngestServePath];
 
     if (servePath) {
-      ret.pathname = servePath;
+      /**
+       * Parse path and query separately. Assigning a string containing `?` to
+       * {@link URL.pathname} percent-encodes the separator (`%3F`), which breaks
+       * Vercel Deployment Protection bypass and other query-based routing.
+       */
+      const serveUrl = new URL(servePath, "http://localhost");
+      ret.pathname = serveUrl.pathname;
+      serveUrl.searchParams.forEach((value, key) => {
+        ret.searchParams.set(key, value);
+      });
+    }
+
+    const bypassSecret = this.env[envKeys.VercelAutomationBypassSecret];
+    if (bypassSecret) {
+      ret.searchParams.set("x-vercel-protection-bypass", bypassSecret);
     }
 
     if (this.serveOrigin) {

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -114,6 +114,15 @@ export enum envKeys {
   VercelEnvKey = "VERCEL_ENV",
 
   /**
+   * When set on Vercel, contains the automation bypass secret for Deployment
+   * Protection. The SDK sends this as the `x-vercel-protection-bypass` query
+   * parameter so Inngest Cloud can invoke protected preview deployments.
+   *
+   * {@link https://vercel.com/docs/security/deployment-protection#protection-bypass-for-automation}
+   */
+  VercelAutomationBypassSecret = "VERCEL_AUTOMATION_BYPASS_SECRET",
+
+  /**
    * Standard Node.js environment indicator (e.g. `"production"`, `"development"`,
    * `"test"`). Read by some framework adapters to choose the request scheme,
    * and by prod-mode inference.


### PR DESCRIPTION
## Summary

When `INNGEST_SERVE_PATH` included a query string (for example `x-vercel-protection-bypass`), assigning that full string to `URL.pathname` caused `?` to be percent-encoded as `%3F`, so Vercel treated it as part of the path and ignored the bypass.

## Changes

- Parse `servePath` with `URL` / `URLSearchParams` so path and query stay separate.
- Add support for `VERCEL_AUTOMATION_BYPASS_SECRET`, setting `x-vercel-protection-bypass` via `searchParams`.

## Testing

- Added unit coverage in `InngestCommHandler.test.ts`.

Fixes #1427.

Made with [Cursor](https://cursor.com)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes URL construction in `reqUrl()` so that a `servePath` containing a query string (e.g. `?x-vercel-protection-bypass=…`) is parsed properly instead of having `?` percent-encoded as `%3F` in the pathname. Also adds first-class support for `VERCEL_AUTOMATION_BYPASS_SECRET`, appending it as a real query parameter.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 927e8df7f63e08cbf168fc02202d2e188814a4d4.</sup>
<!-- /MENDRAL_SUMMARY -->