### PR TITLE
fix: prevent streaming heartbeat from crashing on disconnect

### DIFF
--- a/.changeset/few-carpets-fix.md
+++ b/.changeset/few-carpets-fix.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix a crash when using `serve({ streaming: true })` and the client disconnects before a run completes

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1398,7 +1398,9 @@ export class InngestCommHandler<
       const method = await actions.method("starting streaming response");
 
       if (method === "POST") {
-        const { stream, finalize } = await createStream();
+        const { stream, finalize } = await createStream({
+          logger: this.client[internalLoggerSymbol],
+        });
 
         /**
          * Errors are handled by `handleAction` here to ensure that an

--- a/packages/inngest/src/helpers/stream.test.ts
+++ b/packages/inngest/src/helpers/stream.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { createStream } from "./stream.ts";
+
+/**
+ * When the consumer cancels the stream (client or proxy disconnect), the
+ * controller closes and later `enqueue`s throw `Invalid state: Controller is
+ * already closed`. Unguarded, that crashed the process from the heartbeat timer
+ * and rejected from `finalize`; these tests keep both paths from regressing.
+ */
+describe("createStream", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("heartbeat does not throw after the consumer cancels the stream", async () => {
+    vi.useFakeTimers();
+
+    const { stream } = await createStream();
+
+    const reader = stream.getReader();
+    await reader.cancel();
+
+    // A throw here used to escape the `setInterval` callback and crash the process
+    expect(() => vi.advanceTimersByTime(3000)).not.toThrow();
+  });
+
+  test("finalize does not reject after the consumer cancels the stream", async () => {
+    const { stream, finalize } = await createStream();
+
+    const reader = stream.getReader();
+    await reader.cancel();
+
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+
+    // Temporarily own the unhandledRejection channel so the assertion is
+    // explicit and a pre-fix rejection doesn't leak into the rest of the suite.
+    const existing = process.listeners("unhandledRejection");
+    for (const l of existing) {
+      process.off("unhandledRejection", l);
+    }
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      finalize({ status: 201, body: "ok" });
+
+      // Yield a macrotask so the finalize chain settles and Node's
+      // unhandled-rejection detection runs (a microtask tick is not enough).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      process.off("unhandledRejection", onRejection);
+      for (const l of existing) {
+        process.on("unhandledRejection", l as (reason: unknown) => void);
+      }
+    }
+
+    expect(rejections).toEqual([]);
+  });
+});

--- a/packages/inngest/src/helpers/stream.ts
+++ b/packages/inngest/src/helpers/stream.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "../middleware/logger.ts";
 import { stringify } from "./strings.ts";
 
 /**
@@ -21,6 +22,12 @@ export const createStream = (opts?: {
    * Defaults to `" "`.
    */
   value?: string;
+
+  /**
+   * Reports write failures not already known about via `cancel()` (not all
+   * runtimes call it reliably on disconnect).
+   */
+  logger?: Logger;
 }): Promise<{ finalize: (data: unknown) => void; stream: ReadableStream }> => {
   /**
    * We need to resolve this promise with both the stream and the `finalize`
@@ -42,27 +49,55 @@ export const createStream = (opts?: {
 
   return new Promise(async (resolve, reject) => {
     try {
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
+      let closed = false;
+
       const stream = new ReadableStream({
         start(controller) {
           const encoder = new TextEncoder();
 
-          const heartbeat = setInterval(() => {
-            controller.enqueue(encoder.encode(value));
+          heartbeat = setInterval(() => {
+            if (closed) return;
+
+            try {
+              controller.enqueue(encoder.encode(value));
+            } catch (err) {
+              // `cancel()` normally clears this interval before we'd ever hit
+              // this catch, so reaching it means the runtime didn't call it.
+              closed = true;
+              clearInterval(heartbeat);
+              opts?.logger?.debug(
+                { err },
+                "Failed to write heartbeat to stream",
+              );
+            }
           }, interval);
 
           const finalize = (data: unknown) => {
             clearInterval(heartbeat);
 
-            // `data` may be a `Promise`. If it is, we need to wait for it to
-            // resolve before sending it. To support this elegantly we'll always
-            // assume it's a promise and handle that case.
-            void Promise.resolve(data).then((resolvedData) => {
-              controller.enqueue(encoder.encode(stringify(resolvedData)));
-              controller.close();
-            });
+            void Promise.resolve(data)
+              .then((resolvedData) => {
+                if (closed) return;
+                closed = true;
+
+                controller.enqueue(encoder.encode(stringify(resolvedData)));
+                controller.close();
+              })
+              .catch((err) => {
+                opts?.logger?.debug(
+                  { err },
+                  "Failed to write final value to stream",
+                );
+              });
           };
 
           passFinalize(finalize);
+        },
+
+        cancel() {
+          closed = true;
+          clearInterval(heartbeat);
         },
       });
 


### PR DESCRIPTION
## Summary
When `serve({ streaming: true })` is used and the consumer disconnects, the runtime cancels the response stream and closes its controller. The heartbeat `setInterval` then called `controller.enqueue()` on the controller, throwing an uncaught exception.

Add a `cancel()` handler to stop the heartbeat on disconnect, guard the heartbeat enqueue, and add `.catch()` to finalize.

## Checklist

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A bugfix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

Fixes #1475
[EXE-1672](https://linear.app/inngest/issue/EXE-1672/bug-serve-streaming-true-crashes-node-with-uncaught-typeerror-invalid)
