### PR TITLE
refactor(checkpointing): RequestID -> GenerationID

### DIFF
--- a/.changeset/hot-tires-carry.md
+++ b/.changeset/hot-tires-carry.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Update internal tracing values used for identifying checkpointed data.

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -553,6 +553,7 @@ export class InngestApi {
     runId: string;
     fnId: string;
     queueItemId: string;
+    generationId: number | undefined;
     requestId: string | undefined;
     requestStartedAt: number | undefined;
     steps: OutgoingOp[];
@@ -561,10 +562,9 @@ export class InngestApi {
       run_id: args.runId,
       fn_id: args.fnId,
       qi_id: args.queueItemId,
-      ...(args.requestId ? { request_id: args.requestId } : {}),
-      ...(args.requestStartedAt
-        ? { request_started_at: args.requestStartedAt }
-        : {}),
+      request_id: args.requestId,
+      generation_id: args.generationId,
+      request_started_at: args.requestStartedAt,
       steps: args.steps,
       ts: new Date().valueOf(),
     });

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -2252,6 +2252,17 @@ export class InngestCommHandler<
         "getting request ID for execution",
         headerKeys.RequestId,
       );
+
+      const rawGenerationId = await actions.headers(
+        "getting generation ID for execution",
+        headerKeys.GenerationId,
+      );
+      const parsedGenerationId = Number(rawGenerationId);
+      const generationId =
+        rawGenerationId && Number.isInteger(parsedGenerationId)
+          ? parsedGenerationId
+          : undefined;
+
       const jobId = await actions.headers(
         "getting job ID for execution",
         headerKeys.InngestJobId,
@@ -2306,6 +2317,7 @@ export class InngestCommHandler<
 
           queueItemId: ctx?.qi_id,
           requestId: requestId ?? undefined,
+          generationId: generationId ?? undefined,
           requestStartedAt,
           stepState,
           priorDefers: defers,

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -143,6 +143,11 @@ export interface InngestExecutionOptions {
   requestId?: string;
 
   /**
+   * Incrementing ID used to denote the generation in which this job was queued
+   */
+  generationId?: number;
+
+  /**
    * Time the SDK starts handling an execution request. Format is unix millis.
    */
   requestStartedAt?: number;

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -478,6 +478,7 @@ class InngestExecutionEngine
             fnId: internalFnId,
             queueItemId,
             requestId: this.options.requestId,
+            generationId: this.options.generationId,
             requestStartedAt: this.options.requestStartedAt,
             steps,
           }),

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -181,7 +181,7 @@ export enum headerKeys {
   Framework = "x-inngest-framework",
   NoRetry = "x-inngest-no-retry",
   RequestId = "x-request-id",
-  GenerationId = "x-generation-id",
+  GenerationId = "x-inngest-generation-id",
   InngestJobId = "x-inngest-job-id",
   RequestVersion = "x-inngest-req-version",
   RetryAfter = "retry-after",

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -181,6 +181,7 @@ export enum headerKeys {
   Framework = "x-inngest-framework",
   NoRetry = "x-inngest-no-retry",
   RequestId = "x-request-id",
+  GenerationId = "x-generation-id",
   InngestJobId = "x-inngest-job-id",
   RequestVersion = "x-inngest-req-version",
   RetryAfter = "retry-after",


### PR DESCRIPTION
## Summary

Parse a new `x-generation-id` header and forward it as `generation_id` on checkpoint requests, so the executor can correlate jobs to the generation that queued them.

Related to: https://github.com/inngest/inngest/pull/4342

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
