### PR TITLE
fix(types): re-export InngestApi, MaybePromise, GroupExperiment, ParallelOptions from main entry

### DIFF
--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -39,6 +39,7 @@
 
 export * from "@inngest/ai";
 export type { StandardSchemaV1 } from "@standard-schema/spec";
+export type { InngestApi } from "./api/api";
 export { experiment } from "./components/ExperimentStrategies.ts";
 export type { StepFetch } from "./components/Fetch";
 export { fetch } from "./components/Fetch.ts";
@@ -56,8 +57,10 @@ export type { InngestFunction } from "./components/InngestFunction";
 export type { InngestFunctionReference } from "./components/InngestFunctionReference";
 export { referenceFunction } from "./components/InngestFunctionReference.ts";
 export type {
+  GroupExperiment,
   GroupTools,
   GroupToolsDeps,
+  ParallelOptions,
 } from "./components/InngestGroupTools";
 export { group, step } from "./components/InngestStepTools.ts";
 export { Middleware } from "./components/middleware/index.ts";
@@ -91,6 +94,7 @@ export type {
 export type {
   ExclusiveKeys,
   IsStringLiteral,
+  MaybePromise,
   SendEventPayload,
   StrictUnion,
   StrictUnionHelper,


### PR DESCRIPTION
## Problem

Two open issues report `TS2742`/`TS2883` errors for consumers using TypeScript `composite` projects or `declaration: true` emit:

- **#1510** — `step.sendSignal()` return type leaks `InngestApi.SendSignalResponse` from the internal `./api/api` module path, which is not in the package `exports` map. TypeScript can't generate a portable declaration reference and throws TS2742 on any function that uses `step`.
- **#1514** — `MaybePromise`, `GroupExperiment`, and `ParallelOptions` appear in public API signatures but are not re-exported, causing TS2883 during declaration emit.

## Fix

Add four `export type` statements to `packages/inngest/src/index.ts`:

```ts
export type { InngestApi } from "./api/api";          // fixes #1510
export type { GroupExperiment, ParallelOptions } from "./components/InngestGroupTools";  // fixes #1514
export type { MaybePromise } from "./helpers/types";   // fixes #1514
```

All are `export type` — zero runtime/bundle impact. The pattern follows the approach used in PR #1432.

## Checklist

- [x] Types-only change, no runtime diff
- [x] Follows existing export style in `src/index.ts`
- [x] Closes #1510, #1514

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds four `export type` re-exports (`InngestApi`, `GroupExperiment`, `ParallelOptions`, `MaybePromise`) to the main package entry point to fix TS2742/TS2883 errors in consumer TypeScript projects using `composite` or `declaration: true` settings.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 88baf85474b83b599c834d8c0b92b91139710a5e.</sup>
<!-- /MENDRAL_SUMMARY -->