### PR TITLE
Workflow Failure Op ID Fix

### DIFF
--- a/packages/workflow/DOCS.md
+++ b/packages/workflow/DOCS.md
@@ -270,7 +270,7 @@ const handler: WorkflowHandler = async ({ step }) => {
 
 onResult: (ops) => {
   // ops = [{
-  //   id: "error",
+  //   id: "error:0",
   //   op: "StepError",
   //   error: {
   //     name: "Error",
@@ -305,7 +305,7 @@ const handler: WorkflowHandler = async ({ step }) => {
 
 onResult: (ops) => {
   // ops = [{
-  //   id: "error",
+  //   id: "error:0",
   //   op: "StepError",
   //   error: {
   //     name: "RetryAfterError",
@@ -338,7 +338,7 @@ const handler: WorkflowHandler = async ({ step }) => {
 
 onResult: (ops) => {
   // ops = [{
-  //   id: "error",
+  //   id: "error:0",
   //   op: "StepFailed",
   //   error: {
   //     name: "NonRetriableError",
@@ -420,26 +420,26 @@ onResult: (ops) => {
 
 ## Function Failure
 
-When the workflow handler throws an unhandled error (not inside a step), `onResult` receives either `StepError` or `StepFailed` depending on the error type:
+When the workflow handler throws an unhandled error (not inside a step), `onResult` receives either `StepError` or `StepFailed` depending on the error type. The op id is `error:<attempt>`, keeping failure ops unique across retries:
 
 ```typescript
 // Retriable failure (regular Error)
 const handler: WorkflowHandler = async () => {
   throw new Error("Something broke");
 };
-// onResult: [{ id: "error", op: "StepError", error: { message: "Something broke", ... } }]
+// onResult: [{ id: "error:0", op: "StepError", error: { message: "Something broke", ... } }]
 
 // Non-retriable failure (NonRetriableError)
 const handler: WorkflowHandler = async () => {
   throw new NonRetriableError("Bad request");
 };
-// onResult: [{ id: "error", op: "StepFailed", error: { message: "Bad request", ... } }]
+// onResult: [{ id: "error:0", op: "StepFailed", error: { message: "Bad request", ... } }]
 
 // Retry after specific duration
 const handler: WorkflowHandler = async () => {
   throw new RetryAfterError("Slow down", "1m");
 };
-// onResult: [{ id: "error", op: "StepError", error: { ... }, opts: { retryAfter: "1m" } }]
+// onResult: [{ id: "error:0", op: "StepError", error: { ... }, opts: { retryAfter: "1m" } }]
 ```
 
 ---

--- a/packages/workflow/src/workflow.test.ts
+++ b/packages/workflow/src/workflow.test.ts
@@ -154,6 +154,25 @@ describe("run", () => {
     expect(ops).toHaveLength(1);
     expect(ops![0].op).toBe(StepOpCode.StepFailed);
   });
+
+  it("should emit unique ids for failure ops across attempts", async () => {
+    const handler: WorkflowHandler = async () => {
+      throw new Error("boom");
+    };
+
+    const ids: string[] = [];
+    for (const attempt of [0, 1]) {
+      await run(handler, {
+        input: makeInput({ attempt }),
+        onResult: async (result) => {
+          ids.push(result[0].id);
+        },
+      });
+    }
+
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });
 
 describe("readInput", () => {

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -110,7 +110,7 @@ export async function run(
         ? StepOpCode.StepFailed
         : StepOpCode.StepError;
       resultOps = [{
-        id: "error",
+        id: `error:${input.attempt}`,
         op,
         error: result.error,
         ...(typeof result.retriable === "string"
@@ -121,7 +121,7 @@ export async function run(
     }
     case "step-not-found":
       resultOps = [{
-        id: "error",
+        id: result.step.id,
         op: StepOpCode.StepFailed,
         error: { message: `Step not found: ${result.step.id}` },
       }];

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -51,7 +51,7 @@ export async function run(
 
   const events = (input.events ?? [input.event]) as [
     EventPayload,
-    ...EventPayload[,
+    ...EventPayload[],
   ];
 
   const allowedTools = options.allowedStepTools;


### PR DESCRIPTION
## Summary

`function-rejected` and `step-not-found` both emitted ops with the hardcoded id "error", so repeated failures produced duplicate ids, which broke orchestrators that derive unique identifiers from op ids (e.g. Temporal ActivityIds). This PR switches their ids to be:
- function-rejected: `error:<attempt>` (no step reference available)
- step-not-found: the requested step's id


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
