### PR TITLE
feat(defers): add support for abort()

### DIFF
--- a/.changeset/lovely-parents-sneeze.md
+++ b/.changeset/lovely-parents-sneeze.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Added support for aborting deferred runs via defer().abort()

--- a/packages/inngest/src/components/execution/InngestExecution.ts
+++ b/packages/inngest/src/components/execution/InngestExecution.ts
@@ -123,7 +123,7 @@ export interface InngestExecutionOptions {
    * tracks which ones it has already received so the SDK can avoid
    * re-emitting them on replay.
    */
-  priorDefers?: Record<string, unknown>;
+  priorDefers?: Record<string, { abortable?: boolean }>;
 
   stepCompletionOrder: string[];
   stepMode: StepMode;

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -1,13 +1,15 @@
 import { fromPartial } from "@total-typescript/shoehorn";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { InngestApi } from "../../api/api.ts";
+import { createDefer } from "../../experimental.ts";
 import { ExecutionVersion } from "../../helpers/consts.ts";
 import { createClient } from "../../test/helpers.ts";
-import { StepMode, StepOpCode } from "../../types.ts";
+import { type Context, StepMode, StepOpCode } from "../../types.ts";
 import { InngestFunction } from "../InngestFunction.ts";
 import type { MetadataUpdate } from "../InngestMetadata.ts";
 import type { GenericStepTools } from "../InngestStepTools.ts";
 import { NonRetriableError } from "../NonRetriableError.ts";
+import { _internals } from "./engine.ts";
 import type { ExecutionResults } from "./InngestExecution.ts";
 
 describe("Execution engine checkpoint retry behavior", () => {
@@ -49,7 +51,7 @@ describe("Execution engine checkpoint retry behavior", () => {
     extraPartialOptions = {},
   }: {
     mockApi: Partial<InngestApi>;
-    handler: (ctx: { step: GenericStepTools }) => Promise<unknown>;
+    handler: (ctx: Context.Any & { step: GenericStepTools }) => unknown;
     stepMode: StepMode;
     checkpointingConfig?: {
       bufferedSteps: number;
@@ -98,6 +100,42 @@ describe("Execution engine checkpoint retry behavior", () => {
     });
 
     return { execution, client, fn };
+  };
+
+  const runDeferExecution = async ({
+    handler,
+    priorDefers,
+  }: {
+    handler: (
+      ctx: Context.Any,
+      deferFn: ReturnType<typeof createDefer>,
+    ) => unknown;
+    priorDefers?: Record<string, { abortable?: boolean }>;
+  }) => {
+    const client = createClient({ id: "test" });
+    const deferFn = createDefer(client, { id: "foo" }, async () => {});
+    const fn = client.createFunction(
+      { id: "test-fn", triggers: [{ event: "test/event" }] },
+      (ctx) => handler(ctx, deferFn),
+    );
+
+    const execution = fn["createExecution"]({
+      partialOptions: {
+        client,
+        data: fromPartial({ event: mockEvent }),
+        runId: "test-run-id",
+        stepState: {},
+        stepCompletionOrder: [],
+        reqArgs: [],
+        headers: {},
+        stepMode: StepMode.AsyncCheckpointing,
+        queueItemId: "queue-item-123",
+        internalFnId: "internal-fn-456",
+        priorDefers,
+      },
+    });
+
+    return await execution.start();
   };
 
   /**
@@ -283,6 +321,49 @@ describe("Execution engine checkpoint retry behavior", () => {
       const stepsFound = result as ExecutionResults["steps-found"];
       expect(stepsFound.steps).toHaveLength(1);
       expect(stepsFound.steps[0]!.data).toBe("result");
+    });
+
+    describe("defer abort lazy ops", () => {
+      test("immediate abort reports only DeferAbort for the defer", async () => {
+        const result = await runDeferExecution({
+          handler: ({ defer }, deferFn) => {
+            const { abort } = defer("foo", { function: deferFn, data: {} });
+            abort();
+            return "done";
+          },
+        });
+
+        expect(result.type).toBe("steps-found");
+        const stepsFound = result as ExecutionResults["steps-found"];
+        const deferOps = stepsFound.steps.filter(
+          (step) =>
+            step.op === StepOpCode.DeferAdd ||
+            step.op === StepOpCode.DeferAbort,
+        );
+
+        expect(deferOps).toHaveLength(1);
+        expect(deferOps[0]).toMatchObject({
+          op: StepOpCode.DeferAbort,
+          opts: { target_hashed_id: _internals.hashId("foo") },
+        });
+      });
+
+      test("abort noops when the prior defer is not abortable", async () => {
+        const result = await runDeferExecution({
+          priorDefers: { [_internals.hashId("foo")]: { abortable: false } },
+          handler: ({ defer }, deferFn) => {
+            const { abort } = defer("foo", { function: deferFn, data: {} });
+            abort();
+            return "done";
+          },
+        });
+
+        expect(result.type).toBe("steps-found");
+        const stepsFound = result as ExecutionResults["steps-found"];
+        expect(
+          stepsFound.steps.some((step) => step.op === StepOpCode.DeferAbort),
+        ).toBe(false);
+      });
     });
 
     test("flushes buffered steps before returning parallel steps to executor", async () => {

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -44,6 +44,7 @@ import {
   type APIStepPayload,
   type Context,
   type DeferFn,
+  type DeferHandle,
   type EventPayload,
   type FailureEventArgs,
   type Handler,
@@ -2672,6 +2673,7 @@ class InngestExecutionEngine
     return (idOrOptions, { function: deferFn, data, experiment }) => {
       const log = this.options.client[internalLoggerSymbol];
       const runId = this.fnArg.runId;
+      const noopHandle: DeferHandle = { abort: () => {} };
 
       try {
         if (!isDeferredFunction(deferFn)) {
@@ -2679,11 +2681,13 @@ class InngestExecutionEngine
             { runId },
             "defer skipped: function not created via createDefer",
           );
-          return;
+          return noopHandle;
         }
 
         const { schema } = deferFn;
         const deferFnSlug = deferFn.id(this.options.client.id);
+        const stepOptions = getStepOptions(idOrOptions);
+        const hashedId = _internals.hashId(stepOptions.id);
 
         let input: unknown = data;
         if (schema) {
@@ -2693,14 +2697,14 @@ class InngestExecutionEngine
               { runId },
               "defer() requires a synchronous schema validator. The defer call was skipped.",
             );
-            return;
+            return noopHandle;
           }
           if (result.issues) {
             log.error(
               { runId, issues: result.issues },
               "defer skipped: schema validation failed",
             );
-            return;
+            return noopHandle;
           }
           input = result.value ?? data;
         }
@@ -2713,7 +2717,7 @@ class InngestExecutionEngine
             : input;
 
         void stepHandler({
-          args: [idOrOptions, finalInput],
+          args: [stepOptions, finalInput],
           matchOp: (stepOptions, inputArg) => ({
             id: stepOptions.id,
             mode: StepMode.Sync,
@@ -2726,10 +2730,53 @@ class InngestExecutionEngine
         }).catch((err: unknown) => {
           log.error({ runId, err }, "defer skipped: unexpected error");
         });
+
+        return {
+          abort: () => {
+            try {
+              if (this.state.priorDefers[hashedId]?.abortable === false) {
+                return;
+              }
+
+              const abortId = `${hashedId}:abort`;
+              if (this.state.lazyOps.hasId(_internals.hashId(abortId))) {
+                return;
+              }
+
+              void stepHandler({
+                args: [{ id: abortId, name: stepOptions.name }, null],
+                matchOp: (abortStepOptions) => ({
+                  id: abortStepOptions.id,
+                  mode: StepMode.Sync,
+                  op: StepOpCode.DeferAbort,
+                  name: stepOptions.name ?? stepOptions.id,
+                  displayName: stepOptions.name ?? stepOptions.id,
+                  opts: {
+                    target_hashed_id: hashedId,
+                    fn_slug: deferFnSlug,
+                    id: stepOptions.id,
+                  },
+                  userland: { id: stepOptions.id },
+                }),
+              }).catch((err: unknown) => {
+                log.error(
+                  { runId, err },
+                  "defer abort skipped: unexpected error",
+                );
+              });
+            } catch (err) {
+              log.error(
+                { runId, err },
+                "defer abort skipped: unexpected error",
+              );
+            }
+          },
+        };
       } catch (err) {
         // Fire-and-forget: a misbehaving schema validator, malformed args, or
         // any other unexpected throw must not derail the surrounding handler.
         log.error({ runId, err }, "defer skipped: unexpected error");
+        return noopHandle;
       }
     };
   }
@@ -3084,7 +3131,7 @@ export interface ExecutionState {
    * normal steps (they have no result), so this lives separately from
    * `stepState`.
    */
-  priorDefers: Record<string, unknown>;
+  priorDefers: Record<string, { abortable?: boolean }>;
 
   /**
    * The number of steps we expect to fulfil based on the state passed from the

--- a/packages/inngest/src/components/execution/lazyOps.ts
+++ b/packages/inngest/src/components/execution/lazyOps.ts
@@ -1,4 +1,4 @@
-import { type OutgoingOp, StepMode } from "../../types.ts";
+import { type OutgoingOp, StepMode, StepOpCode } from "../../types.ts";
 import type { MatchOpFn, StepToolOptions } from "../InngestStepTools.ts";
 
 /**
@@ -49,6 +49,17 @@ export class LazyOps {
    * Buffer an op for later shipment.
    */
   push(op: OutgoingOp): void {
+    if (op.op === StepOpCode.DeferAbort) {
+      // If there's a matching DeferAdd op, remove it. We don't want to report
+      // the same defer with DeferAdd and DeferAbort in the same request.
+      this.buffer = this.buffer.filter((buffered) => {
+        return !(
+          buffered.op === StepOpCode.DeferAdd &&
+          buffered.id === op.opts?.target_hashed_id
+        );
+      });
+    }
+
     this.buffer.push(op);
     this.pushedIds.add(op.id);
   }

--- a/packages/inngest/src/helpers/functions.ts
+++ b/packages/inngest/src/helpers/functions.ts
@@ -151,7 +151,10 @@ export const parseFnData = (
           event: z.record(z.any()),
           events: z.array(z.record(z.any())).default([]),
           steps: stepSchema,
-          defers: z.record(z.unknown()).optional().default({}),
+          defers: z
+            .record(z.object({ abortable: z.boolean().optional() }))
+            .optional()
+            .default({}),
           ctx: z
             .object({
               run_id: z.string(),

--- a/packages/inngest/src/test/integration/defer/abort.test.ts
+++ b/packages/inngest/src/test/integration/defer/abort.test.ts
@@ -1,0 +1,246 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  sleep,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { expect } from "vitest";
+import { createDefer } from "../../../experimental.ts";
+import { Inngest } from "../../../index.ts";
+import { createServer } from "../../../node.ts";
+import { matrixCheckpointing } from "../utils.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+matrixCheckpointing("aborted defer never runs", async (checkpointing) => {
+  const parentState = createState({});
+  const deferState = createState({});
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    checkpointing,
+  });
+  const eventName = randomSuffix("evt");
+  const foo = createDefer(client, { id: "foo" }, async ({ runId }) => {
+    deferState.runId = runId;
+  });
+  const fn = client.createFunction(
+    {
+      id: "fn",
+      retries: 0,
+      triggers: { event: eventName },
+    },
+    async ({ defer, runId }) => {
+      parentState.runId = runId;
+      const ref = defer("foo", { function: foo, data: {} });
+      ref.abort();
+    },
+  );
+  await createTestApp({
+    client,
+    functions: [fn, foo],
+    serve: createServer,
+  });
+
+  await client.send({ name: eventName, data: {} });
+  await parentState.waitForRunComplete();
+
+  // Wait long enough to give the aborted defer a chance to run (it shouldn't)
+  await sleep(5000);
+  expect(deferState.runId).toBeNull();
+});
+
+matrixCheckpointing(
+  "abort after the add has shipped prevents the deferred run",
+  async (checkpointing) => {
+    // The step between the defer and the abort forces the `DeferAdd` to ship
+    // before the abort is emitted, exercising the shipped-target path.
+
+    const parentState = createState({});
+    const deferState = createState({});
+
+    const client = new Inngest({
+      id: randomSuffix(testFileName),
+      isDev: true,
+      checkpointing,
+    });
+    const eventName = randomSuffix("evt");
+    const foo = createDefer(client, { id: "foo" }, async ({ runId }) => {
+      deferState.runId = runId;
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 0,
+        triggers: { event: eventName },
+      },
+      async ({ defer, runId, step }) => {
+        parentState.runId = runId;
+        const ref = defer("foo", { function: foo, data: {} });
+        await step.run("between", async () => {});
+        ref.abort();
+      },
+    );
+    await createTestApp({
+      client,
+      functions: [fn, foo],
+      serve: createServer,
+    });
+
+    await client.send({ name: eventName, data: {} });
+    await parentState.waitForRunComplete();
+
+    await sleep(5000);
+    expect(deferState.runId).toBeNull();
+  },
+);
+
+matrixCheckpointing(
+  "abort inside step.run ships with the step result",
+  async (checkpointing) => {
+    // The sleep forces the add to ship before the aborting step runs, so the
+    // abort emitted inside the step closure is bundled with the step result.
+
+    const parentState = createState({});
+    const deferState = createState({});
+
+    const client = new Inngest({
+      id: randomSuffix(testFileName),
+      isDev: true,
+      checkpointing,
+    });
+    const eventName = randomSuffix("evt");
+    const foo = createDefer(client, { id: "foo" }, async ({ runId }) => {
+      deferState.runId = runId;
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 0,
+        triggers: { event: eventName },
+      },
+      async ({ defer, runId, step }) => {
+        parentState.runId = runId;
+        const ref = defer("foo", { function: foo, data: {} });
+        await step.sleep("pause", "1s");
+        await step.run("abort", async () => {
+          ref.abort();
+        });
+      },
+    );
+    await createTestApp({
+      client,
+      functions: [fn, foo],
+      serve: createServer,
+    });
+
+    await client.send({ name: eventName, data: {} });
+    await parentState.waitForRunComplete();
+
+    await sleep(5000);
+    expect(deferState.runId).toBeNull();
+  },
+);
+
+matrixCheckpointing(
+  "defer and abort inside the same step closure",
+  async (checkpointing) => {
+    // Both the add and the abort happen inside one `step.run` closure: the
+    // add is cancelled locally and the abort ships alone. On re-entry the
+    // memoized step doesn't re-run, so nothing is re-added.
+
+    const parentState = createState({});
+    const deferState = createState({});
+
+    const client = new Inngest({
+      id: randomSuffix(testFileName),
+      isDev: true,
+      checkpointing,
+    });
+    const eventName = randomSuffix("evt");
+    const foo = createDefer(client, { id: "foo" }, async ({ runId }) => {
+      deferState.runId = runId;
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 0,
+        triggers: { event: eventName },
+      },
+      async ({ defer, runId, step }) => {
+        parentState.runId = runId;
+        await step.run("defer-and-abort", async () => {
+          const ref = defer("foo", { function: foo, data: {} });
+          ref.abort();
+        });
+
+        // Force reentry so the memoized step is replayed
+        await step.sleep("pause", "1s");
+      },
+    );
+    await createTestApp({
+      client,
+      functions: [fn, foo],
+      serve: createServer,
+    });
+
+    await client.send({ name: eventName, data: {} });
+    await parentState.waitForRunComplete();
+
+    await sleep(5000);
+    expect(deferState.runId).toBeNull();
+  },
+);
+
+matrixCheckpointing(
+  "unaborted defers still run alongside an aborted one",
+  async (checkpointing) => {
+    const parentState = createState({});
+    const abortedState = createState({});
+    const keptState = createState({});
+
+    const client = new Inngest({
+      id: randomSuffix(testFileName),
+      isDev: true,
+      checkpointing,
+    });
+    const eventName = randomSuffix("evt");
+    const aborted = createDefer(
+      client,
+      { id: "aborted" },
+      async ({ runId }) => {
+        abortedState.runId = runId;
+      },
+    );
+    const kept = createDefer(client, { id: "kept" }, async ({ runId }) => {
+      keptState.runId = runId;
+    });
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 0,
+        triggers: { event: eventName },
+      },
+      async ({ defer, runId }) => {
+        parentState.runId = runId;
+        const ref = defer("aborted", { function: aborted, data: {} });
+        defer("kept", { function: kept, data: {} });
+        ref.abort();
+      },
+    );
+    await createTestApp({
+      client,
+      functions: [fn, aborted, kept],
+      serve: createServer,
+    });
+
+    await client.send({ name: eventName, data: {} });
+    await parentState.waitForRunComplete();
+    await keptState.waitForRunComplete();
+
+    await sleep(5000);
+    expect(abortedState.runId).toBeNull();
+  },
+);

--- a/packages/inngest/src/test/integration/defer/misc.test.ts
+++ b/packages/inngest/src/test/integration/defer/misc.test.ts
@@ -149,13 +149,14 @@ describe("defer ID collision", async () => {
   }
 });
 
-test("defer in step", async () => {
+matrixCheckpointing("defer in step", async (checkpointing) => {
   // Can call `defer` within a step
 
   const parentState = createState({});
   const deferState = createState({});
 
   const client = new Inngest({
+    checkpointing,
     id: randomSuffix(testFileName),
     isDev: true,
   });

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -512,12 +512,26 @@ export type WithInvocation<T extends EventPayload> = Simplify<
  * EXPERIMENTAL: This API is not yet stable and may change in the future without
  * a major version bump.
  *
+ * Handle returned by `defer(...)`, scoped to that call's deferred run.
+ */
+export type DeferHandle = {
+  /**
+   * Cancel the deferred run. Sync and fire-and-forget. If the executor marks
+   * the defer as no longer abortable, this is a no-op.
+   */
+  abort: () => void;
+};
+
+/**
+ * EXPERIMENTAL: This API is not yet stable and may change in the future without
+ * a major version bump.
+ *
  * Context extension that exposes `defer` on every handler.
  *
  * `defer(id, { function, data })` emits a `DeferAdd` opcode that triggers the
  * referenced defer function (created via `createDefer`) with `data` validated
  * against the function's schema. The data type is inferred from the function's
- * schema.
+ * schema. Returns a {@link DeferHandle} that can cancel the deferred run.
  */
 export type DeferFn = <TFn extends DeferredFunction.Any>(
   id: string,
@@ -532,7 +546,7 @@ export type DeferFn = <TFn extends DeferredFunction.Any>(
     /** Attribute the deferred scorer's result to this experiment variant. */
     experiment?: ExperimentRef;
   },
-) => void;
+) => DeferHandle;
 
 /**
  * A replay-stable handle to a selected experiment variant, returned by


### PR DESCRIPTION
## Summary
Adds `defer()` abort support: `defer(...)` now returns a handle whose `abort()` cancels the deferred run via a `DeferAbort` opcode. Aborts are sync, fire-and-forget, and idempotent; a co-batched add+abort pair is sanitized at the wire boundary so the pair can't race in the executor.


## Checklist

- [x] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- #1625 - Previous version of this PR
- #1628 -`RetryAfterError` timing rides a `Retry-After` header on the 206 — ignored by current executors (default backoff, status quo), honored once the backend supports it. No backend changes required to ship.
- #1629 - The executor's error-discovery re-invocation after a terminal failure is short-circuited (the SDK detects the memoized terminal op and re-reports the rejection without re-running user code or its side effects).
