### PR TITLE
Lower GET endpoint signature verification failures to debug level

### DIFF
--- a/.changeset/twelve-tomatoes-jam.md
+++ b/.changeset/twelve-tomatoes-jam.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Lower GET endpoint signature verification failures to debug level

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1990,7 +1990,15 @@ export class InngestCommHandler<
         if (this.client.mode === "cloud") {
           const validationResult = await signatureValidation;
           if (!validationResult.success) {
-            this.client[internalLoggerSymbol].error(
+            // Debug level instead of error because Inngest Cloud sometimes
+            // probes this endpoint to deduce the correct signing key.
+            //
+            // The primary example is the Vercel integration. The Vercel
+            // deployment webhook event gives us a URL to sync but can't tell us
+            // which Inngest environment it's for. So Inngest Cloud tries signs
+            // a GET request with each possible signing key until it gets a 200
+            // response.
+            this.client[internalLoggerSymbol].debug(
               {
                 err: validationResult.err,
                 method,


### PR DESCRIPTION
# Description

Lower `GET` endpoint signature verification failures to debug level.

# Motivation

`GET` endpoint signature verification failures are expected for Vercel integration users with custom Inngest environments. Inngest Cloud has to probe this endpoint with each signing key until it finds the correct one.

Resolves #1539