### PR TITLE
Standardize variant naming

### DIFF
--- a/.changeset/quiet-moons-cross.md
+++ b/.changeset/quiet-moons-cross.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Standardize variant naming to `variant` instead of `variant_selected`

--- a/packages/inngest/src/components/InngestGroupTools.ts
+++ b/packages/inngest/src/components/InngestGroupTools.ts
@@ -158,7 +158,7 @@ export type VariantResult<
  */
 export interface ExperimentMetadataValues {
   experiment_name: string;
-  variant_selected: string;
+  variant: string;
   selection_strategy: string;
   available_variants: string[];
   variant_weights?: Record<string, number>;
@@ -337,7 +337,7 @@ export const createGroupTools = (deps?: GroupToolsDeps): GroupTools => {
             "merge",
             {
               experiment_name: stepOpts.id,
-              variant_selected: result,
+              variant: result,
               selection_strategy: select.__experimentConfig.strategy,
               available_variants: variantNames,
               ...(select.__experimentConfig.weights && {

--- a/packages/inngest/src/components/experiment.test.ts
+++ b/packages/inngest/src/components/experiment.test.ts
@@ -852,7 +852,7 @@ describe("group.experiment() metadata", () => {
       "merge",
       expect.objectContaining({
         experiment_name: "checkout-flow",
-        variant_selected: "control",
+        variant: "control",
         selection_strategy: "fixed",
         available_variants: ["control", "treatment"],
       }),
@@ -1015,8 +1015,8 @@ describe("group.experiment() metadata", () => {
     const values = call![4] as Record<string, unknown>;
 
     expect(values.experiment_name).toBe("full-meta");
-    expect(values.variant_selected).toBeDefined();
-    expect(["control", "treatment"]).toContain(values.variant_selected);
+    expect(values.variant).toBeDefined();
+    expect(["control", "treatment"]).toContain(values.variant);
     expect(values.selection_strategy).toBe("weighted");
     expect(values.available_variants).toEqual(["control", "treatment"]);
     expect(values.variant_weights).toEqual(weights);


### PR DESCRIPTION
## Summary
Removes `variant_selected` in favor of `variant`

OSS correlated PR: https://github.com/inngest/inngest/pull/4131


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
