### PR TITLE
fix: `step.run` output type collapsing to `{}` with multiple middleware

### DIFF
--- a/.changeset/full-dingos-brush.md
+++ b/.changeset/full-dingos-brush.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `step.run` and `step.invoke` output types collapsing to `{}` for objects with optional properties when using two or more middleware

--- a/packages/inngest/src/components/middleware/middleware.test.ts
+++ b/packages/inngest/src/components/middleware/middleware.test.ts
@@ -33,3 +33,61 @@ test("stepOutputTransform does not affect step.invoke return type", () => {
     },
   );
 });
+
+// stacked default output transforms apply `Jsonify` repeatedly,
+// which used to collapse objects with optional properties to `{}`.
+test("multiple middleware preserve step.run output with optional properties", () => {
+  class MiddlewareA extends Middleware.BaseMiddleware {
+    readonly id = "a";
+  }
+  class MiddlewareB extends Middleware.BaseMiddleware {
+    readonly id = "b";
+  }
+
+  type Widget = { media: { mediaId: string; label?: string }[] };
+
+  const client = new Inngest({
+    id: "test",
+    middleware: [MiddlewareA, MiddlewareB],
+  });
+
+  client.createFunction(
+    { id: "fn", triggers: [{ event: "any" }] },
+    async ({ step }) => {
+      const widget = await step.run(
+        "load",
+        async (): Promise<Widget> => ({ media: [] }),
+      );
+
+      expectTypeOf(widget.media).not.toBeAny();
+      expectTypeOf(widget.media).toEqualTypeOf<
+        { mediaId: string; label?: string }[]
+      >();
+      expectTypeOf(widget.media[0]!.mediaId).toEqualTypeOf<string>();
+    },
+  );
+});
+
+// a handler returning a `step.run` result already has `Jsonify` in its return type,
+// so `step.invoke` applies it a second time.
+test("step.invoke preserves optional properties in invoked step.run output", () => {
+  type Widget = { media: { mediaId: string; label?: string }[] };
+
+  const client = new Inngest({ id: "test" });
+
+  const childFn = client.createFunction(
+    { id: "child", triggers: [{ event: "any" }] },
+    async ({ step }) =>
+      step.run("load", async (): Promise<Widget> => ({ media: [] })),
+  );
+
+  client.createFunction(
+    { id: "parent", triggers: [{ event: "any" }] },
+    async ({ step }) => {
+      const widget = await step.invoke("invoke-child", { function: childFn });
+
+      expectTypeOf(widget.media).not.toBeAny();
+      expectTypeOf(widget.media[0]!.mediaId).toEqualTypeOf<string>();
+    },
+  );
+});

--- a/packages/inngest/src/helpers/jsonify.test.ts
+++ b/packages/inngest/src/helpers/jsonify.test.ts
@@ -108,6 +108,35 @@ describe("Jsonify", () => {
     });
   });
 
+  // The property-access assertions are the real guards here: the `IsEqual`
+  // assertions pass even on broken variants because the deferred aliases
+  // compare equal before resolution.
+  describe("#1532", () => {
+    test("re-applying Jsonify to an object with optional properties is a no-op", () => {
+      type Widget = { media: { mediaId: string; label?: string }[] };
+
+      type Once = Jsonify<Widget>;
+      type Twice = Jsonify<Once>;
+
+      assertType<IsEqual<Once, Twice>>(true);
+      assertType<IsEqual<Twice["media"][number]["mediaId"], string>>(true);
+    });
+
+    test("re-applying Jsonify to a mapped type with optional properties is a no-op", () => {
+      interface Foo {
+        // biome-ignore lint/suspicious/noExplicitAny: intentional
+        [x: string]: any;
+        items: { id: string; label?: string }[];
+      }
+
+      type Once = Jsonify<Foo>;
+      type Twice = Jsonify<Once>;
+
+      assertType<IsEqual<Once, Twice>>(true);
+      assertType<IsEqual<Twice["items"][number]["id"], string>>(true);
+    });
+  });
+
   describe("#537", () => {
     describe("nested { name: string; } object is preserved", () => {
       test("when nullable", () => {

--- a/packages/inngest/src/helpers/jsonify.ts
+++ b/packages/inngest/src/helpers/jsonify.ts
@@ -3,13 +3,10 @@
  * to represent to users how a value will be serialized and deserialized as it
  * passes to and from an Inngest Server.
  *
- * We do not use the `type-fest` package directly due to some version
- * compatibility issues:
- *
- * - `inngest` supports `typescript@>=4.7`
- * - `type-fest@4` supports `typescript@>=5.1`, so the maximum version we can
- *   use is `type-fest@3`
- * - `type-fest@3` is not compatible with `typescript@5.4`
+ * We do not use the `type-fest` package directly because this copy
+ * intentionally diverges from it: `unknown` is preserved, objects mixing
+ * index signatures with known keys are handled, and re-applying `Jsonify` to
+ * its own output is a no-op.
  */
 import type {
   IsAny,
@@ -37,9 +34,17 @@ type JsonifyList<T extends UnknownArray> = T extends readonly []
       ? []
       : Array<T[number] extends NotJsonable ? null : Jsonify<T[number]>>;
 
-type FilterJsonableKeys<T extends object> = {
-  [Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
-}[keyof T];
+/**
+Diverges from `type-fest`: optional properties leak `undefined` into the key
+union, which collapses objects to `{}` when `Jsonify` is re-applied to its
+own output.
+*/
+type FilterJsonableKeys<T extends object> = Exclude<
+  {
+    [Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
+  }[keyof T],
+  undefined
+>;
 
 /**
 JSON serialize objects (not including arrays) and classes.


### PR DESCRIPTION
## Summary

Each default output transform applies `Jsonify`, so two middleware produce `Jsonify<Jsonify<T>>` (`step.invoke` composes the same way). Applying `Jsonify` to its own output collapsed any object with an optional property to `{}`. The chain:

1. `Jsonify` decides which keys to keep by mapping each property to its own name, then reading every value back out:

```ts
type FilterJsonableKeys<T extends object> = {
  [Key in keyof T]: T[Key] extends NotJsonable ? never : Key;
}[keyof T];
```

Reading an optional property always adds `undefined` to what you get back, so for `{ mediaId: string; label?: string }` this produces `"mediaId" | "label" | undefined`.

2. That union feeds `Pick`, which builds one property per union member. TypeScript checks "these must be real keys" only once, against the generic declaration — not again when the type is actually used — so it silently builds an object whose properties are all correct (reading `.mediaId` still works, which is why one application looks healthy) but whose key set is corrupted: `keyof` now includes `undefined`.

3. The second application walks that key set and computes `T[undefined]`, an illegal lookup. Inside a generic, TypeScript doesn't report this; it substitutes its internal error type, the key filters produce nothing, and picking nothing from the object leaves `{}`.

Excluding `undefined` from the union in step 1 keeps it out of the key set, so the output is a clean object and re-application is a no-op. The sibling filters (`FilterDefinedKeys`, `FilterOptionalKeys`) already had this `Exclude`; upstream `type-fest` still lacks it on `FilterJsonableKeys` as of 5.7.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bugfix
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

Fixes inngest/inngest#4483. See also #1532, #1613.
[EXE-1974](https://linear.app/inngest/issue/EXE-1974)