### PR TITLE
feat(score): Make score kind constant

### DIFF
--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -15,7 +15,7 @@ export type MetadataScope = "run" | "step" | "extended_trace";
  */
 export type MetadataKind =
   | "inngest.experiment"
-  | `inngest.score.${string}`
+  | `inngest.score`
   | "inngest.warnings"
   | `userland.${string}`;
 

--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -15,7 +15,7 @@ export type MetadataScope = "run" | "step" | "extended_trace";
  */
 export type MetadataKind =
   | "inngest.experiment"
-  | `inngest.score`
+  | "inngest.score"
   | "inngest.warnings"
   | `userland.${string}`;
 

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -163,7 +163,7 @@ describe("client.score validation", () => {
       {
         kind: "inngest.score",
         op: "merge",
-        values: { "click-through rate (variant A)!": {value: 0.23} },
+        values: { "click-through rate (variant A)!": { value: 0.23 } },
       },
     ]);
   });

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -188,7 +188,7 @@ describe("client.score validation", () => {
       {
         kind: "inngest.score",
         op: "merge",
-        values: { pass: {value: true} },
+        values: { pass: { value: true } },
       },
     ]);
   });

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -78,20 +78,20 @@ describe("client.score validation", () => {
       client.score({
         runId: "run",
         stepId: "step",
-        name: "x".repeat(115),
+        name: "x".repeat(129),
         value: 1,
       }),
-    ).rejects.toThrow("score name must be 114 bytes or fewer");
+    ).rejects.toThrow("score name must be 128 bytes or fewer");
 
-    // 60 × "é" = 120 UTF-8 bytes, under the 114-char limit but over the byte cap.
+    // 60 × "é" = 130 UTF-8 bytes, under the 128-char limit but over the byte cap.
     await expect(
       client.score({
         runId: "run",
         stepId: "step",
-        name: "é".repeat(60),
+        name: "é".repeat(65),
         value: 1,
       }),
-    ).rejects.toThrow("score name must be 114 bytes or fewer");
+    ).rejects.toThrow("score name must be 128 bytes or fewer");
 
     await expect(
       client.score({
@@ -136,7 +136,7 @@ describe("client.score validation", () => {
     ).rejects.toThrow("No run context available");
   });
 
-  test("emits inngest.score.<name> kind with value-keyed payload", async () => {
+  test("emits inngest.score kind with <name>.value-keyed payload", async () => {
     const client = new Inngest({ id: "app" });
     const spy = vi
       .fn<
@@ -161,9 +161,9 @@ describe("client.score validation", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0]?.[0]?.metadata).toEqual([
       {
-        kind: "inngest.score.click-through rate (variant A)!",
+        kind: "inngest.score",
         op: "merge",
-        values: { value: 0.23 },
+        values: { "click-through rate (variant A)!": {value: 0.23} },
       },
     ]);
   });
@@ -186,9 +186,9 @@ describe("client.score validation", () => {
 
     expect(spy.mock.calls[0]?.[0]?.metadata).toEqual([
       {
-        kind: "inngest.score.pass",
+        kind: "inngest.score",
         op: "merge",
-        values: { value: true },
+        values: { pass: {value: true} },
       },
     ]);
   });
@@ -228,17 +228,17 @@ describe("step.score validation", () => {
 
     expect(() =>
       validateStepScoreOptions({
-        name: "x".repeat(115),
+        name: "x".repeat(129),
         value: 1,
       }),
-    ).toThrow("score name must be 114 bytes or fewer");
+    ).toThrow("score name must be 128 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({
-        name: "é".repeat(60),
+        name: "é".repeat(65),
         value: 1,
       }),
-    ).toThrow("score name must be 114 bytes or fewer");
+    ).toThrow("score name must be 128 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -114,7 +114,7 @@ export async function sendScore(
       runId: options.runId,
       stepId: options.stepId,
     },
-    { [options.name]: {value: options.value }},
+    { [options.name]: { value: options.value } },
     `${scoreKind}`,
     "merge",
   );

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -4,11 +4,9 @@ import { performOp } from "./InngestMetadata.ts";
 import type { ExperimentalStepTools } from "./InngestStepTools.ts";
 import { Middleware } from "./middleware/middleware.ts";
 
-// Server caps the full kind at 128 bytes; "inngest.score." is 14 bytes, so the
-// user-supplied suffix can be up to 114 UTF-8 bytes.
-const scoreKindPrefix = "inngest.score." as const;
+const scoreKind = "inngest.score" as const;
 const maxKindByteLength = 128;
-const maxScoreNameByteLength = maxKindByteLength - scoreKindPrefix.length;
+const maxScoreNameByteLength = maxKindByteLength;
 
 type ScoreValue = number | boolean;
 
@@ -116,8 +114,8 @@ export async function sendScore(
       runId: options.runId,
       stepId: options.stepId,
     },
-    { value: options.value },
-    `${scoreKindPrefix}${options.name}`,
+    { [options.name]: {value: options.value }},
+    `${scoreKind}`,
     "merge",
   );
 }
@@ -136,8 +134,8 @@ export async function sendStepScore(
         options.stepId === undefined ? (options.runId ?? null) : options.runId,
       stepId: options.stepId,
     },
-    { value: options.value },
-    `${scoreKindPrefix}${options.name}`,
+    { [options.name]: {value: options.value }},
+    `${scoreKind}`,
     "merge",
   );
 }

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -134,7 +134,7 @@ export async function sendStepScore(
         options.stepId === undefined ? (options.runId ?? null) : options.runId,
       stepId: options.stepId,
     },
-    { [options.name]: {value: options.value }},
+    { [options.name]: { value: options.value } },
     `${scoreKind}`,
     "merge",
   );


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

This makes the score kind constant and changes the underlying scores shape to 

```json
{"<name>": {"value": <value>}}
```

with kind `inngest.score`

instead of 

```json
{"value": <value>}
```

with kind `inngest.score.name`

This has the side effect of relaxing the name length constraints (but we still limit to 128 bytes)

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
