### PR TITLE
fix: preserve RetryAfterError delay when a rejection ships with buffered defers

### DIFF
--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1946,6 +1946,9 @@ export class InngestCommHandler<
               status: 206,
               headers: {
                 "Content-Type": "application/json",
+                ...(result.retryAfter
+                  ? { [headerKeys.RetryAfter]: result.retryAfter }
+                  : {}),
               },
               body: stringify(steps),
               version,

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -31,7 +31,10 @@ export interface ExecutionResults {
   "function-resolved": { data: unknown };
   "step-ran": { step: OutgoingOp; retriable?: boolean | string };
   "function-rejected": { error: unknown; retriable: boolean | string };
-  "steps-found": { steps: [OutgoingOp, ...OutgoingOp[]] };
+  "steps-found": {
+    steps: [OutgoingOp, ...OutgoingOp[]];
+    retryAfter?: string;
+  };
   "step-not-found": {
     step: OutgoingOp;
     foundSteps: BasicFoundStep[];

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -1351,6 +1351,7 @@ describe("defer abort", () => {
         }),
       );
       expect(opsOfType(steps, StepOpCode.StepFailed)).toHaveLength(0);
+      expect(result).not.toHaveProperty("retryAfter");
     });
 
     test("ships StepError for a RetryAfterError rejection", async () => {
@@ -1369,6 +1370,7 @@ describe("defer abort", () => {
       expect(opsOfType(steps, StepOpCode.DeferAdd)).toHaveLength(1);
       expect(opsOfType(steps, StepOpCode.StepError)).toHaveLength(1);
       expect(opsOfType(steps, StepOpCode.StepFailed)).toHaveLength(0);
+      expect(result).toMatchObject({ retryAfter: "30" });
     });
 
     test("preserves NonRetriableError finality through the steps-found conversion", async () => {
@@ -1391,6 +1393,7 @@ describe("defer abort", () => {
           error: expect.objectContaining({ name: "NonRetriableError" }),
         }),
       );
+      expect(result).not.toHaveProperty("retryAfter");
     });
 
     test("ships StepFailed when the final attempt rejects with a retryable error", async () => {

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2022,6 +2022,12 @@ class InngestExecutionEngine
       return result;
     }
 
+    const retryAfter =
+      (result.type === "function-rejected" || result.type === "step-ran") &&
+      typeof result.retriable === "string"
+        ? { retryAfter: result.retriable }
+        : {};
+
     switch (result.type) {
       // Convert terminal results into `steps-found` so the lazy ops ride
       // alongside `RunComplete` / the terminal error op. This lets the executor
@@ -2046,9 +2052,9 @@ class InngestExecutionEngine
       // A `function-rejected` response body has no slot for step ops, so the
       // rejection rides as a synthetic step-level error op instead. Finality
       // travels via the opcode: `StepFailed` finalizes, `StepError` retries.
-      // Unlike the plain rejection path, this loses `RetryAfterError`'s delay
-      // (there's no `Retry-After` header here and no op field for it), so the
-      // executor falls back to its default backoff.
+      // `RetryAfterError`'s delay can't ride the op, so it travels as
+      // `retryAfter`, which the comm handler emits as a `Retry-After` header
+      // on the 206.
       case "function-rejected": {
         const isFinal = result.retriable === false;
         return {
@@ -2063,6 +2069,7 @@ class InngestExecutionEngine
               error: result.error,
             },
           ],
+          ...retryAfter,
         };
       }
 
@@ -2080,6 +2087,7 @@ class InngestExecutionEngine
           ctx: result.ctx,
           ops: result.ops,
           steps: [result.step, ...lazyOps],
+          ...retryAfter,
         };
       }
 

--- a/packages/inngest/src/test/integration/defer/misc.test.ts
+++ b/packages/inngest/src/test/integration/defer/misc.test.ts
@@ -8,7 +8,7 @@ import {
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod";
 import { createDefer } from "../../../experimental.ts";
-import { Inngest, NonRetriableError } from "../../../index.ts";
+import { Inngest, NonRetriableError, RetryAfterError } from "../../../index.ts";
 import { createServer } from "../../../node.ts";
 import { matrixCheckpointing, spyLogger } from "../utils.ts";
 
@@ -372,6 +372,66 @@ matrixCheckpointing(
     await deferState.waitForRunComplete();
 
     // Wait long enough for a second defer to have fired (it shouldn't)
+    await sleep(5000);
+    expect(deferState.counter).toBe(1);
+  },
+);
+
+matrixCheckpointing(
+  "RetryAfterError after defer delays the retry",
+  async (checkpointing) => {
+    // A RetryAfterError thrown at the function level after a defer must delay
+    // the retry by the given duration, and the defer must fire exactly once
+    // across attempts.
+
+    const parentState = createState({ attemptTimes: [] as number[] });
+    const deferState = createState({ counter: 0 });
+
+    const client = new Inngest({
+      id: randomSuffix(testFileName),
+      isDev: true,
+      checkpointing,
+    });
+    const eventName = randomSuffix("evt");
+    const foo = createDefer(client, { id: "foo" }, async ({ runId }) => {
+      deferState.runId = runId;
+      deferState.counter++;
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 1,
+        triggers: { event: eventName },
+      },
+      async ({ attempt, defer, runId }) => {
+        parentState.runId = runId;
+        parentState.attemptTimes.push(Date.now());
+        defer("foo", { function: foo, data: {} });
+
+        if (attempt === 0) {
+          throw new RetryAfterError("rate limited", "5s");
+        }
+      },
+    );
+    await createTestApp({
+      client,
+      functions: [fn, foo],
+      serve: createServer,
+    });
+
+    await client.send({ name: eventName, data: {} });
+    await parentState.waitForRunComplete();
+    await deferState.waitForRunComplete();
+
+    expect(parentState.attemptTimes).toHaveLength(2);
+
+    // The dev server runs with `--retry-interval 1`, so a retry that ignored
+    // the Retry-After would land ~1s after the failure
+    const retryDelay =
+      parentState.attemptTimes[1]! - parentState.attemptTimes[0]!;
+    expect(retryDelay).toBeGreaterThanOrEqual(4000);
+
+    // Wait long enough to give a 2nd defer a chance to trigger (it shouldn't)
     await sleep(5000);
     expect(deferState.counter).toBe(1);
   },

--- a/packages/inngest/src/test/integration/retryAfterError.test.ts
+++ b/packages/inngest/src/test/integration/retryAfterError.test.ts
@@ -136,6 +136,34 @@ test("NonRetriableError thrown inside step.run sets X-Inngest-No-Retry header", 
   expect(res.headers.get(headerKeys.RetryAfter)).toBeNull();
 });
 
+test("RetryAfterError with a buffered defer ships StepError with only a Retry-After header", async () => {
+  const { url, fnId } = await startServerWithDeferThatThrows(
+    new RetryAfterError("rate limited", 600_000),
+  );
+
+  const res = await fetch(`${url}?fnId=${fnId}&stepId=step`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(stepExecBody()),
+  });
+
+  expect(res.status).toBe(206);
+  expect(res.headers.get(headerKeys.RetryAfter)).toBe("600");
+  // Never set on a terminal-error 206: finality travels via the opcode
+  // (`StepFailed` vs `StepError`), not a transport-level header.
+  expect(res.headers.get(headerKeys.NoRetry)).toBeNull();
+
+  const ops = await res.json();
+  expect(ops).toContainEqual(expect.objectContaining({ op: "DeferAdd" }));
+  expect(ops).toContainEqual(
+    expect.objectContaining({
+      op: "StepError",
+      error: expect.objectContaining({ name: "RetryAfterError" }),
+    }),
+  );
+  expect(ops).not.toContainEqual(expect.objectContaining({ op: "StepFailed" }));
+});
+
 test("NonRetriableError with a buffered defer ships StepFailed with no retry headers", async () => {
   const { url, fnId } = await startServerWithDeferThatThrows(
     new NonRetriableError("permanent failure"),


### PR DESCRIPTION
## Summary

Stacked on #1630 .

When a function-level `RetryAfterError` converts to a steps-found response because buffered lazy ops (e.g. a `DeferAdd`) must ride along, the retry delay was silently dropped: the 206 response carried no `Retry-After` header, so the executor fell back to its default backoff. This propagates the retriable duration through the conversion and emits the header.

Current executors ignore the header on a 206 (default backoff — the status quo), and it's honored once the backend supports it, so no backend changes are required to ship.

## Checklist

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A internal behavior fix, no API surface change
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
- EXE-1813