### PR TITLE
EXE-1547: Send StepPlanned before executing steps in checkpointing mode

### DIFF
--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -573,6 +573,37 @@ export class InngestApi {
   }
 
   /**
+   * Announce to the executor that a step is about to run, so it can open a
+   * Running `executor.step` span before the step body executes.
+   */
+  async checkpointStepStarted(args: {
+    runId: string;
+    fnId: string;
+    queueItemId: string;
+    step: OutgoingOp;
+  }): Promise<{ ok: boolean; status?: number }> {
+    const body = JSON.stringify({
+      run_id: args.runId,
+      fn_id: args.fnId,
+      qi_id: args.queueItemId,
+      steps: [args.step],
+      ts: new Date().valueOf(),
+    });
+
+    const result = await this.req(
+      `/v1/checkpoint/${encodeURIComponent(args.runId)}/async`,
+      {
+        method: "POST",
+        body,
+      },
+    );
+
+    // Best-effort: do not throw on non-2xx.
+    if (!result.ok) return { ok: false };
+    return { ok: result.value.ok, status: result.value.status };
+  }
+
+  /**
    * POST stream data to the realtime publish/tee endpoint, forwarding raw
    * bytes to all subscribers via the broadcaster.
    */

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -707,7 +707,7 @@ export const createStepTools = <
      * of the `run` tool, meaning you can return and reason about return data
      * for next steps.
      */
-    run: createStepRun(),
+    run: createStepRun("step.run"),
 
     /**
      * AI tooling for running AI models and other AI-related tasks.

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -838,4 +838,140 @@ describe("Execution engine checkpoint retry behavior", () => {
       });
     });
   });
+
+  // SDK announces each step.run to the executor *before* invoking
+  // the user's fn so the executor can open a Running
+  // `executor.step` span.
+  describe("Execution engine leading stepPlanned behavior", () => {
+    const asyncCheckpointingOpts = {
+      stepMode: StepMode.AsyncCheckpointing as const,
+      checkpointingConfig: {
+        bufferedSteps: 1,
+        maxRuntime: 0,
+        maxInterval: 0,
+      },
+      extraPartialOptions: {
+        queueItemId: "queue-item-123",
+        internalFnId: "internal-fn-456",
+      },
+    };
+
+    test("POSTs once per step.run before fn runs, with op: StepPlanned", async () => {
+      const order: string[] = [];
+      const mockCheckpointStepStarted = vi.fn().mockImplementation(async () => {
+        order.push("step_started");
+        return { ok: true, status: 200 };
+      });
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      await runExecution({
+        mockApi: {
+          checkpointStepStarted: mockCheckpointStepStarted,
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => {
+            order.push("fn:a");
+            return "a";
+          });
+          await step.run("b", () => {
+            order.push("fn:b");
+            return "b";
+          });
+        },
+        ...asyncCheckpointingOpts,
+      });
+
+      expect(mockCheckpointStepStarted).toHaveBeenCalledTimes(2);
+      // Every POST carries op: StepPlanned and no data/error
+      for (const call of mockCheckpointStepStarted.mock.calls) {
+        const step = call[0].step;
+        expect(step.op).toBe(StepOpCode.StepPlanned);
+        expect(step.data).toBeUndefined();
+        expect(step.error).toBeUndefined();
+        expect(step.id).toBeTruthy();
+      }
+      // Ordering: step_started for "a" precedes fn:a, same for b
+      const aStartedIdx = order.indexOf("step_started");
+      const aFnIdx = order.indexOf("fn:a");
+      expect(aStartedIdx).toBeGreaterThanOrEqual(0);
+      expect(aStartedIdx).toBeLessThan(aFnIdx);
+    });
+
+    test("fn body executes even when the POST never resolves", async () => {
+      const order: string[] = [];
+      const mockCheckpointStepStarted = vi.fn().mockImplementation(() => {
+        order.push("post_called");
+        return new Promise(() => {
+          // Never resolves
+        });
+      });
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      await runExecution({
+        mockApi: {
+          checkpointStepStarted: mockCheckpointStepStarted,
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => {
+            order.push("fn_ran");
+            return "a";
+          });
+        },
+        ...asyncCheckpointingOpts,
+      });
+
+      // The POST was started, then fn ran despite the POST not resolving.
+      expect(order).toEqual(["post_called", "fn_ran"]);
+    });
+
+    test("rejected POST is swallowed and fn still completes", async () => {
+      const mockCheckpointStepStarted = vi
+        .fn()
+        .mockRejectedValue(new Error("executor offline"));
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = await runExecution({
+        mockApi: {
+          checkpointStepStarted: mockCheckpointStepStarted,
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => "a");
+          await step.run("b", () => "b");
+          return "done";
+        },
+        ...asyncCheckpointingOpts,
+      });
+
+      expect(mockCheckpointStepStarted).toHaveBeenCalledTimes(2);
+      // Execution completes successfully; rejections did not propagate.
+      expect(result.type).not.toBe("function-rejected");
+    });
+
+    test("payload includes runId, fnId, queueItemId from execution options", async () => {
+      const mockCheckpointStepStarted = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200 });
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      await runExecution({
+        mockApi: {
+          checkpointStepStarted: mockCheckpointStepStarted,
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => "a");
+        },
+        ...asyncCheckpointingOpts,
+      });
+
+      const call = mockCheckpointStepStarted.mock.calls[0]![0];
+      expect(call.runId).toBe("test-run-id");
+      expect(call.fnId).toBe("internal-fn-456");
+      expect(call.queueItemId).toBe("queue-item-123");
+      expect(call.step.displayName).toBe("a");
+    });
+  });
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1662,6 +1662,7 @@ class InngestExecutionEngine
               name,
               displayName,
               userland,
+              ...(opts ? { opts } : {}),
               // GoInterval is nanoseconds. `b: 0` — no duration yet at the
               // leading edge; the completion path emits the full interval.
               timing: { a: start * 1_000_000, b: 0 },

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1640,7 +1640,50 @@ class InngestExecutionEngine
     const wrappedActualHandler =
       this.middlewareManager.buildWrapStepHandlerChain(actualHandler, stepInfo);
 
-    return goIntervalTiming(() => wrappedActualHandler())
+    const start = Date.now();
+
+    // Best-effort send a StepPlanned leading-edge.
+    //
+    // Bypasses `state.checkpointingStepBuffer` to avoid waiting for a response.
+    if (
+      this.options.stepMode === StepMode.AsyncCheckpointing &&
+      this.options.internalFnId &&
+      this.options.queueItemId
+    ) {
+      try {
+        void this.options.client["inngestApi"]
+          .checkpointStepStarted({
+            runId: this.options.runId,
+            fnId: this.options.internalFnId,
+            queueItemId: this.options.queueItemId,
+            step: {
+              id: hashedId,
+              op: StepOpCode.StepPlanned,
+              name,
+              displayName,
+              userland,
+              // GoInterval is nanoseconds. `b: 0` — no duration yet at the
+              // leading edge; the completion path emits the full interval.
+              timing: { a: start * 1_000_000, b: 0 },
+            },
+          })
+          .catch((err: unknown) => {
+            this.devDebug(
+              `step_started POST failed (ignored) for hashedId=%s:`,
+              hashedId,
+              err,
+            );
+          });
+      } catch (err) {
+        this.devDebug(
+          `step_started call threw synchronously (ignored) for hashedId=%s:`,
+          hashedId,
+          err,
+        );
+      }
+    }
+
+    return goIntervalTiming(() => wrappedActualHandler(), start)
       .finally(() => {
         this.devDebug(`finished executing step "${id}"`);
 

--- a/packages/inngest/src/components/middleware/utils.ts
+++ b/packages/inngest/src/components/middleware/utils.ts
@@ -101,7 +101,7 @@ export function stepTypeFromOpCode(
   } else if (op === StepOpCode.InvokeFunction) {
     return "invoke";
   } else if (op === StepOpCode.StepPlanned) {
-    if (opts?.type === undefined) {
+    if (opts?.type === undefined || opts?.type === "step.run") {
       return "run";
     }
     if (opts?.type === "step.sendEvent") {

--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -270,13 +270,13 @@ export type GoInterval = {
 // biome-ignore lint/suspicious/noExplicitAny: match any fn
 export const goIntervalTiming = async <T extends (...args: any[]) => any>(
   fn: T,
+  // Ideally this would use process.hrtime, but that's not available in all
+  // runtimes, so we must revert to less accurate timing and `Date`.
+  start: number = Date.now(),
 ): Promise<{
   resultPromise: Promise<Awaited<ReturnType<T>>>;
   interval: { a: number; b: number };
 }> => {
-  // Ideally this would use process.hrtime, but that's not available in all
-  // runtimes, so we must revert to less accurate timing and `Date`.
-  const start = Date.now();
   const resultPromise = runAsPromise(fn) as Promise<Awaited<ReturnType<T>>>;
 
   // Let the function run to completion.


### PR DESCRIPTION
## Summary

- Users running checkpointing sometimes have long running steps. Currently in the dashboard, it is difficult to determine that the step is in progress rather than hanging.
- We do have the Execution > Attempt 0 row in the execution viewer, but this is separated from where on-going step will eventually live, especially in longer and more complex workflows. Additionally, this eventually disappears once the run finishes.
- We would like to show users that we are working on their step.
- In this PR, we begin sending StepPlanned opcodes before starting a step in checkpointing mode
- We handle those opcodes in https://github.com/inngest/inngest/pull/4201



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

