### PR TITLE
fix: step.run not JSON-serializing during checkpointing

### DIFF
--- a/.changeset/dry-candles-study.md
+++ b/.changeset/dry-candles-study.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix step.run not JSON-serializing during checkpointing

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2856,7 +2856,7 @@ class InngestExecutionEngine
     //
     // Note that serializer middleware will still run after this. So serializers
     // like "Date object preserver" will continue to work.
-    const data = jsonRoundTrip(resultOp.data);
+    const data = JSON.parse(stringify(undefinedToNull(resultOp.data)));
 
     userlandStep.data = data;
     userlandStep.timing = resultOp.timing;
@@ -3275,15 +3275,3 @@ function isNonEmpty<T>(arr: T[]): arr is [T, ...T[]] {
  * Exported for testing.
  */
 export const _internals = { hashOp, hashId, resolveStepIdCollision };
-
-/**
- * Run JSON serialization and deserialization, replicating what happens in a
- * round trip to an Inngest server.
- */
-function jsonRoundTrip(data: unknown): unknown {
-  const serialized = stringify(undefinedToNull(data));
-  if (typeof serialized === "undefined") {
-    return undefined;
-  }
-  return JSON.parse(serialized);
-}

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -33,6 +33,7 @@ import {
   retryWithBackoff,
   runAsPromise,
 } from "../../helpers/promises.ts";
+import { stringify } from "../../helpers/strings.ts";
 import * as Temporal from "../../helpers/temporal.ts";
 import {
   isRecord,
@@ -916,7 +917,7 @@ class InngestExecutionEngine
         // Buffer a copy with transformed data for checkpointing
         this.state.checkpointingStepBuffer.push({
           ...stepToResume,
-          data: stepResult.data,
+          data: stepToResume.data,
         });
       }
 
@@ -2848,7 +2849,14 @@ class InngestExecutionEngine
       );
     }
 
-    const data = undefinedToNull(resultOp.data);
+    // Simulate a round trip. If we don't do this, then `step.run` can return
+    // non-JSON when it checkpointed. This is problematic because reentering the
+    // function would result in a different return value (e.g. retrying after a
+    // later error).
+    //
+    // Note that serializer middleware will still run after this. So serializers
+    // like "Date object preserver" will continue to work.
+    const data = jsonRoundTrip(resultOp.data);
 
     userlandStep.data = data;
     userlandStep.timing = resultOp.timing;
@@ -3267,3 +3275,15 @@ function isNonEmpty<T>(arr: T[]): arr is [T, ...T[]] {
  * Exported for testing.
  */
 export const _internals = { hashOp, hashId, resolveStepIdCollision };
+
+/**
+ * Run JSON serialization and deserialization, replicating what happens in a
+ * round trip to an Inngest server.
+ */
+function jsonRoundTrip(data: unknown): unknown {
+  const serialized = stringify(undefinedToNull(data));
+  if (typeof serialized === "undefined") {
+    return undefined;
+  }
+  return JSON.parse(serialized);
+}

--- a/packages/inngest/src/test/integration/checkpointing/stepRunSerialization.test.ts
+++ b/packages/inngest/src/test/integration/checkpointing/stepRunSerialization.test.ts
@@ -1,0 +1,54 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { expect, test } from "vitest";
+import { Inngest } from "../../../index.ts";
+import { createServer } from "../../../node.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+test("step.run output is JSON serialized even when checkpointed", async () => {
+  // We created this test after discovering that `step.run` could return
+  // non-JSON data during checkpointing
+
+  const date = "2026-02-03T00:00:00.000Z";
+  const state = createState({
+    outputs: [] as unknown[],
+    requestCount: 0,
+  });
+
+  const eventName = randomSuffix("evt");
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      state.requestCount++;
+      const output = await step.run("date-step", () => ({
+        date: new Date(date),
+        list: [new Date(date)],
+        nested: { date: new Date(date) },
+      }));
+
+      state.outputs.push(output);
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  await state.waitForRunComplete();
+  expect(state.requestCount).toEqual(1);
+  expect(state.outputs).toEqual([
+    {
+      date,
+      list: [date],
+      nested: { date },
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

Fix `step.run` not JSON-serializing during checkpointing. In other words, when `step.run` returned its output without an Inngest server round trip, it was returning its handler's return value without applying JSON serialization. This meant that `step.run` sometimes could return non-JSON types (e.g. `Date` object) and sometimes not.

Note that serializer middleware continues to work. The new JSON round trip logic added by this PR runs before the `wrapStep` middleware hook.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable
