### PR TITLE
internal(connect): add main thread response timeout

### DIFF
--- a/packages/inngest/src/components/connect/CONNECT_SDK_SPEC.md
+++ b/packages/inngest/src/components/connect/CONNECT_SDK_SPEC.md
@@ -85,6 +85,9 @@ Worker-initiated, gateway responds.
    - Gateway forwards ACK to executor via gRPC
 
 4. **Worker begins execution + starts lease extension interval**
+   - Execution must produce a response within 2h. If the main thread does not
+     respond in time, the worker times out the request and stops tracking its
+     lease.
 
 5. **Worker → Gateway:** `WORKER_REQUEST_EXTEND_LEASE` (every `extendLeaseIntervalMs`, default 5s)
    - Fields: requestId, accountId, envId, appId, functionSlug, stepId, systemTraceCtx, userTraceCtx, runId, leaseId (current)
@@ -270,6 +273,7 @@ Worker should close WebSocket with:
 | WS write timeout (gateway) | 5s | `wsWriteTimeout` |
 | Handshake timeout (gateway) | 5s | context timeout on initial read |
 | Handshake timeout (worker) | 10s | setTimeout in establishConnection |
+| Execution request timeout (JS SDK) | 2h | `DEFAULT_CONNECT_EXECUTION_REQUEST_TIMEOUT_MS` |
 | Drain grace period | 5s | `time.After(5 * time.Second)` after GATEWAY_CLOSING |
 | Max apps per connection | 100 | `MaxAppsPerConnection` |
 | WS subprotocol | `v0.connect.inngest.com` | `types.GatewaySubProtocol` |

--- a/packages/inngest/src/components/connect/strategies/workerThread/pendingExecutions.test.ts
+++ b/packages/inngest/src/components/connect/strategies/workerThread/pendingExecutions.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { createLogger } from "../core/test-helpers.ts";
+import {
+  ConnectExecutionTimeoutError,
+  PendingExecutions,
+} from "./pendingExecutions.ts";
+
+const timeoutMs = 1_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("timeout", async () => {
+  const logger = createLogger();
+  const pendingExecutions = new PendingExecutions({ logger, timeoutMs });
+  const requestId = "my-request-id";
+
+  const p = pendingExecutions.wait(requestId);
+  expect(pendingExecutions.size).toBe(1);
+
+  // Times out
+  const expectation = expect(p).rejects.toBeInstanceOf(
+    ConnectExecutionTimeoutError,
+  );
+  await vi.advanceTimersByTimeAsync(timeoutMs);
+  await expectation;
+  expect(pendingExecutions.size).toBe(0);
+  expect(logger.warn).toHaveBeenCalledWith(
+    {
+      requestId,
+      timeoutMs,
+    },
+    "Execution request timed out waiting for main thread response",
+  );
+});
+
+test("resolve", async () => {
+  const logger = createLogger();
+  const pendingExecutions = new PendingExecutions({ logger, timeoutMs });
+  const response = new Uint8Array([1, 2, 3]);
+
+  const expectation = expect(pendingExecutions.wait("req-ok")).resolves.toEqual(
+    response,
+  );
+
+  // Successful response
+  pendingExecutions.resolve("req-ok", response);
+
+  await expectation;
+  expect(pendingExecutions.size).toBe(0);
+
+  // Timeout is irrelevant
+  await vi.advanceTimersByTimeAsync(timeoutMs);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+test("reject", async () => {
+  const logger = createLogger();
+  const pendingExecutions = new PendingExecutions({ logger, timeoutMs });
+  const error = new Error("main thread execution failed");
+
+  const expectation = expect(
+    pendingExecutions.wait("req-error"),
+  ).rejects.toThrow(error.message);
+
+  // Unsuccessful response
+  pendingExecutions.reject("req-error", error);
+
+  await expectation;
+  expect(pendingExecutions.size).toBe(0);
+
+  // Timeout is irrelevant
+  await vi.advanceTimersByTimeAsync(timeoutMs);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+test("wait rejects duplicate request IDs", async () => {
+  const logger = createLogger();
+  const pendingExecutions = new PendingExecutions({ logger, timeoutMs });
+  const response = new Uint8Array([1, 2, 3]);
+
+  const expectation = expect(
+    pendingExecutions.wait("req-duplicate"),
+  ).resolves.toEqual(response);
+
+  // Duplicate call throws
+  expect(() => pendingExecutions.wait("req-duplicate")).toThrow(
+    "Pending execution already exists: req-duplicate",
+  );
+
+  // Successful response
+  pendingExecutions.resolve("req-duplicate", response);
+
+  await expectation;
+  expect(pendingExecutions.size).toBe(0);
+
+  // Timeout is irrelevant
+  await vi.advanceTimersByTimeAsync(timeoutMs);
+  expect(logger.warn).not.toHaveBeenCalled();
+});

--- a/packages/inngest/src/components/connect/strategies/workerThread/pendingExecutions.ts
+++ b/packages/inngest/src/components/connect/strategies/workerThread/pendingExecutions.ts
@@ -1,0 +1,121 @@
+import type { Logger } from "../../../../middleware/logger.ts";
+
+/**
+ * A single executor request to process for up to 2 hours. Use the same upper
+ * bound while the worker thread waits for the main thread to return an
+ * execution response, so an unresolved promise cannot hold worker and process
+ * resources indefinitely.
+ */
+const defaultTimeoutMs = 2 * 60 * 60 * 1000;
+
+export class ConnectExecutionTimeoutError extends Error {
+  constructor(requestId: string, timeoutMs: number) {
+    super(
+      `Connect execution request timed out after ${timeoutMs}ms: ${requestId}`,
+    );
+    this.name = "ConnectExecutionTimeoutError";
+  }
+}
+
+interface PendingExecution {
+  resolve: (response: Uint8Array) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface PendingExecutionsOptions {
+  logger: Logger;
+  timeoutMs?: number;
+}
+
+/**
+ * Tracks execution requests sent from the worker thread to the main thread.
+ * Each request must receive an execution response or error before the connect
+ * request timeout, otherwise the worker releases its pending waiter.
+ *
+ * Future improvement: add main-thread-to-worker heartbeats so the worker can
+ * detect a lost execution request sooner than the 2 hour request timeout.  The
+ * heartbeat interval must be generous, e.g. 5 minutes, because user code can
+ * legitimately block the main thread's event loop for extended periods.
+ */
+export class PendingExecutions {
+  private readonly logger: Logger;
+  private readonly pending = new Map<string, PendingExecution>();
+  private readonly timeoutMs: number;
+
+  constructor(opts: PendingExecutionsOptions) {
+    this.logger = opts.logger;
+    this.timeoutMs = opts.timeoutMs ?? defaultTimeoutMs;
+  }
+
+  /**
+   * Wait for the execution request to complete.
+   * Call before posting EXECUTION_REQUEST so a fast response cannot be missed.
+   * There must be at most one waiter per request ID.
+   */
+  wait(requestId: string): Promise<Uint8Array> {
+    if (this.pending.has(requestId)) {
+      throw new Error(`Pending execution already exists: ${requestId}`);
+    }
+
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pending.get(requestId);
+        if (!pending) {
+          return;
+        }
+
+        this.logger.warn(
+          {
+            requestId,
+            timeoutMs: this.timeoutMs,
+          },
+          "Execution request timed out waiting for main thread response",
+        );
+
+        pending.reject(
+          new ConnectExecutionTimeoutError(requestId, this.timeoutMs),
+        );
+        this.pending.delete(requestId);
+      }, this.timeoutMs);
+
+      this.pending.set(requestId, { reject, resolve, timeout });
+    });
+  }
+
+  /**
+   * Complete a pending request with the encoded SDK response returned by the
+   * main thread.
+   */
+  resolve(requestId: string, response: Uint8Array): void {
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    pending.resolve(response);
+    this.pending.delete(requestId);
+  }
+
+  /**
+   * Fail a pending request when the main thread reports an execution error.
+   */
+  reject(requestId: string, error: Error): void {
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    pending.reject(error);
+    this.pending.delete(requestId);
+  }
+
+  /**
+   * Exposed for tests and debug assertions.
+   */
+  get size(): number {
+    return this.pending.size;
+  }
+}

--- a/packages/inngest/src/components/connect/strategies/workerThread/runner.ts
+++ b/packages/inngest/src/components/connect/strategies/workerThread/runner.ts
@@ -15,6 +15,7 @@ import { GatewayExecutorRequestData } from "../../../../proto/src/components/con
 import { MessageBuffer } from "../../buffer.ts";
 import { ConnectionState } from "../../types.ts";
 import { ConnectionCore } from "../core/connection.ts";
+import { PendingExecutions } from "./pendingExecutions.ts";
 import type {
   MainToWorkerMessage,
   SerializableConfig,
@@ -73,21 +74,14 @@ class WorkerRunner {
   private messageBuffer: MessageBuffer | undefined;
   private debugStateInterval: ReturnType<typeof setInterval> | undefined;
   private readonly logger: Logger;
+  private readonly pendingExecutions: PendingExecutions;
 
   constructor() {
     this.logger = this.createMessageLogger();
+    this.pendingExecutions = new PendingExecutions({
+      logger: this.logger,
+    });
   }
-
-  /**
-   * Pending execution responses waiting for user code to complete.
-   */
-  private pendingExecutions: Map<
-    string,
-    {
-      resolve: (response: Uint8Array) => void;
-      reject: (error: Error) => void;
-    }
-  > = new Map();
 
   private sendMessage(msg: WorkerToMainMessage) {
     parentPort?.postMessage(msg);
@@ -148,20 +142,12 @@ class WorkerRunner {
         break;
 
       case "EXECUTION_RESPONSE": {
-        const pending = this.pendingExecutions.get(msg.requestId);
-        if (pending) {
-          pending.resolve(msg.response);
-          this.pendingExecutions.delete(msg.requestId);
-        }
+        this.pendingExecutions.resolve(msg.requestId, msg.response);
         break;
       }
 
       case "EXECUTION_ERROR": {
-        const pending = this.pendingExecutions.get(msg.requestId);
-        if (pending) {
-          pending.reject(new Error(msg.error));
-          this.pendingExecutions.delete(msg.requestId);
-        }
+        this.pendingExecutions.reject(msg.requestId, new Error(msg.error));
         break;
       }
     }
@@ -200,9 +186,7 @@ class WorkerRunner {
         getState: () => this.state,
         handleExecutionRequest: async (request) => {
           // Send execution request to main thread and wait for response
-          const requestPromise = new Promise<Uint8Array>((resolve, reject) => {
-            this.pendingExecutions.set(request.requestId, { resolve, reject });
-          });
+          const requestPromise = this.pendingExecutions.wait(request.requestId);
 
           // Send the request to main thread (as serialized bytes)
           this.sendMessage({


### PR DESCRIPTION
## Summary

Add a timeout when waiting for the main thread response.

Used 2 hours because it's easy and safe, but we should prob add main->worker thread heartbeats in the future.

## Motivation

Not timing out means that it's possible for promises to block forever, consuming resources.