### PR TITLE
fix: Add step attributes to all extended trace spans

### DIFF
--- a/.changeset/cute-sides-laugh.md
+++ b/.changeset/cute-sides-laugh.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix: Add step attribution attributes to all extended trace spans

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -354,10 +354,10 @@ export class InngestSpanProcessor implements SpanProcessor {
 
     const stepCtx = this.#activeStepContext.get(parentState.rootSpanId);
     if (stepCtx) {
-        span.setAttribute(Attribute.InngestStepId, stepCtx.id);
-        span.setAttribute(Attribute.InngestStepIndex, stepCtx.index);
-        span.setAttribute(Attribute.InngestStepHash, stepCtx.hashedStepId);
-        span.setAttribute(Attribute.InngestStepAttempt, stepCtx.attempt);
+      span.setAttribute(Attribute.InngestStepId, stepCtx.id);
+      span.setAttribute(Attribute.InngestStepIndex, stepCtx.index);
+      span.setAttribute(Attribute.InngestStepHash, stepCtx.hashedStepId);
+      span.setAttribute(Attribute.InngestStepAttempt, stepCtx.attempt);
     }
 
     // For direct children of the root span during step execution, set a

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -352,6 +352,14 @@ export class InngestSpanProcessor implements SpanProcessor {
     this.#spansToExport.add(span);
     this.#traceParents.set(spanId, parentState);
 
+    const stepCtx = this.#activeStepContext.get(parentState.rootSpanId);
+    if (stepCtx) {
+        span.setAttribute(Attribute.InngestStepId, stepCtx.id);
+        span.setAttribute(Attribute.InngestStepIndex, stepCtx.index);
+        span.setAttribute(Attribute.InngestStepHash, stepCtx.hashedStepId);
+        span.setAttribute(Attribute.InngestStepAttempt, stepCtx.attempt);
+    }
+
     // For direct children of the root span during step execution, set a
     // dedicated attribute with the deterministic step span ID. The Go executor
     // creates executor.step spans with the same deterministic ID (from the same
@@ -362,7 +370,6 @@ export class InngestSpanProcessor implements SpanProcessor {
         (span as unknown as { parentSpanId?: string }).parentSpanId;
 
       if (spanParentId === parentState.rootSpanId) {
-        const stepCtx = this.#activeStepContext.get(parentState.rootSpanId);
         if (stepCtx) {
           const seed = stepCtx.hashedStepId + ":" + String(stepCtx.attempt);
           const newSpanId = deterministicSpanID(seed);
@@ -376,10 +383,6 @@ export class InngestSpanProcessor implements SpanProcessor {
             stepCtx.attempt,
           );
           span.setAttribute(Attribute.InngestStepParentSpanId, newSpanId);
-          span.setAttribute(Attribute.InngestStepId, stepCtx.id);
-          span.setAttribute(Attribute.InngestStepIndex, stepCtx.index);
-          span.setAttribute(Attribute.InngestStepHash, stepCtx.hashedStepId);
-          span.setAttribute(Attribute.InngestStepAttempt, stepCtx.attempt);
         }
       }
     }


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Add step id attributes to all spans rather than only direct children of the step span

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
