### PR TITLE
Skip declaring startings spans when the span processor is not active (EXE-1950)

### DIFF
--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -13,7 +13,13 @@ describe("InngestMetadataSpanProcessor", () => {
 
   function setup() {
     const processor = new InngestMetadataSpanProcessor();
-    const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+    const provider = new BasicTracerProvider();
+    // Mirror production wiring: register the provider globally and let the
+    // processor attach itself, which flips its `#attached` latch. Injecting via
+    // the constructor would leave the processor unattached, so
+    // `declareStartingSpan` would no-op.
+    trace.setGlobalTracerProvider(provider);
+    processor.attach();
     const tracer = provider.getTracer("test");
     return { processor, tracer };
   }

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -198,6 +198,12 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
     traceparent: string | undefined;
     onAIMetadata: AIMetadataSink;
   }): void {
+    // If this processor is not attached to a  provider, we don't need to
+    // declare starting spans.
+    if (!this.#attached) {
+      return;
+    }
+
     // If we don't have a traceparent, then this isn't a step the Executor is
     // tracking, so we don't track it either.
     if (!traceparent) {


### PR DESCRIPTION
## Summary

- Previously we introduced the span processor that we attempt to attach to the provider during client creation
- When there is no provider to attach to, the processor will receive no spans, and there's no need for the engine to tell the processor about starting spans. Let's skip the work.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
