### PR TITLE
Don't double count Vercel SDK AI spans (EXE-1837)

### DIFF
--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -16,6 +16,7 @@ export type MetadataScope = "run" | "step" | "extended_trace";
 export type MetadataKind =
   | "inngest.experiment"
   | "inngest.warnings"
+  | "inngest.ai"
   | `userland.${string}`;
 
 /**

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -4,7 +4,11 @@ import { fileURLToPath } from "node:url";
 import type { Attributes, AttributeValue } from "@opentelemetry/api";
 import { describe, expect, test } from "vitest";
 import type { AIMetadata } from "./aiExtractor.ts";
-import { aggregate, extractAIMetadataFromAttributes } from "./aiExtractor.ts";
+import {
+  aggregate,
+  extractAIMetadataFromAttributes,
+  toInngestAIMetadataValues,
+} from "./aiExtractor.ts";
 
 /**
  * These fixtures are real OTLP/JSON spans captured from instrumented OpenAI SDK
@@ -217,5 +221,26 @@ describe("aggregate", () => {
   test("omits fields absent from both inputs", () => {
     expect(aggregate({}, {})).toEqual({});
     expect(aggregate({ model: "a" }, {})).toEqual({ model: "a" });
+  });
+});
+
+describe("toInngestAIMetadataValues", () => {
+  test("maps both fields onto the server's snake_case schema", () => {
+    expect(
+      toInngestAIMetadataValues({ model: "gpt-4o", inputTokens: 42 }),
+    ).toEqual({ model: "gpt-4o", input_tokens: 42 });
+  });
+
+  test("omits absent fields rather than zero-valuing them", () => {
+    expect(toInngestAIMetadataValues({ model: "gpt-4o" })).toEqual({
+      model: "gpt-4o",
+    });
+    expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
+      input_tokens: 7,
+    });
+  });
+
+  test("returns undefined when there is nothing to emit", () => {
+    expect(toInngestAIMetadataValues({})).toBeUndefined();
   });
 });

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -192,6 +192,31 @@ describe("extractAIMetadataFromAttributes", () => {
     });
     expect(extracted).toEqual({ model: "semconv-model", inputTokens: 22 });
   });
+
+  // The Vercel AI SDK emits a wrapper span (e.g. `ai.generateText`) whose
+  // `ai.usage.*` duplicates its provider-call child (`ai.generateText.doGenerate`).
+  // The wrapper must extract to nothing so the per-step aggregate doesn't count
+  // the same tokens twice; the child (which carries the documented `.do*`
+  // segment) carries the usage.
+  test("skips the Vercel rollup span so its usage isn't double-counted", () => {
+    const rollup = {
+      "ai.operationId": "ai.generateText",
+      "ai.model.id": "gpt-4.1-nano",
+      "ai.usage.inputTokens": 17,
+    };
+    expect(extractAIMetadataFromAttributes(rollup)).toEqual({});
+
+    // The provider-call (leaf) span is still extracted normally.
+    const leaf = {
+      "ai.operationId": "ai.generateText.doGenerate",
+      "ai.model.id": "gpt-4.1-nano",
+      "ai.usage.inputTokens": 17,
+    };
+    expect(extractAIMetadataFromAttributes(leaf)).toEqual({
+      model: "gpt-4.1-nano",
+      inputTokens: 17,
+    });
+  });
 });
 
 describe("aggregate", () => {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -68,6 +68,31 @@ interface Candidate {
 }
 
 /**
+ * We identify rollup spans as spans with Vercel's unique "ai.operationId" attribute key
+ * and a value that does not container ".do", based on their naming patterns.
+ *
+ * @see https://ai-sdk.dev/docs/ai-sdk-core/telemetry
+ */
+const VERCEL_PROVIDER_CALL_SEGMENT = /\.do[A-Z]/;
+
+/**
+ * Whether the span is a Vercel AI SDK framework wrapper span.
+ *
+ * The Vercel AI SDK emits a span *tree*: a framework rollup span
+ * (`ai.generateText`) whose children are the provider-call (leaf)
+ * spans (`ai.generateText.doGenerate`).
+ *
+ * Both carry overlapping data about calls, so using both would double count.
+ * We choose to skip the rollup span.
+ */
+const isVercelRollupSpan = (attributes: Attributes): boolean => {
+  const op = attributes["ai.operationId"];
+  // Only Vercel AI SDK spans carry `ai.operationId`; among them, the
+  // provider-call leaf has a `.do*` segment and the wrapper does not.
+  return typeof op === "string" && !VERCEL_PROVIDER_CALL_SEGMENT.test(op);
+};
+
+/**
  * Extracts AI model metadata from a span's attributes.
  *
  * Attributes are matched across multiple instrumentation conventions
@@ -80,6 +105,12 @@ interface Candidate {
 export const extractAIMetadataFromAttributes = (
   attributes: Attributes,
 ): AIMetadata => {
+  // The Vercel AI SDK's rollup span duplicates its provider-call child's usage;
+  // skip it to avoid double counting.
+  if (isVercelRollupSpan(attributes)) {
+    return {};
+  }
+
   // Track the highest-precedence (lowest convention) candidate seen per field.
   const candidates: Partial<Record<Field, Candidate>> = {};
 

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -142,3 +142,29 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
 
   return metadata;
 };
+
+/**
+ * Maps an {@link AIMetadata} value onto the server's `inngest.ai` metadata
+ * schema (snake_case keys). Only the fields we extract are emitted; absent
+ * fields are omitted rather than zero-valued. Returns `undefined` when there
+ * is nothing to emit, so callers can skip stamping metadata entirely.
+ */
+export const toInngestAIMetadataValues = (
+  metadata: AIMetadata,
+): Record<string, unknown> | undefined => {
+  const values: Record<string, unknown> = {};
+
+  if (metadata.model !== undefined) {
+    values.model = metadata.model;
+  }
+
+  if (metadata.inputTokens !== undefined) {
+    values.input_tokens = metadata.inputTokens;
+  }
+
+  if (Object.keys(values).length === 0) {
+    return undefined;
+  }
+
+  return values;
+};

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.out
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-5.4-nano",
-  "system": "openai.responses",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 17,
-  "output_tokens": 40,
-  "total_tokens": 57
-}
+no AI metadata extracted

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/embeddings.otlp.json.out
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/embeddings.otlp.json.out
@@ -12,14 +12,4 @@ SPAN ai.embed.doEmbed
 }
 
 SPAN ai.embed
-{
-  "model": "text-embedding-3-small",
-  "system": "openai.embedding",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": null,
-  "input_tokens": 10,
-  "output_tokens": 0,
-  "total_tokens": 10
-}
+no AI metadata extracted

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.out
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-4.1-nano",
-  "system": "openai.chat",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 22,
-  "output_tokens": 6,
-  "total_tokens": 28
-}
+no AI metadata extracted

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.out
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-5.4-nano",
-  "system": "openai.responses",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 42,
-  "output_tokens": 195,
-  "total_tokens": 237
-}
+no AI metadata extracted

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.out
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.streamText.doStream
 }
 
 SPAN ai.streamText
-{
-  "model": "gpt-4.1-nano",
-  "system": "openai.chat",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 11,
-  "output_tokens": 10,
-  "total_tokens": 21
-}
+no AI metadata extracted

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.out
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-4.1-nano",
-  "system": "openai.chat",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "tool-calls"
-  ],
-  "input_tokens": 56,
-  "output_tokens": 14,
-  "total_tokens": 70
-}
+no AI metadata extracted


### PR DESCRIPTION
## Summary

- The Vercel SDK AI emits multiple spans per LLM call
- The parent is a roll up that has aggregated data about the LLM call(s)
- We perform our own aggregation, so parsing both leads to double counting. Let's ignore the roll up span until we want to extract data only found there and not in the children.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

