### PR TITLE
Parse langfuse attributes for AI Metadata (EXE-1938)

### DIFF
--- a/.changeset/parse-langfuse.md
+++ b/.changeset/parse-langfuse.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add metadata to steps containing LLM calls instrumented with OTel by Langfuse

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -144,6 +144,32 @@ describe("extractAIMetadataFromAttributes", () => {
     });
     expect(extracted).toEqual({ model: "semconv-model", inputTokens: 22 });
   });
+
+  test("langfuse input tokens win over a co-present gen_ai count", () => {
+    const attributes = {
+      "gen_ai.response.model": "gpt-4.1-nano-another",
+      "gen_ai.usage.input_tokens": 100,
+      "langfuse.observation.model.name": "gpt-4.1-nano-2025-04-14",
+      "langfuse.observation.usage_details":
+        '{"input":22,"output":6,"total":28,"input_cached_tokens":5}',
+    };
+    // Order-independent: langfuse outranks semconv regardless of key order.
+    const expected = { inputTokens: 22 };
+    expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
+    expect(
+      extractAIMetadataFromAttributes(
+        Object.fromEntries(Object.entries(attributes).reverse()),
+      ),
+    ).toEqual(expected);
+  });
+
+  test("ignores a malformed langfuse usage_details blob", () => {
+    expect(
+      extractAIMetadataFromAttributes({
+        "langfuse.observation.usage_details": "not json",
+      }),
+    ).toEqual({});
+  });
 });
 
 describe("aggregate", () => {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -19,23 +19,89 @@ export interface AIMetadata {
  * numbers override higher numbers.
  */
 enum Convention {
-  Semconv = 1,
-  OpenInference = 2,
-  Vercel = 3,
+  Langfuse = 1,
+  Semconv = 2,
+  OpenInference = 3,
+  Vercel = 4,
 }
 
 type Field = keyof AIMetadata;
 
 interface Mapping {
-  field: Field;
+  /**
+   * The canonical {@link AIMetadata} field this attribute populates. Omitted
+   * for composite attributes that only carry an {@link Mapping.expand}.
+   */
+  field?: Field;
   convention: Convention;
+  /**
+   * Composite attributes (e.g. a JSON blob of token counts) provide an
+   * `expand` that explodes the raw value into synthetic scalar attributes,
+   * each re-matched against {@link keyFieldMap}.
+   */
+  expand?: (value: AttributeValue) => Record<string, AttributeValue>;
 }
+
+/**
+ * Prefix for the synthetic attributes produced by
+ * {@link expandLangfuseUsageDetails}, kept distinct from any real attribute
+ * namespace.
+ */
+const langfuseUsagePrefix = "__langfuse.usage_details.";
+
+/**
+ * Parses the `langfuse.observation.usage_details` JSON blob (e.g.
+ * `{"input":17,"output":36,"total":53}`) and emits a synthetic scalar
+ * attribute for each count we track. Only `input` is emitted; the other counts
+ * (output, total, cached, reasoning, …) are intentionally dropped since this
+ * extractor tracks input tokens alone.
+ */
+const expandLangfuseUsageDetails = (
+  value: AttributeValue,
+): Record<string, AttributeValue> => {
+  if (typeof value !== "string" || value === "") {
+    return {};
+  }
+
+  let counts: unknown;
+  try {
+    counts = JSON.parse(value);
+  } catch {
+    return {};
+  }
+
+  if (typeof counts !== "object" || counts === null) {
+    return {};
+  }
+
+  const input = (counts as Record<string, unknown>).input;
+  if (typeof input !== "number") {
+    return {};
+  }
+
+  return { [`${langfuseUsagePrefix}input`]: input };
+};
 
 /**
  * Maps a source attribute key to the canonical {@link AIMetadata} field it
  * populates and the convention it belongs to.
  */
 const keyFieldMap: Record<string, Mapping> = {
+  // Langfuse (`langfuse.*` telemetry). Langfuse reports token usage as a single
+  // JSON blob under `usage_details`; it is expanded into synthetic per-count
+  // attributes that are matched back through this map. Langfuse only emits a
+  // response model (not the requested model), which this extractor doesn't
+  // track, so no `model` mapping is registered here. Langfuse outranks the
+  // other conventions when several are present on one span.
+  "langfuse.observation.usage_details": {
+    convention: Convention.Langfuse,
+    expand: expandLangfuseUsageDetails,
+  },
+  [`${langfuseUsagePrefix}input`]: {
+    field: "inputTokens",
+    convention: Convention.Langfuse,
+  },
+
   // OpenTelemetry Semantic Conventions
   "gen_ai.request.model": { field: "model", convention: Convention.Semconv },
   "gen_ai.usage.input_tokens": {
@@ -83,6 +149,16 @@ export const extractAIMetadataFromAttributes = (
   // Track the highest-precedence (lowest convention) candidate seen per field.
   const candidates: Partial<Record<Field, Candidate>> = {};
 
+  const record = (mapping: Mapping, value: AttributeValue) => {
+    if (!mapping.field) {
+      return;
+    }
+    const existing = candidates[mapping.field];
+    if (!existing || mapping.convention < existing.convention) {
+      candidates[mapping.field] = { value, convention: mapping.convention };
+    }
+  };
+
   for (const [key, value] of Object.entries(attributes)) {
     if (value === undefined) {
       continue;
@@ -93,10 +169,21 @@ export const extractAIMetadataFromAttributes = (
       continue;
     }
 
-    const existing = candidates[mapping.field];
-    if (!existing || mapping.convention < existing.convention) {
-      candidates[mapping.field] = { value, convention: mapping.convention };
+    // Composite attribute: explode into synthetic children and match each back
+    // through the map.
+    if (mapping.expand) {
+      for (const [childKey, childValue] of Object.entries(
+        mapping.expand(value),
+      )) {
+        const childMapping = keyFieldMap[childKey];
+        if (childMapping) {
+          record(childMapping, childValue);
+        }
+      }
+      continue;
     }
+
+    record(mapping, value);
   }
 
   const metadata: AIMetadata = {};

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json
@@ -1,0 +1,234 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "112f0ac11a707ae86e5beeca4e69c274",
+              "spanId": "0eff81027f19c6cc",
+              "name": "OpenAI.responses",
+              "kind": 1,
+              "startTimeUnixNano": "1780441264063000000",
+              "endTimeUnixNano": "1780441264969987000",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-basic_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-basic_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "Write a one-sentence bedtime story about a unicorn."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano-2026-03-17"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"parallel_tool_calls\":true,\"store\":true,\"temperature\":1,\"tool_choice\":\"auto\",\"top_p\":0.98,\"truncation\":\"disabled\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "Once upon a moonlit night, a gentle unicorn tucked in the stars with its shimmering horn, humming lullabies until the whole sky drifted off to sleep."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":17,\"output\":36,\"total\":53,\"input_cached_tokens\":0,\"output_reasoning_tokens\":0}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.reasoning",
+                  "value": {
+                    "stringValue": "{\"context\":\"current_turn\",\"effort\":\"none\",\"summary\":null}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.tools",
+                  "value": {
+                    "stringValue": "[]"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.metadata",
+                  "value": {
+                    "stringValue": "{}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.status",
+                  "value": {
+                    "stringValue": "completed"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json.snap
@@ -1,0 +1,8 @@
+[
+  {
+    "span": "OpenAI.responses",
+    "metadata": {
+      "inputTokens": 17
+    }
+  }
+]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/embeddings.otlp.json
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/embeddings.otlp.json
@@ -1,0 +1,204 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "f4d5f632e8f3495b35a51c53d4f43013",
+              "spanId": "5c584938b1fcf355",
+              "name": "OpenAI.embeddings",
+              "kind": 1,
+              "startTimeUnixNano": "1780441267558000000",
+              "endTimeUnixNano": "1780441267694131209",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-embeddings"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-embeddings"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "The quick brown fox jumps over the lazy dog."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "text-embedding-3-small"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": ""
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/embeddings.otlp.json.snap
@@ -1,0 +1,6 @@
+[
+  {
+    "span": "OpenAI.embeddings",
+    "metadata": {}
+  }
+]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json
@@ -1,0 +1,210 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "d0508b44b19758f0c1b11f40a51495aa",
+              "spanId": "6bf40ce119b0664e",
+              "name": "OpenAI.chat",
+              "kind": 1,
+              "startTimeUnixNano": "1780441264971000000",
+              "endTimeUnixNano": "1780441265261486167",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-params_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-params_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "{\"messages\":[{\"role\":\"system\",\"content\":\"You are a terse assistant.\"},{\"role\":\"user\",\"content\":\"Name three primary colors.\"}]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano-2025-04-14"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"frequency_penalty\":0.2,\"max_tokens\":64,\"presence_penalty\":0.1,\"seed\":42,\"stop\":[\"\\n\\n\"],\"temperature\":0.7,\"top_p\":0.9,\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "{\"role\":\"assistant\",\"content\":\"Red, blue, yellow.\",\"refusal\":null,\"annotations\":[]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":22,\"output\":6,\"total\":28,\"input_cached_tokens\":0,\"input_audio_tokens\":0,\"output_reasoning_tokens\":0,\"output_audio_tokens\":0,\"output_accepted_prediction_tokens\":0,\"output_rejected_prediction_tokens\":0}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json.snap
@@ -1,0 +1,8 @@
+[
+  {
+    "span": "OpenAI.chat",
+    "metadata": {
+      "inputTokens": 22
+    }
+  }
+]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json
@@ -1,0 +1,234 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "a82f012672983aa393d7309287721ecc",
+              "spanId": "b02f67378b40e2bd",
+              "name": "OpenAI.responses",
+              "kind": 1,
+              "startTimeUnixNano": "1780441266710000000",
+              "endTimeUnixNano": "1780441267555921458",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-reasoning_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-reasoning_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "What is 17 * 24? Think briefly."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano-2026-03-17"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"parallel_tool_calls\":true,\"store\":true,\"temperature\":1,\"tool_choice\":\"auto\",\"top_p\":0.98,\"truncation\":\"disabled\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "17 × 24 = **408**."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":17,\"output\":13,\"total\":30,\"input_cached_tokens\":0,\"output_reasoning_tokens\":0}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.reasoning",
+                  "value": {
+                    "stringValue": "{\"context\":\"current_turn\",\"effort\":\"low\",\"summary\":null}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.tools",
+                  "value": {
+                    "stringValue": "[]"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.metadata",
+                  "value": {
+                    "stringValue": "{}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.status",
+                  "value": {
+                    "stringValue": "completed"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json.snap
@@ -1,0 +1,8 @@
+[
+  {
+    "span": "OpenAI.responses",
+    "metadata": {
+      "inputTokens": 17
+    }
+  }
+]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json
@@ -1,0 +1,216 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "86a472475f9372999ad6aa874e12df16",
+              "spanId": "30aed59495f699d5",
+              "name": "OpenAI.chat",
+              "kind": 1,
+              "startTimeUnixNano": "1780441266156000000",
+              "endTimeUnixNano": "1780441266709381625",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-stream_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-stream_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "{\"messages\":[{\"role\":\"user\",\"content\":\"Count to five.\"}]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"stream\":true,\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "One, two, three, four, five."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":11,\"output\":10,\"total\":21,\"input_cached_tokens\":0,\"input_audio_tokens\":0,\"output_reasoning_tokens\":0,\"output_audio_tokens\":0,\"output_accepted_prediction_tokens\":0,\"output_rejected_prediction_tokens\":0}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.completion_start_time",
+                  "value": {
+                    "stringValue": "\"2026-06-02T23:01:06.474Z\""
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json.snap
@@ -1,0 +1,8 @@
+[
+  {
+    "span": "OpenAI.chat",
+    "metadata": {
+      "inputTokens": 11
+    }
+  }
+]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json
@@ -1,0 +1,210 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "02bd7e7b957101fa67a5abe0b53c568f",
+              "spanId": "55c7c54a6af87ed5",
+              "name": "OpenAI.chat",
+              "kind": 1,
+              "startTimeUnixNano": "1780441265262000000",
+              "endTimeUnixNano": "1780441266153239417",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-tools_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-tools_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "{\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris? Use the tool.\"}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get the current weather for a city\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],\"tool_choice\":\"auto\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano-2025-04-14"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"call_xHygFhB4GwfnVFJ0Xf2E9gxP\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"Paris\\\"}\"}}],\"refusal\":null,\"annotations\":[]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":56,\"output\":30,\"total\":86,\"input_cached_tokens\":0,\"input_audio_tokens\":0,\"output_reasoning_tokens\":0,\"output_audio_tokens\":0,\"output_accepted_prediction_tokens\":0,\"output_rejected_prediction_tokens\":0}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json.snap
@@ -1,0 +1,8 @@
+[
+  {
+    "span": "OpenAI.chat",
+    "metadata": {
+      "inputTokens": 56
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- In https://github.com/inngest/inngest-js/pull/1562, we introduced parsing AI Metadata from common OTel instrumenters
- In this PR, we add support for Langfuse, who has a more complex way of emitting usage data. OSS already supports Langfuse.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

