### PR TITLE
some fixes for client token subscription shape inconsistencies and excessive reconnects

### DIFF
--- a/.changeset/realtime-client-token.md
+++ b/.changeset/realtime-client-token.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow `useRealtime` to accept direct client subscription tokens from `getClientSubscriptionToken()` when `channel` and `topics` are provided as hook options, and avoid reconnecting solely because an inline token factory or token object gets a new render identity.

--- a/examples/realtime/tanstack-start-realtime/.gitignore
+++ b/examples/realtime/tanstack-start-realtime/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+.DS_Store
+.env
+
+.output
+.nitro
+.tanstack

--- a/examples/realtime/tanstack-start-realtime/package.json
+++ b/examples/realtime/tanstack-start-realtime/package.json
@@ -12,7 +12,7 @@
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-router": "~1.131.44",
     "@tanstack/react-start": "~1.131.44",
-    "inngest": "^4.0.0",
+    "inngest": "^4.4.0",
     "openai": "^4.80.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/inngest/src/react.runtime.test.ts
+++ b/packages/inngest/src/react.runtime.test.ts
@@ -231,6 +231,119 @@ describe("useRealtime runtime behavior", () => {
     await hook.unmount();
   });
 
+  test("accepts direct client subscription tokens when channel and topics are provided", async () => {
+    const sub = createControlledSubscription();
+    mockedSubscribe.mockResolvedValue(sub.subscription);
+
+    const hook = await renderUseRealtime({
+      channel: "test-channel",
+      topics: ["status"],
+      token: {
+        key: "abc",
+        apiBaseUrl: "http://localhost:8288/",
+      },
+      reconnect: false,
+    });
+
+    await vi.waitFor(() => {
+      expect(mockedSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "test-channel",
+          topics: ["status"],
+          key: "abc",
+          apiBaseUrl: "http://localhost:8288/",
+        }),
+      );
+      expect(hook.getLatest()?.connectionStatus).toBe("open");
+    });
+
+    await hook.unmount();
+  });
+
+  test("does not reconnect when an inline token factory changes identity on render", async () => {
+    const sub = createControlledSubscription();
+    mockedSubscribe.mockResolvedValue(sub.subscription);
+    let latest: UseRealtimeResult | null = null;
+    let renderer: ReactTestRenderer | undefined;
+
+    const Harness = () => {
+      latest = useRealtime({
+        channel: "test-channel",
+        topics: ["status"],
+        token: async () => ({
+          key: "abc",
+          apiBaseUrl: "http://localhost:8288/",
+        }),
+        reconnect: false,
+      });
+      return null;
+    };
+
+    await act(async () => {
+      renderer = create(React.createElement(Harness));
+    });
+
+    await vi.waitFor(() => {
+      expect(mockedSubscribe).toHaveBeenCalledTimes(1);
+      expect(latest?.connectionStatus).toBe("open");
+    });
+
+    await act(async () => {
+      await sub.push(makeDataMessage("status", { message: "hello" }));
+    });
+
+    await vi.waitFor(() => {
+      expect(latest?.messages.byTopic["status"]).toBeDefined();
+    });
+    expect(mockedSubscribe).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
+  test("does not reconnect when an inline client token object changes identity on render", async () => {
+    const sub = createControlledSubscription();
+    mockedSubscribe.mockResolvedValue(sub.subscription);
+    let latest: UseRealtimeResult | null = null;
+    let renderer: ReactTestRenderer | undefined;
+
+    const Harness = () => {
+      latest = useRealtime({
+        channel: "test-channel",
+        topics: ["status"],
+        token: {
+          key: "abc",
+          apiBaseUrl: "http://localhost:8288/",
+        },
+        reconnect: false,
+      });
+      return null;
+    };
+
+    await act(async () => {
+      renderer = create(React.createElement(Harness));
+    });
+
+    await vi.waitFor(() => {
+      expect(mockedSubscribe).toHaveBeenCalledTimes(1);
+      expect(latest?.connectionStatus).toBe("open");
+    });
+
+    await act(async () => {
+      await sub.push(makeDataMessage("status", { message: "hello" }));
+    });
+
+    await vi.waitFor(() => {
+      expect(latest?.messages.byTopic["status"]).toBeDefined();
+    });
+    expect(mockedSubscribe).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
   test("pauses while hidden and resumes when visible again", async () => {
     const visibility = installFakeDocument("hidden");
     const sub = createControlledSubscription();

--- a/packages/inngest/src/react.test.ts
+++ b/packages/inngest/src/react.test.ts
@@ -4,6 +4,7 @@ import { realtime, staticSchema } from "./index.ts";
 import {
   type ClientSubscriptionToken,
   getClientSubscriptionToken,
+  type UseRealtimeOptions,
   type UseRealtimeResult,
   useRealtime,
 } from "./react.ts";
@@ -80,6 +81,22 @@ describe("react exports", () => {
       key: string;
       apiBaseUrl?: string;
     }>();
+  });
+
+  test("useRealtime accepts client subscription tokens with channel and topics", () => {
+    const channel = agentChat({ threadId: "thread-1" });
+    const token: ClientSubscriptionToken = {
+      key: "token",
+      apiBaseUrl: "http://localhost:8288/",
+    };
+
+    const options = {
+      channel,
+      topics: ["status"] as const,
+      token,
+    } satisfies UseRealtimeOptions<ChatInstance, readonly ["status"]>;
+
+    expectTypeOf(options.token).toEqualTypeOf<ClientSubscriptionToken>();
   });
 });
 

--- a/packages/inngest/src/react.ts
+++ b/packages/inngest/src/react.ts
@@ -23,8 +23,17 @@ export type UseRealtimeRunStatus =
 
 export type ClientSubscriptionToken = Realtime.Subscribe.ClientToken;
 
-type TokenFactory = () => Promise<
-  string | ClientSubscriptionToken | Realtime.Subscribe.Token
+type TokenTopics<
+  TTopics extends readonly string[] | undefined = readonly string[] | undefined,
+> = TTopics extends readonly string[] ? [...TTopics] : string[];
+
+type TokenFactory<
+  TChannel extends Realtime.ChannelInput = Realtime.ChannelInput,
+  TTopics extends readonly string[] | undefined = readonly string[] | undefined,
+> = () => Promise<
+  | string
+  | ClientSubscriptionToken
+  | Realtime.Subscribe.Token<TChannel, TokenTopics<TTopics>>
 >;
 type UseRealtimePauseReason = "hidden" | "disabled" | null;
 
@@ -112,7 +121,10 @@ export interface UseRealtimeOptions<
   // Either a pre-minted subscription token or a token factory that returns
   // a token key string, a client token from
   // `getClientSubscriptionToken()`, or a full token object.
-  token?: Realtime.Subscribe.Token | TokenFactory;
+  token?:
+    | ClientSubscriptionToken
+    | Realtime.Subscribe.Token<TChannel, TokenTopics<TTopics>>
+    | TokenFactory<TChannel, TTopics>;
 
   key?: string;
   enabled?: boolean;
@@ -285,6 +297,25 @@ export const useRealtime = <
   const channelKey =
     typeof channel === "string" ? channel : (channel?.name ?? undefined);
   const topicsKey = topics ? JSON.stringify([...topics]) : "";
+  const tokenInputKey =
+    typeof tokenInput === "function"
+      ? "factory"
+      : tokenInput
+        ? isSubscriptionToken(tokenInput)
+          ? JSON.stringify({
+              apiBaseUrl: tokenInput.apiBaseUrl,
+              channel:
+                typeof tokenInput.channel === "string"
+                  ? tokenInput.channel
+                  : tokenInput.channel.name,
+              key: tokenInput.key,
+              topics: [...tokenInput.topics],
+            })
+          : JSON.stringify({
+              apiBaseUrl: tokenInput.apiBaseUrl,
+              key: tokenInput.key,
+            })
+        : "";
   const [allMessages, setAllMessages] = useState<Realtime.Message[]>([]);
   const [messageDelta, setMessageDelta] = useState<Realtime.Message[]>([]);
   const [messagesByTopic, setMessagesByTopic] = useState<
@@ -308,10 +339,15 @@ export const useRealtime = <
   const bufferIntervalRef = useRef(bufferInterval);
   const messageLimitRef = useRef(historyLimit);
   const runStatusRef = useRef(runStatus);
+  const tokenInputRef = useRef(tokenInput);
 
   useEffect(() => {
     runStatusRef.current = runStatus;
   }, [runStatus]);
+
+  useEffect(() => {
+    tokenInputRef.current = tokenInput;
+  }, [tokenInput]);
 
   useEffect(() => {
     bufferIntervalRef.current = bufferInterval;
@@ -444,12 +480,29 @@ export const useRealtime = <
     };
 
     const resolveToken = async (): Promise<Realtime.Subscribe.Token> => {
-      if (tokenInput && typeof tokenInput !== "function") {
-        return tokenInput;
+      const currentTokenInput = tokenInputRef.current;
+
+      if (currentTokenInput && typeof currentTokenInput !== "function") {
+        if (isSubscriptionToken(currentTokenInput)) {
+          return currentTokenInput as Realtime.Subscribe.Token;
+        }
+
+        if (!channel || !topics) {
+          throw new Error(
+            "useRealtime token object did not include channel/topics and channel/topics were not provided",
+          );
+        }
+
+        return {
+          channel: channel as Realtime.ChannelInput,
+          topics: topics as string[],
+          key: currentTokenInput.key,
+          apiBaseUrl: currentTokenInput.apiBaseUrl,
+        } as Realtime.Subscribe.Token;
       }
 
-      if (typeof tokenInput === "function") {
-        const next = await tokenInput();
+      if (typeof currentTokenInput === "function") {
+        const next = await currentTokenInput();
         if (typeof next === "string") {
           if (!channel || !topics) {
             throw new Error(
@@ -658,7 +711,7 @@ export const useRealtime = <
     reconnect,
     reconnectMaxMs,
     reconnectMinMs,
-    tokenInput,
+    tokenInputKey,
     topicsKey,
     validate,
   ]);


### PR DESCRIPTION
## Summary
Got some good feedback in a support [ticket](https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01KSDK8RP8RPZ4F75KWFVV28RV). 

This allows direct `ClientSubscriptionToken` values from `getClientSubscriptionToken()` when channel and topics are provided and prevents reconnect loops caused by inline token factories/token objects changing render identity.


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
