### PR TITLE
fix: preserve step.run output types with multiple middleware

### DIFF
--- a/.changeset/tame-ducks-cheer.md
+++ b/.changeset/tame-ducks-cheer.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `step.run` output types collapsing to `{}` when two or more middleware are used and a returned object has an optional property

--- a/packages/inngest/src/components/middleware/middleware.test.ts
+++ b/packages/inngest/src/components/middleware/middleware.test.ts
@@ -33,3 +33,39 @@ test("stepOutputTransform does not affect step.invoke return type", () => {
     },
   );
 });
+
+test("multiple middleware preserve step.run output with optional properties", () => {
+  // Two no-op middleware. Their default `stepOutputTransform` each applies
+  // `Jsonify`, so stacking them used to nest `Jsonify<Jsonify<...>>`. With a
+  // returned element carrying an optional property, that nesting tripped
+  // TypeScript's instantiation guard and silently degraded the element to
+  // `JsonifyObject<{}>`, so property access failed. One middleware never did.
+  class MiddlewareA extends Middleware.BaseMiddleware {
+    readonly id = "a";
+  }
+  class MiddlewareB extends Middleware.BaseMiddleware {
+    readonly id = "b";
+  }
+
+  type Widget = { media: { mediaId: string; label?: string }[] };
+
+  const client = new Inngest({
+    id: "test",
+    middleware: [MiddlewareA, MiddlewareB],
+  });
+
+  client.createFunction(
+    { id: "fn", triggers: [{ event: "any" }] },
+    async ({ step }) => {
+      const widget = await step.run(
+        "load",
+        async (): Promise<Widget> => ({ media: [] }),
+      );
+
+      expectTypeOf(widget.media).not.toBeAny();
+      expectTypeOf(widget.media).toEqualTypeOf<
+        { mediaId: string; label?: string }[]
+      >();
+    },
+  );
+});

--- a/packages/inngest/src/components/middleware/middleware.ts
+++ b/packages/inngest/src/components/middleware/middleware.ts
@@ -1,4 +1,4 @@
-import type { Jsonify } from "../../helpers/jsonify.ts";
+import type { Jsonify, JsonValue } from "../../helpers/jsonify.ts";
 import type { MaybePromise } from "../../helpers/types.ts";
 import type {
   Context,
@@ -35,9 +35,17 @@ export namespace Middleware {
 
   /**
    * Default transform. Applies the same transform as `JSON.stringify`.
+   *
+   * Inputs that are already JSON values are passed through untouched.
+   * `Jsonify` is idempotent on such types, so this is the same result, but it
+   * avoids re-instantiating the recursive `Jsonify` on an already-jsonified
+   * type. That matters when middleware stack: each middleware's default
+   * transform wraps the previous one's output, and nesting `Jsonify<Jsonify<…>>`
+   * could exceed TypeScript's instantiation depth and silently degrade an
+   * object with optional properties to `{}`.
    */
   export interface DefaultStaticTransform extends StaticTransform {
-    Out: Jsonify<this["In"]>;
+    Out: [this["In"]] extends [JsonValue] ? this["In"] : Jsonify<this["In"]>;
   }
 
   /**


### PR DESCRIPTION
## Summary

When a client has two or more middleware, `step.run`'s output type can collapse to `{}` if the returned value contains an object with an optional property. Reading any property off it then fails to type-check, even though the value is correct at runtime.

Root cause: each middleware's default `stepOutputTransform` is `Jsonify<In>`. With N middleware those nest as `Jsonify<Jsonify<...>>`. An optional property pushes `Jsonify` down its `UndefinedToOptional` path, and the extra nesting crosses TypeScript's instantiation-depth guard. TS does not raise TS2589 here; it silently resolves the inner type to `JsonifyObject<{}>`. A single middleware stays under the limit, which is why the bug only appears at two or more.

Fix: pass inputs that are already JSON values through the default transform unchanged. `Jsonify` is idempotent on those types so the result type is identical, but the second and later transforms stop re-instantiating `Jsonify`, so the depth stays bounded no matter how many middleware are stacked. Custom `stepOutputTransform`s are unaffected.

Added a type test covering two no-op middleware plus a returned element with an optional property, which fails on `main` and passes with this change.

## Checklist

- [ ] ~~Added a docs PR~~ N/A Type-inference fix with no doc-facing surface
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- inngest/inngest#4483