### PR TITLE
Ensure defer data is an object

### DIFF
--- a/.changeset/gentle-sheep-begin.md
+++ b/.changeset/gentle-sheep-begin.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Ensure defer data is an object

--- a/packages/inngest/src/components/DeferredFunction.test.ts
+++ b/packages/inngest/src/components/DeferredFunction.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { z } from "zod";
 import { createDefer } from "./DeferredFunction.ts";
 import { Inngest } from "./Inngest.ts";
 
@@ -21,6 +22,46 @@ describe("createDefer ID validation", () => {
       expect(() => {
         createDefer(client, { id }, async () => {});
       }).not.toThrow();
+    },
+  );
+});
+
+test("defer data must be an object", () => {
+  const client = new Inngest({ id: "test" });
+
+  const withoutSchema = createDefer(
+    client,
+    { id: "without-schema" },
+    async () => {},
+  );
+  const withSchema = createDefer(
+    client,
+    { id: "with-schema", schema: z.object({ msg: z.string() }) },
+    async () => {},
+  );
+
+  client.createFunction(
+    {
+      id: "fn",
+      triggers: { event: "test" },
+    },
+    async ({ defer }) => {
+      // No schema means `data` is `Record<string, any>`
+      defer("without-schema", { function: withoutSchema, data: {} });
+      type WithoutSchemaData = Parameters<
+        typeof defer<typeof withoutSchema>
+      >[1]["data"];
+      expectTypeOf<WithoutSchemaData>().not.toBeAny();
+      // biome-ignore lint/suspicious/noExplicitAny: no schema = any values
+      expectTypeOf<WithoutSchemaData>().toEqualTypeOf<Record<string, any>>();
+
+      // Schema means `data` is the schema type
+      defer("with-schema", { function: withSchema, data: { msg: "hi" } });
+      type WithSchemaData = Parameters<
+        typeof defer<typeof withSchema>
+      >[1]["data"];
+      expectTypeOf<WithSchemaData>().not.toBeAny();
+      expectTypeOf<WithSchemaData>().toEqualTypeOf<{ msg: string }>();
     },
   );
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2636,6 +2636,11 @@ class InngestExecutionEngine
           return;
         }
 
+        if (!isRecord(data)) {
+          log.error({ runId }, "defer skipped: data must be an object");
+          return;
+        }
+
         const { schema } = deferFn;
         const deferFnSlug = deferFn.id(this.options.client.id);
 

--- a/packages/inngest/src/test/integration/defer/schema.test.ts
+++ b/packages/inngest/src/test/integration/defer/schema.test.ts
@@ -53,7 +53,7 @@ test("schema validation succeeds", async () => {
       defer("foo", { function: foo, data: { msg } });
 
       // Assert that the static type is correct (we don't want `data` to be
-      // `any`)
+      // `Record<string, any>`)
       expectTypeOf<
         Parameters<typeof defer<typeof foo>>[1]["data"]
       >().not.toBeAny();
@@ -287,6 +287,63 @@ test("defer without schema defaults to any", async () => {
   await parentState.waitForRunComplete();
   await deferState.waitForRunComplete();
   expect(deferState.eventData).toEqual({ key: "value" });
+});
+
+test("non-object data logs and skips defer", async () => {
+  const state = createState({
+    deferHandlerReached: false,
+  });
+
+  const logger = spyLogger();
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    logger,
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(client, { id: "foo" }, async () => {
+    state.deferHandlerReached = true;
+  });
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+    },
+    async ({ defer, runId }) => {
+      state.runId = runId;
+
+      // Bypass static types to exercise the runtime guard.
+      defer("foo", { function: foo, data: "nope" as never });
+
+      // Assert that the static type is correct
+      expectTypeOf<
+        Parameters<typeof defer<typeof foo>>[1]["data"]
+      >().not.toBeAny();
+      expectTypeOf<
+        Parameters<typeof defer<typeof foo>>[1]["data"]
+      >().toEqualTypeOf<Record<string, any>>();
+    },
+  );
+  await createTestApp({
+    client,
+    functions: [fn, foo],
+    serve: createServer,
+  });
+
+  await client.send({ name: eventName, data: {} });
+  await state.waitForRunComplete();
+
+  // Wait long enough to give the defer handler a chance to run (it shouldn't)
+  await sleep(2000);
+  expect(state.deferHandlerReached).toBe(false);
+
+  expect(logger.error).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runId: state.runId,
+    }),
+    "defer skipped: data must be an object",
+  );
 });
 
 test("mixed defer functions: with and without schema", () => {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -504,16 +504,18 @@ export type WithInvocation<T extends EventPayload> = Simplify<
  * against the function's schema. The data type is inferred from the function's
  * schema.
  */
+type DeferData<TFn extends DeferredFunction.Any> = TFn extends DeferredFunction<
+  StandardSchemaV1<infer D extends Record<string, unknown>>
+>
+  ? D
+  : // biome-ignore lint/suspicious/noExplicitAny: no schema = any
+    Record<string, any>;
+
 export type DeferFn = <TFn extends DeferredFunction.Any>(
   id: string,
   options: {
     function: TFn;
-    data: TFn extends DeferredFunction<
-      StandardSchemaV1<infer D extends Record<string, unknown>>
-    >
-      ? D
-      : // biome-ignore lint/suspicious/noExplicitAny: no schema = any
-        Record<string, any>;
+    data: DeferData<NoInfer<TFn>>;
   },
 ) => void;
 


### PR DESCRIPTION
## Summary
Ensure `defer()` data is an object.

## Checklist
- [x] Added unit/integration tests
- [x] Added changesets if applicable