### PR TITLE
feat: add throttle scope config support

### DIFF
--- a/.changeset/sharp-timers-share.md
+++ b/.changeset/sharp-timers-share.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add throttle scope support to function configuration.

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -34,6 +34,7 @@ import { createClient, runFnWithStack } from "../test/helpers.ts";
 import {
   type ClientOptions,
   type FailureEventPayload,
+  functionConfigSchema,
   type OutgoingOp,
   StepMode,
   StepOpCode,
@@ -155,6 +156,80 @@ describe("optimizeParallelism deprecation warning", () => {
       vi.fn(),
     );
     expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("function config", () => {
+  test("serializes throttle scope when specified", () => {
+    const clientId = "testclient";
+    const inngest = createClient({ id: clientId });
+
+    const fn = inngest.createFunction(
+      {
+        id: "send-email",
+        throttle: {
+          scope: "account",
+          key: '"resend-api"',
+          limit: 2,
+          period: "1s",
+          burst: 2,
+        },
+        triggers: [{ event: "email/send.requested" }],
+      },
+      () => undefined,
+    );
+
+    const [fnConfig] = fn["getConfig"]({
+      baseUrl: new URL("https://example.com"),
+      appPrefix: clientId,
+    });
+
+    if (!fnConfig) {
+      throw new Error("Expected function config");
+    }
+
+    expect(fnConfig.throttle).toEqual({
+      scope: "account",
+      key: '"resend-api"',
+      limit: 2,
+      period: "1s",
+      burst: 2,
+    });
+    expect(functionConfigSchema.safeParse(fnConfig).success).toBe(true);
+  });
+
+  test("does not add throttle scope when omitted", () => {
+    const clientId = "testclient";
+    const inngest = createClient({ id: clientId });
+
+    const fn = inngest.createFunction(
+      {
+        id: "send-email",
+        throttle: {
+          key: '"resend-api"',
+          limit: 2,
+          period: "1s",
+        },
+        triggers: [{ event: "email/send.requested" }],
+      },
+      () => undefined,
+    );
+
+    const [fnConfig] = fn["getConfig"]({
+      baseUrl: new URL("https://example.com"),
+      appPrefix: clientId,
+    });
+
+    if (!fnConfig) {
+      throw new Error("Expected function config");
+    }
+
+    expect(fnConfig.throttle).toEqual({
+      key: '"resend-api"',
+      limit: 2,
+      period: "1s",
+    });
+    expect(fnConfig.throttle).not.toHaveProperty("scope");
   });
 });
 

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -530,6 +530,16 @@ export namespace InngestFunction {
       key?: string;
 
       /**
+       * An optional scope for the throttle limit. By default, throttle limits
+       * are scoped to this function.
+       *
+       * Use "env" or "account" to share throttle capacity across functions in
+       * an environment or account, for example when multiple functions call the
+       * same external service with a shared quota.
+       */
+      scope?: "fn" | "env" | "account";
+
+      /**
        * The total number of runs allowed to start within the given `period`.  The limit is
        * applied evenly over the period.
        */

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1376,10 +1376,12 @@ export interface RegisterOptions {
  * when validating config. We cannot add comments to Zod fields, so we just use
  * an extra type check to ensure it matches our exported expectations.
  */
+const executionScopeSchema = z.enum(["fn", "env", "account"]);
+
 const concurrencyOptionSchema = z.strictObject({
   limit: z.number(),
   key: z.string().optional(),
-  scope: z.enum(["fn", "env", "account"]).optional(),
+  scope: executionScopeSchema.optional(),
 });
 
 const _checkConcurrencySchemaAligns: IsEqual<
@@ -1687,6 +1689,7 @@ export const functionConfigSchema = z.strictObject({
   throttle: z
     .strictObject({
       key: z.string().optional(),
+      scope: executionScopeSchema.optional(),
       limit: z.number(),
       period: z.string().transform((x) => x as TimeStr),
       burst: z.number().optional(),


### PR DESCRIPTION
## Summary
Adds TypeScript SDK support for `throttle.scope` so functions can opt into function, environment, or account-level throttle buckets. The config validator now accepts the field, and `getConfig()` preserves an explicit scope while leaving omitted scope unchanged.

## Checklist
- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A SDK support only; docs can follow the public feature rollout.
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Verification
- `pnpm install`
- `pnpm --filter @inngest/test build`
- `pnpm --filter inngest pb:version`
- `pnpm --filter inngest test src/components/InngestFunction.test.ts`
- `pnpm --filter inngest test`
- `pnpm --filter inngest test:types`
- `pnpm --filter inngest lint`
- `pnpm --filter inngest build`

## Related
- SDK companion to server/runtime support: inngest/inngest#4407
- Related feature request: inngest/inngest#3701
