### PR TITLE
fix: avoid repeated default middleware transforms

### DIFF
--- a/.changeset/sharp-bikes-compare.md
+++ b/.changeset/sharp-bikes-compare.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Avoid re-applying the default JSON output transform for middleware stacks where every middleware uses the default transform, preserving nested `step.run()` and function output inference with multiple default middlewares.

--- a/packages/inngest/src/components/middleware/middleware.test.ts
+++ b/packages/inngest/src/components/middleware/middleware.test.ts
@@ -1,6 +1,37 @@
 import { test } from "vitest";
+import type { Jsonify } from "../../helpers/jsonify.ts";
+import type { IsEqual } from "../../helpers/types.ts";
+import type { ApplyAllMiddlewareTransforms } from "../../types.ts";
 import { Inngest } from "../Inngest.ts";
 import { Middleware } from "./middleware.ts";
+
+test("default middleware output transforms are applied only once", () => {
+  class MW1 extends Middleware.BaseMiddleware {
+    readonly id = "test-1";
+  }
+
+  class MW2 extends Middleware.BaseMiddleware {
+    readonly id = "test-2";
+  }
+
+  type StepResult = {
+    passed: boolean;
+    checks: { name: string; passed: boolean; message: string }[];
+  };
+
+  type StepOutput = ApplyAllMiddlewareTransforms<
+    [typeof MW1, typeof MW2],
+    StepResult
+  >;
+  type FunctionOutput = ApplyAllMiddlewareTransforms<
+    [typeof MW1, typeof MW2],
+    StepResult,
+    "functionOutputTransform"
+  >;
+
+  assertType<IsEqual<StepOutput, Jsonify<StepResult>>>(true);
+  assertType<IsEqual<FunctionOutput, Jsonify<StepResult>>>(true);
+});
 
 test("stepOutputTransform does not affect step.invoke return type", () => {
   interface PreserveDate extends Middleware.StaticTransform {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -774,8 +774,46 @@ export type ApplyAllMiddlewareTransforms<
   T,
   TKind extends TransformKind = "stepOutputTransform",
 > = TMw extends [Middleware.Class, ...Middleware.Class[]]
-  ? ApplyMiddlewareTransformsInternal<TMw, T, TKind>
+  ? AnyMiddlewareOverridesTransform<TMw, TKind> extends true
+    ? ApplyMiddlewareTransformsInternal<TMw, T, TKind>
+    : Jsonify<T>
   : Jsonify<T>; // No middleware or empty array - apply default Jsonify
+
+/**
+ * Whether a middleware transform explicitly overrides the default Jsonify
+ * transform. Default transforms are collapsed to a single Jsonify application
+ * so nested object/array inference does not degrade across middleware stacks.
+ */
+type AnyMiddlewareOverridesTransform<
+  TMw extends Middleware.Class[] | undefined,
+  TKind extends TransformKind,
+> = TMw extends [
+  infer First extends Middleware.Class,
+  ...infer Rest extends Middleware.Class[],
+]
+  ? IsDefaultMiddlewareTransform<
+      GetMiddlewareTransformerByKind<First, TKind>
+    > extends true
+    ? AnyMiddlewareOverridesTransform<Rest, TKind>
+    : true
+  : false;
+
+type DefaultTransformProbe = {
+  readonly __inngestDefaultTransformCheck: Date;
+};
+
+type IsDefaultMiddlewareTransform<
+  TTransform extends Middleware.StaticTransform,
+> = IsSame<
+  ApplyMiddlewareStaticTransform<TTransform, DefaultTransformProbe>,
+  Jsonify<DefaultTransformProbe>
+>;
+
+type IsSame<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B
+  ? 1
+  : 2
+  ? true
+  : false;
 
 /**
  * Internal helper that recursively applies middleware transforms.


### PR DESCRIPTION
## Summary

Fixes the type-level regression in #1532 where two or more middlewares using the default output transform recursively apply `Jsonify` and collapse nested `step.run()` / function output inference to `JsonifyObject<{}>`.

This keeps custom middleware transform chaining intact, but collapses an all-default middleware stack to a single `Jsonify<T>` application, which matches the runtime JSON serialization semantics described in the issue.

Added a regression test covering both `stepOutputTransform` and `functionOutputTransform` for two default middlewares, plus a patch changeset.

## Verification

- `pnpm --dir packages/inngest exec biome check src/types.ts src/components/middleware/middleware.test.ts`
- `pnpm --dir packages/inngest exec tsc --noEmit --allowImportingTsExtensions --declaration --declarationMap --esModuleInterop --forceConsistentCasingInFileNames --isolatedModules --lib ES2022,DOM --module Preserve --moduleDetection force --moduleResolution bundler --noFallthroughCasesInSwitch --noImplicitOverride --noImplicitReturns --noUncheckedIndexedAccess --resolveJsonModule --rewriteRelativeImportExtensions --skipLibCheck --strict --strictNullChecks --target ES2022 --types node,vitest/globals --verbatimModuleSyntax src/components/middleware/middleware.test.ts`

Notes from local setup:
- `pnpm --dir packages/inngest test:types` currently stops on missing local `@inngest/test` declarations in existing ALS/log tests; no error remains in `Inngest.test.ts` after preserving custom transform chaining.
- `pnpm --dir packages/inngest test src/components/middleware/middleware.test.ts` is blocked locally by Rollup's macOS ARM native optional package failing code signature loading in the Codex Node runtime before Vitest starts.

## Checklist

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Type-level bug fix with no docs surface change
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- EXE-1868
- Fixes #1532

Disclosure: I used AI assistance to inspect the issue/repo and draft this patch; I reviewed the contribution guidelines, found no CLA/DCO requirement in this repo, and validated the targeted type/lint checks above.
