### PR TITLE
test: replace deprecated fetch-mock-jest

### DIFF
--- a/packages/middleware-validation/package.json
+++ b/packages/middleware-validation/package.json
@@ -49,7 +49,7 @@
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.14",
     "eslint": "^8.30.0",
-    "fetch-mock-jest": "^1.5.1",
+    "@fetch-mock/jest": "^0.2.20",
     "jest": "^29.3.1",
     "nock": "^13.2.9",
     "ts-jest": "^29.1.0",

--- a/packages/middleware-validation/src/middleware.test.ts
+++ b/packages/middleware-validation/src/middleware.test.ts
@@ -1,5 +1,5 @@
 import { InngestTestEngine } from "@inngest/test";
-import FetchMock from "fetch-mock-jest";
+import fetchMock from "@fetch-mock/jest";
 import { EventSchemas, Inngest, type Logger } from "inngest";
 import { z } from "zod/v3";
 import { z as z4 } from "zod/v4";
@@ -7,7 +7,6 @@ import { validationMiddleware } from "./middleware";
 
 const baseUrl = "https://unreachable.com";
 const eventKey = "123";
-const fetchMock = FetchMock.sandbox();
 
 describe("validationMiddleware", () => {
   test("should allow an event through with no schema", async () => {
@@ -617,7 +616,7 @@ describe("validationMiddleware", () => {
 
         const inngest = new Inngest({
           id: "test",
-          fetch: fetchMock as typeof fetch,
+          fetch: fetchMock.fetchHandler.bind(fetchMock),
           baseUrl,
           eventKey,
           schemas: new EventSchemas().fromZod({
@@ -648,7 +647,7 @@ describe("validationMiddleware", () => {
 
         const inngest = new Inngest({
           id: "test",
-          fetch: fetchMock as typeof fetch,
+          fetch: fetchMock.fetchHandler.bind(fetchMock),
           baseUrl,
           eventKey,
           schemas: new EventSchemas().fromSchema({
@@ -753,7 +752,7 @@ describe("validationMiddleware", () => {
 
         const inngest = new Inngest({
           id: "test",
-          fetch: fetchMock as typeof fetch,
+          fetch: fetchMock.fetchHandler.bind(fetchMock),
           baseUrl,
           eventKey,
           schemas: new EventSchemas().fromZod({
@@ -795,7 +794,7 @@ describe("validationMiddleware", () => {
 
         const inngest = new Inngest({
           id: "test",
-          fetch: fetchMock as typeof fetch,
+          fetch: fetchMock.fetchHandler.bind(fetchMock),
           baseUrl,
           eventKey,
           schemas: new EventSchemas().fromSchema({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,9 @@ importers:
       '@eslint/js':
         specifier: ^9.7.0
         version: 9.7.0
+      '@fetch-mock/jest':
+        specifier: ^0.2.20
+        version: 0.2.20(@jest/globals@29.5.0)(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)))
       '@inngest/test':
         specifier: 0.1.9
         version: 0.1.9(@sveltejs/kit@1.27.3(svelte@4.2.5)(vite@7.0.2(@types/node@24.3.0)(jiti@2.5.1)(yaml@2.9.0)))(@vercel/node@2.15.9)(aws-lambda@1.0.7)(express@4.19.2)(fastify@4.21.0)(h3@1.8.1)(hono@4.2.7)(koa@2.14.2)(next@13.5.4(@babel/core@7.23.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@19.0.0))(react@19.0.0))(typescript@5.6.3)(zod@3.25.76)
@@ -409,9 +412,6 @@ importers:
       eslint:
         specifier: ^8.30.0
         version: 8.53.0
-      fetch-mock-jest:
-        specifier: ^1.5.1
-        version: 1.5.1(node-fetch@3.3.2)
       jest:
         specifier: ^29.3.1
         version: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
@@ -1439,6 +1439,13 @@ packages:
 
   '@fastify/fast-json-stringify-compiler@4.3.0':
     resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
+
+  '@fetch-mock/jest@0.2.20':
+    resolution: {integrity: sha512-DGX2bhBInodaWPMV3+UZ530aVM3wDj16sAPjFzkrwb0JwNWIQK07CNbYprQ3Tmd2ixDJeaNx2E0aNb+hRb8FFA==}
+    engines: {node: '>=18.11.0'}
+    peerDependencies:
+      '@jest/globals': '*'
+      jest: '*'
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -3004,6 +3011,9 @@ packages:
   '@types/express@5.0.3':
     resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
 
+  '@types/glob-to-regexp@0.4.4':
+    resolution: {integrity: sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==}
+
   '@types/graceful-fs@4.1.6':
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
 
@@ -3927,9 +3937,6 @@ packages:
     resolution: {integrity: sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==}
     engines: {node: '>= 0.8'}
 
-  core-js@3.37.1:
-    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
-
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -4081,6 +4088,10 @@ packages:
 
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destr@2.0.1:
     resolution: {integrity: sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==}
@@ -4605,24 +4616,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fetch-mock-jest@1.5.1:
-    resolution: {integrity: sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==}
-    engines: {node: '>=8.0.0'}
-    deprecated: 'Use https://www.npmjs.com/package/@fetch-mock/jest instead. The underlying version of fetch-mock will also need upgrading: see https://www.wheresrhys.co.uk/fetch-mock/docs/Usage/upgrade-guide'
-    peerDependencies:
-      node-fetch: '*'
-    peerDependenciesMeta:
-      node-fetch:
-        optional: true
-
-  fetch-mock@9.11.0:
-    resolution: {integrity: sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==}
-    engines: {node: '>=4.0.0'}
-    peerDependencies:
-      node-fetch: '*'
-    peerDependenciesMeta:
-      node-fetch:
-        optional: true
+  fetch-mock@12.6.0:
+    resolution: {integrity: sha512-oAy0OqAvjAvduqCeWveBix7LLuDbARPqZZ8ERYtBcCURA3gy7EALA3XWq0tCNxsSg+RmmJqyaeeZlOCV9abv6w==}
+    engines: {node: '>=18.11.0'}
 
   figures@5.0.0:
     resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
@@ -5244,9 +5240,6 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
-  is-subset@0.1.1:
-    resolution: {integrity: sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==}
-
   is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
@@ -5586,10 +5579,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -6026,9 +6015,6 @@ packages:
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
-  path-to-regexp@2.4.0:
-    resolution: {integrity: sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==}
-
   path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
 
@@ -6300,6 +6286,10 @@ packages:
   regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -8371,6 +8361,12 @@ snapshots:
   '@fastify/fast-json-stringify-compiler@4.3.0':
     dependencies:
       fast-json-stringify: 5.8.0
+
+  '@fetch-mock/jest@0.2.20(@jest/globals@29.5.0)(jest@29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3)))':
+    dependencies:
+      '@jest/globals': 29.5.0
+      fetch-mock: 12.6.0
+      jest: 29.5.0(@types/node@24.3.0)(ts-node@10.9.1(@types/node@24.3.0)(typescript@5.6.3))
 
   '@grpc/grpc-js@1.14.3':
     dependencies:
@@ -10543,6 +10539,8 @@ snapshots:
       '@types/express-serve-static-core': 5.0.7
       '@types/serve-static': 1.15.8
 
+  '@types/glob-to-regexp@0.4.4': {}
+
   '@types/graceful-fs@4.1.6':
     dependencies:
       '@types/node': 22.13.10
@@ -11723,8 +11721,6 @@ snapshots:
       depd: 2.0.0
       keygrip: 1.1.0
 
-  core-js@3.37.1: {}
-
   create-require@1.1.1: {}
 
   cross-env@7.0.3:
@@ -11842,6 +11838,8 @@ snapshots:
   depd@2.0.0: {}
 
   deprecation@2.3.1: {}
+
+  dequal@2.0.3: {}
 
   destr@2.0.1: {}
 
@@ -12526,30 +12524,12 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fetch-mock-jest@1.5.1(node-fetch@3.3.2):
+  fetch-mock@12.6.0:
     dependencies:
-      fetch-mock: 9.11.0(node-fetch@3.3.2)
-    optionalDependencies:
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
-  fetch-mock@9.11.0(node-fetch@3.3.2):
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/runtime': 7.22.6
-      core-js: 3.37.1
-      debug: 4.4.3
+      '@types/glob-to-regexp': 0.4.4
+      dequal: 2.0.3
       glob-to-regexp: 0.4.1
-      is-subset: 0.1.1
-      lodash.isequal: 4.5.0
-      path-to-regexp: 2.4.0
-      querystring: 0.2.0
-      whatwg-url: 14.2.0
-    optionalDependencies:
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
+      regexparam: 3.0.0
 
   figures@5.0.0:
     dependencies:
@@ -13300,8 +13280,6 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
-  is-subset@0.1.1: {}
-
   is-symbol@1.0.4:
     dependencies:
       has-symbols: 1.0.3
@@ -13931,8 +13909,6 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
-  lodash.isequal@4.5.0: {}
-
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
@@ -14355,8 +14331,6 @@ snapshots:
 
   path-to-regexp@0.1.7: {}
 
-  path-to-regexp@2.4.0: {}
-
   path-to-regexp@6.2.1: {}
 
   path-type@4.0.0: {}
@@ -14632,6 +14606,8 @@ snapshots:
       call-bind: 1.0.2
       define-properties: 1.2.0
       functions-have-names: 1.2.3
+
+  regexparam@3.0.0: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
## Summary

`fetch-mock-jest@1.x` is deprecated and transitively resolves `node-fetch@3` (ESM-only), which breaks `@inngest/middleware-validation`'s Jest CJS test run with `SyntaxError: Cannot use import statement outside a module`. Swap it for the official successor `@fetch-mock/jest`, which uses native `fetch` on Node 18+ and pulls in no `node-fetch` at all.

## Related

I noticed it in the mendral nag [here](https://github.com/inngest/inngest-js/pull/1522#discussion_r3228884978).

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the deprecated `fetch-mock-jest@1.x` package with its official successor `@fetch-mock/jest`, updating the import, removing the sandbox wrapper pattern, and binding `fetchHandler` directly to the Inngest client's `fetch` option.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b62082d638d9378ccc503733891d52712620de1e.</sup>
<!-- /MENDRAL_SUMMARY -->