### PR TITLE
feat(defers): add transformDeferInput middleware hook

### DIFF
--- a/.changeset/slick-sloths-matter.md
+++ b/.changeset/slick-sloths-matter.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add transformDeferInput middleware hook

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -27,6 +27,7 @@ import {
   type StepOptionsOrId,
   type TriggerEventFromFunction,
 } from "../types.ts";
+import type { DeferredFunction } from "./DeferredFunction.ts";
 import { getAsyncCtx, getAsyncCtxSync } from "./execution/als.ts";
 import type { InngestExecution } from "./execution/InngestExecution.ts";
 import { fetch as stepFetch } from "./Fetch.ts";
@@ -174,9 +175,13 @@ export type MatchOpFn<
 ) => Omit<HashedOp, "data" | "error">;
 
 export type StepHandler = (info: {
+  args: [StepOptionsOrId, ...unknown[]];
+  defer?: {
+    fn: DeferredFunction.Any;
+    data: Record<string, unknown>;
+  };
   matchOp: MatchOpFn;
   opts?: StepToolOptions;
-  args: [StepOptionsOrId, ...unknown[]];
 }) => Promise<unknown>;
 
 export interface StepToolOptions<

--- a/packages/inngest/src/components/execution/defer.md
+++ b/packages/inngest/src/components/execution/defer.md
@@ -28,7 +28,7 @@ const sendEmail = createDefer(
   async ({ event, step }) => {
     event.data.to; // typed from `schema`
     event.data.body;
-  },
+  }
 );
 ```
 
@@ -53,7 +53,7 @@ const orderPlaced = inngest.createFunction(
   { id: "order-placed", triggers: { event: "order/placed" } },
   async ({ defer }) => {
     defer("send", { function: sendEmail, data: { to: "a@b.com", body: "hi" } });
-  },
+  }
 );
 ```
 
@@ -95,6 +95,8 @@ The backend records each `DeferAdd` against the parent run as it arrives. The de
 
 On replay, the executor sends back a `defers` map of hashed step IDs it has already received. The SDK uses `priorDefers` to skip re-emitting them.
 
+The `transformDeferInput` middleware hook runs against `data` after schema validation, just before the op is buffered. Use it for serialization or encryption. Returning an empty `defers` array drops the call silently.
+
 ## Todo
 
 ### Known gaps (correctness)
@@ -119,5 +121,3 @@ Net-new capabilities. None affect correctness of the current API.
 - **Support aborting a `defer` call.** -- A `DeferAbort` opcode is reserved on the backend but the SDK doesn't yet emit it. Needs a user-facing API (e.g. `const { abort } = defer("id", { function, data })`) and the matching opcode emission.
 
 - **Support starting a deferred run immediately.** -- Today the deferred run starts only when the parent run finalizes. We may want an opt-in path (e.g. `defer("id", { function, data }).now()`).
-
-- **Middleware hook** -- We need a hook to make encryption and serialization work (e.g. `transformDeferInput`).

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2349,6 +2349,10 @@ class InngestExecutionEngine
           this.state.lazyOps.markSeen(hashedId);
           return;
         }
+        // Reserve the id synchronously, before the `applyToDefer` await below.
+        // `defer()` is fire-and-forget, so two sync calls with the same id
+        // would otherwise both pass the `hasId` check above and race to push.
+        this.state.lazyOps.markSeen(hashedId);
         if (defer) {
           const prepared = await this.middlewareManager.applyToDefer({
             deferFn: defer.fn,

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2316,6 +2316,7 @@ class InngestExecutionEngine
 
     const stepHandler: StepHandler = async ({
       args,
+      defer,
       matchOp,
       opts,
     }): Promise<unknown> => {
@@ -2347,6 +2348,16 @@ class InngestExecutionEngine
           // duplicate) is detected and warned about above.
           this.state.lazyOps.markSeen(hashedId);
           return;
+        }
+        if (defer) {
+          const prepared = await this.middlewareManager.applyToDefer({
+            deferFn: defer.fn,
+            data: defer.data,
+          });
+          if (!prepared) {
+            return;
+          }
+          opId.opts = { ...opId.opts, input: prepared.data };
         }
         this.state.lazyOps.push({
           id: hashedId,
@@ -2639,7 +2650,7 @@ class InngestExecutionEngine
         const { schema } = deferFn;
         const deferFnSlug = deferFn.id(this.options.client.id);
 
-        let input: unknown = data;
+        let input: Record<string, unknown> = data;
         if (schema) {
           const result = schema["~standard"].validate(data);
           if (result instanceof Promise) {
@@ -2661,6 +2672,7 @@ class InngestExecutionEngine
 
         void stepHandler({
           args: [idOrOptions, input],
+          defer: { fn: deferFn, data: input },
           matchOp: (stepOptions, inputArg) => ({
             id: stepOptions.id,
             mode: StepMode.Sync,

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -1,6 +1,7 @@
 import { timeStr } from "../../helpers/strings.ts";
 import type { Logger } from "../../middleware/logger.ts";
 import type { Context, StepOpCode } from "../../types.ts";
+import type { DeferredFunction } from "../DeferredFunction.ts";
 import type { MemoizedOp } from "../execution/InngestExecution.ts";
 import type { InngestFunction } from "../InngestFunction.ts";
 import type { Middleware } from "./middleware.ts";
@@ -30,6 +31,11 @@ export interface ApplyToStepInput {
   memoized: boolean;
 }
 
+export interface ApplyToDeferInput {
+  deferFn: DeferredFunction.Any;
+  data: Record<string, unknown>;
+}
+
 export interface PreparedStep {
   entryPoint: () => Promise<unknown>;
 
@@ -50,6 +56,10 @@ export interface PreparedStep {
   stepInfo: Middleware.StepInfo;
 }
 
+export interface PreparedDefer {
+  data: Record<string, unknown>;
+}
+
 /**
  * Manages middleware. Hides middleware complexity from elsewhere in the
  * codebase. Not for for public use.
@@ -63,6 +73,12 @@ export class MiddlewareManager {
    * optimization.
    */
   private readonly hasTransformStepInput: boolean;
+
+  /**
+   * Whether any middleware defines `transformDeferInput`. Used for perf
+   * optimization.
+   */
+  private readonly hasTransformDeferInput: boolean;
 
   /**
    * Whether memoization has ended. Used for idempotency, since memoization must
@@ -95,6 +111,9 @@ export class MiddlewareManager {
 
     this.hasTransformStepInput = middleware.some((mw) =>
       Boolean(mw?.transformStepInput),
+    );
+    this.hasTransformDeferInput = middleware.some((mw) =>
+      Boolean(mw?.transformDeferInput),
     );
   }
 
@@ -177,6 +196,28 @@ export class MiddlewareManager {
       setActualHandler,
       stepInfo,
     };
+  }
+
+  /**
+   * Runs `transformDeferInput` middleware. Returns `null` when middleware
+   * drops the defer (empty `defers` array); the caller should skip emitting
+   * the op.
+   */
+  async applyToDefer(input: ApplyToDeferInput): Promise<PreparedDefer | null> {
+    if (!this.hasTransformDeferInput) {
+      return { data: input.data };
+    }
+
+    const transformed = await this.transformDeferInput(
+      input.deferFn,
+      input.data,
+    );
+    // TODO: when we add batching, return all defers instead of the first.
+    const firstDefer = transformed.defers[0];
+    if (!firstDefer) {
+      return null;
+    }
+    return { data: firstDefer.data };
   }
 
   private buildStepInfo(opts: StepInfoOptions): Middleware.StepInfo {
@@ -280,6 +321,28 @@ export class MiddlewareManager {
     for (const mw of this.middleware) {
       if (mw?.transformStepInput) {
         result = await mw.transformStepInput(result);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Apply transformDeferInput middleware in forward order.
+   * Each middleware builds on the previous result.
+   */
+  private async transformDeferInput(
+    deferFn: DeferredFunction.Any,
+    data: Record<string, unknown>,
+  ): Promise<Middleware.TransformDeferInputArgs> {
+    let result: Middleware.TransformDeferInputArgs = {
+      fn: this.fn,
+      defers: [{ deferFn, data }],
+    };
+
+    for (const mw of this.middleware) {
+      if (mw?.transformDeferInput) {
+        result = await mw.transformDeferInput(result);
       }
     }
 

--- a/packages/inngest/src/components/middleware/middleware.ts
+++ b/packages/inngest/src/components/middleware/middleware.ts
@@ -7,6 +7,7 @@ import type {
   SendEventBaseOutput,
   StepOptions,
 } from "../../types.ts";
+import type { DeferredFunction } from "../DeferredFunction.ts";
 import type { Inngest } from "../Inngest.ts";
 import type { InngestFunction } from "../InngestFunction.ts";
 import type { createStepTools } from "../InngestStepTools.ts";
@@ -52,6 +53,17 @@ export namespace Middleware {
   export type TransformSendEventArgs = {
     events: EventPayload<Record<string, unknown>>[];
     readonly fn: DeepReadonly<InngestFunction.Any> | null;
+  };
+
+  /**
+   * The argument passed to `transformDeferInput`.
+   */
+  export type TransformDeferInputArgs = {
+    readonly fn: DeepReadonly<InngestFunction.Any>;
+    defers: Array<{
+      readonly deferFn: DeepReadonly<DeferredFunction.Any>;
+      data: Record<string, unknown>;
+    }>;
   };
 
   /**
@@ -448,6 +460,19 @@ export namespace Middleware {
     transformSendEvent?(
       arg: Middleware.TransformSendEventArgs,
     ): MaybePromise<Middleware.TransformSendEventArgs>;
+
+    /**
+     * Called when sending deferred functions.
+     * Return the (potentially modified) arg object.
+     *
+     * Use cases:
+     * - Serialize or encrypt defer data before sending it to the Inngest Server.
+     *
+     * Do not mutate arguments.
+     */
+    transformDeferInput?(
+      arg: Middleware.TransformDeferInputArgs,
+    ): MaybePromise<Middleware.TransformDeferInputArgs>;
 
     /**
      * Called 1 time per step per request (likely multiple times per step).

--- a/packages/inngest/src/test/integration/defer/middleware.test.ts
+++ b/packages/inngest/src/test/integration/defer/middleware.test.ts
@@ -5,6 +5,7 @@ import {
   testNameFromFileUrl,
 } from "@inngest/test-harness";
 import { expect, expectTypeOf, test } from "vitest";
+import { z } from "zod";
 import { createDefer } from "../../../experimental.ts";
 import {
   dependencyInjectionMiddleware,
@@ -114,4 +115,107 @@ test("no step hooks", async () => {
     wrapStep: 0,
     wrapStepHandler: 0,
   });
+});
+
+test("transformDeferInput can modify data", async () => {
+  const deferState = createState({ value: 0 });
+
+  class MW extends Middleware.BaseMiddleware {
+    readonly id = "mw";
+    override transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Middleware.TransformDeferInputArgs {
+      return {
+        ...arg,
+        defers: arg.defers.map((d) => ({ ...d, data: { value: 42 } })),
+      };
+    }
+  }
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [MW],
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(
+    client,
+    { id: "foo", schema: z.object({ value: z.number() }) },
+    async ({ event, runId }) => {
+      deferState.runId = runId;
+      deferState.value = event.data.value;
+    },
+  );
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: { event: eventName } },
+    async ({ defer }) => {
+      defer("foo", { function: foo, data: { value: 1 } });
+    },
+  );
+  await createTestApp({ client, functions: [fn, foo], serve: createServer });
+
+  await client.send({ name: eventName });
+  await deferState.waitForRunComplete();
+  expect(deferState.value).toBe(42);
+});
+
+test("transformDeferInput composes in forward order", async () => {
+  const deferState = createState({ value: 0 });
+
+  class MW1 extends Middleware.BaseMiddleware {
+    readonly id = "mw1";
+    override transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Middleware.TransformDeferInputArgs {
+      return {
+        ...arg,
+        defers: arg.defers.map((d) => ({
+          ...d,
+          data: { value: (d.data.value as number) * 10 },
+        })),
+      };
+    }
+  }
+
+  class MW2 extends Middleware.BaseMiddleware {
+    readonly id = "mw2";
+    override transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Middleware.TransformDeferInputArgs {
+      return {
+        ...arg,
+        defers: arg.defers.map((d) => ({
+          ...d,
+          data: { value: (d.data.value as number) + 5 },
+        })),
+      };
+    }
+  }
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [MW1, MW2],
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(
+    client,
+    { id: "foo", schema: z.object({ value: z.number() }) },
+    async ({ event, runId }) => {
+      deferState.runId = runId;
+      deferState.value = event.data.value;
+    },
+  );
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: { event: eventName } },
+    async ({ defer }) => {
+      defer("foo", { function: foo, data: { value: 1 } });
+    },
+  );
+  await createTestApp({ client, functions: [fn, foo], serve: createServer });
+
+  await client.send({ name: eventName });
+  await deferState.waitForRunComplete();
+  // Forward order: MW1 runs first (1 * 10 = 10), then MW2 (10 + 5 = 15)
+  expect(deferState.value).toBe(15);
 });


### PR DESCRIPTION
## Summary

Add a `transformDeferInput` middleware hook


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A no docs needed
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
[EXE-1815: Add middleware support](https://linear.app/inngest/issue/EXE-1815/add-middleware-support)
