### PR TITLE
feat(experiment): score() from group.experiment() for scoring outside the variant callback

### DIFF
--- a/packages/inngest/src/components/InngestGroupTools.ts
+++ b/packages/inngest/src/components/InngestGroupTools.ts
@@ -6,6 +6,7 @@ import {
   getAsyncLocalStorage,
   isALSFallback,
 } from "./execution/als.ts";
+import type { ScoreOptions, ScoreStepTool } from "./InngestScore.ts";
 import { getStepOptions } from "./InngestStepTools.ts";
 import { NonRetriableError } from "./NonRetriableError.ts";
 
@@ -129,16 +130,40 @@ export interface ExperimentOptions<
 
 /**
  * Options for `group.experiment()` when `withVariant` is true, which causes
- * the return type to include both the result and the selected variant name.
+ * the return type to include the result, the selected variant name, and a
+ * `score` function for attaching scores to the experiment from later steps.
  */
 export interface ExperimentOptionsWithVariant<
   TVariants extends Record<string, () => unknown>,
 > extends ExperimentOptions<TVariants> {
   /**
-   * When true, the return value includes the variant name alongside the result.
+   * When true, the return value includes the variant name and a `score`
+   * function alongside the result.
    */
   withVariant: true;
 }
+
+/**
+ * Options accepted by the `score` function returned from `group.experiment()`.
+ * The score always attaches to the current run's experiment, so only the score
+ * name and value are configurable.
+ */
+export type ExperimentScoreOptions = Pick<ScoreOptions, "name" | "value">;
+
+/**
+ * Attaches a score to the experiment that returned it.
+ *
+ * Must be called as a top-level step within the same function execution that
+ * created the experiment (typically in a later step). The score lands
+ * co-located with the experiment's variant, exactly as an in-callback
+ * `step.score()` would, and survives retries because it is a memoized step.
+ *
+ * @param memoizationId - The durable step ID used to memoize this score write.
+ */
+export type ExperimentScorer = (
+  memoizationId: string,
+  options: ExperimentScoreOptions,
+) => Promise<void>;
 
 /**
  * Computes the return type of an experiment based on variant callbacks.
@@ -169,8 +194,9 @@ export interface ExperimentMetadataValues {
  */
 export interface GroupExperiment {
   /**
-   * Run an A/B experiment that selects and executes a variant. Returns both
-   * the result and the selected variant name.
+   * Run an A/B experiment that selects and executes a variant. Returns the
+   * result, the selected variant name, and a `score` function for attaching
+   * scores to the experiment from later steps.
    */
   <TVariants extends Record<string, () => unknown>>(
     idOrOptions: StepOptionsOrId,
@@ -178,6 +204,7 @@ export interface GroupExperiment {
   ): Promise<{
     result: VariantResult<never, TVariants>;
     variant: string;
+    score: ExperimentScorer;
   }>;
 
   /**
@@ -257,6 +284,13 @@ export interface GroupToolsDeps {
    */
   // biome-ignore lint/suspicious/noExplicitAny: internal plumbing
   experimentStepRun?: (...args: any[]) => Promise<any>;
+
+  /**
+   * The `step.score` tool, extracted from step tools via the score symbol.
+   * Used by the `score` function returned from `group.experiment()`. Undefined
+   * when not available.
+   */
+  experimentStepScore?: ScoreStepTool;
 }
 
 /**
@@ -392,6 +426,18 @@ export const createGroupTools = (deps?: GroupToolsDeps): GroupTools => {
     // for the hashed ID fallback) so that variant sub-steps discovered on
     // replay still carry experiment fields in their opts and the executor
     // can attach metadata to their ClickHouse rows.
+    // The experiment fields propagated into every sub-step's OutgoingOp.opts.
+    // These are all replay-stable: `variant` is memoized via the selection
+    // step and the name/strategy are literals. `experimentStepID` is best-effort
+    // (empty on replay) and unused by the executor, which stamps the variant
+    // from `experimentName`/`variant` alone.
+    const experimentContext = {
+      experimentStepID: experimentStepHashedId ?? "",
+      experimentName: stepOpts.id,
+      variant: selectedVariant,
+      selectionStrategy: select.__experimentConfig.strategy,
+    };
+
     const currentCtx = getAsyncCtxSync();
     const stepTracker = { found: false };
     let result: unknown;
@@ -402,12 +448,7 @@ export const createGroupTools = (deps?: GroupToolsDeps): GroupTools => {
         ...currentCtx,
         execution: {
           ...currentCtx.execution,
-          experimentContext: {
-            experimentStepID: experimentStepHashedId ?? "",
-            experimentName: stepOpts.id,
-            variant: selectedVariant,
-            selectionStrategy: select.__experimentConfig.strategy,
-          },
+          experimentContext,
           experimentStepTracker: stepTracker,
         },
       };
@@ -427,8 +468,53 @@ export const createGroupTools = (deps?: GroupToolsDeps): GroupTools => {
       );
     }
 
+    // A scorer that attaches to this experiment from a later step. It re-enters
+    // the experiment context (above) so the score's underlying step picks up
+    // the experiment fields in its opts — the executor then stamps the variant
+    // onto the same row as the score value, exactly as an in-callback
+    // `step.score()` would. Replay-safe: the captured context is deterministic
+    // and the score is a memoized step.
+    const score: ExperimentScorer = async (memoizationId, scoreOptions) => {
+      const stepScore = deps?.experimentStepScore;
+      if (!stepScore) {
+        throw new Error(
+          "`experiment.score()` requires step tools to be available. " +
+            "Ensure you are calling this within an Inngest function execution.",
+        );
+      }
+
+      const scoreCtx = getAsyncCtxSync();
+      if (!scoreCtx?.execution || isALSFallback()) {
+        throw new Error(
+          "`experiment.score()` must be called within the same Inngest " +
+            "function execution that created the experiment.",
+        );
+      }
+
+      const als = await getAsyncLocalStorage();
+      const scopedCtx: AsyncContext = {
+        ...scoreCtx,
+        execution: {
+          ...scoreCtx.execution,
+          experimentContext,
+        },
+      };
+
+      await als.run(scopedCtx, () =>
+        stepScore(memoizationId, {
+          // Target the score step itself so the value lands at step scope on
+          // the score step's own row — the same row the executor stamps the
+          // variant onto (via the experiment context above). Without a stepId
+          // the score is run-scoped and never co-locates with the experiment.
+          stepId: memoizationId,
+          name: scoreOptions.name,
+          value: scoreOptions.value,
+        }),
+      );
+    };
+
     if (withVariant) {
-      return { result, variant: selectedVariant };
+      return { result, variant: selectedVariant, score };
     }
 
     return result;

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -57,8 +57,10 @@ import type {
   MetadataScope,
   MetadataUpdate,
 } from "../InngestMetadata.ts";
+import { scoreSymbol } from "../InngestScore.ts";
 import {
   createStepTools,
+  type ExperimentalStepTools,
   type ExperimentStepTools,
   experimentStepRunSymbol,
   type FoundStep,
@@ -2051,11 +2053,14 @@ class InngestExecutionEngine
     const experimentStepRun = (step as unknown as ExperimentStepTools)[
       experimentStepRunSymbol
     ];
+    const experimentStepScore = (step as unknown as ExperimentalStepTools)[
+      scoreSymbol
+    ];
 
     let fnArg = {
       ...(this.options.data as { event: EventPayload }),
       step,
-      group: createGroupTools({ experimentStepRun }),
+      group: createGroupTools({ experimentStepRun, experimentStepScore }),
       defer,
     } as unknown as Context.Any;
 

--- a/packages/inngest/src/components/experiment.test.ts
+++ b/packages/inngest/src/components/experiment.test.ts
@@ -115,7 +115,23 @@ const createHarness = () => {
     ctx,
   );
 
-  const deps: GroupToolsDeps = { experimentStepRun: experimentStepRun };
+  /**
+   * Records the `experimentContext` that was active in ALS each time the score
+   * tool ran. The real `step.score` is a `step.run` under the hood, so it reads
+   * this context to spread the experiment fields into the step's opts — this
+   * captures what it would see.
+   */
+  const scoreContexts: unknown[] = [];
+  const experimentStepScore = vi.fn(
+    async (
+      _memoId: string,
+      _opts: { name: string; value: number | boolean },
+    ) => {
+      scoreContexts.push(als.getStore()?.execution?.experimentContext);
+    },
+  );
+
+  const deps: GroupToolsDeps = { experimentStepRun, experimentStepScore };
   const group = createGroupTools(deps);
 
   /**
@@ -124,7 +140,16 @@ const createHarness = () => {
    */
   const run = <T>(fn: () => Promise<T>): Promise<T> => als.run(ctx, fn);
 
-  return { group, exec, ctx, experimentStepRun, HASHED_STEP_ID, run };
+  return {
+    group,
+    exec,
+    ctx,
+    experimentStepRun,
+    experimentStepScore,
+    scoreContexts,
+    HASHED_STEP_ID,
+    run,
+  };
 };
 
 // ====================================================================
@@ -538,10 +563,11 @@ describe("group.experiment() return shapes", () => {
       }),
     );
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       result: "result-b",
       variant: "b",
     });
+    expect(typeof result.score).toBe("function");
   });
 });
 
@@ -818,6 +844,174 @@ describe("group.experiment() ALS propagation", () => {
 
     expect(capturedTracker).toBeDefined();
     expect(capturedTracker!.found).toBe(false);
+  });
+});
+
+// ====================================================================
+// experiment.score() — scoring from a later step
+// ====================================================================
+
+describe("group.experiment() score()", () => {
+  test("withVariant return includes a score function", async () => {
+    const { group, run } = createHarness();
+
+    const result = await run(() =>
+      group.experiment("exp", {
+        variants: {
+          a: () => {
+            fakeStepCall();
+            return "a";
+          },
+        },
+        select: experiment.fixed("a"),
+        withVariant: true,
+      }),
+    );
+
+    expect(typeof result.score).toBe("function");
+  });
+
+  test("score() runs the score tool inside the experiment context", async () => {
+    const { group, run, experimentStepScore, scoreContexts, HASHED_STEP_ID } =
+      createHarness();
+
+    const { score } = await run(() =>
+      group.experiment("checkout-flow", {
+        variants: {
+          control: () => {
+            fakeStepCall();
+            return "c";
+          },
+        },
+        select: experiment.fixed("control"),
+        withVariant: true,
+      }),
+    );
+
+    await run(() => score("score-latency", { name: "latency", value: 42 }));
+
+    // Forwards the memo id and targets the score step itself (step scope) so
+    // the value co-locates with the variant on the score step's own row.
+    expect(experimentStepScore).toHaveBeenCalledWith("score-latency", {
+      stepId: "score-latency",
+      name: "latency",
+      value: 42,
+    });
+
+    // The score's underlying step sees the same experiment fields an
+    // in-callback score would, so the executor stamps the variant onto its row.
+    expect(scoreContexts[0]).toEqual({
+      experimentStepID: HASHED_STEP_ID,
+      experimentName: "checkout-flow",
+      variant: "control",
+      selectionStrategy: "fixed",
+    });
+  });
+
+  test("score() re-enters the experiment context on replay without a hashed step ID", async () => {
+    // On replay the selection step is memoized, so experimentStepHashedId stays
+    // undefined. The scorer must still carry the (replay-stable) variant/name —
+    // the executor stamps from those, not from experimentStepID.
+    const exec = mockExecution();
+    const ctx: AsyncContext = {
+      app: {} as AsyncContext["app"],
+      execution: {
+        instance: exec,
+        ctx: { runId: "run-id-replay" } as never,
+      },
+    };
+
+    const memoizedStepRun = vi.fn(
+      async (_idOrOptions: unknown, _callback: unknown) => "control",
+    );
+
+    const scoreContexts: unknown[] = [];
+    const experimentStepScore = vi.fn(async () => {
+      scoreContexts.push(als.getStore()?.execution?.experimentContext);
+    });
+
+    const group = createGroupTools({
+      experimentStepRun: memoizedStepRun,
+      experimentStepScore,
+    });
+
+    const { score } = await als.run(ctx, () =>
+      group.experiment("my-exp", {
+        variants: {
+          control: () => {
+            fakeStepCall();
+            return "old";
+          },
+          new_flow: () => {
+            fakeStepCall();
+            return "new";
+          },
+        },
+        select: experiment.fixed("control"),
+        withVariant: true,
+      }),
+    );
+
+    await als.run(ctx, () => score("s", { name: "ok", value: true }));
+
+    expect(scoreContexts[0]).toEqual({
+      experimentStepID: "",
+      experimentName: "my-exp",
+      variant: "control",
+      selectionStrategy: "fixed",
+    });
+  });
+
+  test("score() throws when the score tool dep is missing", async () => {
+    const exec = mockExecution();
+    const ctx: AsyncContext = {
+      app: {} as AsyncContext["app"],
+      execution: {
+        instance: exec,
+        ctx: { runId: "run-id-123" } as never,
+      },
+    };
+    const { fn: experimentStepRun } = createMockExperimentStepRun(exec, ctx);
+    const group = createGroupTools({ experimentStepRun });
+
+    const { score } = await als.run(ctx, () =>
+      group.experiment("exp", {
+        variants: {
+          a: () => {
+            fakeStepCall();
+            return "a";
+          },
+        },
+        select: experiment.fixed("a"),
+        withVariant: true,
+      }),
+    );
+
+    await expect(
+      als.run(ctx, () => score("s", { name: "x", value: 1 })),
+    ).rejects.toThrow("requires step tools to be available");
+  });
+
+  test("score() throws when called outside a function execution", async () => {
+    const { group, run } = createHarness();
+
+    const { score } = await run(() =>
+      group.experiment("exp", {
+        variants: {
+          a: () => {
+            fakeStepCall();
+            return "a";
+          },
+        },
+        select: experiment.fixed("a"),
+        withVariant: true,
+      }),
+    );
+
+    // Called without an active ALS execution context.
+    await expect(score("s", { name: "x", value: 1 })).rejects.toThrow(
+      "must be called within the same Inngest function execution",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a way to score a `group.experiment()` from **outside** the variant callback — in a later step, or after a retry — without any backend changes.

`group.experiment(..., { withVariant: true })` now returns a `score` function:

```ts
export const inlineScore = inngest.createFunction(
  { id: "inline-score", triggers: { event: "checkout/started" } },
  async ({ group, step }) => {
    const { result, score } = await group.experiment("checkout-flow", {
      variants: {
        control: () => step.run("control", () => runCheckout("v1")),
        challenger: () => step.run("challenger", () => runCheckout("v2")),
      },
      select: experiment.weighted({ control: 50, challenger: 50 }),
      withVariant: true, // required to get `score`
    });

    await score("score-success", { name: "success", value: result.ok });

    return result;
  },
);
```

### How it works

The experiments dashboard attributes a score to a variant by **co-location**: the score (`inngest.score.<name>`) and the experiment attribution (`inngest.experiment` name + variant) must land on the **same `type='run'` step row**.

`score()` achieves that with no step-id bookkeeping:

1. It captures the experiment's variant/name. These are **replay-stable** — the variant is memoized via the selection step and the name is a literal — so it never relies on the hashed step id (which is unavailable on replay).
2. When called, it runs the score as its own step **inside the experiment's ALS context**, so the executor stamps the variant onto the score step's row from the step opts (the same path in-callback variant sub-steps use).
3. It targets that same step at **step scope**, so the score *value* batches onto the same row. Variant + value co-located → the dashboard aggregates it.

Because the function body re-executes top-to-bottom on every step boundary and retry, the `score` handle is deterministically reconstructed each time — so it works from a later step and survives retries. It stays on the batch path (no cross-step API write), so it does **not** touch `buildTarget` or depend on step-attempt resolution.

Call `score()` as a top-level step (not nested inside another `step.run` callback).

## Checklist

- [ ] ~~Added a docs PR~~ N/A — experimental API on an unreleased feature branch.
- [x] Added unit/integration tests — `experiment.test.ts` covers ALS re-entry, replay stability (empty hashed id), and the missing-dep / outside-execution guards. Validated end-to-end against the cloud stack: co-located scores for inline, later-step, and retry runs, confirmed via the experiments aggregation query.
- [ ] ~~Added changesets~~ N/A — targets the phase-1 scoring feature branch, not a release branch.

## Related
- INN-
