### PR TITLE
Fix wrong step attempt when updating metadata

### DIFF
--- a/.changeset/strong-mayflies-sniff.md
+++ b/.changeset/strong-mayflies-sniff.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix wrong step attempt when updating metadata

--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -213,7 +213,7 @@ export function buildTarget(
       run_id: targetRunId,
       step_id: config.stepId ?? ctxStepId,
       step_index: config.stepIndex,
-      step_attempt: config.attempt ?? ctxAttempt,
+      step_attempt: config.attempt ?? undefined,
     };
   } else if (config.runId !== undefined) {
     return {


### PR DESCRIPTION
## Summary
Fix wrong step attempt when updating metadata. The cause was using `ctx.attempt` when it should be unspecified.

We noticed this issue with the new `inngest.score()` method. When retrying a later step, `ctx.attempt === 1` even though the target step only had 1 attempt