### PR TITLE
Support deprecated `gen_ai.system` for AI Metadata Extraction (EXE-1976)

### DIFF
--- a/.changeset/nice-books-vanish.md
+++ b/.changeset/nice-books-vanish.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Support deprecated `gen_ai.system` for AI Metadata Extraction

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -154,6 +154,32 @@ describe("extractAIMetadataFromAttributes", () => {
     });
   });
 
+  describe("provider", () => {
+    test("reads the deprecated gen_ai.system when the canonical key is absent", () => {
+      expect(
+        extractAIMetadataFromAttributes({ "gen_ai.system": "anthropic" }),
+      ).toEqual({ provider: "anthropic" });
+    });
+
+    test("prefers gen_ai.provider.name over the deprecated gen_ai.system", () => {
+      expect(
+        extractAIMetadataFromAttributes({
+          "gen_ai.provider.name": "openai",
+          "gen_ai.system": "anthropic",
+        }),
+      ).toEqual({ provider: "openai" });
+    });
+
+    test("falls back to gen_ai.system when the canonical key is empty", () => {
+      expect(
+        extractAIMetadataFromAttributes({
+          "gen_ai.provider.name": "",
+          "gen_ai.system": "anthropic",
+        }),
+      ).toEqual({ provider: "anthropic" });
+    });
+  });
+
   test("reports only the provider-supplied total; never derives one", () => {
     // With input + output but no total, the total field is simply absent.
     expect(
@@ -342,9 +368,10 @@ describe("FIELD_SPECS", () => {
   test("every source key is a gen_ai.* semantic convention attribute", () => {
     // Guards the allowlist against typos: every source must live in the
     // OpenTelemetry GenAI (`gen_ai.*`) namespace.
-    const nonGenAi = FIELD_SPECS.map((spec) => spec.source).filter(
-      (source) => !source.startsWith("gen_ai."),
-    );
+    const nonGenAi = FIELD_SPECS.flatMap((spec) => [
+      spec.source,
+      ...(spec.fallbackSources ?? []),
+    ]).filter((source) => !source.startsWith("gen_ai."));
 
     expect(nonGenAi).toEqual([]);
   });

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -90,8 +90,15 @@ type TextField = FieldsWithValue<string>;
 type NumberField = FieldsWithValue<number>;
 
 interface BaseFieldSpec {
-  /** The source `gen_ai.*` attribute key. */
+  /** The canonical (preferred) source `gen_ai.*` attribute key. */
   source: string;
+  /**
+   * Deprecated source keys to read when {@link BaseFieldSpec.source} is absent
+   * or carries no usable value, in descending precedence. The preferred
+   * {@link BaseFieldSpec.source} always wins when it supplies a value; these are
+   * only consulted as fallbacks.
+   */
+  fallbackSources?: readonly string[];
   valueType: ValueType;
   merge: MergeStrategy;
 }
@@ -111,10 +118,15 @@ interface NumberFieldSpec extends BaseFieldSpec {
 
 type FieldSpec = TextFieldSpec | NumberFieldSpec;
 
-function textField(field: TextField, source: string): TextFieldSpec {
+function textField(
+  field: TextField,
+  source: string,
+  fallbackSources?: readonly string[],
+): TextFieldSpec {
   return {
     field,
     source,
+    fallbackSources,
     valueType: "text",
     merge: "replace",
   };
@@ -143,7 +155,9 @@ export const FIELD_SPECS = [
   // Identity & classification.
   textField("requestModel", "gen_ai.request.model"),
   textField("responseModel", "gen_ai.response.model"),
-  textField("provider", "gen_ai.provider.name"),
+  // `gen_ai.system` is the deprecated predecessor of `gen_ai.provider.name`;
+  // the canonical key wins when both are present on a span.
+  textField("provider", "gen_ai.provider.name", ["gen_ai.system"]),
   textField("responseId", "gen_ai.response.id"),
 
   // Token usage.
@@ -205,20 +219,28 @@ export const extractAIMetadataFromAttributes = (
   const metadata: AIMetadata = {};
 
   for (const spec of FIELD_SPECS) {
-    const value = attributes[spec.source];
-    if (value === undefined) {
-      continue;
-    }
+    // Read the canonical key first, then any deprecated fallbacks in order,
+    // taking the first that yields a usable value.
+    const sources = [spec.source, ...(spec.fallbackSources ?? [])];
 
-    if (spec.valueType === "text") {
-      const text = typeof value === "string" ? value : String(value);
-      if (text !== "") {
-        metadata[spec.field] = text;
+    for (const source of sources) {
+      const value = attributes[source];
+      if (value === undefined) {
+        continue;
       }
-    } else {
-      const num = parseNumericAttribute(value);
-      if (num !== undefined) {
-        metadata[spec.field] = num;
+
+      if (spec.valueType === "text") {
+        const text = typeof value === "string" ? value : String(value);
+        if (text !== "") {
+          metadata[spec.field] = text;
+          break;
+        }
+      } else {
+        const num = parseNumericAttribute(value);
+        if (num !== undefined) {
+          metadata[spec.field] = num;
+          break;
+        }
       }
     }
   }

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-5.4-nano",
       "responseModel": "gpt-5.4-nano-2026-03-17",
+      "provider": "openai",
       "responseId": "resp_0b898006b71f980e006a30976c7ae8819a9f9dfe79dd711f39",
       "inputTokens": 17,
       "outputTokens": 46,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/embeddings.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "text-embedding-3-small",
       "responseModel": "text-embedding-3-small",
+      "provider": "openai",
       "inputTokens": 10
     }
   }

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
+      "provider": "openai",
       "responseId": "chatcmpl-DrBr1MuPKdHPsQKsEJiGPeor6ptxv",
       "inputTokens": 22,
       "outputTokens": 6,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
+      "provider": "openai",
       "responseId": "chatcmpl-DrBr3uruHirhUsB9574xMBlIPvKi2",
       "inputTokens": 11,
       "outputTokens": 10

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
+      "provider": "openai",
       "responseId": "chatcmpl-DrBr2Rq2QohIZSHpQZggjEIGFCnek",
       "inputTokens": 56,
       "outputTokens": 30

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-5.4-nano",
       "responseModel": "gpt-5.4-nano-2026-03-17",
+      "provider": "openai.responses",
       "responseId": "resp_01dd5d400c40c9ef006a30976041748199a7658d39393c5fd9",
       "inputTokens": 17,
       "outputTokens": 40

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
+      "provider": "openai.chat",
       "responseId": "chatcmpl-DrBrtFuAQlLXg4oa4L76UUtX9ck0t",
       "inputTokens": 22,
       "outputTokens": 6,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
+      "provider": "openai.chat",
       "responseId": "chatcmpl-DrBruw0ipxM6NO9pr53HGKTeUDGsv",
       "inputTokens": 11,
       "outputTokens": 14

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
@@ -4,6 +4,7 @@
     "metadata": {
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
+      "provider": "openai.chat",
       "responseId": "chatcmpl-DrBrthIp6Qs0mY9a1VKXPa8s03XKf",
       "inputTokens": 56,
       "outputTokens": 30


### PR DESCRIPTION
## Summary

- Previously, we added support for extracting the provider from attributes, like OpenAI
- Let's add support for the previous key for this that was deprecated

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

~~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [x] Added unit/integration tests
- [x] Added changesets if applicable