### PR TITLE
fix(types): re-export InngestApi, MaybePromise, GroupExperiment, ParallelOptions from public entry

### DIFF
--- a/.changeset/fix-portable-public-type-exports.md
+++ b/.changeset/fix-portable-public-type-exports.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix: re-export InngestApi, MaybePromise, GroupExperiment, and ParallelOptions from the public entry point to prevent TS2742/TS2883 declaration-emit errors in composite and declaration:true consumer projects

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -39,6 +39,7 @@
 
 export * from "@inngest/ai";
 export type { StandardSchemaV1 } from "@standard-schema/spec";
+export type { InngestApi } from "./api/api.ts";
 export { experiment } from "./components/ExperimentStrategies.ts";
 export type { StepFetch } from "./components/Fetch";
 export { fetch } from "./components/Fetch.ts";
@@ -56,8 +57,10 @@ export type { InngestFunction } from "./components/InngestFunction";
 export type { InngestFunctionReference } from "./components/InngestFunctionReference";
 export { referenceFunction } from "./components/InngestFunctionReference.ts";
 export type {
+  GroupExperiment,
   GroupTools,
   GroupToolsDeps,
+  ParallelOptions,
 } from "./components/InngestGroupTools";
 export { group, step } from "./components/InngestStepTools.ts";
 export { Middleware } from "./components/middleware/index.ts";
@@ -91,6 +94,7 @@ export type {
 export type {
   ExclusiveKeys,
   IsStringLiteral,
+  MaybePromise,
   SendEventPayload,
   StrictUnion,
   StrictUnionHelper,

--- a/packages/inngest/test/composite_project/src/index.ts
+++ b/packages/inngest/test/composite_project/src/index.ts
@@ -31,7 +31,13 @@ type CatchAll =
   | Inngest.StepOptionsOrId
   | Inngest.StrictUnion<any>
   | Inngest.TimeStr
-  | Inngest.UnionKeys<any>;
+  | Inngest.UnionKeys<any>
+  // Types that were missing from the public entry and caused TS2742/TS2883
+  // during declaration emit in composite / declaration:true projects (#1510, #1514)
+  | Inngest.InngestApi.SendSignalResponse
+  | Inngest.MaybePromise<string>
+  | Inngest.GroupExperiment
+  | Inngest.ParallelOptions;
 
 class MyMiddleware extends Inngest.Middleware.BaseMiddleware {
   readonly id = "test";


### PR DESCRIPTION
## Problem

Two related declaration-emit portability regressions affect consumers who compile with `declaration: true` or `composite: true`:

**#1510** — Since `inngest@4.2.5`, `step.sendSignal()` returns `Promise<InngestApi.SendSignalResponse>`. Because `InngestApi` lives in `src/api/api.ts`, which is not in the package `exports` map, TypeScript cannot write a portable specifier when emitting consumer `.d.ts` files. It falls back to a relative `node_modules/inngest/api/api` path and emits:

```
error TS2742: The inferred type of 'fn' cannot be named without a reference to
'../../node_modules/inngest/api/api'. This is likely not portable.
```

The leak cascades into every `createFunction` export, even those that never call `step.sendSignal`, because `step` is part of the inferred handler type.

**#1514** — `MaybePromise`, `GroupExperiment`, and `ParallelOptions` appear in the public API surface (`dependencyInjectionMiddleware`, `GroupTools.experiment`, `GroupTools.parallel`) but were never re-exported from `src/index.ts`, causing `TS2883` during declaration emit.

## Fix

Four `export type` additions to `packages/inngest/src/index.ts`, following the exact same pattern used in #1432 ("Fix composite project type exports"):

```diff
+export type { InngestApi } from "./api/api.ts";
 export type {
+  GroupExperiment,
   GroupTools,
   GroupToolsDeps,
+  ParallelOptions,
 } from "./components/InngestGroupTools";
 export type {
   ExclusiveKeys,
   IsStringLiteral,
+  MaybePromise,
   ...
 } from "./helpers/types";
```

Using `export type` (not `export`) is intentional: it ensures zero runtime/bundle impact while making the types reachable by TypeScript's declaration emitter.

## Verification

- `tsc --noEmit` over `src/index.ts` with `strict: true` produces **0 TS2742 / TS2883 errors** with this change applied.
- Extended `test/composite_project/src/index.ts` `CatchAll` union with all four new symbols (`InngestApi.SendSignalResponse`, `MaybePromise<string>`, `GroupExperiment`, `ParallelOptions`) so future regressions are caught by `pnpm test:composite`.
- Changeset added (`patch` for `inngest`).

## Related

- Closes #1510
- Closes #1514
- Follows pattern from #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)