### PR TITLE
Fix waitForSignal not in middleware StepType union

### DIFF
--- a/.changeset/itchy-turtles-wonder.md
+++ b/.changeset/itchy-turtles-wonder.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix waitForSignal not in middleware StepType union

--- a/packages/inngest/src/components/middleware/middleware.ts
+++ b/packages/inngest/src/components/middleware/middleware.ts
@@ -248,6 +248,7 @@ export namespace Middleware {
     | "sendEvent"
     | "sleep"
     | "waitForEvent"
+    | "waitForSignal"
   >;
 
   export type StepInfo = {

--- a/packages/inngest/src/components/middleware/utils.test.ts
+++ b/packages/inngest/src/components/middleware/utils.test.ts
@@ -71,6 +71,12 @@ describe("stepTypeFromOpCode", () => {
     );
   });
 
+  test("WaitForSignal returns 'waitForSignal'", () => {
+    expect(
+      stepTypeFromOpCode(StepOpCode.WaitForSignal, undefined, logger),
+    ).toBe("waitForSignal");
+  });
+
   test("AiGateway with type 'step.ai.infer' returns 'ai.infer'", () => {
     expect(
       stepTypeFromOpCode(

--- a/packages/inngest/src/components/middleware/utils.ts
+++ b/packages/inngest/src/components/middleware/utils.ts
@@ -117,6 +117,8 @@ export function stepTypeFromOpCode(
     return "sleep";
   } else if (op === StepOpCode.WaitForEvent) {
     return "waitForEvent";
+  } else if (op === StepOpCode.WaitForSignal) {
+    return "waitForSignal";
   }
 
   logger.warn({ op, type: opts?.type }, "Unknown step type");


### PR DESCRIPTION
## Summary

Fix `"waitForSignal"` not in middleware `StepType` union

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `"waitForSignal"` to the middleware `StepType` union and implements the corresponding mapping in `stepTypeFromOpCode`, fixing an omission that caused `WaitForSignal` ops to fall through to the unknown-step warning path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 5c8eb9d1fcd24823fcd9a7665712d6238c496889.</sup>
<!-- /MENDRAL_SUMMARY -->