### PR TITLE
fix(middleware): map step.ai.wrap planned op to ai.wrap step type

### DIFF
--- a/.changeset/fix-step-ai-wrap-unknown-type.md
+++ b/.changeset/fix-step-ai-wrap-unknown-type.md
@@ -1,0 +1,14 @@
+---
+"inngest": patch
+---
+
+fix(middleware): map `step.ai.wrap` planned op to `ai.wrap` step type
+
+`step.ai.wrap()` emits a `StepPlanned` op with `opts.type === "step.ai.wrap"`,
+but `stepTypeFromOpCode` only recognised `step.ai.wrap` under the
+`AiGateway` opcode branch. Normal `step.ai.wrap()` usage therefore fell
+through to `unknown` and logged an "Unknown step type" warning.
+
+Adds the missing `step.ai.wrap` case to the `StepPlanned` branch so
+middleware step-type metadata is correct and the warning no longer fires.
+The existing `AiGateway` mapping is preserved.

--- a/packages/inngest/src/components/middleware/utils.test.ts
+++ b/packages/inngest/src/components/middleware/utils.test.ts
@@ -43,6 +43,16 @@ describe("stepTypeFromOpCode", () => {
     ).toBe("realtime.publish");
   });
 
+  test("StepPlanned with type 'step.ai.wrap' returns 'ai.wrap'", () => {
+    expect(
+      stepTypeFromOpCode(
+        StepOpCode.StepPlanned,
+        { type: "step.ai.wrap" },
+        logger,
+      ),
+    ).toBe("ai.wrap");
+  });
+
   test("StepPlanned with unknown type returns 'unknown'", () => {
     expect(
       stepTypeFromOpCode(

--- a/packages/inngest/src/components/middleware/utils.ts
+++ b/packages/inngest/src/components/middleware/utils.ts
@@ -113,6 +113,9 @@ export function stepTypeFromOpCode(
     if (opts?.type === "group.experiment") {
       return "group.experiment";
     }
+    if (opts?.type === "step.ai.wrap") {
+      return "ai.wrap";
+    }
   } else if (op === StepOpCode.Sleep) {
     return "sleep";
   } else if (op === StepOpCode.WaitForEvent) {


### PR DESCRIPTION
## Summary

`step.ai.wrap()` is implemented via `createStepRun("step.ai.wrap")` ([InngestStepTools.ts:764](https://github.com/inngest/inngest-js/blob/main/packages/inngest/src/components/InngestStepTools.ts#L764)), which emits a `StepPlanned` op with `opts.type === \"step.ai.wrap\"`. The `stepTypeFromOpCode` mapper at [middleware/utils.ts:87-126](https://github.com/inngest/inngest-js/blob/main/packages/inngest/src/components/middleware/utils.ts#L87-L126) only recognised `step.ai.wrap` inside the `AiGateway` branch — which is not the opcode actually emitted at runtime — so normal `step.ai.wrap()` usage fell through to `\"unknown\"` and logged `\"Unknown step type\"` on every call.

This PR adds the missing case to the `StepPlanned` branch so middleware step-type metadata is correct and the warning no longer fires for valid usage. The existing `AiGateway` mapping is preserved (it's harmless and already test-covered, so removing it could be a separate cleanup if it's known-unreachable).

## What was wrong

In `packages/inngest/src/components/InngestStepTools.ts`:
- `step.ai.infer` → `StepOpCode.AiGateway` with `opts.type = \"step.ai.infer\"` (line 739)
- `step.ai.wrap` → `createStepRun(\"step.ai.wrap\")` → `StepOpCode.StepPlanned` with `opts.type = \"step.ai.wrap\"` (line 363, 764)

The mapper only handled `\"step.ai.wrap\"` under `StepOpCode.AiGateway`, so the actual `StepPlanned + \"step.ai.wrap\"` path returned `\"unknown\"`.

## Change

```diff
 } else if (op === StepOpCode.StepPlanned) {
   if (opts?.type === undefined) {
     return \"run\";
   }
   if (opts?.type === \"step.sendEvent\") {
     return \"sendEvent\";
   }
   if (opts?.type === \"step.realtime.publish\") {
     return \"realtime.publish\";
   }
   if (opts?.type === \"group.experiment\") {
     return \"group.experiment\";
   }
+  if (opts?.type === \"step.ai.wrap\") {
+    return \"ai.wrap\";
+  }
 }
```

Plus a unit test mirroring the existing `AiGateway + step.ai.wrap` case for the `StepPlanned` branch, and a `patch` changeset.

## Test plan

- [x] `pnpm vitest run src/components/middleware/utils.test.ts` — 44/44 pass, including the new `StepPlanned + step.ai.wrap` case
- [x] `pnpm lint` (Biome) — clean
- [x] Existing `AiGateway + step.ai.wrap` test still passes (mapping preserved)

Closes #1555