### PR TITLE
feat(defers): add transformDeferInput middleware hook

### DIFF
--- a/.changeset/slick-sloths-matter.md
+++ b/.changeset/slick-sloths-matter.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Add transformDeferInput middleware hook

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -17,6 +17,7 @@ import {
   type Context,
   type EventMeta,
   type EventPayload,
+  type ExperimentRef,
   type HashedOp,
   type InvocationResult,
   type InvokeTargetFunctionDefinition,
@@ -188,6 +189,7 @@ export type StepHandler = (info: {
   defer?: {
     fn: DeferredFunction.Any;
     data: Record<string, unknown>;
+    experiment?: ExperimentRef;
   };
   matchOp: MatchOpFn;
   opts?: StepToolOptions;

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -30,6 +30,7 @@ import {
   type StepOptionsOrId,
   type TriggerEventFromFunction,
 } from "../types.ts";
+import type { DeferredFunction } from "./DeferredFunction.ts";
 import { getAsyncCtx, getAsyncCtxSync } from "./execution/als.ts";
 import type { InngestExecution } from "./execution/InngestExecution.ts";
 import { fetch as stepFetch } from "./Fetch.ts";
@@ -183,9 +184,13 @@ export type MatchOpFn<
 ) => Omit<HashedOp, "data" | "error">;
 
 export type StepHandler = (info: {
+  args: [StepOptionsOrId, ...unknown[]];
+  defer?: {
+    fn: DeferredFunction.Any;
+    data: Record<string, unknown>;
+  };
   matchOp: MatchOpFn;
   opts?: StepToolOptions;
-  args: [StepOptionsOrId, ...unknown[]];
 }) => Promise<unknown>;
 
 export interface StepToolOptions<

--- a/packages/inngest/src/components/execution/ARCHITECTURE.md
+++ b/packages/inngest/src/components/execution/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 Most opcodes without a local handler (`Sleep`, `WaitForEvent`, etc.) suspend the run. The SDK ships the opcode, the backend schedules the work, then the backend re-invokes the function with the result memoized in state. The opcode *is* the suspension.
 
-Lazy ops (`StepOpCode.DeferAdd`) are fire-and-forget. User code keeps executing in the same run, so the op has no natural moment to ship. We resolve the user's `await` eagerly and park the op in `state.pendingLazyOps` until the next wire message carries it (checkpoint or response).
+Lazy ops (`StepOpCode.DeferAdd`) are fire-and-forget. User code keeps executing in the same run, so the op has no natural moment to ship. We resolve the user's `await` eagerly and park the op in `state.lazyOps` until the next wire message carries it (checkpoint or response).
 
 `defer()` must work anywhere in a handler: top-level, inside `step.run()`, and in any combination. Routing through the core loop handles the top-level case fine but deadlocks inside `step.run()`, since the outer step already holds the loop. Buffering handles both cases uniformly and lets consecutive calls batch into a single ship for free.
 
@@ -12,4 +12,6 @@ The buffer drains onto whichever wire message comes next: an outbound checkpoint
 
 Lazy ops bypass `state.steps` and the step middleware pipeline entirely. They aren't user-addressable as steps (no handler, no memoization, no awaitable result), so step hooks like `transformStepInput` / `wrapStep` / `onStepStart` have nothing to do with them. The engine's step handler short-circuits at the top: `isLazyOp(opts, opId)` returns true → hash the ID, push the op, return. Replay ops are filtered by `priorDefers[hashedId]`, sent by the executor in the request payload.
 
-The `LazyOps` class (`lazyOps.ts`) is just a buffer: `push(op)` appends, `drain()` takes and clears, `has()` peeks. The engine owns op construction and shipping. The async `function-resolved` / `function-rejected` / `steps-found` handlers route their final response through `attachLazyOps`, which drains the buffer and bundles ops alongside the terminal `RunComplete` / `StepFailed` / `StepError` op (converting a terminal result into `steps-found` when ops are buffered). The remaining drain sites (`checkpoint()` and `maybeReturnNewSteps`) drain directly because they ship raw `OutgoingOp[]`, not an `ExecutionResult`. Sync-mode terminal rejection and the `checkpoint()` API-failure fallback still don't go through `attachLazyOps`; see the Todo in `defer.md`.
+Buffer entries are *pending*: `push(id, ready)` reserves the id synchronously and stores an `OutgoingOp` promise. Async preparation (schema validation + `transformDeferInput`) settles later; `drain()` awaits and drops entries that resolve `null`.
+
+`LazyOps` (`lazyOps.ts`) is just the buffer: `push(id, ready)` appends, `drain()` takes/awaits/clears, `hasId()` peeks. The engine owns op construction and shipping. Async terminal handlers route through `attachLazyOps`; direct op-shipping paths (`checkpoint()` and `maybeReturnNewSteps`) drain inline. Sync-mode terminal rejection and the `checkpoint()` API-failure fallback still don't go through `attachLazyOps`; see the Todo in `defer.md`.

--- a/packages/inngest/src/components/execution/defer.md
+++ b/packages/inngest/src/components/execution/defer.md
@@ -28,7 +28,7 @@ const sendEmail = createDefer(
   async ({ event, step }) => {
     event.data.to; // typed from `schema`
     event.data.body;
-  },
+  }
 );
 ```
 
@@ -53,7 +53,7 @@ const orderPlaced = inngest.createFunction(
   { id: "order-placed", triggers: { event: "order/placed" } },
   async ({ defer }) => {
     defer("send", { function: sendEmail, data: { to: "a@b.com", body: "hi" } });
-  },
+  }
 );
 ```
 
@@ -95,6 +95,8 @@ The backend records each `DeferAdd` against the parent run as it arrives. The de
 
 On replay, the executor sends back a `defers` map of hashed step IDs it has already received. The SDK uses `priorDefers` to skip re-emitting them.
 
+The `transformDeferInput` middleware hook runs against `data` after schema validation, just before the op is buffered. Use it for serialization or encryption. Returning an empty `defers` array drops the call silently.
+
 ## Todo
 
 ### Known gaps (correctness)
@@ -119,5 +121,3 @@ Net-new capabilities. None affect correctness of the current API.
 - **Support aborting a `defer` call.** -- A `DeferAbort` opcode is reserved on the backend but the SDK doesn't yet emit it. Needs a user-facing API (e.g. `const { abort } = defer("id", { function, data })`) and the matching opcode emission.
 
 - **Support starting a deferred run immediately.** -- Today the deferred run starts only when the parent run finalizes. We may want an opt-in path (e.g. `defer("id", { function, data }).now()`).
-
-- **Middleware hook** -- We need a hook to make encryption and serialization work (e.g. `transformDeferInput`).

--- a/packages/inngest/src/components/execution/defer.md
+++ b/packages/inngest/src/components/execution/defer.md
@@ -73,7 +73,7 @@ await step.run("notify", async () => {
 
 `schema` is optional (`StandardSchemaV1`). When present, `data` is validated at the call site and again on the receiver side. The receiver-side check catches serialization round-trips that change the shape (e.g. `Date` becoming an ISO string). The same schema types `event.data` in the handler.
 
-Call-site validation must be synchronous because `defer(...)` itself is sync. If the schema's `validate` returns a Promise, the SDK logs the error and skips the call (see "Error handling"). Receiver-side validation is async, so async validators work there.
+Call-site validation runs asynchronously after the op is buffered (`defer(...)` itself stays sync), so async validators are supported. A failure logs an error and drops the op before it ships (see "Error handling").
 
 Without a schema, `data` falls back to `Record<string, any>`.
 
@@ -95,7 +95,7 @@ The backend records each `DeferAdd` against the parent run as it arrives. The de
 
 On replay, the executor sends back a `defers` map of hashed step IDs it has already received. The SDK uses `priorDefers` to skip re-emitting them.
 
-The `transformDeferInput` middleware hook runs against `data` after schema validation, just before the op is buffered. Use it for serialization or encryption. Returning an empty `defers` array drops the call silently.
+The `transformDeferInput` middleware hook runs against `data` after schema validation. Use it for serialization or encryption. The op is buffered synchronously at `defer(...)`, while validation and middleware settle asynchronously; drain waits for that preparation before shipping. This avoids miss-on-finish races, but a slow or hung validator/middleware can delay parent checkpoint/finalization (no timeout today).
 
 ## Todo
 
@@ -111,8 +111,6 @@ removing the experimental label.
 ### Future features (additive)
 
 Net-new capabilities. None affect correctness of the current API.
-
-- **Support async call-site validation** -- `defer()` itself must stay sync (fire-and-forget, no `await` at the call site), so we can't `await schema.validate(data)` inline. Maybe we can attach the pending validation promise to the buffered lazy op and await it at drain time, before the op is reported. A failure should reject the run the same way a sync validation failure does today.
 
 - **Support `onFailure`** -- We may add it later.
 

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2394,6 +2394,10 @@ class InngestExecutionEngine
           this.state.lazyOps.markSeen(hashedId);
           return;
         }
+        // Reserve the id synchronously, before the `applyToDefer` await below.
+        // `defer()` is fire-and-forget, so two sync calls with the same id
+        // would otherwise both pass the `hasId` check above and race to push.
+        this.state.lazyOps.markSeen(hashedId);
         if (defer) {
           const prepared = await this.middlewareManager.applyToDefer({
             deferFn: defer.fn,

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2361,6 +2361,7 @@ class InngestExecutionEngine
 
     const stepHandler: StepHandler = async ({
       args,
+      defer,
       matchOp,
       opts,
     }): Promise<unknown> => {
@@ -2392,6 +2393,16 @@ class InngestExecutionEngine
           // duplicate) is detected and warned about above.
           this.state.lazyOps.markSeen(hashedId);
           return;
+        }
+        if (defer) {
+          const prepared = await this.middlewareManager.applyToDefer({
+            deferFn: defer.fn,
+            data: defer.data,
+          });
+          if (!prepared) {
+            return;
+          }
+          opId.opts = { ...opId.opts, input: prepared.data };
         }
         this.state.lazyOps.push({
           id: hashedId,
@@ -2689,7 +2700,7 @@ class InngestExecutionEngine
         const stepOptions = getStepOptions(idOrOptions);
         const hashedId = _internals.hashId(stepOptions.id);
 
-        let input: unknown = data;
+        let input: Record<string, unknown> = data;
         if (schema) {
           const result = schema["~standard"].validate(data);
           if (result instanceof Promise) {
@@ -2718,6 +2729,7 @@ class InngestExecutionEngine
 
         void stepHandler({
           args: [stepOptions, finalInput],
+          defer: { fn: deferFn, data: finalInput },
           matchOp: (stepOptions, inputArg) => ({
             id: stepOptions.id,
             mode: StepMode.Sync,

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2697,41 +2697,13 @@ class InngestExecutionEngine
           return noopHandle;
         }
 
-        const { schema } = deferFn;
         const deferFnSlug = deferFn.id(this.options.client.id);
         const stepOptions = getStepOptions(idOrOptions);
         const hashedId = _internals.hashId(stepOptions.id);
 
-        let input: Record<string, unknown> = data;
-        if (schema) {
-          const result = schema["~standard"].validate(data);
-          if (result instanceof Promise) {
-            log.error(
-              { runId },
-              "defer() requires a synchronous schema validator. The defer call was skipped.",
-            );
-            return noopHandle;
-          }
-          if (result.issues) {
-            log.error(
-              { runId, issues: result.issues },
-              "defer skipped: schema validation failed",
-            );
-            return noopHandle;
-          }
-          input = result.value ?? data;
-        }
-
-        // The experiment ref rides in a reserved input key the receiver strips
-        // before the handler runs; set after schema validation so it can't trip it.
-        const finalInput =
-          experiment && isRecord(input)
-            ? { ...input, [deferExperimentKey]: experiment }
-            : input;
-
         void stepHandler({
-          args: [stepOptions, finalInput],
-          defer: { fn: deferFn, data: finalInput },
+          args: [stepOptions, data],
+          defer: { fn: deferFn, data, experiment },
           matchOp: (stepOptions, inputArg) => ({
             id: stepOptions.id,
             mode: StepMode.Sync,
@@ -2823,7 +2795,14 @@ class InngestExecutionEngine
       data: input,
     });
 
-    return { ...op, opts: { ...op.opts, input: prepared.data } };
+    // The experiment ref rides in a reserved input key the receiver strips
+    // before the handler runs; add it after validation + middleware so the
+    // schema can't strip it and middleware can't observe it.
+    const finalInput = defer.experiment
+      ? { ...prepared.data, [deferExperimentKey]: defer.experiment }
+      : prepared.data;
+
+    return { ...op, opts: { ...op.opts, input: finalInput } };
   }
 
   /**

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -449,7 +449,7 @@ class InngestExecutionEngine
   }
 
   private async checkpoint(steps: OutgoingOp[]): Promise<void> {
-    const lazyOps = this.state.lazyOps.drain();
+    const lazyOps = await this.state.lazyOps.drain();
     if (lazyOps.length > 0) {
       steps = [...steps, ...lazyOps];
     }
@@ -860,7 +860,7 @@ class InngestExecutionEngine
 
       const allSteps: OutgoingOp[] = [
         ...(newSteps ?? []),
-        ...this.state.lazyOps.drain(),
+        ...(await this.state.lazyOps.drain()),
       ];
       if (allSteps.length === 0) {
         return;
@@ -1357,7 +1357,7 @@ class InngestExecutionEngine
           // `steps-found` batch — we want to bundle them with the final
           // response (alongside `RunComplete` or any newly-discovered
           // real steps) so the executor doesn't need an extra round-trip.
-          const lazyOps = this.state.lazyOps.drain();
+          const lazyOps = await this.state.lazyOps.drain();
 
           const output = await asyncHandlers["function-resolved"](
             checkpoint,
@@ -2014,11 +2014,11 @@ class InngestExecutionEngine
    * fire-and-forget and have no natural shipping moment, so each terminal code
    * path must ship them or they're silently dropped.
    */
-  private attachLazyOps(
+  private async attachLazyOps(
     result: ExecutionResult,
     extras: readonly OutgoingOp[] = [],
-  ): ExecutionResult {
-    const lazyOps = this.state.lazyOps.drain();
+  ): Promise<ExecutionResult> {
+    const lazyOps = await this.state.lazyOps.drain();
     if (lazyOps.length === 0 && extras.length === 0) {
       return result;
     }
@@ -2081,7 +2081,7 @@ class InngestExecutionEngine
       // drained ops so they ship on the next outbound message.
       default:
         for (const op of lazyOps) {
-          this.state.lazyOps.push(op);
+          this.state.lazyOps.push(op.id, op);
         }
         return result;
     }
@@ -2394,21 +2394,7 @@ class InngestExecutionEngine
           this.state.lazyOps.markSeen(hashedId);
           return;
         }
-        // Reserve the id synchronously, before the `applyToDefer` await below.
-        // `defer()` is fire-and-forget, so two sync calls with the same id
-        // would otherwise both pass the `hasId` check above and race to push.
-        this.state.lazyOps.markSeen(hashedId);
-        if (defer) {
-          const prepared = await this.middlewareManager.applyToDefer({
-            deferFn: defer.fn,
-            data: defer.data,
-          });
-          if (!prepared) {
-            return;
-          }
-          opId.opts = { ...opId.opts, input: prepared.data };
-        }
-        this.state.lazyOps.push({
+        const op: OutgoingOp = {
           id: hashedId,
           op: opId.op,
           name: opId.name,
@@ -2416,7 +2402,19 @@ class InngestExecutionEngine
           opts: opId.opts,
           userland: opId.userland,
           data: null,
-        });
+        };
+
+        // Reserve membership synchronously; async prep may settle later.
+        const ready = defer
+          ? this.prepareDeferOp(op, defer).catch((err: unknown) => {
+              this.options.client[internalLoggerSymbol].error(
+                { runId: this.fnArg.runId, err },
+                "defer skipped: unexpected error",
+              );
+              return null;
+            })
+          : op;
+        this.state.lazyOps.push(hashedId, ready);
         return;
       }
 
@@ -2676,13 +2674,13 @@ class InngestExecutionEngine
 
   /**
    * Build the `defer(idOrOptions, { function, data })` method exposed on
-   * every handler context. Validates `data` against the target function's
-   * schema (if any) and emits a `DeferAdd` opcode that routes to the
-   * target's companion function slug.
+   * every handler context. Emits a `DeferAdd` opcode that routes to the
+   * target's companion function slug. Schema validation and middleware
+   * transforms happen in `prepareDeferOp`, after the op is buffered.
    *
    * `defer()` is fire-and-forget: a misuse should not derail the user's
-   * handler. Validation failures (wrong function, async schema validator,
-   * schema mismatch) are logged and the call is silently skipped.
+   * handler. Validation failures (wrong function, schema mismatch) are
+   * logged and the call is silently skipped.
    */
   private buildDefer(stepHandler: StepHandler): DeferFn {
     return (idOrOptions, { function: deferFn, data, experiment }) => {
@@ -2789,12 +2787,43 @@ class InngestExecutionEngine
           },
         };
       } catch (err) {
-        // Fire-and-forget: a misbehaving schema validator, malformed args, or
-        // any other unexpected throw must not derail the surrounding handler.
+        // Fire-and-forget: malformed args or any other unexpected throw must
+        // not derail the surrounding handler.
         log.error({ runId, err }, "defer skipped: unexpected error");
         return noopHandle;
       }
     };
+  }
+
+  /**
+   * Prepare a buffered `DeferAdd` op (schema validation + middleware).
+   * Runs after buffering so `defer()` stays sync. Resolves `null` to skip.
+   */
+  private async prepareDeferOp(
+    op: OutgoingOp,
+    defer: NonNullable<Parameters<StepHandler>[0]["defer"]>,
+  ): Promise<OutgoingOp | null> {
+    let input = defer.data;
+
+    const { schema } = defer.fn;
+    if (schema) {
+      const result = await schema["~standard"].validate(input);
+      if (result.issues) {
+        this.options.client[internalLoggerSymbol].error(
+          { runId: this.fnArg.runId, issues: result.issues },
+          "defer skipped: schema validation failed",
+        );
+        return null;
+      }
+      input = result.value ?? input;
+    }
+
+    const prepared = await this.middlewareManager.applyToDefer({
+      deferFn: defer.fn,
+      data: input,
+    });
+
+    return { ...op, opts: { ...op.opts, input: prepared.data } };
   }
 
   /**

--- a/packages/inngest/src/components/execution/lazyOps.ts
+++ b/packages/inngest/src/components/execution/lazyOps.ts
@@ -6,10 +6,14 @@ import type { MatchOpFn, StepToolOptions } from "../InngestStepTools.ts";
  * buffered until the next outbound wire message (e.g. checkpointing a
  * `step.run`).
  *
+ * Entries are promises: `defer()` reserves membership synchronously, while
+ * async preparation (schema validation + `transformDeferInput`) settles later.
+ * `drain()` awaits the prepared ops.
+ *
  * The engine owns shipping. This helper owns the buffer.
  */
 export class LazyOps {
-  private buffer: OutgoingOp[] = [];
+  private buffer: Promise<OutgoingOp | null>[] = [];
 
   // Tracks every id pushed during this execution, including those already
   // drained. `buffer` alone can't answer "have we seen this id?" once a
@@ -18,7 +22,7 @@ export class LazyOps {
   private pushedIds: Set<string> = new Set();
 
   /**
-   * Number of ops waiting to ship.
+   * Number of ops waiting to ship, including those still preparing.
    */
   get length(): number {
     return this.buffer.length;
@@ -33,35 +37,41 @@ export class LazyOps {
   }
 
   /**
-   * Take ownership of buffered ops and clear the buffer. Callers ship them on
-   * whichever wire message comes next.
+   * Take ownership of buffered ops and clear the buffer, waiting for pending
+   * entries to settle. Entries that resolve `null` are dropped.
+   *
+   * A `DeferAdd` whose matching `DeferAbort` is in the same batch is dropped:
+   * we don't want to report the same defer with `DeferAdd` and `DeferAbort`
+   * in the same request. Entries settle async, so this dedup happens here
+   * rather than at push time.
    */
-  drain(): OutgoingOp[] {
+  async drain(): Promise<OutgoingOp[]> {
     if (this.buffer.length === 0) {
       return [];
     }
-    const ops = this.buffer;
+    const pending = this.buffer;
     this.buffer = [];
-    return ops;
+    const ops = (await Promise.all(pending)).filter(
+      (op): op is OutgoingOp => op !== null,
+    );
+    const abortedIds = new Set(
+      ops
+        .filter((op) => op.op === StepOpCode.DeferAbort)
+        .map((op) => op.opts?.target_hashed_id),
+    );
+    return ops.filter(
+      (op) => !(op.op === StepOpCode.DeferAdd && abortedIds.has(op.id)),
+    );
   }
 
   /**
-   * Buffer an op for later shipment.
+   * Buffer an op for later shipment. Reserve the id synchronously so duplicate
+   * detection does not depend on `ready` having settled. `ready` must never
+   * reject; resolve `null` to skip.
    */
-  push(op: OutgoingOp): void {
-    if (op.op === StepOpCode.DeferAbort) {
-      // If there's a matching DeferAdd op, remove it. We don't want to report
-      // the same defer with DeferAdd and DeferAbort in the same request.
-      this.buffer = this.buffer.filter((buffered) => {
-        return !(
-          buffered.op === StepOpCode.DeferAdd &&
-          buffered.id === op.opts?.target_hashed_id
-        );
-      });
-    }
-
-    this.buffer.push(op);
-    this.pushedIds.add(op.id);
+  push(id: string, ready: OutgoingOp | Promise<OutgoingOp | null>): void {
+    this.buffer.push(Promise.resolve(ready));
+    this.pushedIds.add(id);
   }
 
   /**

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -1,6 +1,7 @@
 import { timeStr } from "../../helpers/strings.ts";
 import type { Logger } from "../../middleware/logger.ts";
 import type { Context, StepOpCode } from "../../types.ts";
+import type { DeferredFunction } from "../DeferredFunction.ts";
 import type { MemoizedOp } from "../execution/InngestExecution.ts";
 import type { InngestFunction } from "../InngestFunction.ts";
 import type { Middleware } from "./middleware.ts";
@@ -30,6 +31,11 @@ export interface ApplyToStepInput {
   memoized: boolean;
 }
 
+export interface ApplyToDeferInput {
+  deferFn: DeferredFunction.Any;
+  data: Record<string, unknown>;
+}
+
 export interface PreparedStep {
   entryPoint: () => Promise<unknown>;
 
@@ -50,6 +56,10 @@ export interface PreparedStep {
   stepInfo: Middleware.StepInfo;
 }
 
+export interface PreparedDefer {
+  data: Record<string, unknown>;
+}
+
 /**
  * Manages middleware. Hides middleware complexity from elsewhere in the
  * codebase. Not for for public use.
@@ -63,6 +73,12 @@ export class MiddlewareManager {
    * optimization.
    */
   private readonly hasTransformStepInput: boolean;
+
+  /**
+   * Whether any middleware defines `transformDeferInput`. Used for perf
+   * optimization.
+   */
+  private readonly hasTransformDeferInput: boolean;
 
   /**
    * Whether memoization has ended. Used for idempotency, since memoization must
@@ -95,6 +111,9 @@ export class MiddlewareManager {
 
     this.hasTransformStepInput = middleware.some((mw) =>
       Boolean(mw?.transformStepInput),
+    );
+    this.hasTransformDeferInput = middleware.some((mw) =>
+      Boolean(mw?.transformDeferInput),
     );
   }
 
@@ -177,6 +196,28 @@ export class MiddlewareManager {
       setActualHandler,
       stepInfo,
     };
+  }
+
+  /**
+   * Runs `transformDeferInput` middleware. Returns `null` when middleware
+   * drops the defer (empty `defers` array); the caller should skip emitting
+   * the op.
+   */
+  async applyToDefer(input: ApplyToDeferInput): Promise<PreparedDefer | null> {
+    if (!this.hasTransformDeferInput) {
+      return { data: input.data };
+    }
+
+    const transformed = await this.transformDeferInput(
+      input.deferFn,
+      input.data,
+    );
+    // TODO: when we add batching, return all defers instead of the first.
+    const firstDefer = transformed.defers[0];
+    if (!firstDefer) {
+      return null;
+    }
+    return { data: firstDefer.data };
   }
 
   private buildStepInfo(opts: StepInfoOptions): Middleware.StepInfo {
@@ -280,6 +321,28 @@ export class MiddlewareManager {
     for (const mw of this.middleware) {
       if (mw?.transformStepInput) {
         result = await mw.transformStepInput(result);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Apply transformDeferInput middleware in forward order.
+   * Each middleware builds on the previous result.
+   */
+  private async transformDeferInput(
+    deferFn: DeferredFunction.Any,
+    data: Record<string, unknown>,
+  ): Promise<Middleware.TransformDeferInputArgs> {
+    let result: Middleware.TransformDeferInputArgs = {
+      fn: this.fn,
+      defers: [{ deferFn, data }],
+    };
+
+    for (const mw of this.middleware) {
+      if (mw?.transformDeferInput) {
+        result = await mw.transformDeferInput(result);
       }
     }
 

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -199,11 +199,9 @@ export class MiddlewareManager {
   }
 
   /**
-   * Runs `transformDeferInput` middleware. Returns `null` when middleware
-   * drops the defer (empty `defers` array); the caller should skip emitting
-   * the op.
+   * Runs `transformDeferInput` middleware.
    */
-  async applyToDefer(input: ApplyToDeferInput): Promise<PreparedDefer | null> {
+  async applyToDefer(input: ApplyToDeferInput): Promise<PreparedDefer> {
     if (!this.hasTransformDeferInput) {
       return { data: input.data };
     }
@@ -212,12 +210,7 @@ export class MiddlewareManager {
       input.deferFn,
       input.data,
     );
-    // TODO: when we add batching, return all defers instead of the first.
-    const firstDefer = transformed.defers[0];
-    if (!firstDefer) {
-      return null;
-    }
-    return { data: firstDefer.data };
+    return { data: transformed.data };
   }
 
   private buildStepInfo(opts: StepInfoOptions): Middleware.StepInfo {
@@ -337,7 +330,8 @@ export class MiddlewareManager {
   ): Promise<Middleware.TransformDeferInputArgs> {
     let result: Middleware.TransformDeferInputArgs = {
       fn: this.fn,
-      defers: [{ deferFn, data }],
+      deferFn,
+      data,
     };
 
     for (const mw of this.middleware) {

--- a/packages/inngest/src/components/middleware/middleware.ts
+++ b/packages/inngest/src/components/middleware/middleware.ts
@@ -7,6 +7,7 @@ import type {
   SendEventBaseOutput,
   StepOptions,
 } from "../../types.ts";
+import type { DeferredFunction } from "../DeferredFunction.ts";
 import type { Inngest } from "../Inngest.ts";
 import type { InngestFunction } from "../InngestFunction.ts";
 import type { createStepTools } from "../InngestStepTools.ts";
@@ -52,6 +53,17 @@ export namespace Middleware {
   export type TransformSendEventArgs = {
     events: EventPayload<Record<string, unknown>>[];
     readonly fn: DeepReadonly<InngestFunction.Any> | null;
+  };
+
+  /**
+   * The argument passed to `transformDeferInput`.
+   */
+  export type TransformDeferInputArgs = {
+    readonly fn: DeepReadonly<InngestFunction.Any>;
+    defers: Array<{
+      readonly deferFn: DeepReadonly<DeferredFunction.Any>;
+      data: Record<string, unknown>;
+    }>;
   };
 
   /**
@@ -448,6 +460,19 @@ export namespace Middleware {
     transformSendEvent?(
       arg: Middleware.TransformSendEventArgs,
     ): MaybePromise<Middleware.TransformSendEventArgs>;
+
+    /**
+     * Called when sending deferred functions.
+     * Return the (potentially modified) arg object.
+     *
+     * Use cases:
+     * - Serialize or encrypt defer data before sending it to the Inngest Server.
+     *
+     * Do not mutate arguments.
+     */
+    transformDeferInput?(
+      arg: Middleware.TransformDeferInputArgs,
+    ): MaybePromise<Middleware.TransformDeferInputArgs>;
 
     /**
      * Called 1 time per step per request (likely multiple times per step).

--- a/packages/inngest/src/components/middleware/middleware.ts
+++ b/packages/inngest/src/components/middleware/middleware.ts
@@ -60,10 +60,8 @@ export namespace Middleware {
    */
   export type TransformDeferInputArgs = {
     readonly fn: DeepReadonly<InngestFunction.Any>;
-    defers: Array<{
-      readonly deferFn: DeepReadonly<DeferredFunction.Any>;
-      data: Record<string, unknown>;
-    }>;
+    readonly deferFn: DeepReadonly<DeferredFunction.Any>;
+    data: Record<string, unknown>;
   };
 
   /**

--- a/packages/inngest/src/test/integration/defer/middleware.test.ts
+++ b/packages/inngest/src/test/integration/defer/middleware.test.ts
@@ -5,6 +5,7 @@ import {
   testNameFromFileUrl,
 } from "@inngest/test-harness";
 import { expect, expectTypeOf, test } from "vitest";
+import { z } from "zod";
 import { createDefer } from "../../../experimental.ts";
 import {
   dependencyInjectionMiddleware,
@@ -114,4 +115,107 @@ test("no step hooks", async () => {
     wrapStep: 0,
     wrapStepHandler: 0,
   });
+});
+
+test("transformDeferInput can modify data", async () => {
+  const deferState = createState({ value: 0 });
+
+  class MW extends Middleware.BaseMiddleware {
+    readonly id = "mw";
+    override transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Middleware.TransformDeferInputArgs {
+      return {
+        ...arg,
+        defers: arg.defers.map((d) => ({ ...d, data: { value: 42 } })),
+      };
+    }
+  }
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [MW],
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(
+    client,
+    { id: "foo", schema: z.object({ value: z.number() }) },
+    async ({ event, runId }) => {
+      deferState.runId = runId;
+      deferState.value = event.data.value;
+    },
+  );
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: { event: eventName } },
+    async ({ defer }) => {
+      defer("foo", { function: foo, data: { value: 1 } });
+    },
+  );
+  await createTestApp({ client, functions: [fn, foo], serve: createServer });
+
+  await client.send({ name: eventName });
+  await deferState.waitForRunComplete();
+  expect(deferState.value).toBe(42);
+});
+
+test("transformDeferInput composes in forward order", async () => {
+  const deferState = createState({ value: 0 });
+
+  class MW1 extends Middleware.BaseMiddleware {
+    readonly id = "mw1";
+    override transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Middleware.TransformDeferInputArgs {
+      return {
+        ...arg,
+        defers: arg.defers.map((d) => ({
+          ...d,
+          data: { value: (d.data.value as number) * 10 },
+        })),
+      };
+    }
+  }
+
+  class MW2 extends Middleware.BaseMiddleware {
+    readonly id = "mw2";
+    override transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Middleware.TransformDeferInputArgs {
+      return {
+        ...arg,
+        defers: arg.defers.map((d) => ({
+          ...d,
+          data: { value: (d.data.value as number) + 5 },
+        })),
+      };
+    }
+  }
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [MW1, MW2],
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(
+    client,
+    { id: "foo", schema: z.object({ value: z.number() }) },
+    async ({ event, runId }) => {
+      deferState.runId = runId;
+      deferState.value = event.data.value;
+    },
+  );
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: { event: eventName } },
+    async ({ defer }) => {
+      defer("foo", { function: foo, data: { value: 1 } });
+    },
+  );
+  await createTestApp({ client, functions: [fn, foo], serve: createServer });
+
+  await client.send({ name: eventName });
+  await deferState.waitForRunComplete();
+  // Forward order: MW1 runs first (1 * 10 = 10), then MW2 (10 + 5 = 15)
+  expect(deferState.value).toBe(15);
 });

--- a/packages/inngest/src/test/integration/defer/middleware.test.ts
+++ b/packages/inngest/src/test/integration/defer/middleware.test.ts
@@ -3,6 +3,7 @@ import {
   createTestApp,
   randomSuffix,
   testNameFromFileUrl,
+  waitFor,
 } from "@inngest/test-harness";
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod";
@@ -125,10 +126,7 @@ test("transformDeferInput can modify data", async () => {
     override transformDeferInput(
       arg: Middleware.TransformDeferInputArgs,
     ): Middleware.TransformDeferInputArgs {
-      return {
-        ...arg,
-        defers: arg.defers.map((d) => ({ ...d, data: { value: 42 } })),
-      };
+      return { ...arg, data: { value: 42 } };
     }
   }
 
@@ -167,13 +165,7 @@ test("transformDeferInput composes in forward order", async () => {
     override transformDeferInput(
       arg: Middleware.TransformDeferInputArgs,
     ): Middleware.TransformDeferInputArgs {
-      return {
-        ...arg,
-        defers: arg.defers.map((d) => ({
-          ...d,
-          data: { value: (d.data.value as number) * 10 },
-        })),
-      };
+      return { ...arg, data: { value: (arg.data.value as number) * 10 } };
     }
   }
 
@@ -182,13 +174,7 @@ test("transformDeferInput composes in forward order", async () => {
     override transformDeferInput(
       arg: Middleware.TransformDeferInputArgs,
     ): Middleware.TransformDeferInputArgs {
-      return {
-        ...arg,
-        defers: arg.defers.map((d) => ({
-          ...d,
-          data: { value: (d.data.value as number) + 5 },
-        })),
-      };
+      return { ...arg, data: { value: (arg.data.value as number) + 5 } };
     }
   }
 
@@ -218,4 +204,50 @@ test("transformDeferInput composes in forward order", async () => {
   await deferState.waitForRunComplete();
   // Forward order: MW1 runs first (1 * 10 = 10), then MW2 (10 + 5 = 15)
   expect(deferState.value).toBe(15);
+});
+
+test("async transformDeferInput is applied before the defer op ships", async () => {
+  const parentState = createState({ transformComplete: false });
+  const deferState = createState({ value: 0 });
+
+  class MW extends Middleware.BaseMiddleware {
+    readonly id = "mw";
+    override async transformDeferInput(
+      arg: Middleware.TransformDeferInputArgs,
+    ): Promise<Middleware.TransformDeferInputArgs> {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      parentState.transformComplete = true;
+      return { ...arg, data: { value: 42 } };
+    }
+  }
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [MW],
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(
+    client,
+    { id: "foo", schema: z.object({ value: z.number() }) },
+    async ({ event, runId }) => {
+      deferState.runId = runId;
+      deferState.value = event.data.value;
+    },
+  );
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: { event: eventName } },
+    async ({ defer, runId }) => {
+      parentState.runId = runId;
+      defer("foo", { function: foo, data: { value: 1 } });
+    },
+  );
+  await createTestApp({ client, functions: [fn, foo], serve: createServer });
+
+  await client.send({ name: eventName });
+  await parentState.waitForRunComplete();
+  await waitFor(() => expect(parentState.transformComplete).toBe(true), 3_000);
+  await waitFor(() => expect(deferState.runId).not.toBeNull(), 3_000);
+  await deferState.waitForRunComplete();
+  expect(deferState.value).toBe(42);
 });

--- a/packages/inngest/src/test/integration/defer/misc.test.ts
+++ b/packages/inngest/src/test/integration/defer/misc.test.ts
@@ -17,7 +17,6 @@ const testFileName = testNameFromFileUrl(import.meta.url);
 test("re-encountered defer does not trigger new deferred run", async () => {
   // When a deferred function is re-encountered (e.g. function re-entry), it
   // should not trigger a new deferred run
-
   const parentState = createState({});
   const deferState = createState({ counter: 0 });
 

--- a/packages/inngest/src/test/integration/defer/misc.test.ts
+++ b/packages/inngest/src/test/integration/defer/misc.test.ts
@@ -481,3 +481,48 @@ test("propagates experiment ref to the deferred run", async () => {
     variant: "control",
   });
 });
+
+test("propagates experiment ref alongside a stripping schema", async () => {
+  // A schema that strips unknown keys must not drop the reserved experiment
+  // ref: it rides outside the validated payload, so both the schema data and
+  // the experiment attribution reach the deferred run.
+  const childState = createState({
+    eventData: null as Record<string, unknown> | null,
+    parents: null as unknown as {
+      fnSlug: string;
+      runId: string;
+      experiment?: { experimentName: string; variant: string };
+    }[],
+  });
+  const client = new Inngest({ id: randomSuffix(testFileName), isDev: true });
+  const eventName = randomSuffix("evt");
+
+  const child = createDefer(
+    client,
+    { id: "child", schema: z.object({ msg: z.string() }) },
+    async ({ event, parents, runId }) => {
+      childState.runId = runId;
+      childState.eventData = event.data;
+      childState.parents = parents;
+    },
+  );
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: { event: eventName } },
+    async ({ defer }) => {
+      defer("c", {
+        function: child,
+        data: { msg: "hello" },
+        experiment: { experimentName: "checkout-flow", variant: "control" },
+      });
+    },
+  );
+  await createTestApp({ client, functions: [fn, child], serve: createServer });
+  await client.send({ name: eventName, data: {} });
+  await childState.waitForRunComplete();
+
+  expect(childState.eventData).toEqual({ msg: "hello" });
+  expect(childState.parents[0]!.experiment).toEqual({
+    experimentName: "checkout-flow",
+    variant: "control",
+  });
+});

--- a/packages/inngest/src/test/integration/defer/schema.test.ts
+++ b/packages/inngest/src/test/integration/defer/schema.test.ts
@@ -74,6 +74,59 @@ test("schema validation succeeds", async () => {
   expect(deferState.eventData).toEqual({ msg: "hello" });
 });
 
+test("async schema validator succeeds in parent function", async () => {
+  const parentState = createState({});
+  const deferState = createState({
+    eventData: null as Record<string, unknown> | null,
+  });
+
+  const asyncSchema: StandardSchemaV1<Record<string, unknown>> = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: async (value) => {
+        await sleep(10);
+        return { value: value as Record<string, unknown> };
+      },
+    },
+  };
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(
+    client,
+    { id: "foo", schema: asyncSchema },
+    async ({ event, runId }) => {
+      deferState.runId = runId;
+      deferState.eventData = event.data;
+    },
+  );
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+    },
+    async ({ defer, runId }) => {
+      parentState.runId = runId;
+      defer("foo", { function: foo, data: { msg: "hello" } });
+    },
+  );
+  await createTestApp({
+    client,
+    functions: [fn, foo],
+    serve: createServer,
+  });
+
+  await client.send({ name: eventName, data: {} });
+  await parentState.waitForRunComplete();
+  await deferState.waitForRunComplete();
+  expect(deferState.eventData).toEqual({ msg: "hello" });
+});
+
 test("re-encountered defer does not trigger new deferred run", async () => {
   // When a deferred function is re-encountered (e.g. function re-entry), it
   // should not trigger a new deferred run


### PR DESCRIPTION
## Summary

Add `transformDeferInput` and support for async defer validations


## Checklist

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
Old, PR: https://github.com/inngest/inngest-js/pull/1559
Revert: https://github.com/inngest/inngest-js/pull/1563
Follow Up: https://github.com/inngest/inngest-js/pull/1560
