### PR TITLE
refactor: emit inngest.score.<name> kind

### DIFF
--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -15,7 +15,7 @@ export type MetadataScope = "run" | "step" | "extended_trace";
  */
 export type MetadataKind =
   | "inngest.experiment"
-  | "inngest.score"
+  | `inngest.score.${string}`
   | "inngest.warnings"
   | `userland.${string}`;
 

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import type { KnownKeys } from "../helpers/types.ts";
 import { Inngest } from "./Inngest.ts";
@@ -54,16 +54,25 @@ describe("client.score validation", () => {
         stepId: "step",
         value: 1,
       } as unknown as ScoreOptions),
-    ).rejects.toThrow("invalid score name");
+    ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
       client.score({
         runId: "run",
         stepId: "step",
-        name: "bad-name",
+        name: "",
         value: 1,
       }),
-    ).rejects.toThrow("invalid score name");
+    ).rejects.toThrow("score name must be a non-empty string");
+
+    await expect(
+      client.score({
+        runId: "run",
+        stepId: "step",
+        name: "x".repeat(115),
+        value: 1,
+      }),
+    ).rejects.toThrow("score name must be 114 characters or fewer");
 
     await expect(
       client.score({
@@ -84,6 +93,63 @@ describe("client.score validation", () => {
         value: 1,
       } satisfies ScoreOptions),
     ).rejects.toThrow("No run context available");
+  });
+
+  test("emits inngest.score.<name> kind with value-keyed payload", async () => {
+    const client = new Inngest({ id: "app" });
+    const spy = vi
+      .fn<
+        (args: {
+          target: { run_id: string };
+          metadata: Array<{
+            kind: string;
+            op: string;
+            values: Record<string, unknown>;
+          }>;
+        }) => Promise<void>
+      >()
+      .mockResolvedValue();
+    (client as unknown as { updateMetadata: typeof spy }).updateMetadata = spy;
+
+    await client.score({
+      runId: "run-abc",
+      name: "click-through rate (variant A)!",
+      value: 0.23,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]?.metadata).toEqual([
+      {
+        kind: "inngest.score.click-through rate (variant A)!",
+        op: "merge",
+        values: { value: 0.23 },
+      },
+    ]);
+  });
+
+  test("accepts boolean values in the named-score shape", async () => {
+    const client = new Inngest({ id: "app" });
+    const spy = vi
+      .fn<
+        (args: {
+          metadata: Array<{
+            kind: string;
+            values: Record<string, unknown>;
+          }>;
+        }) => Promise<void>
+      >()
+      .mockResolvedValue();
+    (client as unknown as { updateMetadata: typeof spy }).updateMetadata = spy;
+
+    await client.score({ runId: "run-abc", name: "pass", value: true });
+
+    expect(spy.mock.calls[0]?.[0]?.metadata).toEqual([
+      {
+        kind: "inngest.score.pass",
+        op: "merge",
+        values: { value: true },
+      },
+    ]);
   });
 });
 
@@ -107,10 +173,17 @@ describe("step.score validation", () => {
 
     expect(() =>
       validateStepScoreOptions({
-        name: "bad-name",
+        name: "",
         value: 1,
       }),
-    ).toThrow("invalid score name");
+    ).toThrow("score name must be a non-empty string");
+
+    expect(() =>
+      validateStepScoreOptions({
+        name: "x".repeat(115),
+        value: 1,
+      }),
+    ).toThrow("score name must be 114 characters or fewer");
 
     expect(() =>
       validateStepScoreOptions({
@@ -120,11 +193,18 @@ describe("step.score validation", () => {
     ).toThrow("finite number or boolean");
   });
 
-  test("accepts optional targets and boolean values", () => {
+  test("accepts optional targets, arbitrary names, and boolean values", () => {
     expect(() =>
       validateStepScoreOptions({
         name: "accuracy",
         value: true,
+      } satisfies ScoreOptions),
+    ).not.toThrow();
+
+    expect(() =>
+      validateStepScoreOptions({
+        name: "click-through rate (variant A)!",
+        value: 0.23,
       } satisfies ScoreOptions),
     ).not.toThrow();
   });

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -97,6 +97,15 @@ describe("client.score validation", () => {
       client.score({
         runId: "run",
         stepId: "step",
+        name: "foo\nbar",
+        value: 1,
+      }),
+    ).rejects.toThrow("score name must not contain control characters");
+
+    await expect(
+      client.score({
+        runId: "run",
+        stepId: "step",
         name: "accuracy",
         value: Number.NaN,
       }),
@@ -217,6 +226,13 @@ describe("step.score validation", () => {
         value: 1,
       }),
     ).toThrow("score name must be 114 bytes or fewer");
+
+    expect(() =>
+      validateStepScoreOptions({
+        name: "foo\tbar",
+        value: 1,
+      }),
+    ).toThrow("score name must not contain control characters");
 
     expect(() =>
       validateStepScoreOptions({

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -100,7 +100,20 @@ describe("client.score validation", () => {
         name: "foo\nbar",
         value: 1,
       }),
-    ).rejects.toThrow("score name must not contain control characters");
+    ).rejects.toThrow(
+      "score name must not contain control characters or single quotes",
+    );
+
+    await expect(
+      client.score({
+        runId: "run",
+        stepId: "step",
+        name: "it's-broken",
+        value: 1,
+      }),
+    ).rejects.toThrow(
+      "score name must not contain control characters or single quotes",
+    );
 
     await expect(
       client.score({
@@ -232,7 +245,18 @@ describe("step.score validation", () => {
         name: "foo\tbar",
         value: 1,
       }),
-    ).toThrow("score name must not contain control characters");
+    ).toThrow(
+      "score name must not contain control characters or single quotes",
+    );
+
+    expect(() =>
+      validateStepScoreOptions({
+        name: "it's-broken",
+        value: 1,
+      }),
+    ).toThrow(
+      "score name must not contain control characters or single quotes",
+    );
 
     expect(() =>
       validateStepScoreOptions({

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -69,10 +69,29 @@ describe("client.score validation", () => {
       client.score({
         runId: "run",
         stepId: "step",
+        name: "   ",
+        value: 1,
+      }),
+    ).rejects.toThrow("score name must be a non-empty string");
+
+    await expect(
+      client.score({
+        runId: "run",
+        stepId: "step",
         name: "x".repeat(115),
         value: 1,
       }),
-    ).rejects.toThrow("score name must be 114 characters or fewer");
+    ).rejects.toThrow("score name must be 114 bytes or fewer");
+
+    // 60 × "é" = 120 UTF-8 bytes, under the 114-char limit but over the byte cap.
+    await expect(
+      client.score({
+        runId: "run",
+        stepId: "step",
+        name: "é".repeat(60),
+        value: 1,
+      }),
+    ).rejects.toThrow("score name must be 114 bytes or fewer");
 
     await expect(
       client.score({
@@ -180,10 +199,24 @@ describe("step.score validation", () => {
 
     expect(() =>
       validateStepScoreOptions({
+        name: "   ",
+        value: 1,
+      }),
+    ).toThrow("score name must be a non-empty string");
+
+    expect(() =>
+      validateStepScoreOptions({
         name: "x".repeat(115),
         value: 1,
       }),
-    ).toThrow("score name must be 114 characters or fewer");
+    ).toThrow("score name must be 114 bytes or fewer");
+
+    expect(() =>
+      validateStepScoreOptions({
+        name: "é".repeat(60),
+        value: 1,
+      }),
+    ).toThrow("score name must be 114 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -4,9 +4,11 @@ import { performOp } from "./InngestMetadata.ts";
 import type { ExperimentalStepTools } from "./InngestStepTools.ts";
 import { Middleware } from "./middleware/middleware.ts";
 
-// Server caps the full kind at 128 chars; "inngest.score." is 14 chars, so the
-// user-supplied suffix can be up to 114.
-const maxScoreNameLength = 114;
+// Server caps the full kind at 128 bytes; "inngest.score." is 14 bytes, so the
+// user-supplied suffix can be up to 114 UTF-8 bytes.
+const scoreKindPrefix = "inngest.score." as const;
+const maxKindByteLength = 128;
+const maxScoreNameByteLength = maxKindByteLength - scoreKindPrefix.length;
 
 type ScoreValue = number | boolean;
 
@@ -64,13 +66,14 @@ function validateScoreFields(
     });
   }
 
-  if (typeof options.name !== "string" || options.name.length === 0) {
+  if (typeof options.name !== "string" || options.name.trim().length === 0) {
     throw new Error("score name must be a non-empty string");
   }
 
-  if (options.name.length > maxScoreNameLength) {
+  const nameByteLength = new TextEncoder().encode(options.name).length;
+  if (nameByteLength > maxScoreNameByteLength) {
     throw new Error(
-      `score name must be ${maxScoreNameLength} characters or fewer`,
+      `score name must be ${maxScoreNameByteLength} bytes or fewer in UTF-8 (got ${nameByteLength})`,
     );
   }
 
@@ -104,7 +107,7 @@ export async function sendScore(
       stepId: options.stepId,
     },
     { value: options.value },
-    `inngest.score.${options.name}`,
+    `${scoreKindPrefix}${options.name}`,
     "merge",
   );
 }
@@ -124,7 +127,7 @@ export async function sendStepScore(
       stepId: options.stepId,
     },
     { value: options.value },
-    `inngest.score.${options.name}`,
+    `${scoreKindPrefix}${options.name}`,
     "merge",
   );
 }

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -70,6 +70,11 @@ function validateScoreFields(
     throw new Error("score name must be a non-empty string");
   }
 
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — rejecting control chars in user-supplied names
+  if (/[\x00-\x1f\x7f]/.test(options.name)) {
+    throw new Error("score name must not contain control characters");
+  }
+
   const nameByteLength = new TextEncoder().encode(options.name).length;
   if (nameByteLength > maxScoreNameByteLength) {
     throw new Error(

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -4,7 +4,9 @@ import { performOp } from "./InngestMetadata.ts";
 import type { ExperimentalStepTools } from "./InngestStepTools.ts";
 import { Middleware } from "./middleware/middleware.ts";
 
-const scoreNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]{0,63}$/;
+// Server caps the full kind at 128 chars; "inngest.score." is 14 chars, so the
+// user-supplied suffix can be up to 114.
+const maxScoreNameLength = 114;
 
 type ScoreValue = number | boolean;
 
@@ -62,9 +64,13 @@ function validateScoreFields(
     });
   }
 
-  if (typeof options.name !== "string" || !scoreNameRegex.test(options.name)) {
+  if (typeof options.name !== "string" || options.name.length === 0) {
+    throw new Error("score name must be a non-empty string");
+  }
+
+  if (options.name.length > maxScoreNameLength) {
     throw new Error(
-      `invalid score name "${String(options.name)}"; must match ${scoreNameRegex.source}`,
+      `score name must be ${maxScoreNameLength} characters or fewer`,
     );
   }
 
@@ -97,8 +103,8 @@ export async function sendScore(
       runId: options.runId,
       stepId: options.stepId,
     },
-    { [options.name]: options.value },
-    "inngest.score",
+    { value: options.value },
+    `inngest.score.${options.name}`,
     "merge",
   );
 }
@@ -117,8 +123,8 @@ export async function sendStepScore(
         options.stepId === undefined ? (options.runId ?? null) : options.runId,
       stepId: options.stepId,
     },
-    { [options.name]: options.value },
-    "inngest.score",
+    { value: options.value },
+    `inngest.score.${options.name}`,
     "merge",
   );
 }

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -70,9 +70,14 @@ function validateScoreFields(
     throw new Error("score name must be a non-empty string");
   }
 
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — rejecting control chars in user-supplied names
-  if (/[\x00-\x1f\x7f]/.test(options.name)) {
-    throw new Error("score name must not contain control characters");
+  // Single quote rejection mirrors the cloud MetricKeyRegex; without it,
+  // valid-looking score names like "it's-broken" would silently drop in
+  // variant aggregation.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — rejecting control chars and single quotes in user-supplied names
+  if (/[\x00-\x1f\x7f']/.test(options.name)) {
+    throw new Error(
+      "score name must not contain control characters or single quotes",
+    );
   }
 
   const nameByteLength = new TextEncoder().encode(options.name).length;

--- a/packages/inngest/src/test/integration/scorer/misc.test.ts
+++ b/packages/inngest/src/test/integration/scorer/misc.test.ts
@@ -84,10 +84,10 @@ test("success", async () => {
   expect(metadata).toEqual(
     expect.arrayContaining([
       {
-        kind: "inngest.score",
+        kind: "inngest.score.verbosity",
         scope: "run",
         updatedAt: expect.any(String),
-        values: { verbosity: 2 },
+        values: { value: 2 },
       },
     ]),
   );

--- a/packages/inngest/src/test/integration/scoring/utils.ts
+++ b/packages/inngest/src/test/integration/scoring/utils.ts
@@ -1,11 +1,15 @@
 import type { RunMetadata, TraceMetadataNode } from "@inngest/test-harness";
 
-function scoreEntries(metadata: RunMetadata[]) {
-  return metadata.filter((md) => md.kind === "inngest.score");
-}
+const namedScorePrefix = "inngest.score.";
 
-function scoreValues(metadata: RunMetadata[]) {
-  return Object.assign({}, ...scoreEntries(metadata).map((md) => md.values));
+function scoreValues(metadata: RunMetadata[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const md of metadata) {
+    if (md.kind.startsWith(namedScorePrefix)) {
+      out[md.kind.slice(namedScorePrefix.length)] = md.values.value;
+    }
+  }
+  return out;
 }
 
 export function expectScoreValue(


### PR DESCRIPTION
## Summary
Mirrors the OSS server change. `client.score({name, value})` and `step.score()` now emit kind `inngest.score.${name}` with payload `{value}`. Dropped the alphanumeric regex on `name`. Names can be any non-empty string up to 114 chars. `MetadataKind` widened to include `inngest.score.${string}`.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
