### PR TITLE
fix: parallel steps hanging when optimizeParallelism is false

### DIFF
--- a/.changeset/empty-boxes-provide.md
+++ b/.changeset/empty-boxes-provide.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix run hangs on parallel steps when optimizeParallelism is off

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -2214,15 +2214,10 @@ export class InngestCommHandler<
       headerReqVersion,
       this.client[internalLoggerSymbol],
     );
-    const { sdkDecided } = immediateFnData;
     let version = ExecutionVersion.V2;
 
     // Handle opting out of optimized parallelism
-    if (
-      version === ExecutionVersion.V2 &&
-      sdkDecided &&
-      fn.fn["shouldOptimizeParallelism"]?.() === false
-    ) {
+    if (fn.fn["shouldOptimizeParallelism"]?.() === false) {
       version = ExecutionVersion.V1;
     }
 

--- a/packages/inngest/src/components/optimizedParallelism.test.ts
+++ b/packages/inngest/src/components/optimizedParallelism.test.ts
@@ -346,25 +346,27 @@ describe("EXE-1135: Default to optimized parallelism", () => {
   });
 
   describe("execution version selection", () => {
-    const sdkDecidesRequestBody = {
+    const requestBody = (version: number) => ({
       event: { name: "test/event", data: {} },
       events: [{ name: "test/event", data: {} }],
       steps: {},
       ctx: { run_id: "run-123", attempt: 0 },
-      version: -1, // SDK decides
-    };
+      version,
+    });
 
     const createHandler = (
       client: ReturnType<typeof createClient>,
       fn: ReturnType<ReturnType<typeof createClient>["createFunction"]>,
+      bodyVersion: number = -1,
     ) => {
-      const bodyStr = JSON.stringify(sdkDecidesRequestBody);
+      const body = requestBody(bodyVersion);
+      const bodyStr = JSON.stringify(body);
       return new InngestCommHandler({
         frameworkName: "test",
         client,
         functions: [fn],
         handler: () => ({
-          body: () => sdkDecidesRequestBody,
+          body: () => body,
           headers: (key: string) =>
             key.toLowerCase() === "content-length"
               ? bodyStr.length.toString()
@@ -386,24 +388,35 @@ describe("EXE-1135: Default to optimized parallelism", () => {
       {
         fnOpt: undefined,
         clientOpt: undefined,
+        bodyVersion: -1,
         expectedVersion: ExecutionVersion.V2,
         desc: "default",
       },
       {
         fnOpt: false,
         clientOpt: undefined,
+        bodyVersion: -1,
         expectedVersion: ExecutionVersion.V1,
         desc: "function opt-out",
       },
       {
         fnOpt: undefined,
         clientOpt: false,
+        bodyVersion: -1,
         expectedVersion: ExecutionVersion.V1,
         desc: "client opt-out",
       },
+      // The SDK should keep opt-out runs on V1 based on optimizeParallelism
+      {
+        fnOpt: false,
+        clientOpt: undefined,
+        bodyVersion: 2,
+        expectedVersion: ExecutionVersion.V1,
+        desc: "opt-out with incoming V2",
+      },
     ])(
       "uses V$expectedVersion with $desc",
-      async ({ fnOpt, clientOpt, expectedVersion }) => {
+      async ({ fnOpt, clientOpt, bodyVersion, expectedVersion }) => {
         const client = createClient({
           id: "test",
           isDev: true,
@@ -418,7 +431,7 @@ describe("EXE-1135: Default to optimized parallelism", () => {
           async () => "done",
         );
 
-        const handler = createHandler(client, fn);
+        const handler = createHandler(client, fn, bodyVersion);
         const response = (await handler.createHandler()()) as {
           headers: Record<string, string>;
         };


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->
When `optimizeParallelism` is set to `false` (which is not the default
in V4), the execution engine is downgraded to V1. But on subsequent
steps, `sdkDecided` gets overriden to `false` and the SDK keeps sending
the default V2 value. Eventually a race can happen where the executor
assigns back the V2 value to the run and starts coalescing parallel
steps and could race into hanging the run.



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
