### PR TITLE
feat(otel): ESM loader hook entrypoint for extended traces module instrumentation

### DIFF
--- a/.changeset/otel-esm-loader-hook.md
+++ b/.changeset/otel-esm-loader-hook.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add `inngest/experimental/otel-register`, a `node --import`-able entrypoint that registers OpenTelemetry's ESM loader hook so `extendedTracesMiddleware`'s `"createProvider"`/`"auto"` instrumentation can patch ES modules. Also warn when module instrumentation is detected to be inactive in ESM apps, where extended traces would otherwise silently miss spans from modules like `http`, databases, and AI SDKs.

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -242,6 +242,14 @@
       "import": "./experimental/durable-endpoints/client.js",
       "require": "./experimental/durable-endpoints/client.cjs"
     },
+    "./experimental/otel-register": {
+      "types": {
+        "import": "./experimental/otel-register.d.ts",
+        "require": "./experimental/otel-register.d.cts"
+      },
+      "import": "./experimental/otel-register.js",
+      "require": "./experimental/otel-register.cjs"
+    },
     "./realtime": {
       "types": {
         "import": "./realtime.d.ts",

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -56,10 +56,54 @@ export const createProvider = async (
     trace.setGlobalTracerProvider(p);
     context.setGlobalContextManager(new AsyncHooksContextManager().enable());
 
+    await warnIfModulePatchingInactive();
+
     return { success: true, processor };
   } catch (err) {
     debug("failed to create provider:", err);
     return { success: false, error: err };
+  }
+};
+
+/**
+ * Most OTel instrumentations patch modules at load time by hooking
+ * `require()`, which cannot see ES module imports. In an ESM app that hasn't
+ * registered OTel's loader hook, the instrumentations registered by
+ * `createProvider` silently capture nothing (http, databases, AI SDKs, etc.).
+ *
+ * `http` is always included in the auto-instrumentations registered above, so
+ * an unpatched `http` namespace right after registration means module
+ * patching is inactive for ESM imports. Only checked in the ESM build — in
+ * CJS apps the `require()` hook works and patches modules lazily, so this
+ * probe would be a false positive there.
+ */
+const warnIfModulePatchingInactive = async (): Promise<void> => {
+  try {
+    // `typeof module` distinguishes our ESM build from our CJS build at
+    // runtime; bundlers rewrite `require` references, so it can't be used
+    // here.
+    const isEsm = typeof module === "undefined";
+    const instrumentationOverridden =
+      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS !== undefined ||
+      process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS !== undefined;
+    if (!isEsm || instrumentationOverridden) {
+      return;
+    }
+
+    type MaybeWrapped = { __wrapped?: boolean } | undefined;
+    const http = (await import("node:http")) as {
+      get?: MaybeWrapped;
+      default?: { get?: MaybeWrapped };
+    };
+    const get = http.get ?? http.default?.get;
+    if (get?.__wrapped !== true) {
+      console.warn(
+        "inngest: OTel module instrumentation appears to be inactive, so extended traces will miss spans from modules like http, databases, and AI SDKs. ESM apps must register OpenTelemetry's module loader hook before any other code runs by starting Node with `--import inngest/experimental/otel-register`.",
+      );
+    }
+  } catch (err) {
+    // This is purely a diagnostic; never break provider creation over it.
+    debug("failed to check module instrumentation:", err);
   }
 };
 

--- a/packages/inngest/src/experimental/otel-register.test.ts
+++ b/packages/inngest/src/experimental/otel-register.test.ts
@@ -1,0 +1,15 @@
+const { register } = vi.hoisted(() => ({ register: vi.fn() }));
+
+vi.mock("node:module", () => ({ register }));
+
+describe("otel-register", () => {
+  test("registers the OpenTelemetry ESM loader hook", async () => {
+    await import("./otel-register.ts");
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(
+      "@opentelemetry/instrumentation/hook.mjs",
+      { parentURL: expect.stringContaining("otel-register") },
+    );
+  });
+});

--- a/packages/inngest/src/experimental/otel-register.ts
+++ b/packages/inngest/src/experimental/otel-register.ts
@@ -1,0 +1,50 @@
+/**
+ * Registers OpenTelemetry's ESM loader hook so that module-load-based
+ * instrumentations (http, Express, pg, Anthropic, etc.) can patch ES modules.
+ *
+ * In CommonJS apps, OpenTelemetry instrumentations patch modules by hooking
+ * `require()`, which works at any point at runtime. In ESM apps, imports are
+ * resolved by the module loader before any application code runs, so patching
+ * requires a loader hook that must be registered before the application's
+ * modules are imported. A middleware can never do that itself; it has to
+ * happen via Node's `--import` flag.
+ *
+ * Use this entrypoint when using `extendedTracesMiddleware` with the
+ * `"createProvider"` (or `"auto"`) behaviour in an ESM application:
+ *
+ * ```sh
+ * node --import inngest/experimental/otel-register ./app.js
+ * ```
+ *
+ * @module
+ */
+import * as nodeModule from "node:module";
+
+type ModuleWithRegister = {
+  register?: (specifier: string, opts: { parentURL: string }) => void;
+};
+
+// Resolve `register` across our ESM and CJS builds; it's also absent on
+// Node.js versions older than 20.6.
+const mod = nodeModule as ModuleWithRegister & { default?: ModuleWithRegister };
+const register = mod.register ?? mod.default?.register;
+
+try {
+  if (typeof register === "function") {
+    // Resolve the hook relative to this file so it uses the same copy of
+    // `@opentelemetry/instrumentation` as the instrumentations registered by
+    // `extendedTracesMiddleware`.
+    register("@opentelemetry/instrumentation/hook.mjs", {
+      parentURL: import.meta.url,
+    });
+  } else {
+    console.warn(
+      "inngest: this version of Node.js does not support module.register(); OpenTelemetry instrumentation will not be able to patch ES modules",
+    );
+  }
+} catch (err) {
+  console.warn(
+    "inngest: failed to register the OpenTelemetry ESM loader hook; extended traces may miss spans from instrumented modules",
+    err,
+  );
+}

--- a/packages/inngest/tsdown.config.ts
+++ b/packages/inngest/tsdown.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     "src/remix.ts",
     "src/experimental/durable-endpoints/index.ts",
     "src/experimental/durable-endpoints/client.ts",
+    "src/experimental/otel-register.ts",
     "src/sveltekit.ts",
     "src/types.ts",
 


### PR DESCRIPTION
## Summary

Fixes #1564 — in ESM apps, `extendedTracesMiddleware`'s `createProvider`/`auto` path silently captures no module-based instrumentation spans (`http`, Express, `pg`, Anthropic, …): `require-in-the-middle` hooks can't see ES module imports, and ESM import hoisting loads the app's module graph before the middleware body ever runs. Only `diagnostics_channel`-based instrumentation (fetch/undici) survives.

Two changes:

1. **New entrypoint `inngest/experimental/otel-register`** — registers OpenTelemetry's `import-in-the-middle` loader hook, for use with Node's `--import` flag:

   ```sh
   node --import inngest/experimental/otel-register ./app.js
   ```

   The hook must be registered before the app's modules load, which only the CLI flag can guarantee; verified that IITM then retro-patches modules that were statically imported before the middleware initializes, so the documented "middleware first" pattern works again under ESM.

2. **Warning on silent data loss** — after `createProvider` registers instrumentations, probe whether `http` (always part of the auto-instrumentations) was actually patched for ESM imports; if not, warn and point at the entrypoint. Gated to the ESM build (`typeof module === "undefined"`) because the CJS require hook patches lazily and would false-positive.

Deliberately *not* calling `module.register()` at runtime from `createProvider`: modules loaded before hook registration can never be retro-patched, and implicitly installing a loader hook that proxies every subsequent import is the same class of global side effect that broke `inngest.send()` in #1324.

Verified against a packed tarball (Node 24, `@opentelemetry/auto-instrumentations-node` 0.76.0):

| Scenario | `http` patched | warning |
|---|---|---|
| ESM, `createProvider`, no hook | ❌ | ✅ warns |
| ESM, `createProvider`, `--import inngest/experimental/otel-register` | ✅ (incl. statically-imported-before-init modules) | — |
| CJS, `createProvider` | ✅ | — |
| ESM, `extendProvider` + OTel v2 `NodeSDK` | n/a — processor attaches fine | — |

Docs follow-up needed separately in `inngest/website`: the extended-traces page's "import the middleware before any other code" guidance only holds for CJS.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- #1564
- #1324 / #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
