### PR TITLE
fix(extended traces): Emit extended trace spans parented to the finalized step span

### DIFF
--- a/.changeset/good-emus-float.md
+++ b/.changeset/good-emus-float.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix(extended traces): Emit extended trace spans parented to the finalized step span

--- a/packages/inngest/src/components/execution/otel/processor.ts
+++ b/packages/inngest/src/components/execution/otel/processor.ts
@@ -371,12 +371,11 @@ export class InngestSpanProcessor implements SpanProcessor {
 
       if (spanParentId === parentState.rootSpanId) {
         if (stepCtx) {
-          const seed = stepCtx.hashedStepId + ":" + String(stepCtx.attempt);
-          const newSpanId = deterministicSpanID(seed);
+          const newSpanId = deterministicSpanID(stepCtx.hashedStepId);
           trackDebug(
             "setting inngest.step.parentSpanId=%s (seed=%s) on span %s step %s index %d attempt %d",
             newSpanId,
-            seed,
+            stepCtx.hashedStepId,
             spanId,
             stepCtx.id,
             stepCtx.index,


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

Now that step span IDs are generally deterministic and finalized step spans are `f(step ID)`, change the extended trace span emission to be parented to the finalized step span (so that we don't need to reparent in rollup for successful steps).

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
