### PR TITLE
Parse finish reasons from AI Metadata (EXE-1976)

### DIFF
--- a/.changeset/wise-drinks-knock.md
+++ b/.changeset/wise-drinks-knock.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Support parsing finish reasons for AI Metadata Extraction

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -216,6 +216,30 @@ describe("extractAIMetadataFromAttributes", () => {
     ).toEqual({ temperature: 0 });
   });
 
+  test("extracts finish reasons as a list of strings", () => {
+    expect(
+      extractAIMetadataFromAttributes({
+        "gen_ai.response.finish_reasons": ["stop", "tool_calls"],
+      }),
+    ).toEqual({ finishReasons: ["stop", "tool_calls"] });
+  });
+
+  test("drops empty and non-string finish-reason entries", () => {
+    expect(
+      extractAIMetadataFromAttributes({
+        "gen_ai.response.finish_reasons": ["", "stop"],
+      }),
+    ).toEqual({ finishReasons: ["stop"] });
+  });
+
+  test("drops finish reasons when the list reduces to nothing", () => {
+    expect(
+      extractAIMetadataFromAttributes({
+        "gen_ai.response.finish_reasons": [],
+      }),
+    ).toEqual({});
+  });
+
   test("ignores unmapped, content, and sensitive keys", () => {
     expect(
       extractAIMetadataFromAttributes({
@@ -313,6 +337,12 @@ describe("aggregate", () => {
     });
   });
 
+  test("replaces finish reasons rather than concatenating them", () => {
+    expect(
+      aggregate({ finishReasons: ["stop"] }, { finishReasons: ["tool_calls"] }),
+    ).toEqual({ finishReasons: ["tool_calls"] });
+  });
+
   test("returns an empty object when both inputs are empty", () => {
     expect(aggregate({}, {})).toEqual({});
   });
@@ -326,6 +356,7 @@ describe("toInngestAIMetadataValues", () => {
         responseModel: "gpt-4o-2024-08-06",
         provider: "openai",
         responseId: "chatcmpl-abc",
+        finishReasons: ["stop"],
         inputTokens: 42,
         outputTokens: 8,
         totalTokens: 50,
@@ -344,6 +375,7 @@ describe("toInngestAIMetadataValues", () => {
       response_model: "gpt-4o-2024-08-06",
       provider: "openai",
       response_id: "chatcmpl-abc",
+      finish_reasons: ["stop"],
       input_tokens: 42,
       output_tokens: 8,
       total_tokens: 50,

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -27,6 +27,11 @@ export interface AIMetadata {
   provider?: string;
   /** The provider's identifier for the response, e.g. `chatcmpl-...`. */
   responseId?: string;
+  /**
+   * Why generation stopped, as reported by the provider, e.g. `["stop"]`,
+   * `["length"]`, or `["tool_calls"]`. Last-write-wins across calls.
+   */
+  finishReasons?: string[];
 
   // Token usage (summed).
 
@@ -66,7 +71,7 @@ export interface AIMetadata {
   seed?: number;
 }
 
-type ValueType = "text" | "number";
+type ValueType = "text" | "number" | "stringList";
 type MergeStrategy = "replace" | "sum";
 
 /**
@@ -88,6 +93,7 @@ type FieldsWithValue<TValue> = {
 
 type TextField = FieldsWithValue<string>;
 type NumberField = FieldsWithValue<number>;
+type StringListField = FieldsWithValue<string[]>;
 
 interface BaseFieldSpec {
   /** The canonical (preferred) source `gen_ai.*` attribute key. */
@@ -116,7 +122,14 @@ interface NumberFieldSpec extends BaseFieldSpec {
   valueType: "number";
 }
 
-type FieldSpec = TextFieldSpec | NumberFieldSpec;
+interface StringListFieldSpec extends BaseFieldSpec {
+  /** The canonical {@link AIMetadata} field this populates. */
+  field: StringListField;
+  valueType: "stringList";
+  merge: "replace";
+}
+
+type FieldSpec = TextFieldSpec | NumberFieldSpec | StringListFieldSpec;
 
 function textField(
   field: TextField,
@@ -145,6 +158,18 @@ function numberField(
   };
 }
 
+function stringListField(
+  field: StringListField,
+  source: string,
+): StringListFieldSpec {
+  return {
+    field,
+    source,
+    valueType: "stringList",
+    merge: "replace",
+  };
+}
+
 /**
  * Every `gen_ai.*` attribute we capture, mapped to its canonical field.
  *
@@ -159,6 +184,7 @@ export const FIELD_SPECS = [
   // the canonical key wins when both are present on a span.
   textField("provider", "gen_ai.provider.name", ["gen_ai.system"]),
   textField("responseId", "gen_ai.response.id"),
+  stringListField("finishReasons", "gen_ai.response.finish_reasons"),
 
   // Token usage.
   numberField("inputTokens", "gen_ai.usage.input_tokens", "sum"),
@@ -200,12 +226,26 @@ function parseNumericAttribute(value: unknown): number | undefined {
 }
 
 /**
+ * Coerces an attribute to a list of non-empty strings, or `undefined` when it
+ * yields none. OTLP arrays may carry non-string or empty entries; those are
+ * dropped, and an array that reduces to nothing is treated as absent.
+ */
+function parseStringListAttribute(value: unknown): string[] | undefined {
+  const items = Array.isArray(value) ? value : [value];
+  const strings = items.filter(
+    (item): item is string => typeof item === "string" && item !== "",
+  );
+  return strings.length > 0 ? strings : undefined;
+}
+
+/**
  * Extracts {@link AIMetadata} from a span's attributes.
  *
  * Only the allowlisted {@link FIELD_SPECS} are read. Every other attribute is
  * ignored. Numeric fields accept numbers and quoted numeric strings and are
  * otherwise dropped, as OTLP/JSON may encode int64 as a quoted string. Text
- * fields are dropped when empty.
+ * fields are dropped when empty. String-list fields keep only non-empty string
+ * entries and are dropped when none remain.
  *
  * Returns an empty object for spans carrying no recognised `gen_ai.*`
  * attributes.
@@ -233,6 +273,12 @@ export const extractAIMetadataFromAttributes = (
         const text = typeof value === "string" ? value : String(value);
         if (text !== "") {
           metadata[spec.field] = text;
+          break;
+        }
+      } else if (spec.valueType === "stringList") {
+        const list = parseStringListAttribute(value);
+        if (list !== undefined) {
+          metadata[spec.field] = list;
           break;
         }
       } else {
@@ -278,6 +324,13 @@ export const aggregate = (a: AIMetadata, b: AIMetadata): AIMetadata => {
       }
     } else if (spec.valueType === "text") {
       // Text fields are always replace.
+      const bValue = b[spec.field];
+      if (bValue === undefined) {
+        continue;
+      }
+      out[spec.field] = bValue;
+    } else {
+      // String-list fields are always replace.
       const bValue = b[spec.field];
       if (bValue === undefined) {
         continue;

--- a/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/cache_messages.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/cache_messages.otlp.json.snap
@@ -5,6 +5,9 @@
       "requestModel": "claude-sonnet-4-6",
       "responseModel": "claude-sonnet-4-6",
       "provider": "anthropic",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 13,
       "outputTokens": 4,
       "totalTokens": 17,
@@ -19,6 +22,9 @@
       "requestModel": "claude-sonnet-4-6",
       "responseModel": "claude-sonnet-4-6",
       "provider": "anthropic",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 3,
       "outputTokens": 4,
       "totalTokens": 7,

--- a/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.snap
@@ -5,6 +5,9 @@
       "requestModel": "claude-sonnet-4-6",
       "responseModel": "claude-sonnet-4-6",
       "provider": "anthropic",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 52,
       "outputTokens": 450,
       "totalTokens": 502,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai",
       "responseId": "chatcmpl-DrBr1MuPKdHPsQKsEJiGPeor6ptxv",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 22,
       "outputTokens": 6,
       "temperature": 0.7,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai",
       "responseId": "chatcmpl-DrBr3uruHirhUsB9574xMBlIPvKi2",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 11,
       "outputTokens": 10
     }

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai",
       "responseId": "chatcmpl-DrBr2Rq2QohIZSHpQZggjEIGFCnek",
+      "finishReasons": [
+        "tool_calls"
+      ],
       "inputTokens": 56,
       "outputTokens": 30
     }

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/basic_responses.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-5.4-nano-2026-03-17",
       "provider": "openai",
       "responseId": "resp_0bd56df113f7e736006a30974f58008198a1e6e04b34495b9d",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 17,
       "outputTokens": 43,
       "totalTokens": 60

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/params_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai",
       "responseId": "chatcmpl-DrBrcL88UfT4NHRfP1xcL1UtpKZSP",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 22,
       "outputTokens": 6,
       "totalTokens": 28,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/stream_chat.otlp.json.snap
@@ -5,7 +5,10 @@
       "requestModel": "gpt-4.1-nano",
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai",
-      "responseId": "chatcmpl-DrBrdQ2FLoMqEewTueUxqUnAaRTTA"
+      "responseId": "chatcmpl-DrBrdQ2FLoMqEewTueUxqUnAaRTTA",
+      "finishReasons": [
+        "stop"
+      ]
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/tools_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai",
       "responseId": "chatcmpl-DrBrdE6062DJuFbeqgRecOx9OQ3WK",
+      "finishReasons": [
+        "tool_call"
+      ],
       "inputTokens": 56,
       "outputTokens": 14,
       "totalTokens": 70

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-5.4-nano-2026-03-17",
       "provider": "openai.responses",
       "responseId": "resp_01dd5d400c40c9ef006a30976041748199a7658d39393c5fd9",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 17,
       "outputTokens": 40
     }

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai.chat",
       "responseId": "chatcmpl-DrBrtFuAQlLXg4oa4L76UUtX9ck0t",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 22,
       "outputTokens": 6,
       "temperature": 0.7,

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai.chat",
       "responseId": "chatcmpl-DrBruw0ipxM6NO9pr53HGKTeUDGsv",
+      "finishReasons": [
+        "stop"
+      ],
       "inputTokens": 11,
       "outputTokens": 14
     }

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
@@ -6,6 +6,9 @@
       "responseModel": "gpt-4.1-nano-2025-04-14",
       "provider": "openai.chat",
       "responseId": "chatcmpl-DrBrthIp6Qs0mY9a1VKXPa8s03XKf",
+      "finishReasons": [
+        "tool-calls"
+      ],
       "inputTokens": 56,
       "outputTokens": 30
     }


### PR DESCRIPTION
## Summary

- Let's also parse finish reasons, `gen_ai.response.finish_reasons`, from spans for AI Metadata
- We previously skipped this one because it introduced a new type

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

~~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [x] Added unit/integration tests
- [x] Added changesets if applicable

