### PR TITLE
fix: Extended Traces not appearing when checkpointing disabled

### DIFF
--- a/.changeset/violet-windows-impress.md
+++ b/.changeset/violet-windows-impress.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix Extended Traces not appearing when checkpointing disabled

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1682,7 +1682,7 @@ class InngestExecutionEngine
 
     this.devDebug(`executing step "${id}"`);
 
-    if (this.rootSpanId && this.options.checkpointingConfig) {
+    if (this.rootSpanId) {
       clientProcessorMap
         .get(this.options.client)
         ?.declareStepExecution(
@@ -1731,7 +1731,7 @@ class InngestExecutionEngine
 
         this.state.executingStep = undefined;
 
-        if (this.rootSpanId && this.options.checkpointingConfig) {
+        if (this.rootSpanId) {
           clientProcessorMap
             .get(this.options.client)
             ?.clearStepExecution(this.rootSpanId);


### PR DESCRIPTION
## Summary

Fix Extended Traces not appearing when checkpointing disabled
