### PR TITLE
Extract advanced token counts from OTel Spans (EXE-1961)

### DIFF
--- a/.changeset/cache-reasoning-tokens.md
+++ b/.changeset/cache-reasoning-tokens.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Begin processing cache-read, cache-creation, and reasoning token counts from OTel spans for AI Metadata

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -187,11 +187,13 @@ describe("extractAIMetadataFromAttributes", () => {
         '{"input":22,"output":6,"total":28,"input_cached_tokens":5}',
     };
     // Order-independent: langfuse outranks semconv regardless of key order.
+    // `input_cached_tokens` from the same blob surfaces as cacheReadTokens.
     const expected = {
       responseModel: "gpt-4.1-nano-2025-04-14",
       inputTokens: 22,
       outputTokens: 6,
       totalTokens: 28,
+      cacheReadTokens: 5,
     };
     expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
     expect(
@@ -219,6 +221,35 @@ describe("extractAIMetadataFromAttributes", () => {
         "gen_ai.usage.total_tokens": 99,
       }),
     ).toEqual({ inputTokens: 22, outputTokens: 6, totalTokens: 99 });
+  });
+
+  test("falls back to the nested Vercel token detail attributes", () => {
+    // When only the nested `*TokenDetails` breakdown is present (not the flat
+    // top-level count), the fallback keyRank mapping still captures it.
+    expect(
+      extractAIMetadataFromAttributes({
+        "ai.usage.inputTokenDetails.cacheReadTokens": 2048,
+        "ai.usage.outputTokenDetails.reasoningTokens": 51,
+      }),
+    ).toEqual({ cacheReadTokens: 2048, reasoningTokens: 51 });
+  });
+
+  test("prefers the flat Vercel count over the nested detail when both differ", () => {
+    // The flat normalized count outranks the nested breakdown (keyRank 0 vs 1),
+    // regardless of attribute order.
+    const attributes = {
+      "ai.usage.inputTokenDetails.cacheReadTokens": 1,
+      "ai.usage.cachedInputTokens": 2048,
+      "ai.usage.outputTokenDetails.reasoningTokens": 2,
+      "ai.usage.reasoningTokens": 51,
+    };
+    const expected = { cacheReadTokens: 2048, reasoningTokens: 51 };
+    expect(extractAIMetadataFromAttributes(attributes)).toEqual(expected);
+    expect(
+      extractAIMetadataFromAttributes(
+        Object.fromEntries(Object.entries(attributes).reverse()),
+      ),
+    ).toEqual(expected);
   });
 
   test("does not derive a total when no token counts are present", () => {
@@ -306,6 +337,9 @@ describe("toInngestAIMetadataValues", () => {
         inputTokens: 42,
         outputTokens: 8,
         totalTokens: 50,
+        cacheReadTokens: 30,
+        cacheCreationTokens: 12,
+        reasoningTokens: 4,
       }),
     ).toEqual({
       model: "gpt-4o",
@@ -315,6 +349,9 @@ describe("toInngestAIMetadataValues", () => {
       input_tokens: 42,
       output_tokens: 8,
       total_tokens: 50,
+      cache_read_tokens: 30,
+      cache_creation_tokens: 12,
+      reasoning_tokens: 4,
     });
   });
 

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -32,6 +32,17 @@ export interface AIMetadata {
    * otherwise derived as input + output when either is present.
    */
   totalTokens?: number;
+  /**
+   * Detailed token counts, present only when the emitter reports them.
+   * Providers differ on accounting: OpenAI's cached tokens are a subset of
+   * {@link AIMetadata.inputTokens}, while Anthropic's cache counts are additive
+   * to it — callers must not assume a single relationship.
+   */
+  cacheReadTokens?: number;
+  /** Tokens written to the prompt cache. */
+  cacheCreationTokens?: number;
+  /** Reasoning/thinking tokens, when the emitter reports them separately. */
+  reasoningTokens?: number;
 }
 
 /**
@@ -70,26 +81,35 @@ interface Mapping {
 }
 
 /**
- * Prefix for the synthetic attributes produced by
- * {@link expandLangfuseUsageDetails}, kept distinct from any real attribute
- * namespace.
+ * Prefix for the synthetic attributes exploded from the
+ * `langfuse.observation.usage_details` JSON blob (e.g.
+ * `{"input":17,"output":36,"total":53}`), kept distinct from any real attribute
+ * namespace. The double underscore marks them derived.
  */
 const langfuseUsagePrefix = "__langfuse.usage_details.";
 
 /**
- * The usage counts we lift out of the `langfuse.observation.usage_details` JSON
- * blob (e.g. `{"input":17,"output":36,"total":53}`). Langfuse emits more counts
- * (cached, reasoning, …), but this extractor only reads the ones it tracks.
+ * Prefix for the synthetic attributes exploded from the langsmith
+ * `gen_ai.usage.input_token_details` JSON blob (e.g.
+ * `{"audio":0,"cache_read":2048}`). The double underscore marks them derived.
  */
-const langfuseUsageKeys = ["input", "output", "total"] as const;
+const genAIInputTokenDetailsPrefix = "__gen_ai.input_token_details.";
 
 /**
- * Parses the `langfuse.observation.usage_details` JSON blob and emits a synthetic
- * scalar attribute for each count we track. Only `input`, `output`, and `total`
- * are emitted; the other counts are intentionally dropped since this extractor
- * tracks input, output, and total tokens alone.
+ * Prefix for the synthetic attributes exploded from the langsmith
+ * `gen_ai.usage.output_token_details` JSON blob (e.g. `{"reasoning":51}`).
  */
-const expandLangfuseUsageDetails = (
+const genAIOutputTokenDetailsPrefix = "__gen_ai.output_token_details.";
+
+/**
+ * Parses a stringified JSON object of integer counts and emits one synthetic
+ * scalar attribute per integer entry, keyed as `${prefix}${key}`. Several
+ * emitters pack token detail into a single JSON-string attribute rather than
+ * scalar attributes; this explodes them so each entry flows back through
+ * {@link keyFieldMap} like any other attribute. Non-integer entries are skipped.
+ */
+const expandIntBlob = (
+  prefix: string,
   value: AttributeValue,
 ): Record<string, AttributeValue> => {
   if (typeof value !== "string" || value === "") {
@@ -108,15 +128,31 @@ const expandLangfuseUsageDetails = (
   }
 
   const out: Record<string, AttributeValue> = {};
-  for (const key of langfuseUsageKeys) {
-    const count = parsed[key];
-    if (typeof count === "number") {
-      out[`${langfuseUsagePrefix}${key}`] = count;
+  for (const [key, count] of Object.entries(parsed)) {
+    if (typeof count === "number" && Number.isInteger(count)) {
+      out[`${prefix}${key}`] = count;
     }
   }
 
   return out;
 };
+
+/** Explodes the `langfuse.observation.usage_details` blob under {@link langfuseUsagePrefix}. */
+const expandLangfuseUsageDetails = (
+  value: AttributeValue,
+): Record<string, AttributeValue> => expandIntBlob(langfuseUsagePrefix, value);
+
+/** Explodes the langsmith `gen_ai.usage.input_token_details` blob. */
+const expandGenAIInputTokenDetails = (
+  value: AttributeValue,
+): Record<string, AttributeValue> =>
+  expandIntBlob(genAIInputTokenDetailsPrefix, value);
+
+/** Explodes the langsmith `gen_ai.usage.output_token_details` blob. */
+const expandGenAIOutputTokenDetails = (
+  value: AttributeValue,
+): Record<string, AttributeValue> =>
+  expandIntBlob(genAIOutputTokenDetailsPrefix, value);
 
 /**
  * Maps a source attribute key to the canonical {@link AIMetadata} field it
@@ -143,6 +179,14 @@ const keyFieldMap: Record<string, Mapping> = {
   },
   [`${langfuseUsagePrefix}total`]: {
     field: "totalTokens",
+    convention: Convention.Langfuse,
+  },
+  [`${langfuseUsagePrefix}input_cached_tokens`]: {
+    field: "cacheReadTokens",
+    convention: Convention.Langfuse,
+  },
+  [`${langfuseUsagePrefix}output_reasoning_tokens`]: {
+    field: "reasoningTokens",
     convention: Convention.Langfuse,
   },
   "langfuse.observation.model.name": {
@@ -179,8 +223,43 @@ const keyFieldMap: Record<string, Mapping> = {
     field: "outputTokens",
     convention: Convention.Semconv,
   },
+  // NOT an official OTel GenAI semconv attribute: the spec defines only
+  // input/output token counts, no total. Emitted in practice by Traceloop and
+  // others, so we still accept it.
   "gen_ai.usage.total_tokens": {
     field: "totalTokens",
+    convention: Convention.Semconv,
+  },
+  "gen_ai.usage.cache_read.input_tokens": {
+    field: "cacheReadTokens",
+    convention: Convention.Semconv,
+  },
+  "gen_ai.usage.cache_creation.input_tokens": {
+    field: "cacheCreationTokens",
+    convention: Convention.Semconv,
+  },
+  // NOT an official OTel GenAI semconv attribute: the spec uses flat scalar
+  // attributes (e.g. gen_ai.usage.cache_read.input_tokens), not a nested
+  // *_token_details object. This is langsmith's convention, which packs
+  // cache/audio detail into a single JSON blob; expand it into synthetic
+  // children matched back below.
+  "gen_ai.usage.input_token_details": {
+    convention: Convention.Semconv,
+    expand: expandGenAIInputTokenDetails,
+  },
+  [`${genAIInputTokenDetailsPrefix}cache_read`]: {
+    field: "cacheReadTokens",
+    convention: Convention.Semconv,
+  },
+  // NOT an official OTel GenAI semconv attribute (see input_token_details
+  // above): langsmith's nested blob, vs. the spec's flat
+  // gen_ai.usage.reasoning.output_tokens.
+  "gen_ai.usage.output_token_details": {
+    convention: Convention.Semconv,
+    expand: expandGenAIOutputTokenDetails,
+  },
+  [`${genAIOutputTokenDetailsPrefix}reasoning`]: {
+    field: "reasoningTokens",
     convention: Convention.Semconv,
   },
 
@@ -200,6 +279,14 @@ const keyFieldMap: Record<string, Mapping> = {
   },
   "llm.token_count.total": {
     field: "totalTokens",
+    convention: Convention.OpenInference,
+  },
+  "llm.token_count.prompt_details.cache_read": {
+    field: "cacheReadTokens",
+    convention: Convention.OpenInference,
+  },
+  "llm.token_count.completion_details.reasoning": {
+    field: "reasoningTokens",
     convention: Convention.OpenInference,
   },
   // `llm.system` identifies the AI product/vendor (openai, anthropic, …),
@@ -233,6 +320,31 @@ const keyFieldMap: Record<string, Mapping> = {
   "ai.usage.totalTokens": {
     field: "totalTokens",
     convention: Convention.Vercel,
+  },
+  // Cached-input count. The AI SDK emits both a flat top-level attribute and a
+  // nested `inputTokenDetails` breakdown carrying the same value; neither is
+  // documented in the telemetry spec and Vercel marks neither deprecated. The
+  // flat form is the canonical normalized `LanguageModelUsage` field, so it
+  // wins (keyRank 0); the nested form is a fallback (keyRank 1) for emitters
+  // that report only the breakdown.
+  "ai.usage.cachedInputTokens": {
+    field: "cacheReadTokens",
+    convention: Convention.Vercel,
+  },
+  "ai.usage.inputTokenDetails.cacheReadTokens": {
+    field: "cacheReadTokens",
+    convention: Convention.Vercel,
+    keyRank: 1,
+  },
+  // Reasoning count; same flat-vs-nested duplication as cachedInputTokens above.
+  "ai.usage.reasoningTokens": {
+    field: "reasoningTokens",
+    convention: Convention.Vercel,
+  },
+  "ai.usage.outputTokenDetails.reasoningTokens": {
+    field: "reasoningTokens",
+    convention: Convention.Vercel,
+    keyRank: 1,
   },
   // Embeddings spans emit only a single `ai.usage.tokens` count (no
   // input/output split); map it to inputTokens to match the semconv embeddings
@@ -366,6 +478,23 @@ export const extractAIMetadataFromAttributes = (
     metadata.totalTokens = totalTokens;
   }
 
+  // Detailed token counts, stored raw as each emitter reports them; no
+  // cross-field derivation since providers account for them differently.
+  const cacheReadTokens = count("cacheReadTokens");
+  if (cacheReadTokens !== undefined) {
+    metadata.cacheReadTokens = cacheReadTokens;
+  }
+
+  const cacheCreationTokens = count("cacheCreationTokens");
+  if (cacheCreationTokens !== undefined) {
+    metadata.cacheCreationTokens = cacheCreationTokens;
+  }
+
+  const reasoningTokens = count("reasoningTokens");
+  if (reasoningTokens !== undefined) {
+    metadata.reasoningTokens = reasoningTokens;
+  }
+
   return metadata;
 };
 
@@ -414,6 +543,24 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
     metadata.totalTokens = (a.totalTokens ?? 0) + (b.totalTokens ?? 0);
   }
 
+  if (a.cacheReadTokens !== undefined || b.cacheReadTokens !== undefined) {
+    metadata.cacheReadTokens =
+      (a.cacheReadTokens ?? 0) + (b.cacheReadTokens ?? 0);
+  }
+
+  if (
+    a.cacheCreationTokens !== undefined ||
+    b.cacheCreationTokens !== undefined
+  ) {
+    metadata.cacheCreationTokens =
+      (a.cacheCreationTokens ?? 0) + (b.cacheCreationTokens ?? 0);
+  }
+
+  if (a.reasoningTokens !== undefined || b.reasoningTokens !== undefined) {
+    metadata.reasoningTokens =
+      (a.reasoningTokens ?? 0) + (b.reasoningTokens ?? 0);
+  }
+
   return metadata;
 };
 
@@ -454,6 +601,18 @@ export const toInngestAIMetadataValues = (
 
   if (metadata.totalTokens !== undefined) {
     values.total_tokens = metadata.totalTokens;
+  }
+
+  if (metadata.cacheReadTokens !== undefined) {
+    values.cache_read_tokens = metadata.cacheReadTokens;
+  }
+
+  if (metadata.cacheCreationTokens !== undefined) {
+    values.cache_creation_tokens = metadata.cacheCreationTokens;
+  }
+
+  if (metadata.reasoningTokens !== undefined) {
+    values.reasoning_tokens = metadata.reasoningTokens;
   }
 
   if (Object.keys(values).length === 0) {

--- a/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/cache_messages.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/cache_messages.otlp.json.snap
@@ -7,7 +7,9 @@
       "system": "anthropic",
       "inputTokens": 13,
       "outputTokens": 4,
-      "totalTokens": 17
+      "totalTokens": 17,
+      "cacheReadTokens": 0,
+      "cacheCreationTokens": 2463
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "anthropic",
       "inputTokens": 3,
       "outputTokens": 4,
-      "totalTokens": 7
+      "totalTokens": 7,
+      "cacheReadTokens": 2463,
+      "cacheCreationTokens": 10
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.snap
@@ -7,7 +7,9 @@
       "system": "anthropic",
       "inputTokens": 52,
       "outputTokens": 450,
-      "totalTokens": 502
+      "totalTokens": 502,
+      "cacheReadTokens": 0,
+      "cacheCreationTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/basic_responses.otlp.json.snap
@@ -5,7 +5,9 @@
       "responseModel": "gpt-5.4-nano-2026-03-17",
       "inputTokens": 17,
       "outputTokens": 41,
-      "totalTokens": 58
+      "totalTokens": 58,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/cache_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/cache_chat.otlp.json.snap
@@ -5,7 +5,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "inputTokens": 191,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   },
   {
@@ -14,7 +16,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "inputTokens": 191,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/params_chat.otlp.json.snap
@@ -5,7 +5,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "inputTokens": 22,
       "outputTokens": 6,
-      "totalTokens": 28
+      "totalTokens": 28,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/reasoning_responses.otlp.json.snap
@@ -5,7 +5,9 @@
       "responseModel": "gpt-5.4-nano-2026-03-17",
       "inputTokens": 42,
       "outputTokens": 211,
-      "totalTokens": 295
+      "totalTokens": 295,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 42
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/stream_chat.otlp.json.snap
@@ -5,7 +5,9 @@
       "responseModel": "gpt-4.1-nano",
       "inputTokens": 11,
       "outputTokens": 10,
-      "totalTokens": 21
+      "totalTokens": 21,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langfuse_observe/tools_chat.otlp.json.snap
@@ -5,7 +5,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "inputTokens": 56,
       "outputTokens": 30,
-      "totalTokens": 86
+      "totalTokens": 86,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "resp_0b898006b71f980e006a30976c7ae8819a9f9dfe79dd711f39",
       "inputTokens": 17,
       "outputTokens": 46,
-      "totalTokens": 63
+      "totalTokens": 63,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/cache_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/cache_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBsAXqUMaHYPrj5ZXESBND59etIW",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   },
   {
@@ -20,7 +22,9 @@
       "responseId": "chatcmpl-DrBsAELJFLtxa5IkhXuaDco7u8p7T",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/params_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBs5NWq2cjOCfOmsXB701DaqqHMF",
       "inputTokens": 22,
       "outputTokens": 6,
-      "totalTokens": 28
+      "totalTokens": 28,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/reasoning_responses.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "resp_0b427a55574fd2a6006a30976fba7481989905eecdba88aab7",
       "inputTokens": 42,
       "outputTokens": 238,
-      "totalTokens": 280
+      "totalTokens": 280,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 51
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/tools_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBs68ShlhujNjnFypB1xKq8Q9G1r",
       "inputTokens": 56,
       "outputTokens": 30,
-      "totalTokens": 86
+      "totalTokens": 86,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/basic_responses.otlp.json.snap
@@ -6,7 +6,9 @@
       "system": "openai",
       "inputTokens": 17,
       "outputTokens": 40,
-      "totalTokens": 57
+      "totalTokens": 57,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/cache_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/cache_chat.otlp.json.snap
@@ -6,7 +6,9 @@
       "system": "openai",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   },
   {
@@ -16,7 +18,9 @@
       "system": "openai",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/params_chat.otlp.json.snap
@@ -6,7 +6,9 @@
       "system": "openai",
       "inputTokens": 22,
       "outputTokens": 6,
-      "totalTokens": 28
+      "totalTokens": 28,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/reasoning_responses.otlp.json.snap
@@ -6,7 +6,9 @@
       "system": "openai",
       "inputTokens": 42,
       "outputTokens": 191,
-      "totalTokens": 233
+      "totalTokens": 233,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 44
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_openinference_arize/tools_chat.otlp.json.snap
@@ -6,7 +6,9 @@
       "system": "openai",
       "inputTokens": 56,
       "outputTokens": 30,
-      "totalTokens": 86
+      "totalTokens": 86,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "resp_01dd5d400c40c9ef006a30976041748199a7658d39393c5fd9",
       "inputTokens": 17,
       "outputTokens": 40,
-      "totalTokens": 57
+      "totalTokens": 57,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "openai.responses",
       "inputTokens": 17,
       "outputTokens": 40,
-      "totalTokens": 57
+      "totalTokens": 57,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/cache_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/cache_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBrxZaLAohSzytpjuElSDvbE0a1S",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "openai.chat",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   },
   {
@@ -30,7 +34,9 @@
       "responseId": "chatcmpl-DrBrxfDhpflYHItQYi67qqh1qKBIa",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   },
   {
@@ -40,7 +46,9 @@
       "system": "openai.chat",
       "inputTokens": 2239,
       "outputTokens": 1,
-      "totalTokens": 2240
+      "totalTokens": 2240,
+      "cacheReadTokens": 2048,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBrtFuAQlLXg4oa4L76UUtX9ck0t",
       "inputTokens": 22,
       "outputTokens": 6,
-      "totalTokens": 28
+      "totalTokens": 28,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "openai.chat",
       "inputTokens": 22,
       "outputTokens": 6,
-      "totalTokens": 28
+      "totalTokens": 28,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "resp_075c5a0fa12d9c42006a3097629c388198b6cf046b3222fd4b",
       "inputTokens": 42,
       "outputTokens": 261,
-      "totalTokens": 303
+      "totalTokens": 303,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 48
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "openai.responses",
       "inputTokens": 42,
       "outputTokens": 261,
-      "totalTokens": 303
+      "totalTokens": 303,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 48
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBruw0ipxM6NO9pr53HGKTeUDGsv",
       "inputTokens": 11,
       "outputTokens": 14,
-      "totalTokens": 25
+      "totalTokens": 25,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "openai.chat",
       "inputTokens": 11,
       "outputTokens": 14,
-      "totalTokens": 25
+      "totalTokens": 25,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
@@ -8,7 +8,9 @@
       "responseId": "chatcmpl-DrBrthIp6Qs0mY9a1VKXPa8s03XKf",
       "inputTokens": 56,
       "outputTokens": 30,
-      "totalTokens": 86
+      "totalTokens": 86,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   },
   {
@@ -18,7 +20,9 @@
       "system": "openai.chat",
       "inputTokens": 56,
       "outputTokens": 30,
-      "totalTokens": 86
+      "totalTokens": 86,
+      "cacheReadTokens": 0,
+      "reasoningTokens": 0
     }
   }
 ]


### PR DESCRIPTION
## Summary

- Previously, we extracted input tokens, output tokens, and total tokens.
- Now let's capture more advanced token fields

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
