### PR TITLE
Bring JS AI Metadata fields to closer to parity with OSS (EXE-1938)

### DIFF
--- a/.changeset/metadata-fields.md
+++ b/.changeset/metadata-fields.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Begin processing total tokens, response id, system, response model, and output tokens from OTel spans for AI Metadata

--- a/packages/inngest/CLAUDE.md
+++ b/packages/inngest/CLAUDE.md
@@ -81,6 +81,20 @@ pnpm proto              # Generate TypeScript from .proto files
 3. `pnpm test:types` must pass (TypeScript compilation)
 4. `pnpm build` must succeed
 
+### TypeScript Conventions
+
+- **Prefer existing type guards over inline checks + `as` casts.** Before writing
+  `typeof x === "object" && x !== null` followed by `x as SomeType`, look for a
+  shared guard (e.g. `isRecord` in `src/helpers/types.ts`) that narrows the type
+  without an unchecked cast. Avoid `as` casts generally — they assert shapes the
+  compiler can't verify.
+- **Prefer truthiness for "present and non-empty" — but not at the cost of
+  narrowing.** `if (value)` excludes both `undefined` and `""`, so an explicit
+  `!== ""` is usually redundant. However, when `value` is a wider union (e.g.
+  `AttributeValue`), keep the `typeof value === "string"` guard: it's what
+  narrows the union to `string` for the assignment. Write
+  `if (typeof value === "string" && value)`, not `if (value)`.
+
 ## Architecture Deep Dive
 
 ### Core Architectural Principles

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -139,6 +139,8 @@ describe("extractAIMetadataFromAttributes", () => {
     const extracted = extractAIMetadataFromAttributes({
       "ai.model.id": "vercel-model",
       "gen_ai.request.model": "semconv-model",
+      "ai.response.model": "vercel-response-model",
+      "gen_ai.response.model": "semconv-response-model",
       "ai.usage.inputTokens": 10,
       "gen_ai.usage.input_tokens": 22,
       "ai.usage.outputTokens": 5,
@@ -146,12 +148,13 @@ describe("extractAIMetadataFromAttributes", () => {
     });
     expect(extracted).toEqual({
       model: "semconv-model",
+      responseModel: "semconv-response-model",
       inputTokens: 22,
       outputTokens: 6,
     });
   });
 
-  test("langfuse input tokens win over a co-present gen_ai count", () => {
+  test("langfuse input tokens and response model win over co-present gen_ai", () => {
     const attributes = {
       "gen_ai.response.model": "gpt-4.1-nano-another",
       "gen_ai.usage.input_tokens": 100,
@@ -160,7 +163,11 @@ describe("extractAIMetadataFromAttributes", () => {
         '{"input":22,"output":6,"total":28,"input_cached_tokens":5}',
     };
     // Order-independent: langfuse outranks semconv regardless of key order.
-    const expected = { inputTokens: 22, outputTokens: 6 };
+    const expected = {
+      responseModel: "gpt-4.1-nano-2025-04-14",
+      inputTokens: 22,
+      outputTokens: 6,
+    };
     expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
     expect(
       extractAIMetadataFromAttributes(
@@ -179,18 +186,31 @@ describe("extractAIMetadataFromAttributes", () => {
 });
 
 describe("aggregate", () => {
-  test("sums input and output tokens and keeps the first model", () => {
+  test("sums input and output tokens and keeps the first models", () => {
     const a: AIMetadata = {
       model: "gpt-4.1-nano",
+      responseModel: "gpt-4.1-nano-2025-04-14",
       inputTokens: 10,
       outputTokens: 4,
     };
-    const b: AIMetadata = { model: "gpt-4o", inputTokens: 22, outputTokens: 8 };
+    const b: AIMetadata = {
+      model: "gpt-4o",
+      responseModel: "gpt-4o-2024-08-06",
+      inputTokens: 22,
+      outputTokens: 8,
+    };
     expect(aggregate(a, b)).toEqual({
       model: "gpt-4.1-nano",
+      responseModel: "gpt-4.1-nano-2025-04-14",
       inputTokens: 32,
       outputTokens: 12,
     });
+  });
+
+  test("falls back to the second response model when the first is absent", () => {
+    expect(
+      aggregate({ inputTokens: 5 }, { responseModel: "gpt-4o-2024-08-06" }),
+    ).toEqual({ responseModel: "gpt-4o-2024-08-06", inputTokens: 5 });
   });
 
   test("treats a missing output token count as zero", () => {
@@ -228,16 +248,25 @@ describe("toInngestAIMetadataValues", () => {
     expect(
       toInngestAIMetadataValues({
         model: "gpt-4o",
+        responseModel: "gpt-4o-2024-08-06",
         inputTokens: 42,
         outputTokens: 8,
       }),
-    ).toEqual({ model: "gpt-4o", input_tokens: 42, output_tokens: 8 });
+    ).toEqual({
+      model: "gpt-4o",
+      response_model: "gpt-4o-2024-08-06",
+      input_tokens: 42,
+      output_tokens: 8,
+    });
   });
 
   test("omits absent fields rather than zero-valuing them", () => {
     expect(toInngestAIMetadataValues({ model: "gpt-4o" })).toEqual({
       model: "gpt-4o",
     });
+    expect(
+      toInngestAIMetadataValues({ responseModel: "gpt-4o-2024-08-06" }),
+    ).toEqual({ response_model: "gpt-4o-2024-08-06" });
     expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
       input_tokens: 7,
     });

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -143,6 +143,8 @@ describe("extractAIMetadataFromAttributes", () => {
       "gen_ai.response.model": "semconv-response-model",
       "ai.model.provider": "vercel-system",
       "gen_ai.provider.name": "semconv-system",
+      "ai.response.id": "vercel-response-id",
+      "gen_ai.response.id": "semconv-response-id",
       "ai.usage.inputTokens": 10,
       "gen_ai.usage.input_tokens": 22,
       "ai.usage.outputTokens": 5,
@@ -152,6 +154,7 @@ describe("extractAIMetadataFromAttributes", () => {
       model: "semconv-model",
       responseModel: "semconv-response-model",
       system: "semconv-system",
+      responseId: "semconv-response-id",
       inputTokens: 22,
       outputTokens: 6,
     });
@@ -210,6 +213,7 @@ describe("aggregate", () => {
       model: "gpt-4.1-nano",
       responseModel: "gpt-4.1-nano-2025-04-14",
       system: "openai.chat",
+      responseId: "chatcmpl-a",
       inputTokens: 10,
       outputTokens: 4,
     };
@@ -217,6 +221,7 @@ describe("aggregate", () => {
       model: "gpt-4o",
       responseModel: "gpt-4o-2024-08-06",
       system: "openai.responses",
+      responseId: "chatcmpl-b",
       inputTokens: 22,
       outputTokens: 8,
     };
@@ -224,6 +229,7 @@ describe("aggregate", () => {
       model: "gpt-4.1-nano",
       responseModel: "gpt-4.1-nano-2025-04-14",
       system: "openai.chat",
+      responseId: "chatcmpl-a",
       inputTokens: 32,
       outputTokens: 12,
     });
@@ -272,6 +278,7 @@ describe("toInngestAIMetadataValues", () => {
         model: "gpt-4o",
         responseModel: "gpt-4o-2024-08-06",
         system: "openai.chat",
+        responseId: "chatcmpl-abc",
         inputTokens: 42,
         outputTokens: 8,
       }),
@@ -279,6 +286,7 @@ describe("toInngestAIMetadataValues", () => {
       model: "gpt-4o",
       response_model: "gpt-4o-2024-08-06",
       system: "openai.chat",
+      response_id: "chatcmpl-abc",
       input_tokens: 42,
       output_tokens: 8,
     });
@@ -293,6 +301,9 @@ describe("toInngestAIMetadataValues", () => {
     ).toEqual({ response_model: "gpt-4o-2024-08-06" });
     expect(toInngestAIMetadataValues({ system: "openai.chat" })).toEqual({
       system: "openai.chat",
+    });
+    expect(toInngestAIMetadataValues({ responseId: "chatcmpl-abc" })).toEqual({
+      response_id: "chatcmpl-abc",
     });
     expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
       input_tokens: 7,

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -141,8 +141,14 @@ describe("extractAIMetadataFromAttributes", () => {
       "gen_ai.request.model": "semconv-model",
       "ai.usage.inputTokens": 10,
       "gen_ai.usage.input_tokens": 22,
+      "ai.usage.outputTokens": 5,
+      "gen_ai.usage.output_tokens": 6,
     });
-    expect(extracted).toEqual({ model: "semconv-model", inputTokens: 22 });
+    expect(extracted).toEqual({
+      model: "semconv-model",
+      inputTokens: 22,
+      outputTokens: 6,
+    });
   });
 
   test("langfuse input tokens win over a co-present gen_ai count", () => {
@@ -154,7 +160,7 @@ describe("extractAIMetadataFromAttributes", () => {
         '{"input":22,"output":6,"total":28,"input_cached_tokens":5}',
     };
     // Order-independent: langfuse outranks semconv regardless of key order.
-    const expected = { inputTokens: 22 };
+    const expected = { inputTokens: 22, outputTokens: 6 };
     expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
     expect(
       extractAIMetadataFromAttributes(
@@ -173,10 +179,25 @@ describe("extractAIMetadataFromAttributes", () => {
 });
 
 describe("aggregate", () => {
-  test("sums input tokens and keeps the first model", () => {
-    const a: AIMetadata = { model: "gpt-4.1-nano", inputTokens: 10 };
-    const b: AIMetadata = { model: "gpt-4o", inputTokens: 22 };
-    expect(aggregate(a, b)).toEqual({ model: "gpt-4.1-nano", inputTokens: 32 });
+  test("sums input and output tokens and keeps the first model", () => {
+    const a: AIMetadata = {
+      model: "gpt-4.1-nano",
+      inputTokens: 10,
+      outputTokens: 4,
+    };
+    const b: AIMetadata = { model: "gpt-4o", inputTokens: 22, outputTokens: 8 };
+    expect(aggregate(a, b)).toEqual({
+      model: "gpt-4.1-nano",
+      inputTokens: 32,
+      outputTokens: 12,
+    });
+  });
+
+  test("treats a missing output token count as zero", () => {
+    expect(aggregate({ outputTokens: 7 }, { model: "b" })).toEqual({
+      model: "b",
+      outputTokens: 7,
+    });
   });
 
   test("falls back to the second model when the first is absent", () => {
@@ -203,10 +224,14 @@ describe("aggregate", () => {
 });
 
 describe("toInngestAIMetadataValues", () => {
-  test("maps both fields onto the server's snake_case schema", () => {
+  test("maps all fields onto the server's snake_case schema", () => {
     expect(
-      toInngestAIMetadataValues({ model: "gpt-4o", inputTokens: 42 }),
-    ).toEqual({ model: "gpt-4o", input_tokens: 42 });
+      toInngestAIMetadataValues({
+        model: "gpt-4o",
+        inputTokens: 42,
+        outputTokens: 8,
+      }),
+    ).toEqual({ model: "gpt-4o", input_tokens: 42, output_tokens: 8 });
   });
 
   test("omits absent fields rather than zero-valuing them", () => {
@@ -215,6 +240,9 @@ describe("toInngestAIMetadataValues", () => {
     });
     expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
       input_tokens: 7,
+    });
+    expect(toInngestAIMetadataValues({ outputTokens: 9 })).toEqual({
+      output_tokens: 9,
     });
   });
 

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -141,6 +141,8 @@ describe("extractAIMetadataFromAttributes", () => {
       "gen_ai.request.model": "semconv-model",
       "ai.response.model": "vercel-response-model",
       "gen_ai.response.model": "semconv-response-model",
+      "ai.model.provider": "vercel-system",
+      "gen_ai.provider.name": "semconv-system",
       "ai.usage.inputTokens": 10,
       "gen_ai.usage.input_tokens": 22,
       "ai.usage.outputTokens": 5,
@@ -149,9 +151,26 @@ describe("extractAIMetadataFromAttributes", () => {
     expect(extracted).toEqual({
       model: "semconv-model",
       responseModel: "semconv-response-model",
+      system: "semconv-system",
       inputTokens: 22,
       outputTokens: 6,
     });
+  });
+
+  test("prefers gen_ai.provider.name over the deprecated gen_ai.system", () => {
+    // Both are semconv; the keyRank tiebreak ranks the deprecated key behind
+    // its replacement regardless of attribute order.
+    const attributes = {
+      "gen_ai.system": "deprecated-system",
+      "gen_ai.provider.name": "current-system",
+    };
+    const expected = { system: "current-system" };
+    expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
+    expect(
+      extractAIMetadataFromAttributes(
+        Object.fromEntries(Object.entries(attributes).reverse()),
+      ),
+    ).toEqual(expected);
   });
 
   test("langfuse input tokens and response model win over co-present gen_ai", () => {
@@ -190,18 +209,21 @@ describe("aggregate", () => {
     const a: AIMetadata = {
       model: "gpt-4.1-nano",
       responseModel: "gpt-4.1-nano-2025-04-14",
+      system: "openai.chat",
       inputTokens: 10,
       outputTokens: 4,
     };
     const b: AIMetadata = {
       model: "gpt-4o",
       responseModel: "gpt-4o-2024-08-06",
+      system: "openai.responses",
       inputTokens: 22,
       outputTokens: 8,
     };
     expect(aggregate(a, b)).toEqual({
       model: "gpt-4.1-nano",
       responseModel: "gpt-4.1-nano-2025-04-14",
+      system: "openai.chat",
       inputTokens: 32,
       outputTokens: 12,
     });
@@ -249,12 +271,14 @@ describe("toInngestAIMetadataValues", () => {
       toInngestAIMetadataValues({
         model: "gpt-4o",
         responseModel: "gpt-4o-2024-08-06",
+        system: "openai.chat",
         inputTokens: 42,
         outputTokens: 8,
       }),
     ).toEqual({
       model: "gpt-4o",
       response_model: "gpt-4o-2024-08-06",
+      system: "openai.chat",
       input_tokens: 42,
       output_tokens: 8,
     });
@@ -267,6 +291,9 @@ describe("toInngestAIMetadataValues", () => {
     expect(
       toInngestAIMetadataValues({ responseModel: "gpt-4o-2024-08-06" }),
     ).toEqual({ response_model: "gpt-4o-2024-08-06" });
+    expect(toInngestAIMetadataValues({ system: "openai.chat" })).toEqual({
+      system: "openai.chat",
+    });
     expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
       input_tokens: 7,
     });

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -157,6 +157,8 @@ describe("extractAIMetadataFromAttributes", () => {
       responseId: "semconv-response-id",
       inputTokens: 22,
       outputTokens: 6,
+      // No total attribute present, so it's derived from input + output.
+      totalTokens: 28,
     });
   });
 
@@ -189,6 +191,7 @@ describe("extractAIMetadataFromAttributes", () => {
       responseModel: "gpt-4.1-nano-2025-04-14",
       inputTokens: 22,
       outputTokens: 6,
+      totalTokens: 28,
     };
     expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
     expect(
@@ -205,6 +208,24 @@ describe("extractAIMetadataFromAttributes", () => {
       }),
     ).toEqual({});
   });
+
+  test("prefers a provider-supplied total over deriving it from input + output", () => {
+    // The provider's total need not equal input + output (e.g. it may include
+    // reasoning tokens), so the supplied value must win over the derived one.
+    expect(
+      extractAIMetadataFromAttributes({
+        "gen_ai.usage.input_tokens": 22,
+        "gen_ai.usage.output_tokens": 6,
+        "gen_ai.usage.total_tokens": 99,
+      }),
+    ).toEqual({ inputTokens: 22, outputTokens: 6, totalTokens: 99 });
+  });
+
+  test("does not derive a total when no token counts are present", () => {
+    expect(
+      extractAIMetadataFromAttributes({ "gen_ai.request.model": "gpt-4o" }),
+    ).toEqual({ model: "gpt-4o" });
+  });
 });
 
 describe("aggregate", () => {
@@ -216,6 +237,7 @@ describe("aggregate", () => {
       responseId: "chatcmpl-a",
       inputTokens: 10,
       outputTokens: 4,
+      totalTokens: 14,
     };
     const b: AIMetadata = {
       model: "gpt-4o",
@@ -224,6 +246,7 @@ describe("aggregate", () => {
       responseId: "chatcmpl-b",
       inputTokens: 22,
       outputTokens: 8,
+      totalTokens: 30,
     };
     expect(aggregate(a, b)).toEqual({
       model: "gpt-4.1-nano",
@@ -232,6 +255,7 @@ describe("aggregate", () => {
       responseId: "chatcmpl-a",
       inputTokens: 32,
       outputTokens: 12,
+      totalTokens: 44,
     });
   });
 
@@ -281,6 +305,7 @@ describe("toInngestAIMetadataValues", () => {
         responseId: "chatcmpl-abc",
         inputTokens: 42,
         outputTokens: 8,
+        totalTokens: 50,
       }),
     ).toEqual({
       model: "gpt-4o",
@@ -289,6 +314,7 @@ describe("toInngestAIMetadataValues", () => {
       response_id: "chatcmpl-abc",
       input_tokens: 42,
       output_tokens: 8,
+      total_tokens: 50,
     });
   });
 
@@ -304,6 +330,9 @@ describe("toInngestAIMetadataValues", () => {
     });
     expect(toInngestAIMetadataValues({ responseId: "chatcmpl-abc" })).toEqual({
       response_id: "chatcmpl-abc",
+    });
+    expect(toInngestAIMetadataValues({ totalTokens: 50 })).toEqual({
+      total_tokens: 50,
     });
     expect(toInngestAIMetadataValues({ inputTokens: 7 })).toEqual({
       input_tokens: 7,

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -9,6 +9,11 @@ import type { Attributes, AttributeValue } from "@opentelemetry/api";
 export interface AIMetadata {
   /** The requested model, e.g. `gpt-4.1-nano`. */
   model?: string;
+  /**
+   * The model that actually served the request. This is often a dated snapshot
+   * of the requested {@link AIMetadata.model} (e.g. `gpt-4.1-nano-2025-04-14`).
+   */
+  responseModel?: string;
   /** The number of input (prompt) tokens consumed by the request. */
   inputTokens?: number;
   /** The number of output (completion) tokens produced by the response. */
@@ -109,9 +114,9 @@ const keyFieldMap: Record<string, Mapping> = {
   // Langfuse (`langfuse.*` telemetry). Langfuse reports token usage as a single
   // JSON blob under `usage_details`; it is expanded into synthetic per-count
   // attributes that are matched back through this map. Langfuse only emits a
-  // response model (not the requested model), which this extractor doesn't
-  // track, so no `model` mapping is registered here. Langfuse outranks the
-  // other conventions when several are present on one span.
+  // response model (not the requested model), so no `model` mapping is
+  // registered here. Langfuse outranks the other conventions when several are
+  // present on one span.
   "langfuse.observation.usage_details": {
     convention: Convention.Langfuse,
     expand: expandLangfuseUsageDetails,
@@ -124,9 +129,17 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "outputTokens",
     convention: Convention.Langfuse,
   },
+  "langfuse.observation.model.name": {
+    field: "responseModel",
+    convention: Convention.Langfuse,
+  },
 
   // OpenTelemetry Semantic Conventions
   "gen_ai.request.model": { field: "model", convention: Convention.Semconv },
+  "gen_ai.response.model": {
+    field: "responseModel",
+    convention: Convention.Semconv,
+  },
   "gen_ai.usage.input_tokens": {
     field: "inputTokens",
     convention: Convention.Semconv,
@@ -136,8 +149,12 @@ const keyFieldMap: Record<string, Mapping> = {
     convention: Convention.Semconv,
   },
 
-  // OpenInference
-  "llm.model_name": { field: "model", convention: Convention.OpenInference },
+  // OpenInference. `llm.model_name` is the model that served the request (a
+  // response model), not the requested model — hence it maps to `responseModel`.
+  "llm.model_name": {
+    field: "responseModel",
+    convention: Convention.OpenInference,
+  },
   "llm.token_count.prompt": {
     field: "inputTokens",
     convention: Convention.OpenInference,
@@ -149,6 +166,10 @@ const keyFieldMap: Record<string, Mapping> = {
 
   // Vercel AI SDK (native `ai.*` telemetry)
   "ai.model.id": { field: "model", convention: Convention.Vercel },
+  "ai.response.model": {
+    field: "responseModel",
+    convention: Convention.Vercel,
+  },
   "ai.usage.inputTokens": {
     field: "inputTokens",
     convention: Convention.Vercel,
@@ -228,6 +249,11 @@ export const extractAIMetadataFromAttributes = (
     metadata.model = model;
   }
 
+  const responseModel = candidates.responseModel?.value;
+  if (typeof responseModel === "string" && responseModel !== "") {
+    metadata.responseModel = responseModel;
+  }
+
   // Token counts arrive as numbers from the SDK, but OTLP/JSON encodes int64 as
   // either a number or a quoted string, so coerce defensively.
   const inputTokens = candidates.inputTokens?.value;
@@ -252,11 +278,11 @@ export const extractAIMetadataFromAttributes = (
 /**
  * Aggregates two {@link AIMetadata} values into one.
  *
- * Input and output token counts are summed, while `a`'s model takes precedence
+ * Input and output token counts are summed, while `a`'s models take precedence
  * over `b`'s. Each field is only present in the result when at least one input
  * supplies it.
  *
- * @param a - The primary metadata; its `model` wins when both are present.
+ * @param a - The primary metadata; its models win when both are present.
  * @param b - The secondary metadata.
  */
 export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
@@ -265,6 +291,11 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
   const model = a.model ?? b.model;
   if (model !== undefined) {
     metadata.model = model;
+  }
+
+  const responseModel = a.responseModel ?? b.responseModel;
+  if (responseModel !== undefined) {
+    metadata.responseModel = responseModel;
   }
 
   if (a.inputTokens !== undefined || b.inputTokens !== undefined) {
@@ -291,6 +322,10 @@ export const toInngestAIMetadataValues = (
 
   if (metadata.model !== undefined) {
     values.model = metadata.model;
+  }
+
+  if (metadata.responseModel !== undefined) {
+    values.response_model = metadata.responseModel;
   }
 
   if (metadata.inputTokens !== undefined) {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -14,6 +14,12 @@ export interface AIMetadata {
    * of the requested {@link AIMetadata.model} (e.g. `gpt-4.1-nano-2025-04-14`).
    */
   responseModel?: string;
+  /**
+   * The AI provider/system that served the request, stored raw per emitter
+   * (e.g. `openai`, or the provider + API surface like `openai.chat`). Emitted
+   * as `system` on the server schema.
+   */
+  system?: string;
   /** The number of input (prompt) tokens consumed by the request. */
   inputTokens?: number;
   /** The number of output (completion) tokens produced by the response. */
@@ -41,6 +47,12 @@ interface Mapping {
    */
   field?: Field;
   convention: Convention;
+  /**
+   * Tiebreak used to order keys within the same convention; lower wins
+   * (default 0). Used e.g. to rank the deprecated `gen_ai.system` behind its
+   * replacement `gen_ai.provider.name`, which are both semconv.
+   */
+  keyRank?: number;
   /**
    * Composite attributes (e.g. a JSON blob of token counts) provide an
    * `expand` that explodes the raw value into synthetic scalar attributes,
@@ -140,6 +152,17 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "responseModel",
     convention: Convention.Semconv,
   },
+  "gen_ai.provider.name": {
+    field: "system",
+    convention: Convention.Semconv,
+  },
+  // Deprecated in semconv in favor of `gen_ai.provider.name`; both are semconv,
+  // so this keyRank places it behind its replacement.
+  "gen_ai.system": {
+    field: "system",
+    convention: Convention.Semconv,
+    keyRank: 1,
+  },
   "gen_ai.usage.input_tokens": {
     field: "inputTokens",
     convention: Convention.Semconv,
@@ -163,11 +186,20 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "outputTokens",
     convention: Convention.OpenInference,
   },
+  // `llm.system` identifies the AI product/vendor (openai, anthropic, …),
+  // matching the semantics of the deprecated semconv `gen_ai.system`.
+  "llm.system": { field: "system", convention: Convention.OpenInference },
 
   // Vercel AI SDK (native `ai.*` telemetry)
   "ai.model.id": { field: "model", convention: Convention.Vercel },
   "ai.response.model": {
     field: "responseModel",
+    convention: Convention.Vercel,
+  },
+  // `ai.model.provider` is the provider + API surface, e.g. `openai.responses`
+  // (not bare `openai`); stored faithfully, no normalization.
+  "ai.model.provider": {
+    field: "system",
     convention: Convention.Vercel,
   },
   "ai.usage.inputTokens": {
@@ -187,6 +219,7 @@ const keyFieldMap: Record<string, Mapping> = {
 interface Candidate {
   value: AttributeValue;
   convention: Convention;
+  keyRank: number;
 }
 
 /**
@@ -209,9 +242,20 @@ export const extractAIMetadataFromAttributes = (
     if (!mapping.field) {
       return;
     }
+    const keyRank = mapping.keyRank ?? 0;
     const existing = candidates[mapping.field];
-    if (!existing || mapping.convention < existing.convention) {
-      candidates[mapping.field] = { value, convention: mapping.convention };
+    // Order by convention first, breaking ties within a convention by keyRank;
+    // lower wins for both.
+    if (
+      !existing ||
+      mapping.convention < existing.convention ||
+      (mapping.convention === existing.convention && keyRank < existing.keyRank)
+    ) {
+      candidates[mapping.field] = {
+        value,
+        convention: mapping.convention,
+        keyRank,
+      };
     }
   };
 
@@ -252,6 +296,11 @@ export const extractAIMetadataFromAttributes = (
   const responseModel = candidates.responseModel?.value;
   if (typeof responseModel === "string" && responseModel !== "") {
     metadata.responseModel = responseModel;
+  }
+
+  const system = candidates.system?.value;
+  if (typeof system === "string" && system !== "") {
+    metadata.system = system;
   }
 
   // Token counts arrive as numbers from the SDK, but OTLP/JSON encodes int64 as
@@ -298,6 +347,11 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
     metadata.responseModel = responseModel;
   }
 
+  const system = a.system ?? b.system;
+  if (system !== undefined) {
+    metadata.system = system;
+  }
+
   if (a.inputTokens !== undefined || b.inputTokens !== undefined) {
     metadata.inputTokens = (a.inputTokens ?? 0) + (b.inputTokens ?? 0);
   }
@@ -326,6 +380,10 @@ export const toInngestAIMetadataValues = (
 
   if (metadata.responseModel !== undefined) {
     values.response_model = metadata.responseModel;
+  }
+
+  if (metadata.system !== undefined) {
+    values.system = metadata.system;
   }
 
   if (metadata.inputTokens !== undefined) {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -11,6 +11,8 @@ export interface AIMetadata {
   model?: string;
   /** The number of input (prompt) tokens consumed by the request. */
   inputTokens?: number;
+  /** The number of output (completion) tokens produced by the response. */
+  outputTokens?: number;
 }
 
 /**
@@ -50,11 +52,23 @@ interface Mapping {
 const langfuseUsagePrefix = "__langfuse.usage_details.";
 
 /**
- * Parses the `langfuse.observation.usage_details` JSON blob (e.g.
- * `{"input":17,"output":36,"total":53}`) and emits a synthetic scalar
- * attribute for each count we track. Only `input` is emitted; the other counts
- * (output, total, cached, reasoning, …) are intentionally dropped since this
- * extractor tracks input tokens alone.
+ * The `langfuse.observation.usage_details` JSON blob (e.g.
+ * `{"input":17,"output":36,"total":53}`). Langfuse emits more counts (total,
+ * cached, reasoning, …), but this extractor only reads the ones it tracks.
+ */
+interface LangfuseUsageDetails {
+  input?: number;
+  output?: number;
+}
+
+/** The usage counts we lift out of the Langfuse blob, in precedence order. */
+const langfuseUsageKeys = ["input", "output"] as const;
+
+/**
+ * Parses the {@link LangfuseUsageDetails} JSON blob and emits a synthetic
+ * scalar attribute for each count we track. Only `input` and `output` are
+ * emitted; the other counts are intentionally dropped since this extractor
+ * tracks input and output tokens alone.
  */
 const expandLangfuseUsageDetails = (
   value: AttributeValue,
@@ -63,23 +77,28 @@ const expandLangfuseUsageDetails = (
     return {};
   }
 
-  let counts: unknown;
+  let parsed: unknown;
   try {
-    counts = JSON.parse(value);
+    parsed = JSON.parse(value);
   } catch {
     return {};
   }
 
-  if (typeof counts !== "object" || counts === null) {
+  if (typeof parsed !== "object" || parsed === null) {
     return {};
   }
 
-  const input = (counts as Record<string, unknown>).input;
-  if (typeof input !== "number") {
-    return {};
+  const counts = parsed as LangfuseUsageDetails;
+
+  const out: Record<string, AttributeValue> = {};
+  for (const key of langfuseUsageKeys) {
+    const count = counts[key];
+    if (typeof count === "number") {
+      out[`${langfuseUsagePrefix}${key}`] = count;
+    }
   }
 
-  return { [`${langfuseUsagePrefix}input`]: input };
+  return out;
 };
 
 /**
@@ -101,11 +120,19 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "inputTokens",
     convention: Convention.Langfuse,
   },
+  [`${langfuseUsagePrefix}output`]: {
+    field: "outputTokens",
+    convention: Convention.Langfuse,
+  },
 
   // OpenTelemetry Semantic Conventions
   "gen_ai.request.model": { field: "model", convention: Convention.Semconv },
   "gen_ai.usage.input_tokens": {
     field: "inputTokens",
+    convention: Convention.Semconv,
+  },
+  "gen_ai.usage.output_tokens": {
+    field: "outputTokens",
     convention: Convention.Semconv,
   },
 
@@ -115,11 +142,19 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "inputTokens",
     convention: Convention.OpenInference,
   },
+  "llm.token_count.completion": {
+    field: "outputTokens",
+    convention: Convention.OpenInference,
+  },
 
   // Vercel AI SDK (native `ai.*` telemetry)
   "ai.model.id": { field: "model", convention: Convention.Vercel },
   "ai.usage.inputTokens": {
     field: "inputTokens",
+    convention: Convention.Vercel,
+  },
+  "ai.usage.outputTokens": {
+    field: "outputTokens",
     convention: Convention.Vercel,
   },
   // Embeddings spans emit only a single `ai.usage.tokens` count (no
@@ -193,13 +228,21 @@ export const extractAIMetadataFromAttributes = (
     metadata.model = model;
   }
 
+  // Token counts arrive as numbers from the SDK, but OTLP/JSON encodes int64 as
+  // either a number or a quoted string, so coerce defensively.
   const inputTokens = candidates.inputTokens?.value;
   if (inputTokens !== undefined) {
-    // Token counts arrive as numbers from the SDK, but OTLP/JSON encodes int64
-    // as either a number or a quoted string, so coerce defensively.
     const n = Number(inputTokens);
     if (!Number.isNaN(n)) {
       metadata.inputTokens = n;
+    }
+  }
+
+  const outputTokens = candidates.outputTokens?.value;
+  if (outputTokens !== undefined) {
+    const n = Number(outputTokens);
+    if (!Number.isNaN(n)) {
+      metadata.outputTokens = n;
     }
   }
 
@@ -209,8 +252,9 @@ export const extractAIMetadataFromAttributes = (
 /**
  * Aggregates two {@link AIMetadata} values into one.
  *
- * Input token counts are summed, while `a`'s model takes precedence over `b`'s.
- * Each field is only present in the result when at least one input supplies it.
+ * Input and output token counts are summed, while `a`'s model takes precedence
+ * over `b`'s. Each field is only present in the result when at least one input
+ * supplies it.
  *
  * @param a - The primary metadata; its `model` wins when both are present.
  * @param b - The secondary metadata.
@@ -225,6 +269,10 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
 
   if (a.inputTokens !== undefined || b.inputTokens !== undefined) {
     metadata.inputTokens = (a.inputTokens ?? 0) + (b.inputTokens ?? 0);
+  }
+
+  if (a.outputTokens !== undefined || b.outputTokens !== undefined) {
+    metadata.outputTokens = (a.outputTokens ?? 0) + (b.outputTokens ?? 0);
   }
 
   return metadata;
@@ -247,6 +295,10 @@ export const toInngestAIMetadataValues = (
 
   if (metadata.inputTokens !== undefined) {
     values.input_tokens = metadata.inputTokens;
+  }
+
+  if (metadata.outputTokens !== undefined) {
+    values.output_tokens = metadata.outputTokens;
   }
 
   if (Object.keys(values).length === 0) {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -26,6 +26,11 @@ export interface AIMetadata {
   inputTokens?: number;
   /** The number of output (completion) tokens produced by the response. */
   outputTokens?: number;
+  /**
+   * The total tokens consumed. Taken from the provider's count when supplied,
+   * otherwise derived as input + output when either is present.
+   */
+  totalTokens?: number;
 }
 
 /**
@@ -72,22 +77,23 @@ const langfuseUsagePrefix = "__langfuse.usage_details.";
 
 /**
  * The `langfuse.observation.usage_details` JSON blob (e.g.
- * `{"input":17,"output":36,"total":53}`). Langfuse emits more counts (total,
- * cached, reasoning, …), but this extractor only reads the ones it tracks.
+ * `{"input":17,"output":36,"total":53}`). Langfuse emits more counts (cached,
+ * reasoning, …), but this extractor only reads the ones it tracks.
  */
 interface LangfuseUsageDetails {
   input?: number;
   output?: number;
+  total?: number;
 }
 
-/** The usage counts we lift out of the Langfuse blob, in precedence order. */
-const langfuseUsageKeys = ["input", "output"] as const;
+/** The usage counts we lift out of the Langfuse blob. */
+const langfuseUsageKeys = ["input", "output", "total"] as const;
 
 /**
  * Parses the {@link LangfuseUsageDetails} JSON blob and emits a synthetic
- * scalar attribute for each count we track. Only `input` and `output` are
- * emitted; the other counts are intentionally dropped since this extractor
- * tracks input and output tokens alone.
+ * scalar attribute for each count we track. Only `input`, `output`, and `total`
+ * are emitted; the other counts are intentionally dropped since this extractor
+ * tracks input, output, and total tokens alone.
  */
 const expandLangfuseUsageDetails = (
   value: AttributeValue,
@@ -143,6 +149,10 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "outputTokens",
     convention: Convention.Langfuse,
   },
+  [`${langfuseUsagePrefix}total`]: {
+    field: "totalTokens",
+    convention: Convention.Langfuse,
+  },
   "langfuse.observation.model.name": {
     field: "responseModel",
     convention: Convention.Langfuse,
@@ -177,6 +187,10 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "outputTokens",
     convention: Convention.Semconv,
   },
+  "gen_ai.usage.total_tokens": {
+    field: "totalTokens",
+    convention: Convention.Semconv,
+  },
 
   // OpenInference. `llm.model_name` is the model that served the request (a
   // response model), not the requested model — hence it maps to `responseModel`.
@@ -190,6 +204,10 @@ const keyFieldMap: Record<string, Mapping> = {
   },
   "llm.token_count.completion": {
     field: "outputTokens",
+    convention: Convention.OpenInference,
+  },
+  "llm.token_count.total": {
+    field: "totalTokens",
     convention: Convention.OpenInference,
   },
   // `llm.system` identifies the AI product/vendor (openai, anthropic, …),
@@ -218,6 +236,10 @@ const keyFieldMap: Record<string, Mapping> = {
   },
   "ai.usage.outputTokens": {
     field: "outputTokens",
+    convention: Convention.Vercel,
+  },
+  "ai.usage.totalTokens": {
+    field: "totalTokens",
     convention: Convention.Vercel,
   },
   // Embeddings spans emit only a single `ai.usage.tokens` count (no
@@ -320,20 +342,36 @@ export const extractAIMetadataFromAttributes = (
 
   // Token counts arrive as numbers from the SDK, but OTLP/JSON encodes int64 as
   // either a number or a quoted string, so coerce defensively.
-  const inputTokens = candidates.inputTokens?.value;
-  if (inputTokens !== undefined) {
-    const n = Number(inputTokens);
-    if (!Number.isNaN(n)) {
-      metadata.inputTokens = n;
+  const count = (field: Field): number | undefined => {
+    const raw = candidates[field]?.value;
+    if (raw === undefined) {
+      return undefined;
     }
+    const n = Number(raw);
+    return Number.isNaN(n) ? undefined : n;
+  };
+
+  const inputTokens = count("inputTokens");
+  if (inputTokens !== undefined) {
+    metadata.inputTokens = inputTokens;
   }
 
-  const outputTokens = candidates.outputTokens?.value;
+  const outputTokens = count("outputTokens");
   if (outputTokens !== undefined) {
-    const n = Number(outputTokens);
-    if (!Number.isNaN(n)) {
-      metadata.outputTokens = n;
+    metadata.outputTokens = outputTokens;
+  }
+
+  // Use the provider's total when supplied, otherwise derive it from input +
+  // output when either is present, mirroring the server-side extractor.
+  let totalTokens = count("totalTokens");
+  if (totalTokens === undefined) {
+    const sum = (inputTokens ?? 0) + (outputTokens ?? 0);
+    if (sum > 0) {
+      totalTokens = sum;
     }
+  }
+  if (totalTokens !== undefined) {
+    metadata.totalTokens = totalTokens;
   }
 
   return metadata;
@@ -342,9 +380,9 @@ export const extractAIMetadataFromAttributes = (
 /**
  * Aggregates two {@link AIMetadata} values into one.
  *
- * Input and output token counts are summed, while `a`'s models take precedence
- * over `b`'s. Each field is only present in the result when at least one input
- * supplies it.
+ * Input, output, and total token counts are summed, while `a`'s models take
+ * precedence over `b`'s. Each field is only present in the result when at least
+ * one input supplies it.
  *
  * @param a - The primary metadata; its models win when both are present.
  * @param b - The secondary metadata.
@@ -378,6 +416,10 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
 
   if (a.outputTokens !== undefined || b.outputTokens !== undefined) {
     metadata.outputTokens = (a.outputTokens ?? 0) + (b.outputTokens ?? 0);
+  }
+
+  if (a.totalTokens !== undefined || b.totalTokens !== undefined) {
+    metadata.totalTokens = (a.totalTokens ?? 0) + (b.totalTokens ?? 0);
   }
 
   return metadata;
@@ -416,6 +458,10 @@ export const toInngestAIMetadataValues = (
 
   if (metadata.outputTokens !== undefined) {
     values.output_tokens = metadata.outputTokens;
+  }
+
+  if (metadata.totalTokens !== undefined) {
+    values.total_tokens = metadata.totalTokens;
   }
 
   if (Object.keys(values).length === 0) {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -20,6 +20,8 @@ export interface AIMetadata {
    * as `system` on the server schema.
    */
   system?: string;
+  /** The provider's identifier for the response, e.g. `chatcmpl-...`. */
+  responseId?: string;
   /** The number of input (prompt) tokens consumed by the request. */
   inputTokens?: number;
   /** The number of output (completion) tokens produced by the response. */
@@ -163,6 +165,10 @@ const keyFieldMap: Record<string, Mapping> = {
     convention: Convention.Semconv,
     keyRank: 1,
   },
+  "gen_ai.response.id": {
+    field: "responseId",
+    convention: Convention.Semconv,
+  },
   "gen_ai.usage.input_tokens": {
     field: "inputTokens",
     convention: Convention.Semconv,
@@ -200,6 +206,10 @@ const keyFieldMap: Record<string, Mapping> = {
   // (not bare `openai`); stored faithfully, no normalization.
   "ai.model.provider": {
     field: "system",
+    convention: Convention.Vercel,
+  },
+  "ai.response.id": {
+    field: "responseId",
     convention: Convention.Vercel,
   },
   "ai.usage.inputTokens": {
@@ -303,6 +313,11 @@ export const extractAIMetadataFromAttributes = (
     metadata.system = system;
   }
 
+  const responseId = candidates.responseId?.value;
+  if (typeof responseId === "string" && responseId !== "") {
+    metadata.responseId = responseId;
+  }
+
   // Token counts arrive as numbers from the SDK, but OTLP/JSON encodes int64 as
   // either a number or a quoted string, so coerce defensively.
   const inputTokens = candidates.inputTokens?.value;
@@ -352,6 +367,11 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
     metadata.system = system;
   }
 
+  const responseId = a.responseId ?? b.responseId;
+  if (responseId !== undefined) {
+    metadata.responseId = responseId;
+  }
+
   if (a.inputTokens !== undefined || b.inputTokens !== undefined) {
     metadata.inputTokens = (a.inputTokens ?? 0) + (b.inputTokens ?? 0);
   }
@@ -384,6 +404,10 @@ export const toInngestAIMetadataValues = (
 
   if (metadata.system !== undefined) {
     values.system = metadata.system;
+  }
+
+  if (metadata.responseId !== undefined) {
+    values.response_id = metadata.responseId;
   }
 
   if (metadata.inputTokens !== undefined) {

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -1,4 +1,5 @@
 import type { Attributes, AttributeValue } from "@opentelemetry/api";
+import { isRecord } from "../../../helpers/types.ts";
 
 /**
  * AI metadata extracted from a span's attributes.
@@ -76,21 +77,14 @@ interface Mapping {
 const langfuseUsagePrefix = "__langfuse.usage_details.";
 
 /**
- * The `langfuse.observation.usage_details` JSON blob (e.g.
- * `{"input":17,"output":36,"total":53}`). Langfuse emits more counts (cached,
- * reasoning, …), but this extractor only reads the ones it tracks.
+ * The usage counts we lift out of the `langfuse.observation.usage_details` JSON
+ * blob (e.g. `{"input":17,"output":36,"total":53}`). Langfuse emits more counts
+ * (cached, reasoning, …), but this extractor only reads the ones it tracks.
  */
-interface LangfuseUsageDetails {
-  input?: number;
-  output?: number;
-  total?: number;
-}
-
-/** The usage counts we lift out of the Langfuse blob. */
 const langfuseUsageKeys = ["input", "output", "total"] as const;
 
 /**
- * Parses the {@link LangfuseUsageDetails} JSON blob and emits a synthetic
+ * Parses the `langfuse.observation.usage_details` JSON blob and emits a synthetic
  * scalar attribute for each count we track. Only `input`, `output`, and `total`
  * are emitted; the other counts are intentionally dropped since this extractor
  * tracks input, output, and total tokens alone.
@@ -109,15 +103,13 @@ const expandLangfuseUsageDetails = (
     return {};
   }
 
-  if (typeof parsed !== "object" || parsed === null) {
+  if (!isRecord(parsed)) {
     return {};
   }
 
-  const counts = parsed as LangfuseUsageDetails;
-
   const out: Record<string, AttributeValue> = {};
   for (const key of langfuseUsageKeys) {
-    const count = counts[key];
+    const count = parsed[key];
     if (typeof count === "number") {
       out[`${langfuseUsagePrefix}${key}`] = count;
     }
@@ -321,22 +313,22 @@ export const extractAIMetadataFromAttributes = (
   const metadata: AIMetadata = {};
 
   const model = candidates.model?.value;
-  if (typeof model === "string" && model !== "") {
+  if (typeof model === "string" && model) {
     metadata.model = model;
   }
 
   const responseModel = candidates.responseModel?.value;
-  if (typeof responseModel === "string" && responseModel !== "") {
+  if (typeof responseModel === "string" && responseModel) {
     metadata.responseModel = responseModel;
   }
 
   const system = candidates.system?.value;
-  if (typeof system === "string" && system !== "") {
+  if (typeof system === "string" && system) {
     metadata.system = system;
   }
 
   const responseId = candidates.responseId?.value;
-  if (typeof responseId === "string" && responseId !== "") {
+  if (typeof responseId === "string" && responseId) {
     metadata.responseId = responseId;
   }
 

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -91,7 +91,9 @@ describe("InngestMetadataSpanProcessor", () => {
       "gen_ai.usage.input_tokens": 42,
     });
 
-    expect(pushed).toEqual([{ model: "gpt-4.1-nano", inputTokens: 42 }]);
+    expect(pushed).toEqual([
+      { model: "gpt-4.1-nano", inputTokens: 42, totalTokens: 42 },
+    ]);
   });
 
   test("pushes once per span; aggregation is the sink owner's job", () => {
@@ -108,8 +110,8 @@ describe("InngestMetadataSpanProcessor", () => {
     });
 
     expect(pushed).toEqual([
-      { model: "gpt-4.1-nano", inputTokens: 10 },
-      { model: "gpt-4.1-mini", inputTokens: 5 },
+      { model: "gpt-4.1-nano", inputTokens: 10, totalTokens: 10 },
+      { model: "gpt-4.1-mini", inputTokens: 5, totalTokens: 5 },
     ]);
   });
 
@@ -137,7 +139,9 @@ describe("InngestMetadataSpanProcessor", () => {
     });
     mid.end();
 
-    expect(pushed).toEqual([{ model: "gpt-4.1-nano", inputTokens: 7 }]);
+    expect(pushed).toEqual([
+      { model: "gpt-4.1-nano", inputTokens: 7, totalTokens: 7 },
+    ]);
   });
 
   test("ignores spans that are not part of a declared run", () => {

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json.snap
@@ -2,7 +2,10 @@
   {
     "span": "OpenAI.responses",
     "metadata": {
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "inputTokens": 17,
+      "outputTokens": 36,
+      "totalTokens": 53
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/embeddings.otlp.json.snap
@@ -1,6 +1,8 @@
 [
   {
     "span": "OpenAI.embeddings",
-    "metadata": {}
+    "metadata": {
+      "responseModel": "text-embedding-3-small"
+    }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json.snap
@@ -2,7 +2,10 @@
   {
     "span": "OpenAI.chat",
     "metadata": {
-      "inputTokens": 22
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json.snap
@@ -2,7 +2,10 @@
   {
     "span": "OpenAI.responses",
     "metadata": {
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "inputTokens": 17,
+      "outputTokens": 13,
+      "totalTokens": 30
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json.snap
@@ -2,7 +2,10 @@
   {
     "span": "OpenAI.chat",
     "metadata": {
-      "inputTokens": 11
+      "responseModel": "gpt-4.1-nano",
+      "inputTokens": 11,
+      "outputTokens": 10,
+      "totalTokens": 21
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json.snap
@@ -2,7 +2,10 @@
   {
     "span": "OpenAI.chat",
     "metadata": {
-      "inputTokens": 56
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "inputTokens": 56,
+      "outputTokens": 30,
+      "totalTokens": 86
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "ChatOpenAI",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai",
+      "responseId": "resp_076af25434275e80006a1f60fe34c081989e65e074eb0213b3",
+      "inputTokens": 17,
+      "outputTokens": 35,
+      "totalTokens": 52
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/params_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "ChatOpenAI",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 22
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmSPnK1FqD0W1V6k55vnLKTyNV9cH",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/reasoning_responses.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "ChatOpenAI",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai",
+      "responseId": "resp_0c58250a28f29e7f006a1f61028f248199962f6ae9f6dcec2f",
+      "inputTokens": 17,
+      "outputTokens": 12,
+      "totalTokens": 29
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/tools_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "ChatOpenAI",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 56
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmSPog8FUcyXw3C6bUGF0WZZDZw1k",
+      "inputTokens": 56,
+      "outputTokens": 30,
+      "totalTokens": 86
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/basic_responses.otlp.json.snap
@@ -2,8 +2,11 @@
   {
     "span": "OpenAI Responses",
     "metadata": {
-      "model": "gpt-5.4-nano-2026-03-17",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai",
+      "inputTokens": 17,
+      "outputTokens": 51,
+      "totalTokens": 68
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/embeddings.otlp.json.snap
@@ -1,6 +1,8 @@
 [
   {
     "span": "OpenAI Embeddings",
-    "metadata": {}
+    "metadata": {
+      "system": "openai"
+    }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/params_chat.otlp.json.snap
@@ -2,8 +2,11 @@
   {
     "span": "OpenAI Chat Completions",
     "metadata": {
-      "model": "gpt-4.1-nano-2025-04-14",
-      "inputTokens": 22
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/reasoning_responses.otlp.json.snap
@@ -2,8 +2,11 @@
   {
     "span": "OpenAI Responses",
     "metadata": {
-      "model": "gpt-5.4-nano-2026-03-17",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai",
+      "inputTokens": 17,
+      "outputTokens": 13,
+      "totalTokens": 30
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/stream_chat.otlp.json.snap
@@ -2,7 +2,8 @@
   {
     "span": "OpenAI Chat Completions",
     "metadata": {
-      "model": "gpt-4.1-nano"
+      "responseModel": "gpt-4.1-nano",
+      "system": "openai"
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/tools_chat.otlp.json.snap
@@ -2,8 +2,11 @@
   {
     "span": "OpenAI Chat Completions",
     "metadata": {
-      "model": "gpt-4.1-nano-2025-04-14",
-      "inputTokens": 56
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "inputTokens": 56,
+      "outputTokens": 30,
+      "totalTokens": 86
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/embeddings.otlp.json.snap
@@ -3,7 +3,10 @@
     "span": "embeddings text-embedding-3-small",
     "metadata": {
       "model": "text-embedding-3-small",
-      "inputTokens": 10
+      "responseModel": "text-embedding-3-small",
+      "system": "openai",
+      "inputTokens": 10,
+      "totalTokens": 10
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-4.1-nano",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 22
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmQgLKk5KeV2yWFNlpzOVrmXErHfC",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-4.1-nano",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 11
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmQgMYCyOdQgzMUm4UU6jFY7NuSGB",
+      "inputTokens": 11,
+      "outputTokens": 10,
+      "totalTokens": 21
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-4.1-nano",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 56
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmQgMTBrf7SFrIb1VMoKSIbKkIcBf",
+      "inputTokens": 56,
+      "outputTokens": 14,
+      "totalTokens": 70
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/basic_responses.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-5.4-nano",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai",
+      "responseId": "resp_0ba2819472261845006a1f474f066c819983ffb0a8d045e3d5",
+      "inputTokens": 17,
+      "outputTokens": 44,
+      "totalTokens": 61
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/params_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-4.1-nano",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 22
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmQhkoGWd8y8RoHHnRbkw7BHGMj8j",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/reasoning_responses.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-5.4-nano",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai",
+      "responseId": "resp_0947697ae2c24bfe006a1f4751ad68819aa81bfb021e3ac05e",
+      "inputTokens": 17,
+      "outputTokens": 13,
+      "totalTokens": 30
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/stream_chat.otlp.json.snap
@@ -2,7 +2,10 @@
   {
     "span": "chat gpt-4.1-nano",
     "metadata": {
-      "model": "gpt-4.1-nano"
+      "model": "gpt-4.1-nano",
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmQhlDTJIJh3jrQMeZ8BBMqtVzv8A"
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/tools_chat.otlp.json.snap
@@ -3,7 +3,12 @@
     "span": "chat gpt-4.1-nano",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 56
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai",
+      "responseId": "chatcmpl-DmQhkWBiDrfqwzKv6CFoRu2DACmfB",
+      "inputTokens": 56,
+      "outputTokens": 14,
+      "totalTokens": 70
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
@@ -3,14 +3,22 @@
     "span": "ai.generateText.doGenerate",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 17
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai.responses",
+      "responseId": "resp_0e56d5c95850276a006a1f57da3d60819a8974cbbffaedd001",
+      "inputTokens": 17,
+      "outputTokens": 40,
+      "totalTokens": 57
     }
   },
   {
     "span": "ai.generateText",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 17
+      "system": "openai.responses",
+      "inputTokens": 17,
+      "outputTokens": 40,
+      "totalTokens": 57
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/embeddings.otlp.json.snap
@@ -3,14 +3,18 @@
     "span": "ai.embed.doEmbed",
     "metadata": {
       "model": "text-embedding-3-small",
-      "inputTokens": 10
+      "system": "openai.embedding",
+      "inputTokens": 10,
+      "totalTokens": 10
     }
   },
   {
     "span": "ai.embed",
     "metadata": {
       "model": "text-embedding-3-small",
-      "inputTokens": 10
+      "system": "openai.embedding",
+      "inputTokens": 10,
+      "totalTokens": 10
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
@@ -3,14 +3,22 @@
     "span": "ai.generateText.doGenerate",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 22
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai.chat",
+      "responseId": "chatcmpl-DmRo36qp18PR3bwmtZfTN9ElKOUVx",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   },
   {
     "span": "ai.generateText",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 22
+      "system": "openai.chat",
+      "inputTokens": 22,
+      "outputTokens": 6,
+      "totalTokens": 28
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.snap
@@ -3,14 +3,22 @@
     "span": "ai.generateText.doGenerate",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 42
+      "responseModel": "gpt-5.4-nano-2026-03-17",
+      "system": "openai.responses",
+      "responseId": "resp_0f7e98e261a60d2a006a1f57ddee9c819b824783b5b0c8e87a",
+      "inputTokens": 42,
+      "outputTokens": 195,
+      "totalTokens": 237
     }
   },
   {
     "span": "ai.generateText",
     "metadata": {
       "model": "gpt-5.4-nano",
-      "inputTokens": 42
+      "system": "openai.responses",
+      "inputTokens": 42,
+      "outputTokens": 195,
+      "totalTokens": 237
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
@@ -3,14 +3,22 @@
     "span": "ai.streamText.doStream",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 11
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai.chat",
+      "responseId": "chatcmpl-DmRo58DlkgVkA2eN9sgElNFLVmm97",
+      "inputTokens": 11,
+      "outputTokens": 10,
+      "totalTokens": 21
     }
   },
   {
     "span": "ai.streamText",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 11
+      "system": "openai.chat",
+      "inputTokens": 11,
+      "outputTokens": 10,
+      "totalTokens": 21
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
@@ -3,14 +3,22 @@
     "span": "ai.generateText.doGenerate",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 56
+      "responseModel": "gpt-4.1-nano-2025-04-14",
+      "system": "openai.chat",
+      "responseId": "chatcmpl-DmRo4ru2GBGYvimObCx5jGYZ8uk0r",
+      "inputTokens": 56,
+      "outputTokens": 14,
+      "totalTokens": 70
     }
   },
   {
     "span": "ai.generateText",
     "metadata": {
       "model": "gpt-4.1-nano",
-      "inputTokens": 56
+      "system": "openai.chat",
+      "inputTokens": 56,
+      "outputTokens": 14,
+      "totalTokens": 70
     }
   }
 ]

--- a/packages/inngest/src/test/integration/traces/stepMetadata.test.ts
+++ b/packages/inngest/src/test/integration/traces/stepMetadata.test.ts
@@ -27,14 +27,20 @@ context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
 
 const testFileName = testNameFromFileUrl(import.meta.url);
 
-// Request model (not response model) and input tokens only, mapped to the
-// server's snake_case `inngest.ai` schema.
+// The fields the extractor lifts from `simulateOpenAICall`'s span, mapped to
+// the server's snake_case `inngest.ai` schema. `gen_ai.operation.name` is not
+// extracted, and `total_tokens` is derived from input + output since the span
+// carries no total.
 const expectedAIMetadata = {
   kind: "inngest.ai",
   scope: "step",
   values: {
-    input_tokens: 18,
     model: "gpt-5.4-nano",
+    response_model: "gpt-5.4-nano-2026-03-17",
+    system: "openai",
+    input_tokens: 18,
+    output_tokens: 39,
+    total_tokens: 57,
   },
 };
 
@@ -105,12 +111,16 @@ matrixCheckpointing("multiple AI calls in a step", async (checkpointing) => {
     return step.name === "my-step" && hasAiMetadata(step.metadata);
   });
 
+  // Two calls in one step aggregate: token counts sum, models/system are kept
+  // from the first.
   expect(getAIMetadata(step)).toEqual([
     {
       ...expectedAIMetadata,
       values: {
         ...expectedAIMetadata.values,
         input_tokens: 2 * expectedAIMetadata.values.input_tokens,
+        output_tokens: 2 * expectedAIMetadata.values.output_tokens,
+        total_tokens: 2 * expectedAIMetadata.values.total_tokens,
       },
     },
   ]);

--- a/packages/inngest/src/test/integration/traces/util.ts
+++ b/packages/inngest/src/test/integration/traces/util.ts
@@ -7,9 +7,10 @@ import { z } from "zod/v3";
  * chat completion, without needing the OpenAI SDK or an API key: a wrapper
  * span containing a `gen_ai.*`-attributed span.
  *
- * The response model and output tokens are deliberately present even though
- * the metadata processor doesn't extract them; tests assert they don't leak
- * into step metadata.
+ * The span carries the full `gen_ai.*` set the extractor recognizes (request +
+ * response model, system, and input/output token counts) so tests can assert
+ * the complete `inngest.ai` metadata shape. `gen_ai.operation.name` is included
+ * to confirm unrecognized attributes don't leak into step metadata.
  */
 export function simulateOpenAICall(): string {
   const tracer = trace.getTracer("@opentelemetry/instrumentation-openai");


### PR DESCRIPTION
## Summary

- Add 6 or so new fields to AI Metadata that we parsed in OSS but did not previously in JS


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable