### PR TITLE
feat: Emit a StepPlanned opcode for long running steps (EXE-1547)

### DIFF
--- a/.changeset/long-steps-report.md
+++ b/.changeset/long-steps-report.md
@@ -1,0 +1,5 @@
+---
+"inngest": feature
+---
+
+Report in-progress steps: in Checkpointing mode, a step running longer than 1s fires a fire-and-forget leading-edge `StepPlanned` checkpoint so the step can be shown as running; on completion a normal full-span `StepRun` supersedes it.

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -838,4 +838,298 @@ describe("Execution engine checkpoint retry behavior", () => {
       });
     });
   });
+
+  // When a step in AsyncCheckpointing runs longer than the in-progress
+  // threshold (1s), the SDK fires a fire-and-forget leading-edge
+  // `StepPlanned` (zero-length span at startMs − 1ms) so the executor can
+  // show an in-progress span. On completion a normal `StepRun` with the full
+  // span follows; the server's last-fragment-wins merge (by start_time, where
+  // the −1ms guarantees a strict ordering) means the `StepRun` overrides
+  // every attribute of the `StepPlanned`.
+  describe("Execution engine in-progress step", () => {
+    const inProgressOpts = {
+      stepMode: StepMode.AsyncCheckpointing as const,
+      checkpointingConfig: { bufferedSteps: 1, maxRuntime: 0, maxInterval: 0 },
+      extraPartialOptions: {
+        queueItemId: "queue-item-123",
+        internalFnId: "internal-fn-456",
+      },
+    };
+
+    // Resolvable Promise helper — separate from the SDK's deferred utility
+    // so failures here don't depend on internal helpers.
+    const defer = <T>() => {
+      let resolve!: (v: T) => void;
+      let reject!: (e: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+
+    // Steps from all flushed checkpoint payloads.
+    const buffered = (mock: ReturnType<typeof vi.fn>) =>
+      mock.mock.calls.flatMap((call) => call[0]?.steps ?? []);
+
+    // Leading-edge `StepPlanned` ops across all checkpoint payloads. The
+    // leading-edge POST shares `checkpointStepsAsync` with buffer flushes;
+    // it's identifiable as the only source of `StepPlanned` ops here.
+    const planned = (mock: ReturnType<typeof vi.fn>) =>
+      buffered(mock).filter(
+        (s: { op: StepOpCode }) => s.op === StepOpCode.StepPlanned,
+      );
+
+    // Assert the trailing op starts exactly 1ms (1e6 ns) after the leading
+    // `StepPlanned`. Epoch-ns values (~1.7e18) exceed Number.MAX_SAFE_INTEGER,
+    // so each carries up to ~256ns of float error — allow a tolerance far
+    // below the 1ms offset.
+    const expectLeadingOffset = (trailingA: number, plannedA: number) => {
+      expect(Math.abs(trailingA - plannedA - 1_000_000)).toBeLessThan(10_000);
+    };
+
+    test("short step → no leading-edge POST", async () => {
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = await runExecution({
+        mockApi: {
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => "a");
+        },
+        ...inProgressOpts,
+      });
+
+      expect(planned(mockCheckpointStepsAsync)).toEqual([]);
+      // Short step: data ships via the normal flow (buffer flush or
+      // step-ran result, depending on bufferedSteps). Either way, no
+      // leading-edge POST.
+      const stepFromResult =
+        result.type === "step-ran"
+          ? [(result as { step: { op: StepOpCode } }).step]
+          : result.type === "steps-found"
+            ? (result as ExecutionResults["steps-found"]).steps
+            : [];
+      const allSteps = [
+        ...stepFromResult,
+        ...buffered(mockCheckpointStepsAsync),
+      ];
+      const stepRuns = allSteps.filter((s) => s.op === StepOpCode.StepRun);
+      expect(stepRuns.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("long step → leading StepPlanned 1ms early, trailing StepRun is a normal full span", async () => {
+      const stepBody = defer<string>();
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const setup = setupExecution({
+        mockApi: {
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => stepBody.promise);
+        },
+        ...inProgressOpts,
+      });
+
+      const execPromise = setup.execution.start();
+
+      // Cross the threshold; leading-edge POST should fire.
+      await vi.advanceTimersByTimeAsync(1500);
+      const plannedOps = planned(mockCheckpointStepsAsync);
+      expect(plannedOps).toHaveLength(1);
+      const plannedOp = plannedOps[0]! as {
+        op: StepOpCode;
+        opts?: Record<string, unknown>;
+        timing: { a: number; b: number };
+      };
+      // Wire convention: zero-length span at `a`.
+      expect(plannedOp.timing.b).toBe(0);
+      expect(plannedOp.timing.a).toBeGreaterThan(0);
+
+      stepBody.resolve("a");
+      await advanceThroughRetries();
+      await execPromise;
+
+      // Trailing StepRun should be in the checkpoint buffer flush.
+      const allSteps = buffered(mockCheckpointStepsAsync);
+      const runs = allSteps.filter((s) => s.op === StepOpCode.StepRun);
+      expect(runs).toHaveLength(1);
+      const run = runs[0]!;
+      // Normal full span: starts at the step's true start, carries the
+      // real duration.
+      expect(run.timing.b).toBeGreaterThan(0);
+      // The leading StepPlanned starts exactly 1ms (1e6 ns) earlier — the
+      // merge tiebreak that lets the StepRun's attributes win server-side.
+      expectLeadingOffset(run.timing.a, plannedOp.timing.a);
+      // Only the one leading-edge StepPlanned ever shipped — no fallback
+      // pushed onto the checkpoint buffer.
+      expect(planned(mockCheckpointStepsAsync)).toHaveLength(1);
+    });
+
+    // The leading POST is fire-and-forget: failure must not change the
+    // trailing op or push anything extra onto the checkpoint buffer.
+    test.each([
+      ["rejects", () => Promise.reject(new Error("executor offline"))],
+      ["hangs", () => new Promise<never>(() => {})],
+    ])(
+      "long step + leading POST %s → trailing StepRun unchanged",
+      async (_label, failureMode) => {
+        const stepBody = defer<string>();
+        // Fail only the leading-edge POST (the call carrying a
+        // `StepPlanned`); normal buffer flushes succeed.
+        const mockCheckpointStepsAsync = vi
+          .fn()
+          .mockImplementation((args: { steps?: { op: StepOpCode }[] }) =>
+            args.steps?.some((s) => s.op === StepOpCode.StepPlanned)
+              ? failureMode()
+              : Promise.resolve(undefined),
+          );
+
+        const setup = setupExecution({
+          mockApi: {
+            checkpointStepsAsync: mockCheckpointStepsAsync,
+          },
+          handler: async ({ step }) => {
+            await step.run("a", () => stepBody.promise);
+          },
+          ...inProgressOpts,
+        });
+
+        const execPromise = setup.execution.start();
+        await vi.advanceTimersByTimeAsync(1500);
+        const plannedOps = planned(mockCheckpointStepsAsync) as {
+          timing: { a: number };
+        }[];
+        expect(plannedOps).toHaveLength(1);
+
+        stepBody.resolve("a");
+        await advanceThroughRetries();
+        await execPromise;
+
+        // No fallback StepPlanned buffered; the trailing StepRun is a
+        // normal full span, identical to the success case.
+        expect(planned(mockCheckpointStepsAsync)).toHaveLength(1);
+        const runs = buffered(mockCheckpointStepsAsync).filter(
+          (s) => s.op === StepOpCode.StepRun,
+        );
+        expect(runs).toHaveLength(1);
+        expect(runs[0]!.timing.b).toBeGreaterThan(0);
+        expectLeadingOffset(runs[0]!.timing.a, plannedOps[0]!.timing.a);
+      },
+    );
+
+    test("long step that throws → StepError carries a normal full span", async () => {
+      const stepBody = defer<string>();
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const setup = setupExecution({
+        mockApi: {
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => stepBody.promise);
+        },
+        ...inProgressOpts,
+      });
+
+      const execPromise = setup.execution.start();
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(planned(mockCheckpointStepsAsync)).toHaveLength(1);
+
+      stepBody.reject(new NonRetriableError("nope"));
+      await advanceThroughRetries();
+      const result = await execPromise;
+
+      // Failed steps don't go through the checkpoint buffer — the error
+      // op rides back to the executor on the execution result (step-ran).
+      expect(result.type).toBe("step-ran");
+      const stepRan = result as {
+        type: "step-ran";
+        step: { op: StepOpCode; timing: { a: number; b: number } };
+      };
+      expect([StepOpCode.StepError, StepOpCode.StepFailed]).toContain(
+        stepRan.step.op,
+      );
+      // Normal full span — the error op is not collapsed or marked.
+      expect(stepRan.step.timing.b).toBeGreaterThan(0);
+      expect(stepRan.step.timing.a).toBeGreaterThan(0);
+      const plannedOp = planned(mockCheckpointStepsAsync)[0]! as {
+        timing: { a: number };
+      };
+      expectLeadingOffset(stepRan.step.timing.a, plannedOp.timing.a);
+    });
+
+    test("two sequential long step.runs → independent trackers, no cross-talk", async () => {
+      const aBody = defer<string>();
+      const bBody = defer<string>();
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const setup = setupExecution({
+        mockApi: {
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => aBody.promise);
+          await step.run("b", () => bBody.promise);
+        },
+        ...inProgressOpts,
+      });
+
+      // Auto-resolve each body after the leading-edge timer has fired,
+      // avoiding brittle manual interleaving with the engine's generator
+      // loop. Each body waits ~1.5s of fake time before resolving.
+      setTimeout(() => aBody.resolve("a"), 3000);
+      setTimeout(() => bBody.resolve("b"), 6000);
+
+      const execPromise = setup.execution.start();
+      // Drive timers far enough to cover both step bodies + grace.
+      for (let i = 0; i < 30; i++) {
+        await vi.advanceTimersByTimeAsync(500);
+      }
+      await execPromise;
+
+      // Two distinct leading-edge POSTs, one per step.
+      const plannedOps = planned(mockCheckpointStepsAsync);
+      expect(plannedOps).toHaveLength(2);
+      const plannedNames = plannedOps.map(
+        (s: { displayName?: string }) => s.displayName,
+      );
+      expect(plannedNames).toEqual(expect.arrayContaining(["a", "b"]));
+
+      // Two distinct trailing StepRuns, both normal full spans.
+      const allBuffered = buffered(mockCheckpointStepsAsync);
+      const runs = allBuffered.filter((s) => s.op === StepOpCode.StepRun);
+      expect(runs).toHaveLength(2);
+      const runNames = runs.map((r) => r.displayName);
+      expect(runNames).toEqual(expect.arrayContaining(["a", "b"]));
+      for (const r of runs) {
+        expect(r.timing.b).toBeGreaterThan(0);
+      }
+    });
+
+    test("non-checkpointing mode → no leading-edge POST", async () => {
+      const stepBody = defer<string>();
+      const mockCheckpointStepsAsync = vi.fn().mockResolvedValue(undefined);
+
+      const setup = setupExecution({
+        mockApi: {
+          checkpointStepsAsync: mockCheckpointStepsAsync,
+        },
+        handler: async ({ step }) => {
+          await step.run("a", () => stepBody.promise);
+        },
+        stepMode: StepMode.Async,
+      });
+
+      const execPromise = setup.execution.start();
+      await vi.advanceTimersByTimeAsync(1500);
+      stepBody.resolve("a");
+      await advanceThroughRetries();
+      await execPromise;
+
+      expect(planned(mockCheckpointStepsAsync)).toEqual([]);
+    });
+  });
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -107,6 +107,13 @@ const { sha1 } = hashjs;
  */
 const CHECKPOINT_RETRY_OPTIONS = { maxAttempts: 5, baseDelay: 100 };
 
+/**
+ * If a step in `AsyncCheckpointing` mode runs for this long without finishing,
+ * the SDK fires a leading-edge `StepPlanned` so the executor can show an
+ * in-progress span.
+ */
+const IN_PROGRESS_THRESHOLD_MS = 1000;
+
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -1686,8 +1693,15 @@ class InngestExecutionEngine
     const wrappedActualHandler =
       this.middlewareManager.buildWrapStepHandlerChain(actualHandler, stepInfo);
 
-    return goIntervalTiming(() => wrappedActualHandler())
+    // In `AsyncCheckpointing`, schedule a leading-edge `StepPlanned` for
+    // steps that exceed the in-progress threshold.
+    const startMs = Date.now();
+    const leadingEdgeTimer = this.scheduleLeadingEdge(startMs, outgoingOp);
+
+    return goIntervalTiming(() => wrappedActualHandler(), startMs)
       .finally(() => {
+        if (leadingEdgeTimer) clearTimeout(leadingEdgeTimer);
+
         this.devDebug(`finished executing step "${id}"`);
 
         this.state.executingStep = undefined;
@@ -1735,6 +1749,77 @@ class InngestExecutionEngine
         ...op,
         timing: interval,
       }));
+  }
+
+  /**
+   * Schedule the leading-edge `StepPlanned` POST for a step that runs past
+   * the in-progress threshold. Returns the timer so the caller can clear it
+   * when the step finishes, or `null` (no tracking) outside checkpointing
+   * mode or when the required identifiers aren't present.
+   */
+  private scheduleLeadingEdge(
+    startMs: number,
+    outgoingOp: OutgoingOp,
+  ): ReturnType<typeof setTimeout> | null {
+    const { internalFnId, queueItemId } = this.options;
+    if (
+      this.options.stepMode !== StepMode.AsyncCheckpointing ||
+      !internalFnId ||
+      !queueItemId
+    ) {
+      return null;
+    }
+
+    return setTimeout(() => {
+      this.firePlannedLeadingEdge({
+        startMs,
+        outgoingOp,
+        internalFnId,
+        queueItemId,
+      });
+    }, IN_PROGRESS_THRESHOLD_MS);
+  }
+
+  /**
+   * Timer callback that POSTs the leading-edge `StepPlanned`.
+   */
+  private firePlannedLeadingEdge(args: {
+    startMs: number;
+    outgoingOp: OutgoingOp;
+    internalFnId: string;
+    queueItemId: string;
+  }): void {
+    const plannedOp: OutgoingOp = {
+      ...args.outgoingOp,
+      op: StepOpCode.StepPlanned,
+      timing: {
+        // Zero-length span starting 1ms before the step's true start.
+        //
+        // The -1ms delta ensures that when this StepPlanned OpCode's span
+        // aggregates with the final StepRun OpCode's span,
+        // the StepRun OpCode's status=Completed overrides the StepPlanned
+        // OpCode's status=Running
+        a: (args.startMs - 1) * 1_000_000,
+        b: 0,
+      },
+    };
+
+    this.options.client["inngestApi"]
+      .checkpointStepsAsync({
+        runId: this.options.runId,
+        fnId: args.internalFnId,
+        queueItemId: args.queueItemId,
+        requestId: this.options.requestId,
+        requestStartedAt: this.options.requestStartedAt,
+        steps: [plannedOp],
+      })
+      .catch((err: unknown) => {
+        this.devDebug(
+          `in-progress leading-edge POST failed for hashedId=%s:`,
+          args.outgoingOp.id,
+          err,
+        );
+      });
   }
 
   /**

--- a/packages/inngest/src/helpers/promises.test.ts
+++ b/packages/inngest/src/helpers/promises.test.ts
@@ -1,4 +1,8 @@
-import { retryWithBackoff, runAsPromise } from "./promises.ts";
+import {
+  goIntervalTiming,
+  retryWithBackoff,
+  runAsPromise,
+} from "./promises.ts";
 
 describe("runAsPromise", () => {
   describe("synchronous functions", () => {
@@ -187,5 +191,38 @@ describe("retryWithBackoff", () => {
 
       vi.useRealTimers();
     });
+  });
+});
+
+describe("goIntervalTiming", () => {
+  test("defaults to starting the interval at invocation time", async () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+
+    const { resultPromise, interval } = await goIntervalTiming(() => "value");
+
+    await expect(resultPromise).resolves.toBe("value");
+    expect(interval.a).toBe(now * 1_000_000);
+    expect(interval.b).toBe(0);
+
+    vi.useRealTimers();
+  });
+
+  test("anchors the interval at a caller-supplied start", async () => {
+    vi.useFakeTimers();
+    const start = Date.now() - 500;
+
+    const { resultPromise, interval } = await goIntervalTiming(
+      () => "value",
+      start,
+    );
+
+    await expect(resultPromise).resolves.toBe("value");
+    // The interval starts at the supplied origin, not at the moment
+    // goIntervalTiming was invoked, so `a + b` still lands on `t_end`.
+    expect(interval.a).toBe(start * 1_000_000);
+    expect(interval.b).toBe(500 * 1_000_000);
+
+    vi.useRealTimers();
   });
 });

--- a/packages/inngest/src/helpers/promises.ts
+++ b/packages/inngest/src/helpers/promises.ts
@@ -271,13 +271,13 @@ export type GoInterval = {
 // biome-ignore lint/suspicious/noExplicitAny: match any fn
 export const goIntervalTiming = async <T extends (...args: any[]) => any>(
   fn: T,
+  // Ideally this would use process.hrtime, but that's not available in all
+  // runtimes, so we must revert to less accurate timing and `Date`.
+  start: number = Date.now(),
 ): Promise<{
   resultPromise: Promise<Awaited<ReturnType<T>>>;
   interval: { a: number; b: number };
 }> => {
-  // Ideally this would use process.hrtime, but that's not available in all
-  // runtimes, so we must revert to less accurate timing and `Date`.
-  const start = Date.now();
   const resultPromise = runAsPromise(fn) as Promise<Awaited<ReturnType<T>>>;
 
   // Let the function run to completion.

--- a/packages/inngest/src/test/integration/checkpointing/stepStarted.test.ts
+++ b/packages/inngest/src/test/integration/checkpointing/stepStarted.test.ts
@@ -1,0 +1,205 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  sleep,
+  testNameFromFileUrl,
+  waitFor,
+} from "@inngest/test-harness";
+import { expect, onTestFinished, test } from "vitest";
+import { isRecord } from "../../../helpers/types.ts";
+import { Inngest } from "../../../index.ts";
+import { createServer } from "../../../node.ts";
+import { StepOpCode } from "../../../types.ts";
+import {
+  createRecordingDevServerProxy,
+  type RecordedRequest,
+} from "../proxy.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+// Builds a matcher for an async checkpoint request carrying a "slow-step" op of
+// the given op code. Both the leading-edge "step started" (StepPlanned) and
+// trailing StepRun requests hit the same async checkpoint endpoint and differ
+// only in the op code carried for the slow step.
+function matchesSlowStepCheckpoint(
+  op: StepOpCode,
+): (request: RecordedRequest) => boolean {
+  return (request) => {
+    if (
+      request.method !== "POST" ||
+      !/^\/v1\/checkpoint\/[^/]+\/async$/.test(request.path) ||
+      !isRecord(request.body)
+    ) {
+      return false;
+    }
+
+    const steps = request.body.steps;
+    if (!Array.isArray(steps)) {
+      return false;
+    }
+
+    return steps.some(
+      (step) =>
+        isRecord(step) && step.op === op && step.displayName === "slow-step",
+    );
+  };
+}
+
+// Progress checkpoints use the normal async checkpoint endpoint. The
+// StepPlanned op is what makes this the "step started" request.
+const isSlowStepStartedRequest = matchesSlowStepCheckpoint(
+  StepOpCode.StepPlanned,
+);
+
+// The trailing-edge request: a normal async checkpoint carrying the
+// completed StepRun for the slow step.
+const isSlowStepRunRequest = matchesSlowStepCheckpoint(StepOpCode.StepRun);
+
+function getStepTiming(request: RecordedRequest): { a: number; b: number } {
+  const steps = (request.body as { steps: unknown[] }).steps;
+  const step = steps.find(
+    (s) => isRecord(s) && s.displayName === "slow-step",
+  ) as { timing: { a: number; b: number } };
+  return step.timing;
+}
+
+test("step takes >1 second", async () => {
+  // When a step takes >1 second, the SDK sends a request to tell Dev Server
+  // that the step started. We'll do that by placing a proxy between this test
+  // and the Dev Server.
+
+  const proxy = createRecordingDevServerProxy();
+  await proxy.start();
+  onTestFinished(() => proxy.stop());
+
+  const state = createState({ stepRunCount: 0 });
+  const client = new Inngest({
+    baseUrl: proxy.url,
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+    },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      return await step.run("slow-step", async () => {
+        state.stepRunCount++;
+
+        // Cross the SDK's 1s in-progress threshold.
+        await sleep(1500);
+
+        return "done";
+      });
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+  expect(result).toBe("done");
+  expect(state.stepRunCount).toBe(1);
+
+  const progressRequest = proxy.requests.find(isSlowStepStartedRequest);
+  if (!progressRequest) {
+    throw new Error("Step started checkpoint request not sent yet");
+  }
+
+  const runId = await state.waitForRunId();
+  expect(progressRequest.body).toEqual({
+    fn_id: expect.any(String),
+    qi_id: expect.any(String),
+    request_id: expect.any(String),
+    request_started_at: expect.any(Number),
+    run_id: runId,
+    steps: [
+      {
+        displayName: "slow-step",
+        id: "bb209016db1e6468df06a4e7204e39b7b77b01f3",
+        name: "slow-step",
+        op: StepOpCode.StepPlanned,
+        opts: {},
+        timing: {
+          a: expect.any(Number),
+          b: 0,
+        },
+        userland: {
+          id: "slow-step",
+        },
+      },
+    ],
+    ts: expect.any(Number),
+  });
+
+  // The trailing StepRun is a completely normal full span. The leading
+  // StepPlanned starts exactly 1ms (1e6 ns) earlier — the merge tiebreak
+  // that guarantees the StepRun's attributes win server-side. Epoch-ns
+  // values exceed Number.MAX_SAFE_INTEGER (~256ns float error each), so
+  // allow a tolerance far below the 1ms offset.
+  const runRequest = await waitFor(() => {
+    const found = proxy.requests.find(isSlowStepRunRequest);
+    if (!found) {
+      throw new Error("Trailing StepRun checkpoint request not found");
+    }
+    return found;
+  });
+  const plannedTiming = getStepTiming(progressRequest);
+  const runTiming = getStepTiming(runRequest);
+  expect(Math.abs(runTiming.a - plannedTiming.a - 1_000_000)).toBeLessThan(
+    10_000,
+  );
+  expect(runTiming.b).toBeGreaterThan(0);
+});
+
+test("step takes <1 second", async () => {
+  // When a step takes <1 second, the SDK does not send a request to tell Dev
+  // Server that the step started. We'll do that by placing a proxy between this
+  // test and the Dev Server.
+
+  const proxy = createRecordingDevServerProxy();
+  await proxy.start();
+  onTestFinished(() => proxy.stop());
+
+  const state = createState({ stepRunCount: 0 });
+  const client = new Inngest({
+    baseUrl: proxy.url,
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+    },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      return await step.run("slow-step", async () => {
+        state.stepRunCount++;
+
+        // Don't cross the SDK's 1s in-progress threshold.
+        await sleep(500);
+
+        return "done";
+      });
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+  expect(result).toBe("done");
+  expect(state.stepRunCount).toBe(1);
+
+  // Wait a little longer just to ensure the "step started" request never sent.
+  await sleep(1000);
+
+  const progressRequest = proxy.requests.find(isSlowStepStartedRequest);
+  expect(progressRequest).toBeUndefined();
+});

--- a/packages/inngest/src/test/integration/proxy.ts
+++ b/packages/inngest/src/test/integration/proxy.ts
@@ -1,13 +1,139 @@
+import http from "node:http";
 import {
+  type AddressInfo,
   createServer as createNetServer,
   type Server as NetServer,
   type Socket,
   connect as tcpConnect,
 } from "node:net";
-import { DEV_SERVER_PORT } from "@inngest/test-harness";
+import { DEV_SERVER_PORT, DEV_SERVER_URL } from "@inngest/test-harness";
 
 // The dev server's Connect WebSocket gateway runs on the port after the API.
 const GATEWAY_WS_PORT = DEV_SERVER_PORT + 1;
+
+export type RecordedRequest = {
+  body: unknown;
+  bodyText: string;
+  method: string;
+  path: string;
+};
+
+function parseBody(bodyText: string): unknown {
+  if (!bodyText) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    return bodyText;
+  }
+}
+
+/**
+ * HTTP proxy for SDK -> Dev Server traffic. Records parsed request bodies
+ * before forwarding each request unchanged to the real Dev Server.
+ */
+export function createRecordingDevServerProxy() {
+  const requests: RecordedRequest[] = [];
+  const sockets = new Set<Socket>();
+  let url: string | undefined;
+
+  const server = http.createServer((clientReq, clientRes) => {
+    const chunks: Buffer[] = [];
+
+    clientReq.on("data", (chunk) => {
+      chunks.push(Buffer.from(chunk));
+    });
+
+    clientReq.on("end", () => {
+      const bodyBuffer = Buffer.concat(chunks);
+      const bodyText = bodyBuffer.toString("utf8");
+      const path = clientReq.url ?? "/";
+      requests.push({
+        body: parseBody(bodyText),
+        bodyText,
+        method: clientReq.method ?? "GET",
+        path,
+      });
+
+      const upstreamUrl = new URL(path, DEV_SERVER_URL);
+      const proxyReq = http.request(
+        upstreamUrl,
+        {
+          method: clientReq.method,
+          headers: {
+            ...clientReq.headers,
+            host: upstreamUrl.host,
+          },
+        },
+        (upstreamRes) => {
+          clientRes.writeHead(
+            upstreamRes.statusCode ?? 500,
+            upstreamRes.headers,
+          );
+          upstreamRes.pipe(clientRes);
+        },
+      );
+
+      proxyReq.on("error", (err) => {
+        if (!clientRes.headersSent) {
+          clientRes.writeHead(502, { "Content-Type": "text/plain" });
+        }
+        clientRes.end(err.message);
+      });
+
+      if (bodyBuffer.length) {
+        proxyReq.write(bodyBuffer);
+      }
+      proxyReq.end();
+    });
+  });
+
+  // Track open sockets so tests can stop the proxy even with keep-alive
+  // connections.
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  return {
+    requests,
+    get url() {
+      if (!url) {
+        throw new Error("Proxy has not started");
+      }
+      return url;
+    },
+    async start() {
+      await new Promise<void>((resolve, reject) => {
+        server.on("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.removeListener("error", reject);
+          const address = server.address() as AddressInfo;
+          url = `http://127.0.0.1:${address.port}`;
+          resolve();
+        });
+      });
+    },
+    async stop() {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      sockets.clear();
+
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
 
 /**
  * Parse WebSocket frames from a raw byte stream and extract binary payloads.

--- a/packages/inngest/src/test/integration/utils.ts
+++ b/packages/inngest/src/test/integration/utils.ts
@@ -1,4 +1,4 @@
-import { DEV_SERVER_URL, sleep, waitFor } from "@inngest/test-harness";
+import { DEV_SERVER_URL, waitFor } from "@inngest/test-harness";
 import { z } from "zod/v3";
 import { Middleware } from "../../../src/index.ts";
 import { StepError } from "../../components/StepError";


### PR DESCRIPTION
## Summary

- We would like to display in-progress steps
- In this PR, for steps that take > 1s, we emit a StepPlanned opcode that enables the dashboard to display that a named step is in progress
- On our StepPlanned opcode, we set the started at to be the actual start time - 1ms. This means when we aggregate the StepPlanned opcode with the completion opcode, the actual start time and completed status will win. This also means that the start time displayed while the step is in progress is 1ms earlier for this long step.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

