### PR TITLE
Process AI Metadata from Spans (EXE-1950)

### DIFF
--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add metadata to steps containing OTel instrumented LLM calls

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -55,6 +55,7 @@ import {
   sendEventResponseSchema,
 } from "../types.ts";
 import { getAsyncCtx } from "./execution/als.ts";
+import { metadataSpanProcessor } from "./execution/otel/metadataProcessor.ts";
 import { InngestFunction } from "./InngestFunction.ts";
 import type { InngestFunctionReference } from "./InngestFunctionReference.ts";
 import {
@@ -359,6 +360,10 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     for (const mw of this.middleware) {
       mw.onRegister?.({ client: this, fn: null });
     }
+
+    // Attach the read-only AI metadata span processor to whatever global OTel
+    // provider already exists. Idempotent across clients; only attaches once.
+    metadataSpanProcessor.attach();
 
     this._appVersion = appVersion;
   }

--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -16,6 +16,7 @@ export type MetadataScope = "run" | "step" | "extended_trace";
 export type MetadataKind =
   | "inngest.experiment"
   | "inngest.warnings"
+  | "inngest.ai"
   | `userland.${string}`;
 
 /**

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -90,6 +90,12 @@ import {
 import { isLazyOp, LazyOps } from "./lazyOps.ts";
 import { clientProcessorMap } from "./otel/access.ts";
 import {
+  type AIMetadata,
+  aggregate as aggregateAIMetadata,
+  toInngestAIMetadataValues,
+} from "./otel/aiExtractor.ts";
+import { metadataSpanProcessor } from "./otel/metadataProcessor.ts";
+import {
   buildSseMetadataEvent,
   prependToStream,
   type SseResponse,
@@ -306,6 +312,28 @@ class InngestExecutionEngine
                 runId: this.options.runId,
                 traceparent: this.options.headers[headerKeys.TraceParent],
                 tracestate: this.options.headers[headerKeys.TraceState],
+              });
+
+              // The metadata span processor is independent of the Extended
+              // Traces processor above.
+              metadataSpanProcessor.declareStartingSpan({
+                span,
+                traceparent: this.options.headers[headerKeys.TraceParent],
+                onAIMetadata: (aiMetadata) => {
+                  // Only attribute AI metadata to spans ending while a
+                  // step's userland code is executing;
+                  if (!this.state.executingStep) {
+                    return;
+                  }
+
+                  this.state.executingStepAIMetadata = this.state
+                    .executingStepAIMetadata
+                    ? aggregateAIMetadata(
+                        this.state.executingStepAIMetadata,
+                        aiMetadata,
+                      )
+                    : aiMetadata;
+                },
               });
 
               return this._start()
@@ -1662,6 +1690,12 @@ class InngestExecutionEngine
         );
     }
 
+    // Reset the per-step AI metadata accumulator. The metadata processor's
+    // sink (registered at run start) folds into it only while `executingStep`
+    // is set; an explicit reset here guards against residue from error paths
+    // that never reached this step's drain.
+    this.state.executingStepAIMetadata = undefined;
+
     let interval: GoInterval | undefined;
 
     // `fn` already has middleware-transformed args baked in via `fnArgs` (i.e.
@@ -1697,6 +1731,15 @@ class InngestExecutionEngine
           clientProcessorMap
             .get(this.options.client)
             ?.clearStepExecution(this.rootSpanId);
+        }
+
+        // Drain the per-step AI metadata accumulator and attach it to the
+        // step's op.
+        const aiMetadata = this.state.executingStepAIMetadata;
+        this.state.executingStepAIMetadata = undefined;
+        const aiValues = aiMetadata && toInngestAIMetadataValues(aiMetadata);
+        if (aiValues) {
+          this.addMetadata(id, "inngest.ai", "step", "merge", aiValues);
         }
 
         if (store?.execution) {
@@ -3004,6 +3047,14 @@ export interface ExecutionState {
    * platforms.
    */
   executingStep?: Readonly<Omit<OutgoingOp, "id">>;
+
+  /**
+   * AI metadata accumulated from userland OTel spans that ended while the
+   * current step was executing, pushed by the metadata span processor's sink
+   * and drained into the step's outgoing op in the step's teardown. Only set
+   * while `executingStep` is.
+   */
+  executingStepAIMetadata?: AIMetadata;
 
   /**
    * A map of step IDs to their data, used to fill previously-completed steps

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -4,7 +4,11 @@ import { fileURLToPath } from "node:url";
 import type { Attributes, AttributeValue } from "@opentelemetry/api";
 import { describe, expect, test } from "vitest";
 import type { AIMetadata } from "./aiExtractor.ts";
-import { aggregate, extractAIMetadataFromAttributes } from "./aiExtractor.ts";
+import {
+  aggregate,
+  extractAIMetadataFromAttributes,
+  toInngestAIMetadataValues,
+} from "./aiExtractor.ts";
 
 /**
  * These fixtures are real OTLP/JSON spans captured from instrumented OpenAI SDK
@@ -217,5 +221,26 @@ describe("aggregate", () => {
   test("omits fields absent from both inputs", () => {
     expect(aggregate({}, {})).toEqual({});
     expect(aggregate({ model: "a" }, {})).toEqual({ model: "a" });
+  });
+});
+
+describe("toInngestAIMetadataValues", () => {
+  test("maps both fields onto the server's snake_case schema", () => {
+    expect(
+      toInngestAIMetadataValues({ model: "gpt-4o", inputTokens: 42 }),
+    ).toEqual({ model: "gpt-4o", input_tokens: 42 });
+  });
+
+  test("omits absent fields rather than zero-valuing them", () => {
+    expect(toInngestAIMetadataValues({ model: "gpt-4o" })).toEqual({
+      model: "gpt-4o",
+    });
+    expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
+      input_tokens: 7,
+    });
+  });
+
+  test("returns undefined when there is nothing to emit", () => {
+    expect(toInngestAIMetadataValues({})).toBeUndefined();
   });
 });

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -142,3 +142,29 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
 
   return metadata;
 };
+
+/**
+ * Maps an {@link AIMetadata} value onto the server's `inngest.ai` metadata
+ * schema (snake_case keys). Only the fields we extract are emitted; absent
+ * fields are omitted rather than zero-valued. Returns `undefined` when there
+ * is nothing to emit, so callers can skip stamping metadata entirely.
+ */
+export const toInngestAIMetadataValues = (
+  metadata: AIMetadata,
+): Record<string, unknown> | undefined => {
+  const values: Record<string, unknown> = {};
+
+  if (metadata.model !== undefined) {
+    values.model = metadata.model;
+  }
+
+  if (metadata.inputTokens !== undefined) {
+    values.input_tokens = metadata.inputTokens;
+  }
+
+  if (Object.keys(values).length === 0) {
+    return undefined;
+  }
+
+  return values;
+};

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -1,0 +1,200 @@
+import { type Attributes, context, trace } from "@opentelemetry/api";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import type { AIMetadata } from "./aiExtractor.ts";
+import { InngestMetadataSpanProcessor } from "./metadataProcessor.ts";
+
+const TRACEPARENT = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+
+describe("InngestMetadataSpanProcessor", () => {
+  afterEach(() => {
+    trace.disable();
+    context.disable();
+  });
+
+  function setup() {
+    const processor = new InngestMetadataSpanProcessor();
+    const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+    const tracer = provider.getTracer("test");
+    return { processor, tracer };
+  }
+
+  function attrsOf(span: unknown): Record<string, unknown> {
+    return (span as { attributes: Record<string, unknown> }).attributes;
+  }
+
+  /** Start a child span under `root`, optionally with attributes, and end it. */
+  function endChild(
+    tracer: ReturnType<BasicTracerProvider["getTracer"]>,
+    root: ReturnType<ReturnType<BasicTracerProvider["getTracer"]>["startSpan"]>,
+    name: string,
+    attributes?: Attributes,
+  ) {
+    const child = tracer.startSpan(
+      name,
+      attributes ? { attributes } : undefined,
+      trace.setSpan(context.active(), root),
+    );
+    child.end();
+  }
+
+  /**
+   * Declare a run root on the processor with a sink that collects every
+   * pushed {@link AIMetadata} value.
+   */
+  function declaredRoot(
+    processor: InngestMetadataSpanProcessor,
+    tracer: ReturnType<BasicTracerProvider["getTracer"]>,
+  ) {
+    const pushed: AIMetadata[] = [];
+    const root = tracer.startSpan("inngest.execution");
+    processor.declareStartingSpan({
+      span: root,
+      traceparent: TRACEPARENT,
+      onAIMetadata: (metadata) => pushed.push(metadata),
+    });
+    return { root, pushed };
+  }
+
+  test("is read-only: leaves tracked span attributes exactly as set", () => {
+    const { processor, tracer } = setup();
+    const { root } = declaredRoot(processor, tracer);
+
+    // An AI span exercises the processor's read path; assert it neither adds
+    // nor removes attributes relative to what the caller set.
+    const aiInput = {
+      "gen_ai.request.model": "gpt-4.1-nano",
+      "gen_ai.usage.input_tokens": 42,
+    };
+    const aiChild = tracer.startSpan(
+      "llm",
+      { attributes: aiInput },
+      trace.setSpan(context.active(), root),
+    );
+    aiChild.end();
+
+    expect(attrsOf(aiChild)).toEqual(aiInput);
+    expect(attrsOf(root)).toEqual({});
+  });
+
+  test("pushes AI metadata to the sink when a tracked span ends", () => {
+    const { processor, tracer } = setup();
+    const { root, pushed } = declaredRoot(processor, tracer);
+
+    endChild(tracer, root, "llm", {
+      "gen_ai.request.model": "gpt-4.1-nano",
+      "gen_ai.usage.input_tokens": 42,
+    });
+
+    expect(pushed).toEqual([{ model: "gpt-4.1-nano", inputTokens: 42 }]);
+  });
+
+  test("pushes once per span; aggregation is the sink owner's job", () => {
+    const { processor, tracer } = setup();
+    const { root, pushed } = declaredRoot(processor, tracer);
+
+    endChild(tracer, root, "llm-1", {
+      "gen_ai.request.model": "gpt-4.1-nano",
+      "gen_ai.usage.input_tokens": 10,
+    });
+    endChild(tracer, root, "llm-2", {
+      "gen_ai.request.model": "gpt-4.1-mini",
+      "gen_ai.usage.input_tokens": 5,
+    });
+
+    expect(pushed).toEqual([
+      { model: "gpt-4.1-nano", inputTokens: 10 },
+      { model: "gpt-4.1-mini", inputTokens: 5 },
+    ]);
+  });
+
+  test("does not call the sink for tracked spans with no AI attributes", () => {
+    const { processor, tracer } = setup();
+    const { root, pushed } = declaredRoot(processor, tracer);
+
+    endChild(tracer, root, "plain");
+
+    expect(pushed).toEqual([]);
+  });
+
+  test("tracks descendants transitively, not just direct children", () => {
+    const { processor, tracer } = setup();
+    const { root, pushed } = declaredRoot(processor, tracer);
+
+    const mid = tracer.startSpan(
+      "mid",
+      undefined,
+      trace.setSpan(context.active(), root),
+    );
+    endChild(tracer, mid, "llm", {
+      "gen_ai.request.model": "gpt-4.1-nano",
+      "gen_ai.usage.input_tokens": 7,
+    });
+    mid.end();
+
+    expect(pushed).toEqual([{ model: "gpt-4.1-nano", inputTokens: 7 }]);
+  });
+
+  test("ignores spans that are not part of a declared run", () => {
+    const { processor, tracer } = setup();
+    const { pushed } = declaredRoot(processor, tracer);
+
+    // A separate root that was never declared: neither it nor its children
+    // are tracked, so their AI attributes are never pushed anywhere.
+    const orphan = tracer.startSpan("orphan");
+    endChild(tracer, orphan, "orphan-child", {
+      "gen_ai.request.model": "gpt-4.1-nano",
+      "gen_ai.usage.input_tokens": 99,
+    });
+    orphan.end();
+
+    expect(pushed).toEqual([]);
+  });
+
+  /** Read a provider's internal span processor list, as the attach does. */
+  function processorsOf(provider: BasicTracerProvider): unknown[] {
+    const active = (provider as unknown as Record<string, unknown>)
+      ._activeSpanProcessor as Record<string, unknown>;
+    return active._spanProcessors as unknown[];
+  }
+
+  test("attach is a no-op when no global provider is registered", () => {
+    const processor = new InngestMetadataSpanProcessor();
+
+    // No provider registered → the proxy delegates to a noop provider, which
+    // cannot be extended. attach must not throw.
+    expect(() => processor.attach()).not.toThrow();
+  });
+
+  test("attach attaches to the pre-existing global provider exactly once", () => {
+    const processor = new InngestMetadataSpanProcessor();
+    const provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+
+    processor.attach();
+    // Repeat calls are latched and must not re-attach (which would
+    // double-process every span and double-count tokens).
+    processor.attach();
+
+    expect(processorsOf(provider).filter((p) => p === processor)).toHaveLength(
+      1,
+    );
+  });
+
+  test("attach can succeed on a later call once a provider appears", () => {
+    const processor = new InngestMetadataSpanProcessor();
+
+    // First call: no provider yet, so nothing attaches.
+    processor.attach();
+
+    const provider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(provider);
+
+    // A later call (e.g. another client constructed after the provider was
+    // set up) attaches successfully.
+    processor.attach();
+
+    expect(processorsOf(provider).filter((p) => p === processor)).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -129,9 +129,21 @@ const spanSinkKey = (traceId: string, spanId: string): string =>
  */
 export class InngestMetadataSpanProcessor implements SpanProcessor {
   /**
-   * A map of tracked spans to their sink. The map is seeded at the
-   * step's root by {@link declareStartingSpan} and propagated to descendants in
-   * {@link onStart}.
+   * A map of tracked spans to their sink.
+   *
+   * We use traceId:spanID as the key, which uniquely identifies each span. See
+   * {@link spanSinkKey}
+   *
+   * The engine seeds the map during {@link declareStartingSpan} with the root
+   * span and its sink.
+   *
+   * During onStart, the processor looks up the span's parent's sink and then
+   * records the span as also using that sink. If the parent is not found, then
+   * the span is not descended from a root step span, and therefore does not
+   * need to have a sink.
+   *
+   * All spans with the same root span that started the step will share the
+   * same sink.
    */
   #spanSinks = new Map<string, AIMetadataSink>();
 

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -1,0 +1,278 @@
+import { type Context, type Span, trace } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import Debug from "debug";
+import {
+  type AIMetadata,
+  extractAIMetadataFromAttributes,
+} from "./aiExtractor.ts";
+import { debugPrefix } from "./consts.ts";
+
+const processorDevDebug = Debug(`${debugPrefix}:InngestMetadataSpanProcessor`);
+
+/**
+ * Receives {@link AIMetadata} extracted from a span the moment it ends.
+ * Supplied by the engine; the engine owns all aggregation and
+ * step-attribution of the pushed values.
+ */
+export type AIMetadataSink = (metadata: AIMetadata) => void;
+
+/**
+ * Resolve the currently-registered global OTel tracer provider, unwrapping
+ * the `ProxyTracerProvider` wrapper that `trace.getTracerProvider()` returns.
+ * Returns `undefined` when no provider is registered.
+ */
+const getGlobalProvider = (): object | undefined => {
+  const globalProvider = trace.getTracerProvider();
+  if (!globalProvider) {
+    return undefined;
+  }
+
+  const existingProvider =
+    "getDelegate" in globalProvider &&
+    typeof globalProvider.getDelegate === "function"
+      ? globalProvider.getDelegate()
+      : globalProvider;
+
+  return existingProvider ?? undefined;
+};
+
+/**
+ * Attempts to add the given span processor to the given OTel provider.
+ * Returns `true` if the processor was attached, `false` if the provider could
+ * not be extended.
+ *
+ * It handles both OTel SDK v1 (`addSpanProcessor()`) and v2 (internal
+ * `_spanProcessors` array).
+ *
+ * This intentionally duplicates the attach logic inside `extendProvider`
+ * (`util.ts`) to avoid imports with instrumentation side effects.
+ */
+const attachToProvider = (
+  provider: object,
+  processor: SpanProcessor,
+): boolean => {
+  // OTel SDK v1 exposes addSpanProcessor() on BasicTracerProvider.
+  if (
+    "addSpanProcessor" in provider &&
+    typeof (provider as { addSpanProcessor?: unknown }).addSpanProcessor ===
+      "function"
+  ) {
+    (
+      provider as unknown as {
+        addSpanProcessor: (p: SpanProcessor) => void;
+      }
+    ).addSpanProcessor(processor);
+    return true;
+  }
+
+  // OTel SDK v2 removed addSpanProcessor() — span processors are constructor-only.
+  // No public API exists to add processors post-construction (OTel issue #5299),
+  // so push into the internal _spanProcessors array.
+  // These fields are TypeScript `private` (not #private), so accessible at runtime.
+  const spanProcessors = getInternalSpanProcessors(provider);
+  if (spanProcessors) {
+    spanProcessors.push(processor);
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Extract the internal span processors array from a BasicTracerProvider.
+ * Returns the mutable array if accessible, undefined otherwise.
+ *
+ * BasicTracerProvider._activeSpanProcessor is a MultiSpanProcessor,
+ * which holds a _spanProcessors: SpanProcessor[] array.
+ * Both are TypeScript `private` (not ES #private), so accessible at runtime.
+ *
+ * Wrapped in try/catch because this accesses internal OTel fields that may
+ * change — must never crash the host app.
+ */
+function getInternalSpanProcessors(provider: unknown): unknown[] | undefined {
+  try {
+    const active = (provider as Record<string, unknown>)?._activeSpanProcessor;
+    if (typeof active !== "object" || active === null) return undefined;
+
+    const arr = (active as Record<string, unknown>)._spanProcessors;
+    return Array.isArray(arr) ? arr : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Builds the `#spanSinks` key for a span. Span IDs are only guaranteed unique
+ * within a single trace, so spans are keyed by trace ID + span ID to avoid
+ * cross-trace collisions.
+ */
+const spanSinkKey = (traceId: string, spanId: string): string =>
+  `${traceId}:${spanId}`;
+
+/**
+ * A read-only OTel span processor that is independent of the Extended Traces
+ * processor (`InngestSpanProcessor`).
+ *
+ * It tracks which spans belong to an Inngest step (seeded by
+ * {@link declareStartingSpan} and passed from parent to child in `onStart`).
+ *
+ * When a tracked span ends, it extracts {@link AIMetadata} from the span's
+ * attributes and pushes it to the span's {@link AIMetadataSink}.
+ */
+export class InngestMetadataSpanProcessor implements SpanProcessor {
+  /**
+   * A map of tracked spans to their sink. The map is seeded at the
+   * step's root by {@link declareStartingSpan} and propagated to descendants in
+   * {@link onStart}.
+   */
+  #spanSinks = new Map<string, AIMetadataSink>();
+
+  /**
+   * A registry used to clean up items from `#spanSinks` when spans fall out of
+   * reference without ending. Avoids leaking entries (and the engine sink
+   * closures they reference) for spans that are never ended and are GC'd.
+   */
+  #spanCleanup = new FinalizationRegistry<string>((key) => {
+    if (key) {
+      this.#spanSinks.delete(key);
+    }
+  });
+
+  /**
+   * Latches once this processor has been attached to a global OTel provider, so
+   * {@link attach} can never push it into a provider's processor list twice
+   * (which would double-process every span and double-count tokens).
+   */
+  #attached = false;
+
+  /**
+   * Idempotently attach this processor to the global OTel provider that already
+   * exists, so it begins receiving span lifecycle events.
+   */
+  attach(): void {
+    if (this.#attached) {
+      return;
+    }
+
+    const provider = getGlobalProvider();
+    if (!provider) {
+      return;
+    }
+
+    if (attachToProvider(provider, this)) {
+      this.#attached = true;
+      processorDevDebug("attached to global OTel provider");
+    }
+  }
+
+  /**
+   * Declare the step's root span. Seeds tracking so that the root and all of
+   * its descendants share the same AIMetadata sink.
+   */
+  public declareStartingSpan({
+    span,
+    traceparent,
+    onAIMetadata,
+  }: {
+    span: Span;
+    traceparent: string | undefined;
+    onAIMetadata: AIMetadataSink;
+  }): void {
+    // If we don't have a traceparent, then this isn't a step the Executor is
+    // tracking, so we don't track it either.
+    if (!traceparent) {
+      return processorDevDebug(
+        "no traceparent found for span",
+        span.spanContext().spanId,
+        "so skipping it",
+      );
+    }
+
+    this.trackSpan(span, onAIMetadata);
+  }
+
+  /**
+   * Mark a span as tracked, recording its step's sink and registering it for
+   * cleanup.
+   *
+   * Read-only: unlike the Extended Traces processor, no attributes
+   * are stamped on the span.
+   */
+  private trackSpan(span: Span, sink: AIMetadataSink): void {
+    const { traceId, spanId } = span.spanContext();
+    const key = spanSinkKey(traceId, spanId);
+
+    this.#spanCleanup.register(span, key, span);
+    this.#spanSinks.set(key, sink);
+  }
+
+  /**
+   * Clean up references to a span that has ended (or been GC'd).
+   */
+  private cleanupSpan(span: Span): void {
+    const { traceId, spanId } = span.spanContext();
+    this.#spanCleanup.unregister(span);
+    this.#spanSinks.delete(spanSinkKey(traceId, spanId));
+  }
+
+  /**
+   * Track children of spans we already care about, so the whole subtree under a
+   * declared root is captured.
+   */
+  onStart(span: Span, parentContext: Context): void {
+    const parentSpanId = trace.getSpanContext(parentContext)?.spanId;
+
+    if (!parentSpanId) {
+      return;
+    }
+
+    // A child span always shares its parent's trace ID, so the parent's key
+    // can be built from the child's own span context.
+    const sink = this.#spanSinks.get(
+      spanSinkKey(span.spanContext().traceId, parentSpanId),
+    );
+    if (!sink) {
+      return;
+    }
+
+    this.trackSpan(span, sink);
+  }
+
+  /**
+   * On end, extract any AI metadata from the span's attributes and push it to
+   * its sink, then clean up the span's tracking entry.
+   */
+  onEnd(span: ReadableSpan): void {
+    const { traceId, spanId } = span.spanContext();
+
+    try {
+      const sink = this.#spanSinks.get(spanSinkKey(traceId, spanId));
+      if (!sink) {
+        return;
+      }
+
+      const aiMetadata = extractAIMetadataFromAttributes(span.attributes);
+      if (Object.keys(aiMetadata).length === 0) {
+        return;
+      }
+
+      sink(aiMetadata);
+    } finally {
+      this.cleanupSpan(span as unknown as Span);
+    }
+  }
+
+  // Nothing to flush or shut down: this processor is read-only and has no
+  // exporter.
+  async forceFlush(): Promise<void> {}
+
+  async shutdown(): Promise<void> {}
+}
+
+/**
+ * The process-wide metadata span processor instance.
+ */
+export const metadataSpanProcessor = new InngestMetadataSpanProcessor();

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -4,6 +4,7 @@ import type {
   SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import Debug from "debug";
+import { isRecord } from "../../../helpers/types.ts";
 import {
   type AIMetadata,
   extractAIMetadataFromAttributes,
@@ -93,11 +94,15 @@ const attachToProvider = (
  * change — must never crash the host app.
  */
 function getInternalSpanProcessors(provider: unknown): unknown[] | undefined {
-  try {
-    const active = (provider as Record<string, unknown>)?._activeSpanProcessor;
-    if (typeof active !== "object" || active === null) return undefined;
+  if (!isRecord(provider)) {
+    return undefined;
+  }
 
-    const arr = (active as Record<string, unknown>)._spanProcessors;
+  try {
+    const active = provider._activeSpanProcessor;
+    if (!isRecord(active)) return undefined;
+
+    const arr = active._spanProcessors;
     return Array.isArray(arr) ? arr : undefined;
   } catch {
     return undefined;
@@ -212,7 +217,7 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
   /**
    * Clean up references to a span that has ended (or been GC'd).
    */
-  private cleanupSpan(span: Span): void {
+  private cleanupSpan(span: ReadableSpan): void {
     const { traceId, spanId } = span.spanContext();
     this.#spanCleanup.unregister(span);
     this.#spanSinks.delete(spanSinkKey(traceId, spanId));
@@ -261,7 +266,7 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
 
       sink(aiMetadata);
     } finally {
-      this.cleanupSpan(span as unknown as Span);
+      this.cleanupSpan(span);
     }
   }
 

--- a/packages/inngest/src/test/integration/traces/stepMetadata.test.ts
+++ b/packages/inngest/src/test/integration/traces/stepMetadata.test.ts
@@ -1,0 +1,164 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { context, trace } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { expect } from "vitest";
+import { Inngest } from "../../../index.ts";
+import { createServer } from "../../../node.ts";
+import { matrixCheckpointing } from "../utils.ts";
+import {
+  getAIMetadata,
+  simulateOpenAICall,
+  waitForTraceSteps,
+} from "./util.ts";
+
+// The metadata span processor is extend-only: the Inngest constructor attaches
+// it to whatever global OTel provider already exists, and never creates one.
+// Register a bare provider (no exporter needed) and a context manager before
+// any client is constructed so the engine's execution spans are recorded and
+// userland spans parent under them.
+trace.setGlobalTracerProvider(new BasicTracerProvider());
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+// Request model (not response model) and input tokens only, mapped to the
+// server's snake_case `inngest.ai` schema.
+const expectedAIMetadata = {
+  kind: "inngest.ai",
+  scope: "step",
+  values: {
+    input_tokens: 18,
+    model: "gpt-5.4-nano",
+  },
+};
+
+matrixCheckpointing(
+  "AI OTel attributes become step metadata",
+  async (checkpointing) => {
+    const state = createState();
+    const eventName = randomSuffix("evt");
+    const client = new Inngest({
+      checkpointing,
+      id: randomSuffix(testFileName),
+      isDev: true,
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn-1",
+        retries: 0,
+        triggers: [{ event: eventName }],
+      },
+      async ({ runId, step }) => {
+        state.runId = runId;
+        await step.run("my-step", simulateOpenAICall);
+      },
+    );
+    await createTestApp({ client, functions: [fn], serve: createServer });
+
+    await client.send({ name: eventName });
+    await state.waitForRunComplete();
+
+    const steps = await waitForTraceSteps(await state.waitForRunId());
+    const step = steps.find((step) => {
+      return step.name === "my-step";
+    });
+
+    expect(getAIMetadata(step)).toEqual([expectedAIMetadata]);
+  },
+);
+
+matrixCheckpointing("multiple AI calls in a step", async (checkpointing) => {
+  const state = createState();
+  const eventName = randomSuffix("evt");
+  const client = new Inngest({
+    checkpointing,
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const fn = client.createFunction(
+    {
+      id: "fn-1",
+      retries: 0,
+      triggers: [{ event: eventName }],
+    },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      await step.run("my-step", () => {
+        simulateOpenAICall();
+        simulateOpenAICall();
+      });
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  await state.waitForRunComplete();
+
+  const steps = await waitForTraceSteps(await state.waitForRunId());
+  const step = steps.find((step) => {
+    return step.name === "my-step";
+  });
+
+  expect(getAIMetadata(step)).toEqual([
+    {
+      ...expectedAIMetadata,
+      values: {
+        ...expectedAIMetadata.values,
+        input_tokens: 2 * expectedAIMetadata.values.input_tokens,
+      },
+    },
+  ]);
+});
+
+matrixCheckpointing(
+  "AI spans outside a step window are not attributed",
+  async (checkpointing) => {
+    const state = createState();
+    const eventName = randomSuffix("evt");
+    const client = new Inngest({
+      checkpointing,
+      id: randomSuffix(testFileName),
+      isDev: true,
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn-1",
+        retries: 0,
+        triggers: [{ event: eventName }],
+      },
+      async ({ runId, step }) => {
+        state.runId = runId;
+        await step.run("ai-step", simulateOpenAICall);
+
+        // Function-body spans end while no step is executing, so they must
+        // not be attributed to any step — including the one about to start.
+        simulateOpenAICall();
+
+        await step.run("no-ai-step", () => "done");
+      },
+    );
+    await createTestApp({ client, functions: [fn], serve: createServer });
+
+    await client.send({ name: eventName });
+    await state.waitForRunComplete();
+
+    const steps = await waitForTraceSteps(await state.waitForRunId());
+    const aiStep = steps.find((step) => {
+      return step.name === "ai-step";
+    });
+    const noAiStep = steps.find((step) => {
+      return step.name === "no-ai-step";
+    });
+
+    expect(aiStep).toBeDefined();
+    expect(noAiStep).toBeDefined();
+    expect(getAIMetadata(aiStep)).toEqual([expectedAIMetadata]);
+    expect(getAIMetadata(noAiStep)).toEqual([]);
+  },
+);

--- a/packages/inngest/src/test/integration/traces/util.ts
+++ b/packages/inngest/src/test/integration/traces/util.ts
@@ -1,0 +1,125 @@
+import { DEV_SERVER_URL, waitFor } from "@inngest/test-harness";
+import { trace } from "@opentelemetry/api";
+import { z } from "zod/v3";
+
+/**
+ * Emits the span shape `@opentelemetry/instrumentation-openai` produces for a
+ * chat completion, without needing the OpenAI SDK or an API key: a wrapper
+ * span containing a `gen_ai.*`-attributed span.
+ *
+ * The response model and output tokens are deliberately present even though
+ * the metadata processor doesn't extract them; tests assert they don't leak
+ * into step metadata.
+ */
+export function simulateOpenAICall(): string {
+  const tracer = trace.getTracer("@opentelemetry/instrumentation-openai");
+  return tracer.startActiveSpan("open-ai-wrapper", (wrapperSpan) => {
+    try {
+      return tracer.startActiveSpan(
+        "open-ai-span",
+        {
+          attributes: {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": "gpt-5.4-nano",
+            "gen_ai.response.model": "gpt-5.4-nano-2026-03-17",
+            "gen_ai.system": "openai",
+            "gen_ai.usage.input_tokens": 18,
+            "gen_ai.usage.output_tokens": 39,
+          },
+        },
+        (span) => {
+          span.end();
+          return "done";
+        },
+      );
+    } finally {
+      wrapperSpan.end();
+    }
+  });
+}
+
+const fetchTraceStepsQuery = `
+  query Query($runID: String!, $preview: Boolean) {
+    run(runID: $runID) {
+      trace(preview: $preview) {
+        childrenSpans {
+          metadata {
+            scope
+            kind
+            values
+          }
+          name
+        }
+      }
+    }
+  }`;
+
+const metadataSchema = z.object({
+  kind: z.string(),
+  scope: z.string(),
+  values: z.record(z.unknown()),
+});
+
+const traceStepSchema = z.object({
+  metadata: z.array(metadataSchema),
+  name: z.string(),
+});
+
+export type TraceStep = z.infer<typeof traceStepSchema>;
+
+const fetchTraceStepsResponseSchema = z.object({
+  data: z.object({
+    run: z
+      .object({
+        trace: z.object({
+          childrenSpans: z.array(traceStepSchema),
+        }),
+      })
+      .nullable(),
+  }),
+});
+
+async function fetchTraceSteps(runId: string): Promise<TraceStep[] | null> {
+  const res = await fetch(`${DEV_SERVER_URL}/v0/gql`, {
+    body: JSON.stringify({
+      operationName: "Query",
+      query: fetchTraceStepsQuery,
+      variables: { preview: true, runID: runId },
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+
+  const parsed = fetchTraceStepsResponseSchema.parse(await res.json());
+  const run = parsed.data.run;
+  if (!run) {
+    return null;
+  }
+
+  return run.trace.childrenSpans;
+}
+
+export async function waitForTraceSteps(runId: string): Promise<TraceStep[]> {
+  return waitFor(async () => {
+    const steps = await fetchTraceSteps(runId);
+    if (!steps) {
+      throw new Error("Run trace not found");
+    }
+
+    return steps;
+  });
+}
+
+export function getAIMetadata(step: TraceStep | undefined) {
+  if (!step) {
+    return [];
+  }
+
+  return step.metadata.filter((metadata) => {
+    return metadata.kind === "inngest.ai" && metadata.scope === "step";
+  });
+}


### PR DESCRIPTION
## Summary

- We would like to process the spans from instrumented LLM calls into AI metadata and attach that metadata on to the encompassing step
- We create a singleton processor that attaches during client creation  to an **already created** provider. We do not handle provider creation or instrumentation here.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
