### PR TITLE
fix(stream): guard heartbeat and finalize against closed ReadableStream controller (fixes #1475)

### DIFF
--- a/.changeset/fix-stream-closed-controller.md
+++ b/.changeset/fix-stream-closed-controller.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+fix(stream): guard heartbeat and finalize against closed ReadableStream controller

--- a/packages/inngest/src/helpers/stream.ts
+++ b/packages/inngest/src/helpers/stream.ts
@@ -42,27 +42,49 @@ export const createStream = (opts?: {
 
   return new Promise(async (resolve, reject) => {
     try {
+      let closed = false;
+      let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
       const stream = new ReadableStream({
         start(controller) {
           const encoder = new TextEncoder();
 
-          const heartbeat = setInterval(() => {
-            controller.enqueue(encoder.encode(value));
+          heartbeatTimer = setInterval(() => {
+            if (closed) return;
+            try {
+              controller.enqueue(encoder.encode(value));
+            } catch {
+              // Controller was closed between the guard and the enqueue; ignore.
+              closed = true;
+              clearInterval(heartbeatTimer);
+            }
           }, interval);
 
           const finalize = (data: unknown) => {
-            clearInterval(heartbeat);
+            clearInterval(heartbeatTimer);
 
             // `data` may be a `Promise`. If it is, we need to wait for it to
             // resolve before sending it. To support this elegantly we'll always
             // assume it's a promise and handle that case.
-            void Promise.resolve(data).then((resolvedData) => {
-              controller.enqueue(encoder.encode(stringify(resolvedData)));
-              controller.close();
-            });
+            void Promise.resolve(data)
+              .then((resolvedData) => {
+                if (closed) return;
+                closed = true;
+                controller.enqueue(encoder.encode(stringify(resolvedData)));
+                controller.close();
+              })
+              .catch(() => {
+                // Stream was already closed by the time the final value resolved.
+              });
           };
 
           passFinalize(finalize);
+        },
+        cancel() {
+          // Consumer closed the stream (e.g. upstream proxy disconnect).
+          // Mark closed so the heartbeat self-cancels without throwing.
+          closed = true;
+          clearInterval(heartbeatTimer);
         },
       });
 


### PR DESCRIPTION
## Root cause

`createStream` in `src/helpers/stream.ts` creates a `ReadableStream` with a heartbeat `setInterval` and a `finalize` callback. Neither path guards against the controller already being closed:

- **Heartbeat**: `controller.enqueue(...)` is called unconditionally every `interval` ms. If an upstream proxy (Vercel Fluid Compute, etc.) disconnects and the platform cancels the stream, the next tick throws inside a bare `setInterval` callback → Node surfaces it as an **uncaught exception** → serverless instance crashes.
- **Finalize**: `Promise.resolve(data).then(...)` has no `.catch()`, and `controller.enqueue` + `controller.close()` inside it are unguarded. A post-cancel resolve produces an unhandled rejection.
- **`cancel` callback**: missing entirely, so there's no hook to self-cancel the interval when the consumer closes the stream.

## Fix

```diff
-     const stream = new ReadableStream({
-       start(controller) {
-         const encoder = new TextEncoder();
-
-         const heartbeat = setInterval(() => {
-           controller.enqueue(encoder.encode(value));
-         }, interval);
-
-         const finalize = (data: unknown) => {
-           clearInterval(heartbeat);
-           void Promise.resolve(data).then((resolvedData) => {
-             controller.enqueue(encoder.encode(stringify(resolvedData)));
-             controller.close();
-           });
-         };
+     let closed = false;
+     let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+     const stream = new ReadableStream({
+       start(controller) {
+         const encoder = new TextEncoder();
+
+         heartbeatTimer = setInterval(() => {
+           if (closed) return;
+           try {
+             controller.enqueue(encoder.encode(value));
+           } catch {
+             closed = true;
+             clearInterval(heartbeatTimer);
+           }
+         }, interval);
+
+         const finalize = (data: unknown) => {
+           clearInterval(heartbeatTimer);
+           void Promise.resolve(data)
+             .then((resolvedData) => {
+               if (closed) return;
+               closed = true;
+               controller.enqueue(encoder.encode(stringify(resolvedData)));
+               controller.close();
+             })
+             .catch(() => {});
+         };
+       },
+       cancel() {
+         closed = true;
+         clearInterval(heartbeatTimer);
+       },
```

- `closed` and `heartbeatTimer` are hoisted outside the `ReadableStream` callbacks so `cancel` can share them with `start`.
- The heartbeat skips enqueue when `closed` and catches the TOCTOU race where the controller closes between the guard and the actual enqueue.
- `finalize` skips enqueue/close when `closed` and adds `.catch()` to handle post-cancel resolves.
- `cancel` sets `closed = true` and clears the interval immediately on consumer disconnect.

Fixes #1475