### PR TITLE
EXE-1547: Defer StepPlanned leading-edge POST by 1s

### DIFF
--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -2,6 +2,7 @@ import { fromPartial } from "@total-typescript/shoehorn";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { InngestApi } from "../../api/api.ts";
 import { ExecutionVersion } from "../../helpers/consts.ts";
+import { createDeferredPromise } from "../../helpers/promises.ts";
 import { createClient } from "../../test/helpers.ts";
 import { StepMode, StepOpCode } from "../../types.ts";
 import { InngestFunction } from "../InngestFunction.ts";
@@ -842,7 +843,16 @@ describe("Execution engine checkpoint retry behavior", () => {
   // SDK announces each step.run to the executor *before* invoking
   // the user's fn so the executor can open a Running
   // `executor.step` span.
+  //
+  // The POST is deferred by STEP_PLANNED_LEADING_EDGE_DELAY_MS (1000ms).
+  // Fast steps (settling before the threshold) skip the POST entirely;
+  // only long-running steps produce a leading-edge span. Tests park step
+  // bodies on deferred promises and manually advance fake timers past
+  // the threshold to exercise the leading-edge path.
   describe("Execution engine leading stepPlanned behavior", () => {
+    // Mirrors the constant in engine.ts. If that value changes, update here.
+    const STEP_PLANNED_LEADING_EDGE_DELAY_MS = 1000;
+
     const asyncCheckpointingOpts = {
       stepMode: StepMode.AsyncCheckpointing as const,
       checkpointingConfig: {
@@ -856,6 +866,12 @@ describe("Execution engine checkpoint retry behavior", () => {
       },
     };
 
+    // Override the outer beforeEach's `shouldAdvanceTime: true` so the
+    // 1s timer only fires when we advance manually.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
     test("POSTs once per step.run before fn runs, with op: StepPlanned", async () => {
       const order: string[] = [];
       const mockCheckpointStepStarted = vi.fn().mockImplementation(async () => {
@@ -864,23 +880,38 @@ describe("Execution engine checkpoint retry behavior", () => {
       });
       const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
 
-      await runExecution({
+      const deferredA = createDeferredPromise<void>();
+      const deferredB = createDeferredPromise<void>();
+
+      const setup = setupExecution({
         mockApi: {
           checkpointStepStarted: mockCheckpointStepStarted,
           checkpointStepsAsync: mockCheckpointStepsAsync,
         },
         handler: async ({ step }) => {
-          await step.run("a", () => {
+          await step.run("a", async () => {
+            await deferredA.promise;
             order.push("fn:a");
             return "a";
           });
-          await step.run("b", () => {
+          await step.run("b", async () => {
+            await deferredB.promise;
             order.push("fn:b");
             return "b";
           });
         },
         ...asyncCheckpointingOpts,
       });
+      const executionPromise = setup.execution.start();
+
+      // Park step a past the threshold so the POST fires.
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS);
+      deferredA.resolve();
+      // Let step a settle and step b's timer schedule.
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS);
+      deferredB.resolve();
+      await advanceThroughRetries();
+      await executionPromise;
 
       expect(mockCheckpointStepStarted).toHaveBeenCalledTimes(2);
       // Every POST carries op: StepPlanned and no data/error
@@ -908,19 +939,29 @@ describe("Execution engine checkpoint retry behavior", () => {
       });
       const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
 
-      await runExecution({
+      const deferred = createDeferredPromise<void>();
+
+      const setup = setupExecution({
         mockApi: {
           checkpointStepStarted: mockCheckpointStepStarted,
           checkpointStepsAsync: mockCheckpointStepsAsync,
         },
         handler: async ({ step }) => {
-          await step.run("a", () => {
+          await step.run("a", async () => {
+            await deferred.promise;
             order.push("fn_ran");
             return "a";
           });
         },
         ...asyncCheckpointingOpts,
       });
+      const executionPromise = setup.execution.start();
+
+      // Fire the leading-edge POST while the step is still in-flight.
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS);
+      deferred.resolve();
+      await advanceThroughRetries();
+      await executionPromise;
 
       // The POST was started, then fn ran despite the POST not resolving.
       expect(order).toEqual(["post_called", "fn_ran"]);
@@ -932,18 +973,35 @@ describe("Execution engine checkpoint retry behavior", () => {
         .mockRejectedValue(new Error("executor offline"));
       const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
 
-      const { result } = await runExecution({
+      const deferredA = createDeferredPromise<void>();
+      const deferredB = createDeferredPromise<void>();
+
+      const setup = setupExecution({
         mockApi: {
           checkpointStepStarted: mockCheckpointStepStarted,
           checkpointStepsAsync: mockCheckpointStepsAsync,
         },
         handler: async ({ step }) => {
-          await step.run("a", () => "a");
-          await step.run("b", () => "b");
+          await step.run("a", async () => {
+            await deferredA.promise;
+            return "a";
+          });
+          await step.run("b", async () => {
+            await deferredB.promise;
+            return "b";
+          });
           return "done";
         },
         ...asyncCheckpointingOpts,
       });
+      const executionPromise = setup.execution.start();
+
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS);
+      deferredA.resolve();
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS);
+      deferredB.resolve();
+      await advanceThroughRetries();
+      const result = await executionPromise;
 
       expect(mockCheckpointStepStarted).toHaveBeenCalledTimes(2);
       // Execution completes successfully; rejections did not propagate.
@@ -956,22 +1014,64 @@ describe("Execution engine checkpoint retry behavior", () => {
         .mockResolvedValue({ ok: true, status: 200 });
       const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
 
-      await runExecution({
+      const deferred = createDeferredPromise<void>();
+
+      const setup = setupExecution({
         mockApi: {
           checkpointStepStarted: mockCheckpointStepStarted,
           checkpointStepsAsync: mockCheckpointStepsAsync,
         },
         handler: async ({ step }) => {
-          await step.run("a", () => "a");
+          await step.run("a", async () => {
+            await deferred.promise;
+            return "a";
+          });
         },
         ...asyncCheckpointingOpts,
       });
+      const executionPromise = setup.execution.start();
+
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS);
+      deferred.resolve();
+      await advanceThroughRetries();
+      await executionPromise;
 
       const call = mockCheckpointStepStarted.mock.calls[0]![0];
       expect(call.runId).toBe("test-run-id");
       expect(call.fnId).toBe("internal-fn-456");
       expect(call.queueItemId).toBe("queue-item-123");
       expect(call.step.displayName).toBe("a");
+    });
+
+    test("fast step settling under the threshold skips the POST", async () => {
+      const mockCheckpointStepStarted = vi
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200 });
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const setup = setupExecution({
+        mockApi: {
+          checkpointStepStarted: mockCheckpointStepStarted,
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          // Synchronous step settles immediately.
+          await step.run("a", () => "a");
+        },
+        ...asyncCheckpointingOpts,
+      });
+
+      // Signal: awaiting full execution guarantees every step's .finally()
+      // has run, which means clearTimeout has been called. No timer advance
+      // first — if .finally() ever stops clearing the timer, this await
+      // hangs (the pending setTimeout keeps the execution alive) and the
+      // test times out instead of silently passing.
+      await setup.execution.start();
+
+      // Confirm the timer was cancelled, not merely unscheduled-yet.
+      await vi.advanceTimersByTimeAsync(STEP_PLANNED_LEADING_EDGE_DELAY_MS * 3);
+
+      expect(mockCheckpointStepStarted).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -121,6 +121,12 @@ const RUN_COMPLETE_STEP_ID = "complete";
 
 const STEP_NOT_FOUND_MAX_FOUND_STEPS = 25;
 
+/**
+ * Delay before sending the StepPlanned leading-edge POST. Steps that settle
+ * before this fires never produce a leading-edge span
+ */
+const STEP_PLANNED_LEADING_EDGE_DELAY_MS = 1000;
+
 export const createExecutionEngine: InngestExecutionFactory = (options) => {
   return new InngestExecutionEngine(options);
 };
@@ -1642,50 +1648,63 @@ class InngestExecutionEngine
 
     const start = Date.now();
 
-    // Best-effort send a StepPlanned leading-edge.
-    //
-    // Bypasses `state.checkpointingStepBuffer` to avoid waiting for a response.
+    // Best-effort send a StepPlanned leading-edge, deferred by
+    // STEP_PLANNED_LEADING_EDGE_DELAY_MS. If the step settles before the
+    // timer fires, the POST is skipped — only long-running steps produce
+    // a leading-edge span. 
+		// 
+		// Bypasses `state.checkpointingStepBuffer` to
+    // avoid waiting for a response.
+    let stepPlannedTimer: ReturnType<typeof setTimeout> | undefined;
     if (
       this.options.stepMode === StepMode.AsyncCheckpointing &&
       this.options.internalFnId &&
       this.options.queueItemId
     ) {
-      try {
-        void this.options.client["inngestApi"]
-          .checkpointStepStarted({
-            runId: this.options.runId,
-            fnId: this.options.internalFnId,
-            queueItemId: this.options.queueItemId,
-            step: {
-              id: hashedId,
-              op: StepOpCode.StepPlanned,
-              name,
-              displayName,
-              userland,
-              ...(opts ? { opts } : {}),
-              // GoInterval is nanoseconds. `b: 0` — no duration yet at the
-              // leading edge; the completion path emits the full interval.
-              timing: { a: start * 1_000_000, b: 0 },
-            },
-          })
-          .catch((err: unknown) => {
-            this.devDebug(
-              `step_started POST failed (ignored) for hashedId=%s:`,
-              hashedId,
-              err,
-            );
-          });
-      } catch (err) {
-        this.devDebug(
-          `step_started call threw synchronously (ignored) for hashedId=%s:`,
-          hashedId,
-          err,
-        );
-      }
+      const internalFnId = this.options.internalFnId;
+      const queueItemId = this.options.queueItemId;
+      stepPlannedTimer = setTimeout(() => {
+        try {
+          void this.options.client["inngestApi"]
+            .checkpointStepStarted({
+              runId: this.options.runId,
+              fnId: internalFnId,
+              queueItemId,
+              step: {
+                id: hashedId,
+                op: StepOpCode.StepPlanned,
+                name,
+                displayName,
+                userland,
+                ...(opts ? { opts } : {}),
+                // GoInterval is nanoseconds. `b: 0` — no duration yet at
+                // the leading edge; the completion path emits the full
+                // interval.
+                timing: { a: start * 1_000_000, b: 0 },
+              },
+            })
+            .catch((err: unknown) => {
+              this.devDebug(
+                `step_started POST failed (ignored) for hashedId=%s:`,
+                hashedId,
+                err,
+              );
+            });
+        } catch (err) {
+          this.devDebug(
+            `step_started call threw synchronously (ignored) for hashedId=%s:`,
+            hashedId,
+            err,
+          );
+        }
+      }, STEP_PLANNED_LEADING_EDGE_DELAY_MS);
     }
 
     return goIntervalTiming(() => wrappedActualHandler(), start)
       .finally(() => {
+        // Cancel the leading-edge POST if the step settled first
+        if (stepPlannedTimer) clearTimeout(stepPlannedTimer);
+
         this.devDebug(`finished executing step "${id}"`);
 
         this.state.executingStep = undefined;


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

- In https://github.com/inngest/inngest-js/pull/1530, we changed the JS SDK to emit StepPlanned before executing steps in checkpoint mode. That's a large multiplier in the number of spans we're sending and saving - most of which will immediately be invalidated by their step's completion
- In this PR, we add a timer to wait for 1s before we fire off the StepPlanned. We can tune this threshold more in the future, but 1s feels like an okay start to filter out the steps that StepPlanned won't provide much value for.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

