### PR TITLE
fix: preserve retryAfter through step error path

### DIFF
--- a/.changeset/warm-corners-check.md
+++ b/.changeset/warm-corners-check.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Fix a bug that didn't respect the RetryAt value

--- a/.changeset/warm-corners-check.md
+++ b/.changeset/warm-corners-check.md
@@ -1,5 +1,5 @@
 ---
-"inngest": minor
+"inngest": patch
 ---
 
-Fix a bug that didn't respect the RetryAt value
+Fix RetryAfterError not respected

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1734,15 +1734,11 @@ class InngestExecutionEngine
     // Step's stream should be rolled back
     this.streamTools.rollback(outgoingOp.id);
 
-    // Serialize the error so it survives JSON.stringify (raw Error
-    // objects have non-enumerable properties that get dropped).
-    // This is critical for checkpoint requests where the error is
-    // sent as JSON in the request body.
-    const serialized = serializeError(error);
-
+    // `transformOutput` runs `retriability(error)` then serializes — pre-serializing
+    // here drops `RetryAfterError.retryAfter` (custom property) and breaks the check.
     return {
       ...outgoingOp,
-      error: serialized,
+      error,
       op: isFinal ? StepOpCode.StepFailed : StepOpCode.StepError,
       ...(metadata && metadata.length > 0 ? { metadata } : {}),
     };

--- a/packages/inngest/src/test/integration/retryAfterError.test.ts
+++ b/packages/inngest/src/test/integration/retryAfterError.test.ts
@@ -1,0 +1,100 @@
+import type { AddressInfo } from "node:net";
+import { randomSuffix, testNameFromFileUrl } from "@inngest/test-harness";
+import { afterEach, expect, test } from "vitest";
+import { headerKeys } from "../../helpers/consts.ts";
+import { Inngest, NonRetriableError, RetryAfterError } from "../../index.ts";
+import { createServer } from "../../node.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+const eventName = "test/event";
+
+let cleanup: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await cleanup?.();
+  cleanup = undefined;
+});
+
+async function startServerWithStepThatThrows(
+  err: Error,
+): Promise<{ url: string; fnId: string }> {
+  const appId = randomSuffix(testFileName);
+  const fnInternalId = "fn";
+
+  const client = new Inngest({ id: appId, isDev: true });
+  const fn = client.createFunction(
+    { id: fnInternalId, retries: 0, triggers: [{ event: eventName }] },
+    async ({ step }) => {
+      await step.run("test-step", () => {
+        throw err;
+      });
+    },
+  );
+
+  const servePath = "/api/inngest";
+  const server = createServer({ client, functions: [fn], servePath });
+  cleanup = () =>
+    new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, () => {
+      server.removeListener("error", reject);
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+
+  return {
+    url: `http://localhost:${port}${servePath}`,
+    fnId: `${appId}-${fnInternalId}`,
+  };
+}
+
+function stepExecBody() {
+  return {
+    ctx: {
+      run_id: "run-1",
+      attempt: 0,
+      disable_immediate_execution: false,
+      use_api: false,
+      stack: { stack: [], current: 0 },
+    },
+    event: { name: eventName, data: {} },
+    events: [{ name: eventName, data: {} }],
+    steps: {},
+  };
+}
+
+test("RetryAfterError thrown inside step.run sets Retry-After header", async () => {
+  const { url, fnId } = await startServerWithStepThatThrows(
+    new RetryAfterError("rate limited", 600_000),
+  );
+
+  const res = await fetch(`${url}?fnId=${fnId}&stepId=step`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(stepExecBody()),
+  });
+
+  expect(res.status).toBe(206);
+  expect(res.headers.get(headerKeys.RetryAfter)).toBe("600");
+  expect(res.headers.get(headerKeys.NoRetry)).toBe("false");
+});
+
+test("NonRetriableError thrown inside step.run sets X-Inngest-No-Retry header", async () => {
+  const { url, fnId } = await startServerWithStepThatThrows(
+    new NonRetriableError("permanent failure"),
+  );
+
+  const res = await fetch(`${url}?fnId=${fnId}&stepId=step`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(stepExecBody()),
+  });
+
+  expect(res.status).toBe(206);
+  expect(res.headers.get(headerKeys.NoRetry)).toBe("true");
+  expect(res.headers.get(headerKeys.RetryAfter)).toBeNull();
+});


### PR DESCRIPTION
## Summary
Don't pre-serialize in `buildStepErrorOp` b/c `transformOutput` already serializes after running `retriability()`. Doing it before drops the custom `retryAfter` property

## Checklist

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related

[EXE-1737: `RetryAfterError` retry-after ignored on step errors when checkpointing is enabled (uses default `BackoffTable` instead)](https://linear.app/inngest/issue/EXE-1737/retryaftererror-retry-after-ignored-on-step-errors-when-checkpointing)

https://github.com/inngest/inngest/issues/4126

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes `RetryAfterError.retryAfter` being silently dropped when a step throws inside a checkpoint request. The root cause was `buildStepErrorOp` pre-serializing the error via `serializeError()` before `transformOutput` could call `retriability(error)` to read the custom `retryAfter` property — serialization strips non-enumerable/custom properties. The fix passes the raw error through and lets `transformOutput` own the full serialize-after-retriability lifecycle. Integration tests cover both `RetryAfterError` and `NonRetriableError` paths.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b6f505f1a9b0968a929797f58a26ed2306fdc8f9.</sup>
<!-- /MENDRAL_SUMMARY -->