### PR TITLE
fix: rename deprecated experiment_name to name

### DIFF
--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -27,7 +27,7 @@ describe("client.score validation", () => {
     const client = new Inngest({ id: "app" });
 
     await expect(
-      client.score(undefined as unknown as ScoreOptions)
+      client.score(undefined as unknown as ScoreOptions),
     ).rejects.toThrow("score options must be an object");
 
     await expect(
@@ -36,7 +36,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "accuracy",
         value: 1,
-      })
+      }),
     ).rejects.toThrow("runId must be a non-empty string");
 
     await expect(
@@ -45,7 +45,7 @@ describe("client.score validation", () => {
         stepId: "",
         name: "accuracy",
         value: 1,
-      })
+      }),
     ).rejects.toThrow("stepId must be a non-empty string");
 
     await expect(
@@ -53,7 +53,7 @@ describe("client.score validation", () => {
         runId: "run",
         stepId: "step",
         value: 1,
-      } as unknown as ScoreOptions)
+      } as unknown as ScoreOptions),
     ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
@@ -62,7 +62,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "",
         value: 1,
-      })
+      }),
     ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
@@ -71,7 +71,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "   ",
         value: 1,
-      })
+      }),
     ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
@@ -80,7 +80,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "x".repeat(129),
         value: 1,
-      })
+      }),
     ).rejects.toThrow("score name must be 128 bytes or fewer");
 
     // 60 × "é" = 130 UTF-8 bytes, under the 128-char limit but over the byte cap.
@@ -90,7 +90,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "é".repeat(65),
         value: 1,
-      })
+      }),
     ).rejects.toThrow("score name must be 128 bytes or fewer");
 
     await expect(
@@ -99,9 +99,9 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "foo\nbar",
         value: 1,
-      })
+      }),
     ).rejects.toThrow(
-      "score name must not contain control characters or single quotes"
+      "score name must not contain control characters or single quotes",
     );
 
     await expect(
@@ -110,9 +110,9 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "it's-broken",
         value: 1,
-      })
+      }),
     ).rejects.toThrow(
-      "score name must not contain control characters or single quotes"
+      "score name must not contain control characters or single quotes",
     );
 
     await expect(
@@ -121,7 +121,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "accuracy",
         value: Number.NaN,
-      })
+      }),
     ).rejects.toThrow("finite number or boolean");
   });
 
@@ -132,7 +132,7 @@ describe("client.score validation", () => {
       client.score({
         name: "accuracy",
         value: 1,
-      } satisfies ScoreOptions)
+      } satisfies ScoreOptions),
     ).rejects.toThrow("No run context available");
   });
 
@@ -201,7 +201,7 @@ describe("step.score validation", () => {
         runId: "",
         name: "accuracy",
         value: 1,
-      })
+      }),
     ).toThrow("runId must be a non-empty string");
 
     expect(() =>
@@ -209,60 +209,60 @@ describe("step.score validation", () => {
         stepId: "",
         name: "accuracy",
         value: 1,
-      })
+      }),
     ).toThrow("stepId must be a non-empty string");
 
     expect(() =>
       validateStepScoreOptions({
         name: "",
         value: 1,
-      })
+      }),
     ).toThrow("score name must be a non-empty string");
 
     expect(() =>
       validateStepScoreOptions({
         name: "   ",
         value: 1,
-      })
+      }),
     ).toThrow("score name must be a non-empty string");
 
     expect(() =>
       validateStepScoreOptions({
         name: "x".repeat(129),
         value: 1,
-      })
+      }),
     ).toThrow("score name must be 128 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({
         name: "é".repeat(65),
         value: 1,
-      })
+      }),
     ).toThrow("score name must be 128 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({
         name: "foo\tbar",
         value: 1,
-      })
+      }),
     ).toThrow(
-      "score name must not contain control characters or single quotes"
+      "score name must not contain control characters or single quotes",
     );
 
     expect(() =>
       validateStepScoreOptions({
         name: "it's-broken",
         value: 1,
-      })
+      }),
     ).toThrow(
-      "score name must not contain control characters or single quotes"
+      "score name must not contain control characters or single quotes",
     );
 
     expect(() =>
       validateStepScoreOptions({
         name: "accuracy",
         value: Number.POSITIVE_INFINITY,
-      })
+      }),
     ).toThrow("finite number or boolean");
   });
 
@@ -271,14 +271,14 @@ describe("step.score validation", () => {
       validateStepScoreOptions({
         name: "accuracy",
         value: true,
-      } satisfies ScoreOptions)
+      } satisfies ScoreOptions),
     ).not.toThrow();
 
     expect(() =>
       validateStepScoreOptions({
         name: "click-through rate (variant A)!",
         value: 0.23,
-      } satisfies ScoreOptions)
+      } satisfies ScoreOptions),
     ).not.toThrow();
   });
 });
@@ -289,21 +289,21 @@ describe("client.score.experiment", () => {
   test("rejects a missing/blank experiment ref", async () => {
     const client = new Inngest({ id: "app" });
     await expect(
-      client.score.experiment({ name: "rating", value: 1 } as never)
+      client.score.experiment({ name: "rating", value: 1 } as never),
     ).rejects.toThrow("experiment must be an object");
     await expect(
       client.score.experiment({
         experiment: { experimentName: "", variant: "control" },
         name: "rating",
         value: 1,
-      })
+      }),
     ).rejects.toThrow("experiment.experimentName must be a non-empty string");
   });
 
   test("reuses score validation for name/value", async () => {
     const client = new Inngest({ id: "app" });
     await expect(
-      client.score.experiment({ experiment: exp, name: "", value: 1 })
+      client.score.experiment({ experiment: exp, name: "", value: 1 }),
     ).rejects.toThrow("score name must be a non-empty string");
   });
 
@@ -322,7 +322,7 @@ describe("client.score.experiment", () => {
           metadata: Array<{ kind: string; values: Record<string, unknown> }>;
         }) => Promise<void>;
       },
-      "updateMetadata"
+      "updateMetadata",
     ).mockImplementation(async ({ target, metadata }) => {
       calls.push({
         target,
@@ -364,7 +364,7 @@ describe("scoreMiddleware", () => {
       { id: "test", triggers: [{ event: "foo" }] },
       ({ step }) => {
         assertType<HasProperty<typeof step, "score">>(false);
-      }
+      },
     );
 
     const inngestWithMiddleware = new Inngest({
@@ -379,7 +379,7 @@ describe("scoreMiddleware", () => {
         assertType<HasProperty<typeof step, "score">>(true);
         assertType<ExperimentalStepTools[typeof scoreSymbol]>(step.score);
         assertType<KnownKeys<typeof step>>("score");
-      }
+      },
     );
   });
 });

--- a/packages/inngest/src/components/InngestScore.test.ts
+++ b/packages/inngest/src/components/InngestScore.test.ts
@@ -27,7 +27,7 @@ describe("client.score validation", () => {
     const client = new Inngest({ id: "app" });
 
     await expect(
-      client.score(undefined as unknown as ScoreOptions),
+      client.score(undefined as unknown as ScoreOptions)
     ).rejects.toThrow("score options must be an object");
 
     await expect(
@@ -36,7 +36,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "accuracy",
         value: 1,
-      }),
+      })
     ).rejects.toThrow("runId must be a non-empty string");
 
     await expect(
@@ -45,7 +45,7 @@ describe("client.score validation", () => {
         stepId: "",
         name: "accuracy",
         value: 1,
-      }),
+      })
     ).rejects.toThrow("stepId must be a non-empty string");
 
     await expect(
@@ -53,7 +53,7 @@ describe("client.score validation", () => {
         runId: "run",
         stepId: "step",
         value: 1,
-      } as unknown as ScoreOptions),
+      } as unknown as ScoreOptions)
     ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
@@ -62,7 +62,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "",
         value: 1,
-      }),
+      })
     ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
@@ -71,7 +71,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "   ",
         value: 1,
-      }),
+      })
     ).rejects.toThrow("score name must be a non-empty string");
 
     await expect(
@@ -80,7 +80,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "x".repeat(129),
         value: 1,
-      }),
+      })
     ).rejects.toThrow("score name must be 128 bytes or fewer");
 
     // 60 × "é" = 130 UTF-8 bytes, under the 128-char limit but over the byte cap.
@@ -90,7 +90,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "é".repeat(65),
         value: 1,
-      }),
+      })
     ).rejects.toThrow("score name must be 128 bytes or fewer");
 
     await expect(
@@ -99,9 +99,9 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "foo\nbar",
         value: 1,
-      }),
+      })
     ).rejects.toThrow(
-      "score name must not contain control characters or single quotes",
+      "score name must not contain control characters or single quotes"
     );
 
     await expect(
@@ -110,9 +110,9 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "it's-broken",
         value: 1,
-      }),
+      })
     ).rejects.toThrow(
-      "score name must not contain control characters or single quotes",
+      "score name must not contain control characters or single quotes"
     );
 
     await expect(
@@ -121,7 +121,7 @@ describe("client.score validation", () => {
         stepId: "step",
         name: "accuracy",
         value: Number.NaN,
-      }),
+      })
     ).rejects.toThrow("finite number or boolean");
   });
 
@@ -132,7 +132,7 @@ describe("client.score validation", () => {
       client.score({
         name: "accuracy",
         value: 1,
-      } satisfies ScoreOptions),
+      } satisfies ScoreOptions)
     ).rejects.toThrow("No run context available");
   });
 
@@ -201,7 +201,7 @@ describe("step.score validation", () => {
         runId: "",
         name: "accuracy",
         value: 1,
-      }),
+      })
     ).toThrow("runId must be a non-empty string");
 
     expect(() =>
@@ -209,60 +209,60 @@ describe("step.score validation", () => {
         stepId: "",
         name: "accuracy",
         value: 1,
-      }),
+      })
     ).toThrow("stepId must be a non-empty string");
 
     expect(() =>
       validateStepScoreOptions({
         name: "",
         value: 1,
-      }),
+      })
     ).toThrow("score name must be a non-empty string");
 
     expect(() =>
       validateStepScoreOptions({
         name: "   ",
         value: 1,
-      }),
+      })
     ).toThrow("score name must be a non-empty string");
 
     expect(() =>
       validateStepScoreOptions({
         name: "x".repeat(129),
         value: 1,
-      }),
+      })
     ).toThrow("score name must be 128 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({
         name: "é".repeat(65),
         value: 1,
-      }),
+      })
     ).toThrow("score name must be 128 bytes or fewer");
 
     expect(() =>
       validateStepScoreOptions({
         name: "foo\tbar",
         value: 1,
-      }),
+      })
     ).toThrow(
-      "score name must not contain control characters or single quotes",
+      "score name must not contain control characters or single quotes"
     );
 
     expect(() =>
       validateStepScoreOptions({
         name: "it's-broken",
         value: 1,
-      }),
+      })
     ).toThrow(
-      "score name must not contain control characters or single quotes",
+      "score name must not contain control characters or single quotes"
     );
 
     expect(() =>
       validateStepScoreOptions({
         name: "accuracy",
         value: Number.POSITIVE_INFINITY,
-      }),
+      })
     ).toThrow("finite number or boolean");
   });
 
@@ -271,14 +271,14 @@ describe("step.score validation", () => {
       validateStepScoreOptions({
         name: "accuracy",
         value: true,
-      } satisfies ScoreOptions),
+      } satisfies ScoreOptions)
     ).not.toThrow();
 
     expect(() =>
       validateStepScoreOptions({
         name: "click-through rate (variant A)!",
         value: 0.23,
-      } satisfies ScoreOptions),
+      } satisfies ScoreOptions)
     ).not.toThrow();
   });
 });
@@ -289,21 +289,21 @@ describe("client.score.experiment", () => {
   test("rejects a missing/blank experiment ref", async () => {
     const client = new Inngest({ id: "app" });
     await expect(
-      client.score.experiment({ name: "rating", value: 1 } as never),
+      client.score.experiment({ name: "rating", value: 1 } as never)
     ).rejects.toThrow("experiment must be an object");
     await expect(
       client.score.experiment({
         experiment: { experimentName: "", variant: "control" },
         name: "rating",
         value: 1,
-      }),
+      })
     ).rejects.toThrow("experiment.experimentName must be a non-empty string");
   });
 
   test("reuses score validation for name/value", async () => {
     const client = new Inngest({ id: "app" });
     await expect(
-      client.score.experiment({ experiment: exp, name: "", value: 1 }),
+      client.score.experiment({ experiment: exp, name: "", value: 1 })
     ).rejects.toThrow("score name must be a non-empty string");
   });
 
@@ -322,7 +322,7 @@ describe("client.score.experiment", () => {
           metadata: Array<{ kind: string; values: Record<string, unknown> }>;
         }) => Promise<void>;
       },
-      "updateMetadata",
+      "updateMetadata"
     ).mockImplementation(async ({ target, metadata }) => {
       calls.push({
         target,
@@ -344,7 +344,7 @@ describe("client.score.experiment", () => {
     // Score uses the constant kind with the name nested under values.
     expect(score?.values).toEqual({ "user-rating": { value: 0.9 } });
     expect(experiment?.values).toEqual({
-      experiment_name: "checkout-flow",
+      name: "checkout-flow",
       variant: "control",
     });
     // Same run-scoped target → merges into one ClickHouse row.
@@ -364,7 +364,7 @@ describe("scoreMiddleware", () => {
       { id: "test", triggers: [{ event: "foo" }] },
       ({ step }) => {
         assertType<HasProperty<typeof step, "score">>(false);
-      },
+      }
     );
 
     const inngestWithMiddleware = new Inngest({
@@ -379,7 +379,7 @@ describe("scoreMiddleware", () => {
         assertType<HasProperty<typeof step, "score">>(true);
         assertType<ExperimentalStepTools[typeof scoreSymbol]>(step.score);
         assertType<KnownKeys<typeof step>>("score");
-      },
+      }
     );
   });
 });

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -1,6 +1,7 @@
 import { isFiniteNumber, isRecord } from "../helpers/types.ts";
 import type { ExperimentRef } from "../types.ts";
 import type { Inngest } from "./Inngest.ts";
+import type { ExperimentMetadataValues } from "./InngestGroupTools.ts";
 import { performOp } from "./InngestMetadata.ts";
 import type { ExperimentalStepTools } from "./InngestStepTools.ts";
 import { Middleware } from "./middleware/middleware.ts";
@@ -51,7 +52,7 @@ export interface ClientScore {
 
 export type ScoreStepTool = (
   memoizationId: string,
-  options: ScoreOptions,
+  options: ScoreOptions
 ) => Promise<void>;
 
 export const scoreSymbol = Symbol.for("inngest.step.score");
@@ -77,7 +78,7 @@ function validateIdField({
 
 function validateScoreFields(
   options: unknown,
-  requiredTargetIds: readonly ("runId" | "stepId")[],
+  requiredTargetIds: readonly ("runId" | "stepId")[]
 ): asserts options is {
   runId?: unknown;
   stepId?: unknown;
@@ -106,14 +107,14 @@ function validateScoreFields(
   // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — rejecting control chars and single quotes in user-supplied names
   if (/[\x00-\x1f\x7f']/.test(options.name)) {
     throw new Error(
-      "score name must not contain control characters or single quotes",
+      "score name must not contain control characters or single quotes"
     );
   }
 
   const nameByteLength = new TextEncoder().encode(options.name).length;
   if (nameByteLength > maxScoreNameByteLength) {
     throw new Error(
-      `score name must be ${maxScoreNameByteLength} bytes or fewer in UTF-8 (got ${nameByteLength})`,
+      `score name must be ${maxScoreNameByteLength} bytes or fewer in UTF-8 (got ${nameByteLength})`
     );
   }
 
@@ -123,20 +124,20 @@ function validateScoreFields(
 }
 
 function validateSendScoreOptions(
-  options: unknown,
+  options: unknown
 ): asserts options is ScoreOptions {
   validateScoreFields(options, []);
 }
 
 export function validateStepScoreOptions(
-  options: unknown,
+  options: unknown
 ): asserts options is ScoreOptions {
   validateScoreFields(options, []);
 }
 
 export async function sendScore(
   client: Inngest,
-  options: ScoreOptions,
+  options: ScoreOptions
 ): Promise<void> {
   validateSendScoreOptions(options);
 
@@ -148,13 +149,13 @@ export async function sendScore(
     },
     { [options.name]: { value: options.value } },
     `${scoreKind}`,
-    "merge",
+    "merge"
   );
 }
 
 export async function sendStepScore(
   client: Inngest,
-  options: ScoreOptions,
+  options: ScoreOptions
 ): Promise<void> {
   validateStepScoreOptions(options);
 
@@ -163,17 +164,17 @@ export async function sendStepScore(
     {
       // Omitted stepId means run scope and null keeps current-run lookup intact.
       runId:
-        options.stepId === undefined ? (options.runId ?? null) : options.runId,
+        options.stepId === undefined ? options.runId ?? null : options.runId,
       stepId: options.stepId,
     },
     { [options.name]: { value: options.value } },
     `${scoreKind}`,
-    "merge",
+    "merge"
   );
 }
 
 function validateExperimentRef(
-  experiment: unknown,
+  experiment: unknown
 ): asserts experiment is ExperimentRef {
   if (!isRecord(experiment)) {
     throw new Error("experiment must be an object");
@@ -190,7 +191,7 @@ function validateExperimentRef(
 
 export async function sendScoreExperiment(
   client: Inngest,
-  options: ScoreExperimentOptions,
+  options: ScoreExperimentOptions
 ): Promise<void> {
   validateSendScoreOptions(options);
   validateExperimentRef(options.experiment);
@@ -207,18 +208,18 @@ export async function sendScoreExperiment(
     client,
     target,
     {
-      experiment_name: options.experiment.experimentName,
+      name: options.experiment.experimentName,
       variant: options.experiment.variant,
-    },
+    } satisfies Pick<ExperimentMetadataValues, "name" | "variant">,
     experimentKind,
-    "merge",
+    "merge"
   );
   await performOp(
     client,
     target,
     { [options.name]: { value: options.value } },
     scoreKind,
-    "merge",
+    "merge"
   );
 }
 
@@ -231,7 +232,7 @@ export const scoreMiddleware = () => {
     }
 
     override transformFunctionInput(
-      arg: Middleware.TransformFunctionInputArgs,
+      arg: Middleware.TransformFunctionInputArgs
     ): Middleware.TransformFunctionInputArgs & {
       ctx: {
         step: {

--- a/packages/inngest/src/components/InngestScore.ts
+++ b/packages/inngest/src/components/InngestScore.ts
@@ -52,7 +52,7 @@ export interface ClientScore {
 
 export type ScoreStepTool = (
   memoizationId: string,
-  options: ScoreOptions
+  options: ScoreOptions,
 ) => Promise<void>;
 
 export const scoreSymbol = Symbol.for("inngest.step.score");
@@ -78,7 +78,7 @@ function validateIdField({
 
 function validateScoreFields(
   options: unknown,
-  requiredTargetIds: readonly ("runId" | "stepId")[]
+  requiredTargetIds: readonly ("runId" | "stepId")[],
 ): asserts options is {
   runId?: unknown;
   stepId?: unknown;
@@ -107,14 +107,14 @@ function validateScoreFields(
   // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — rejecting control chars and single quotes in user-supplied names
   if (/[\x00-\x1f\x7f']/.test(options.name)) {
     throw new Error(
-      "score name must not contain control characters or single quotes"
+      "score name must not contain control characters or single quotes",
     );
   }
 
   const nameByteLength = new TextEncoder().encode(options.name).length;
   if (nameByteLength > maxScoreNameByteLength) {
     throw new Error(
-      `score name must be ${maxScoreNameByteLength} bytes or fewer in UTF-8 (got ${nameByteLength})`
+      `score name must be ${maxScoreNameByteLength} bytes or fewer in UTF-8 (got ${nameByteLength})`,
     );
   }
 
@@ -124,20 +124,20 @@ function validateScoreFields(
 }
 
 function validateSendScoreOptions(
-  options: unknown
+  options: unknown,
 ): asserts options is ScoreOptions {
   validateScoreFields(options, []);
 }
 
 export function validateStepScoreOptions(
-  options: unknown
+  options: unknown,
 ): asserts options is ScoreOptions {
   validateScoreFields(options, []);
 }
 
 export async function sendScore(
   client: Inngest,
-  options: ScoreOptions
+  options: ScoreOptions,
 ): Promise<void> {
   validateSendScoreOptions(options);
 
@@ -149,13 +149,13 @@ export async function sendScore(
     },
     { [options.name]: { value: options.value } },
     `${scoreKind}`,
-    "merge"
+    "merge",
   );
 }
 
 export async function sendStepScore(
   client: Inngest,
-  options: ScoreOptions
+  options: ScoreOptions,
 ): Promise<void> {
   validateStepScoreOptions(options);
 
@@ -164,17 +164,17 @@ export async function sendStepScore(
     {
       // Omitted stepId means run scope and null keeps current-run lookup intact.
       runId:
-        options.stepId === undefined ? options.runId ?? null : options.runId,
+        options.stepId === undefined ? (options.runId ?? null) : options.runId,
       stepId: options.stepId,
     },
     { [options.name]: { value: options.value } },
     `${scoreKind}`,
-    "merge"
+    "merge",
   );
 }
 
 function validateExperimentRef(
-  experiment: unknown
+  experiment: unknown,
 ): asserts experiment is ExperimentRef {
   if (!isRecord(experiment)) {
     throw new Error("experiment must be an object");
@@ -191,7 +191,7 @@ function validateExperimentRef(
 
 export async function sendScoreExperiment(
   client: Inngest,
-  options: ScoreExperimentOptions
+  options: ScoreExperimentOptions,
 ): Promise<void> {
   validateSendScoreOptions(options);
   validateExperimentRef(options.experiment);
@@ -212,14 +212,14 @@ export async function sendScoreExperiment(
       variant: options.experiment.variant,
     } satisfies Pick<ExperimentMetadataValues, "name" | "variant">,
     experimentKind,
-    "merge"
+    "merge",
   );
   await performOp(
     client,
     target,
     { [options.name]: { value: options.value } },
     scoreKind,
-    "merge"
+    "merge",
   );
 }
 
@@ -232,7 +232,7 @@ export const scoreMiddleware = () => {
     }
 
     override transformFunctionInput(
-      arg: Middleware.TransformFunctionInputArgs
+      arg: Middleware.TransformFunctionInputArgs,
     ): Middleware.TransformFunctionInputArgs & {
       ctx: {
         step: {

--- a/packages/inngest/src/test/integration/scorer/misc.test.ts
+++ b/packages/inngest/src/test/integration/scorer/misc.test.ts
@@ -46,7 +46,7 @@ test("scorer targets the attached experiment", async () => {
         kind: "inngest.experiment",
         scope: "run",
         updatedAt: expect.any(String),
-        values: { experiment_name: "exp", variant: "control" },
+        values: { name: "exp", variant: "control" },
       },
       {
         kind: "inngest.score",


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

rename deprecated experiment_name to name

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A remove deprecated experiment_name
- [x] Added unit/integration tests
- [ ] ~~Added changesets if applicable~~ N/A remove deprecated experiment_name

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
