### PR TITLE
fix: unnecessary outgoing Durable Endpoint request

### DIFF
--- a/.changeset/real-mirrors-fry.md
+++ b/.changeset/real-mirrors-fry.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix unnecessary outgoing Durable Endpoint request

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -993,6 +993,7 @@ export class InngestCommHandler<
           events: [event],
           maxAttempts: fn.opts.retries ?? defaultMaxRetries,
         },
+        isDurableEndpoint: true,
         runId,
         headers: {},
         reqArgs: args,
@@ -2296,6 +2297,11 @@ export class InngestCommHandler<
             jobId: jobId ?? undefined,
           },
           internalFnId: ctx?.fn_id,
+
+          // Rely on `forceExecution` to know if this is a Durable Endpoint in
+          // async mode.
+          isDurableEndpoint: forceExecution,
+
           queueItemId: ctx?.qi_id,
           stepState,
           priorDefers: defers,

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -154,6 +154,14 @@ export interface InngestExecutionOptions {
    */
   handlerKind?: "main" | "failure" | "defer";
 
+  /**
+   * Whether this execution is part of a Durable Endpoint flow. Could be either
+   * sync mode (request not from Inngest) or async mode (request from Inngest).
+   *
+   * @default false
+   */
+  isDurableEndpoint?: boolean;
+
   disableImmediateExecution?: boolean;
 
   /**

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1188,7 +1188,7 @@ class InngestExecutionEngine
 
         // If stream was never activated, start the POST now so the
         // client waiting at the GET endpoint gets the result event.
-        if (!this.streamTools.activated) {
+        if (this.options.isDurableEndpoint && !this.streamTools.activated) {
           this.postCheckpointStream();
         }
 
@@ -1216,7 +1216,7 @@ class InngestExecutionEngine
           await this.streamEnd();
         }
 
-        if (!this.streamTools.activated) {
+        if (this.options.isDurableEndpoint && !this.streamTools.activated) {
           this.postCheckpointStream();
         }
 


### PR DESCRIPTION
# Description
Fix a bug where we always sent an outgoing Durable Endpoint streaming request at the end of the function, even in non Durable Endpoints

# Context
We create the stream at the end of the function because Durable Endpoints need to stream their output/error irrespective of whether they explicitly streamed within their body