### PR TITLE
Grab parentSpanID from parent context

### DIFF
--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -1,4 +1,4 @@
-import type { Span } from "@opentelemetry/api";
+import { type Context, type Span, trace } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import {
   detectResources,
@@ -427,14 +427,10 @@ export class InngestSpanProcessor implements SpanProcessor {
    * interface. This is called when a span is started, and is used to track
    * spans that are children of spans we care about.
    */
-  onStart(span: Span): void {
+  onStart(span: Span, parentContext: Context): void {
     const devDebug = processorDevDebug.extend("onStart");
     const spanId = span.spanContext().spanId;
-    // Support both OTel SDK v2.x (parentSpanContext.spanId) and v1.x
-    // (parentSpanId as a plain string) since users may have either version.
-    const parentSpanId =
-      (span as unknown as ReadableSpan).parentSpanContext?.spanId ??
-      (span as unknown as { parentSpanId?: string }).parentSpanId;
+    const parentSpanId = trace.getSpanContext(parentContext)?.spanId;
 
     // The root span isn't captured here, but we can capture children of it
     // here.


### PR DESCRIPTION
## Summary

- A small freshen up: let's grab parent span ID from the parentContext arg instead of performing conversions
- Simpler more robust approach that I found while doing the AI Metadata processor
- I think we originally copied this from a different section that didn't have access to the parent context.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
