### PR TITLE
fix(connect): harden stale websocket request handling

### DIFF
--- a/.changeset/calm-connect-writes.md
+++ b/.changeset/calm-connect-writes.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Harden Connect request and reply handling when WebSocket connections close during execution.

--- a/packages/inngest/src/components/connect/strategies/core/requestProcessor.test.ts
+++ b/packages/inngest/src/components/connect/strategies/core/requestProcessor.test.ts
@@ -39,6 +39,53 @@ describe("ConnectionCore request processing", () => {
       );
       expect(acks.length).toBe(1);
     });
+
+    test("skips request when request socket is no longer open", async () => {
+      const handleExecutionRequest = vi.fn(async () => new Uint8Array(0));
+      const { ws, logger } = await connectAndReady({
+        callbacks: { handleExecutionRequest },
+      });
+
+      ws.readyState = MockWebSocket.CLOSED;
+
+      ws.sendExecutorRequest({
+        requestId: "req-1",
+        appName: "test-app",
+      });
+      await flushMicrotasks();
+
+      expect(
+        ws.getSentMessagesOfType(GatewayMessageType.WORKER_REQUEST_ACK),
+      ).toHaveLength(0);
+      expect(handleExecutionRequest).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: "req-1" }),
+        "Received request on non-active WebSocket, skipping",
+      );
+    });
+
+    test("skips request when sending ACK throws", async () => {
+      const handleExecutionRequest = vi.fn(async () => new Uint8Array(0));
+      const { ws, logger } = await connectAndReady({
+        callbacks: { handleExecutionRequest },
+      });
+
+      ws.send = () => {
+        throw new Error("closed socket");
+      };
+
+      ws.sendExecutorRequest({
+        requestId: "req-1",
+        appName: "test-app",
+      });
+      await flushMicrotasks();
+
+      expect(handleExecutionRequest).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: "req-1" }),
+        "Failed to send request ACK, skipping request",
+      );
+    });
   });
 
   describe("WORKER_REPLY sent after execution", () => {
@@ -139,6 +186,123 @@ describe("ConnectionCore request processing", () => {
       await flushMicrotasks();
 
       expect(onBufferResponse).toHaveBeenCalledWith("req-1", responseBytes);
+    });
+
+    test("buffers response when active connection is not open", async () => {
+      let resolveExecution: ((value: Uint8Array) => void) | undefined;
+      const executionPromise = new Promise<Uint8Array>((resolve) => {
+        resolveExecution = resolve;
+      });
+      const onBufferResponse = vi.fn();
+
+      const { ws, logger } = await connectAndReady({
+        callbacks: {
+          handleExecutionRequest: vi.fn(() => executionPromise),
+          onBufferResponse,
+        },
+      });
+
+      ws.sendExecutorRequest({
+        requestId: "req-1",
+        appName: "test-app",
+      });
+      await flushMicrotasks();
+
+      ws.readyState = MockWebSocket.CLOSED;
+
+      const responseBytes = new Uint8Array([4, 5, 6]);
+      resolveExecution!(responseBytes);
+      await flushMicrotasks();
+
+      expect(onBufferResponse).toHaveBeenCalledWith("req-1", responseBytes);
+      expect(
+        ws.getSentMessagesOfType(GatewayMessageType.WORKER_REPLY),
+      ).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: "req-1" }),
+        "Cannot send worker reply, buffering response",
+      );
+    });
+
+    test("buffers response when sending reply throws", async () => {
+      let resolveExecution: ((value: Uint8Array) => void) | undefined;
+      const executionPromise = new Promise<Uint8Array>((resolve) => {
+        resolveExecution = resolve;
+      });
+      const onBufferResponse = vi.fn();
+
+      const { ws, logger } = await connectAndReady({
+        callbacks: {
+          handleExecutionRequest: vi.fn(() => executionPromise),
+          onBufferResponse,
+        },
+      });
+
+      ws.sendExecutorRequest({
+        requestId: "req-1",
+        appName: "test-app",
+      });
+      await flushMicrotasks();
+
+      const originalSend = ws.send.bind(ws);
+      ws.send = (data: Uint8Array) => {
+        const msg = ConnectMessage.decode(data);
+        if (msg.kind === GatewayMessageType.WORKER_REPLY) {
+          throw new Error("closed socket");
+        }
+        originalSend(data);
+      };
+
+      const responseBytes = new Uint8Array([4, 5, 6]);
+      resolveExecution!(responseBytes);
+      await flushMicrotasks();
+
+      expect(onBufferResponse).toHaveBeenCalledWith("req-1", responseBytes);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: "req-1" }),
+        "Failed to send worker reply, buffering response",
+      );
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: "req-1" }),
+        "Execution error",
+      );
+    });
+
+    test("skips executor requests received on a draining connection", async () => {
+      const handleExecutionRequest = vi.fn(async () => new Uint8Array(0));
+
+      const fetchMock = vi.fn();
+      fetchMock.mockResolvedValueOnce(
+        createMockStartResponse({ connectionId: "conn-1" }),
+      );
+      fetchMock.mockResolvedValueOnce(
+        createMockStartResponse({ connectionId: "conn-2" }),
+      );
+      global.fetch = fetchMock;
+
+      const helpers = createTestCore({
+        callbacks: { handleExecutionRequest },
+      });
+
+      const startPromise = helpers.core.start();
+      await flushMicrotasks();
+      const ws1 = MockWebSocket.instances[0]!;
+      await driveHandshake(ws1);
+      await startPromise;
+
+      ws1.sendGatewayClosing();
+      await flushMicrotasks();
+
+      ws1.sendExecutorRequest({
+        requestId: "req-1",
+        appName: "test-app",
+      });
+      await flushMicrotasks();
+
+      expect(
+        ws1.getSentMessagesOfType(GatewayMessageType.WORKER_REQUEST_ACK),
+      ).toHaveLength(0);
+      expect(handleExecutionRequest).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/inngest/src/components/connect/strategies/core/requestProcessor.ts
+++ b/packages/inngest/src/components/connect/strategies/core/requestProcessor.ts
@@ -62,6 +62,30 @@ export class RequestProcessor {
       connectMessage.payload,
     );
 
+    const activeConn = this.accessor.activeConnection;
+    if (
+      !activeConn ||
+      activeConn.id !== conn.id ||
+      conn.dead ||
+      conn.ws.readyState !== WebSocket.OPEN
+    ) {
+      this.logger.warn(
+        {
+          requestId: gatewayExecutorRequest.requestId,
+          connectionId: conn.id,
+          activeConnectionId: activeConn?.id,
+          readyState: conn.ws.readyState,
+          dead: conn.dead,
+        },
+        "Received request on non-active WebSocket, skipping",
+      );
+      if (activeConn?.id === conn.id) {
+        conn.dead = true;
+        this.wakeSignal.wake(WAKE_REASON.WsClose);
+      }
+      return;
+    }
+
     this.logger.debug(
       {
         requestId: gatewayExecutorRequest.requestId,
@@ -106,29 +130,42 @@ export class RequestProcessor {
       return;
     }
 
-    // Send ACK
-    conn.ws.send(
-      ensureUnsharedArrayBuffer(
-        ConnectMessage.encode(
-          ConnectMessage.create({
-            kind: GatewayMessageType.WORKER_REQUEST_ACK,
-            payload: WorkerRequestAckData.encode(
-              WorkerRequestAckData.create({
-                accountId: gatewayExecutorRequest.accountId,
-                envId: gatewayExecutorRequest.envId,
-                appId: gatewayExecutorRequest.appId,
-                functionSlug: gatewayExecutorRequest.functionSlug,
-                requestId: gatewayExecutorRequest.requestId,
-                stepId: gatewayExecutorRequest.stepId,
-                userTraceCtx: gatewayExecutorRequest.userTraceCtx,
-                systemTraceCtx: gatewayExecutorRequest.systemTraceCtx,
-                runId: gatewayExecutorRequest.runId,
-              }),
-            ).finish(),
-          }),
-        ).finish(),
-      ),
-    );
+    try {
+      conn.ws.send(
+        ensureUnsharedArrayBuffer(
+          ConnectMessage.encode(
+            ConnectMessage.create({
+              kind: GatewayMessageType.WORKER_REQUEST_ACK,
+              payload: WorkerRequestAckData.encode(
+                WorkerRequestAckData.create({
+                  accountId: gatewayExecutorRequest.accountId,
+                  envId: gatewayExecutorRequest.envId,
+                  appId: gatewayExecutorRequest.appId,
+                  functionSlug: gatewayExecutorRequest.functionSlug,
+                  requestId: gatewayExecutorRequest.requestId,
+                  stepId: gatewayExecutorRequest.stepId,
+                  userTraceCtx: gatewayExecutorRequest.userTraceCtx,
+                  systemTraceCtx: gatewayExecutorRequest.systemTraceCtx,
+                  runId: gatewayExecutorRequest.runId,
+                }),
+              ).finish(),
+            }),
+          ).finish(),
+        ),
+      );
+    } catch (err) {
+      this.logger.warn(
+        {
+          requestId: gatewayExecutorRequest.requestId,
+          connectionId: conn.id,
+          err: toError(err),
+        },
+        "Failed to send request ACK, skipping request",
+      );
+      conn.dead = true;
+      this.wakeSignal.wake(WAKE_REASON.WsError);
+      return;
+    }
 
     this.accessor.inProgressRequests.wg.add(1);
     this.accessor.inProgressRequests.requestLeases[
@@ -264,38 +301,63 @@ export class RequestProcessor {
         "Request execution completed",
       );
 
-      if (!this.accessor.activeConnection) {
+      const replyConn = this.accessor.activeConnection;
+      if (!replyConn) {
         this.logger.warn(
           { requestId: gatewayExecutorRequest.requestId },
           "No current WebSocket, buffering response",
         );
-        if (this.callbacks.onBufferResponse) {
-          this.callbacks.onBufferResponse(
-            gatewayExecutorRequest.requestId,
-            responseBytes,
-          );
-        }
+        this.bufferResponse(gatewayExecutorRequest.requestId, responseBytes);
+        return;
+      }
+
+      if (replyConn.ws.readyState !== WebSocket.OPEN) {
+        this.logger.warn(
+          {
+            connectionId: replyConn.id,
+            requestId: gatewayExecutorRequest.requestId,
+            readyState: replyConn.ws.readyState,
+          },
+          "Cannot send worker reply, buffering response",
+        );
+        replyConn.dead = true;
+        this.wakeSignal.wake(WAKE_REASON.WsClose);
+        this.bufferResponse(gatewayExecutorRequest.requestId, responseBytes);
         return;
       }
 
       this.logger.debug(
         {
-          connectionId: this.accessor.activeConnection.id,
+          connectionId: replyConn.id,
           requestId: gatewayExecutorRequest.requestId,
         },
         "Sending worker reply",
       );
 
-      this.accessor.activeConnection.ws.send(
-        ensureUnsharedArrayBuffer(
-          ConnectMessage.encode(
-            ConnectMessage.create({
-              kind: GatewayMessageType.WORKER_REPLY,
-              payload: responseBytes,
-            }),
-          ).finish(),
-        ),
-      );
+      try {
+        replyConn.ws.send(
+          ensureUnsharedArrayBuffer(
+            ConnectMessage.encode(
+              ConnectMessage.create({
+                kind: GatewayMessageType.WORKER_REPLY,
+                payload: responseBytes,
+              }),
+            ).finish(),
+          ),
+        );
+      } catch (err) {
+        this.logger.warn(
+          {
+            connectionId: replyConn.id,
+            requestId: gatewayExecutorRequest.requestId,
+            err: toError(err),
+          },
+          "Failed to send worker reply, buffering response",
+        );
+        replyConn.dead = true;
+        this.wakeSignal.wake(WAKE_REASON.WsError);
+        this.bufferResponse(gatewayExecutorRequest.requestId, responseBytes);
+      }
     } catch (err) {
       const durationMs = Date.now() - startedAt;
       this.logger.warn(
@@ -332,6 +394,10 @@ export class RequestProcessor {
         this.wakeSignal.wake(WAKE_REASON.RequestFinishedOnShutdown);
       }
     }
+  }
+
+  private bufferResponse(requestId: string, responseBytes: Uint8Array): void {
+    this.callbacks.onBufferResponse?.(requestId, responseBytes);
   }
 
   /** Handle a reply ACK from the gateway. */


### PR DESCRIPTION
## Summary

Fixes TS SDK Connect race windows from SYS-856 where executor request ACKs and worker replies could try to use a WebSocket that had already closed or moved into drain.

This PR updates Connect request processing to:

- skip executor requests received on non-active, draining, dead, or non-open WebSockets
- guard `WORKER_REQUEST_ACK` sends and avoid running user code if the ACK cannot be delivered
- buffer `WORKER_REPLY` responses when the active WebSocket is missing, closed, or throws during send
- mark failed send connections dead and wake reconnect so the SDK does not keep targeting a stale socket
- add a patch changeset for `inngest`

## Why

The Linear investigation found the TS SDK did not have the persistent stale connection reference seen in the Go SDK, but it still had smaller race windows around request ACK and reply send. A gateway close or drain could convert these races into misleading execution errors or leave responses waiting for ACK timeout fallback.

## Validation

- [x] Added unit/integration tests
- [x] Added changesets if applicable
- [ ] ~~Added a docs PR~~ N/A internal Connect race hardening

Commands run:

```sh
pnpm --filter inngest exec vitest run src/components/connect/strategies/core/requestProcessor.test.ts
pnpm --filter inngest exec vitest run src/components/connect/strategies/core/connection.test.ts
pnpm exec biome check packages/inngest/src/components/connect/strategies/core/requestProcessor.ts packages/inngest/src/components/connect/strategies/core/requestProcessor.test.ts
```

## Related

- SYS-856

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Hardens Connect request processing against stale/closed WebSocket races by: (1) skipping execution when the incoming request arrives on a non-active, dead, or non-open socket, (2) wrapping both `WORKER_REQUEST_ACK` and `WORKER_REPLY` sends in try/catch to handle mid-flight closes, (3) buffering replies when the socket is unavailable at reply time, and (4) marking connections dead and waking the reconnect signal on any send failure.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 40e4d7d9be097b8267375f854091fd962ef714c9.</sup>
<!-- /MENDRAL_SUMMARY -->