### PR TITLE
fix(scoring): remove warning on inngest.experiment.score

### DIFF
--- a/.changeset/fancy-baths-appear.md
+++ b/.changeset/fancy-baths-appear.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Suppress unnecessary warning log for inngest.experiment.score.

--- a/packages/inngest/src/components/InngestMetadata.test.ts
+++ b/packages/inngest/src/components/InngestMetadata.test.ts
@@ -195,6 +195,48 @@ describe("buildTarget", () => {
   });
 });
 
+describe('"lost on retries" warning at function-body level', () => {
+  const clientAtBodyLevel = () => {
+    vi.spyOn(als, "getAsyncCtx").mockResolvedValue({
+      execution: { ctx: { runId: "run-1" } },
+    } as unknown as als.AsyncContext);
+
+    const client = new Inngest({
+      id: "test",
+      eventKey: "test-key-123",
+      middleware: [experimental.scoreMiddleware()],
+    });
+    vi.spyOn(
+      client as unknown as { updateMetadata: () => Promise<void> },
+      "updateMetadata",
+    ).mockResolvedValue(undefined);
+    vi.spyOn(client[internalLoggerSymbol], "warn").mockImplementation(() => {});
+    return client;
+  };
+
+  test("inngest.score.experiment() does not warn b/c it's meant to run here", async () => {
+    const client = clientAtBodyLevel();
+
+    await client.score.experiment({
+      name: "satisfaction",
+      value: 1,
+      experiment: { experimentName: "summary-strategy", variant: "concise" },
+    });
+
+    expect(client[internalLoggerSymbol].warn).not.toHaveBeenCalled();
+  });
+
+  test("userland metadata.update() still warns", async () => {
+    const client = clientAtBodyLevel();
+
+    await new UnscopedMetadataBuilder(client).update({ foo: "bar" });
+
+    expect(client[internalLoggerSymbol].warn).toHaveBeenCalledWith(
+      expect.stringContaining("may be lost on retries"),
+    );
+  });
+});
+
 describe("MetadataBuilder.update", () => {
   test("batches updates when execution context supports metadata", async () => {
     const addMetadata = vi.fn(() => true);

--- a/packages/inngest/src/components/InngestMetadata.ts
+++ b/packages/inngest/src/components/InngestMetadata.ts
@@ -330,7 +330,9 @@ export async function performOp(
 
   const isInsideRun = !!ctx?.execution;
   const isInsideStep = !!ctx?.execution?.executingStep;
-  if (isInsideRun && !isInsideStep) {
+  const isScoreOrExperimentWrite =
+    kind === "inngest.score" || kind === "inngest.experiment";
+  if (isInsideRun && !isInsideStep && !isScoreOrExperimentWrite) {
     client[internalLoggerSymbol].warn(
       "metadata.update() called outside of a step; this metadata may be lost on retries. Wrap the call in step.run() for durable metadata.",
     );


### PR DESCRIPTION
## Summary

Suppress a warning log that isn't needed for experiments and scores. Without this change, something like this function:

```ts
export const scoreRating = inngest.createFunction(
	{ id: "score-rating", triggers: [summaryRated] },
	async ({ event }) => {
		const { storyId, rating } = event.data;

		await saveRating(storyId, rating, Date.now());

		const story = await getStoryById(storyId);

		if (!story?.servedVariant || !story.experimentName) {
			return { storyId, rating, skipped: "no-variant" };
		}

		await inngest.score.experiment({
			name: "satisfaction",
			value: SATISFACTION[rating],
			experiment: {
				experimentName: story.experimentName,
				variant: story.servedVariant,
			},
		});

		return { storyId, rating, variant: story.servedVariant };
	},
);

```

would result in fun logs like this:

```
metadata.update() called outside of a step; this metadata may be lost on retries. Wrap the call in step.run() for durable metadata. (x675)
metadata.update() called outside of a step; this metadata may be lost on retries. Wrap the call in step.run() for durable metadata. (x676)
metadata.update() called outside of a step; this metadata may be lost on retries. Wrap the call in step.run() for durable metadata. (x677)
metadata.update() called outside of a step; this metadata may be lost on retries. Wrap the call in step.run() for durable metadata. (x678)
```

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
