### PR TITLE
fix: restore OTel context captured at step.run() when executing step callback

### DIFF
--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -1,3 +1,4 @@
+import type { Context as OtelContext } from "@opentelemetry/api";
 import { type AiAdapter, models } from "@inngest/ai";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { z } from "zod/v3";
@@ -168,6 +169,15 @@ export interface FoundStep extends HashedOp {
    * the OutgoingOp so that checkpoint payloads include metadata.
    */
   metadata?: OutgoingOp["metadata"];
+
+  /**
+   * The OTel context that was active when step.run() was called. Captured so
+   * that third-party context entries (e.g. Langfuse propagateAttributes) set
+   * via context.with() are restored when the step callback is executed by
+   * executeStep, which runs from the engine's core loop rather than from
+   * within the original context.with() scope.
+   */
+  otelCtx?: OtelContext;
 }
 
 export type MatchOpFn<

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1,4 +1,4 @@
-import { trace } from "@opentelemetry/api";
+import { context as otelContext, trace } from "@opentelemetry/api";
 import hashjs from "hash.js";
 import ms, { type StringValue } from "ms";
 import { z } from "zod/v3";
@@ -1704,7 +1704,16 @@ class InngestExecutionEngine
 
     // `fn` already has middleware-transformed args baked in via `fnArgs` (i.e.
     // the `transformStepInput` middleware hook already ran).
-    const actualHandler = () => runAsPromise(fn);
+    //
+    // Restore the OTel context that was active when step.run() was called.
+    // executeStep runs from the engine's core loop, which is outside any
+    // context.with() scope the user set up around step.run() (e.g. Langfuse's
+    // propagateAttributes). Without this restore, third-party ALS-backed
+    // context entries (user.id, session.id, etc.) are absent from the spans
+    // created inside the step callback (see #1436).
+    const capturedOtelCtx = foundStep.otelCtx ?? otelContext.active();
+    const actualHandler = () =>
+      otelContext.with(capturedOtelCtx, () => runAsPromise(fn));
 
     await this.middlewareManager.onMemoizationEnd();
     await this.middlewareManager.onStepStart(stepInfo);
@@ -2496,6 +2505,10 @@ class InngestExecutionEngine
         input: stepState?.input,
 
         fn: opts?.fn ? () => opts.fn?.(this.fnArg, ...fnArgs) : undefined,
+        // Snapshot the active OTel context so executeStep can restore it when
+        // it runs the step callback from the core loop (which is outside any
+        // context.with() scope the user may have set up around step.run).
+        otelCtx: opts?.fn ? otelContext.active() : undefined,
         promise,
         fulfilled: isFulfilled,
         hasStepState: Boolean(stepState),


### PR DESCRIPTION
## What

Fixes #1436: third-party OTel context entries (e.g. Langfuse's `propagateAttributes` user/session IDs) set via `context.with()` before calling `step.run()` are lost inside the step callback.

## Root cause

Inngest functions are deterministic replay machines. When a step is first encountered, the engine's `stepHandler` registers the step and returns a pending promise to userland. The actual step callback (`fn`) is executed later by `executeStep`, which is called from the engine's **core loop** — not from within the user's `context.with()` scope.

By the time `executeStep` runs the step callback, the `context.with()` scope that `propagateAttributes` (or any other OTel-context-setting code) set up around `step.run()` has already exited. The OTel `AsyncLocalStorage` no longer holds those context entries, so spans created inside the step callback are missing them.

## Fix

Two small changes:

**`InngestStepTools.ts`** — add `otelCtx?: OtelContext` to `FoundStep` to carry the captured context.

**`engine.ts`** — in `stepHandler`, when a new step with a handler is registered, snapshot `otelContext.active()` and store it in `step.otelCtx`. Then in `executeStep`, wrap the `fn` invocation with `otelContext.with(capturedCtx, ...)` to restore the context the user had active when `step.run()` was called.

```ts
// engine.ts — stepHandler (step registration)
otelCtx: opts?.fn ? otelContext.active() : undefined,

// engine.ts — executeStep (step execution)
const capturedOtelCtx = foundStep.otelCtx ?? otelContext.active();
const actualHandler = () =>
  otelContext.with(capturedOtelCtx, () => runAsPromise(fn));
```

This is the standard OTel pattern for carrying context across async boundaries that don't flow naturally through a continuous `await` chain.

## Testing

Reproducer: wrap `step.run("s", callback)` in `context.with(ctx, ...)` where `ctx` carries a custom OTel attribute. Without this fix, the attribute is absent on spans created inside `callback`. With this fix, it is present.

Fixes #1436