### PR TITLE
internal: add internal sessionPropagation toggle

### DIFF
--- a/packages/inngest/src/components/CLAUDE.md
+++ b/packages/inngest/src/components/CLAUDE.md
@@ -1,0 +1,27 @@
+# Agent Guidance — `src/components/`
+
+Guidance for the core client (`Inngest.ts`), comm handler, and execution code.
+
+## Resolve env vars lazily, never at construction time
+
+**Do not read env vars in the `Inngest` constructor and cache the result.** Some
+runtimes don't expose env vars as global `process.env` at construction:
+
+- Node serverless usually has `process.env` available.
+- Edge / non-Node runtimes (Cloudflare Workers-style APIs, etc.) pass env vars as
+  per-request bindings, and there may be no real `process` at all. The client is
+  constructed once, then `setEnvVars()` populates `this._env` as each request
+  comes in.
+
+If you resolve a setting from an env var in the constructor, edge users will
+silently never pick up that env var — it was empty when the constructor ran.
+
+**Instead, resolve on access via a getter that reads `this._env`.** Follow
+long-standing getters in `Inngest.ts`: `get mode()` (a boolean toggle read via
+`parseAsBoolean(this._env[envKeys.InngestDevMode])`), or `get eventKey()` /
+`get signingKey()` (the `this.options.x || this._env[envKeys.X]` precedence
+one-liner). Read `this._env[envKeys.Foo]` every time the value is needed,
+applying precedence (explicit option > env var > default) inside the getter.
+
+This is why the `setEnvVars()` uses exist — honor them by reading
+`this._env` late, not by snapshotting it early.

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1403,32 +1403,101 @@ describe("inngest.realtime.publish", () => {
 describe("sessionPropagation toggle", () => {
   // `sessionPropagation` is an internal, undocumented option that is
   // intentionally kept off the public `ClientOptions` type, so it's set via a
-  // narrow cast — the same way the SDK reads it internally.
-  const createWithSessionPropagation = (
-    sessionPropagation?: boolean,
-  ): Inngest.Any => {
+  // narrow cast — the same way the SDK reads it internally. `env` stubs
+  // `process.env` for the duration of construction, restoring it afterwards.
+  const createWithSessionPropagation = ({
+    option,
+    env,
+  }: {
+    option?: boolean;
+    env?: Record<string, string>;
+  } = {}): Inngest.Any => {
     const opts = { id: "test" } as ConstructorParameters<typeof Inngest>[0];
 
-    if (sessionPropagation !== undefined) {
-      (opts as { sessionPropagation?: boolean }).sessionPropagation =
-        sessionPropagation;
+    if (option !== undefined) {
+      (opts as { sessionPropagation?: boolean }).sessionPropagation = option;
     }
 
-    return new Inngest(opts);
+    let ogKeys: Record<string, string | undefined> = {};
+    if (env) {
+      ogKeys = Object.keys(env).reduce<Record<string, string | undefined>>(
+        (acc, key) => {
+          acc[key] = process.env[key];
+          process.env[key] = env[key];
+          return acc;
+        },
+        {},
+      );
+    }
+
+    try {
+      return new Inngest(opts);
+    } finally {
+      if (env) {
+        // biome-ignore lint/complexity/noForEach: intentional
+        Object.keys(ogKeys).forEach((key) => {
+          process.env[key] = ogKeys[key];
+        });
+      }
+    }
   };
 
-  test("defaults to false (dark-launch OFF) when the option is omitted", () => {
+  test("defaults to false (dark-launch OFF) when neither option nor env is set", () => {
     const inngest = createWithSessionPropagation();
     expect(inngest[sessionPropagationSymbol]).toBe(false);
   });
 
   test("is true when the internal option is set to true", () => {
-    const inngest = createWithSessionPropagation(true);
+    const inngest = createWithSessionPropagation({ option: true });
     expect(inngest[sessionPropagationSymbol]).toBe(true);
   });
 
   test("is false when the internal option is explicitly false", () => {
-    const inngest = createWithSessionPropagation(false);
+    const inngest = createWithSessionPropagation({ option: false });
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+
+  test("`INNGEST_SESSION_PROPAGATION=true` enables propagation", () => {
+    const inngest = createWithSessionPropagation({
+      env: { [envKeys.InngestSessionPropagation]: "true" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(true);
+  });
+
+  test("`INNGEST_SESSION_PROPAGATION=1` enables propagation", () => {
+    const inngest = createWithSessionPropagation({
+      env: { [envKeys.InngestSessionPropagation]: "1" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(true);
+  });
+
+  test("`INNGEST_SESSION_PROPAGATION=false` disables propagation", () => {
+    const inngest = createWithSessionPropagation({
+      env: { [envKeys.InngestSessionPropagation]: "false" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+
+  test("`INNGEST_SESSION_PROPAGATION=0` disables propagation", () => {
+    const inngest = createWithSessionPropagation({
+      env: { [envKeys.InngestSessionPropagation]: "0" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+
+  test("option `true` overrides env `false`", () => {
+    const inngest = createWithSessionPropagation({
+      option: true,
+      env: { [envKeys.InngestSessionPropagation]: "false" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(true);
+  });
+
+  test("option `false` overrides env `true`", () => {
+    const inngest = createWithSessionPropagation({
+      option: false,
+      env: { [envKeys.InngestSessionPropagation]: "true" },
+    });
     expect(inngest[sessionPropagationSymbol]).toBe(false);
   });
 });

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1405,23 +1405,17 @@ describe("sessionPropagation toggle", () => {
     vi.unstubAllEnvs();
   });
 
-  // `sessionPropagation` is an internal, undocumented option that is
-  // intentionally kept off the public `ClientOptions` type, so it's set via a
-  // narrow cast — the same way the SDK reads it internally. `env` is applied
-  // via `vi.stubEnv` and automatically restored after each test by
-  // `vi.unstubAllEnvs`, so there's no env-var bleed between tests.
+  // Session propagation is resolved from the `INNGEST_SESSION_PROPAGATION` env
+  // var (there's no public/internal client option yet — that arrives with
+  // client-side configuration). `env` is applied via `vi.stubEnv` and
+  // automatically restored after each test by `vi.unstubAllEnvs`, so there's no
+  // env-var bleed between tests.
   const createWithSessionPropagation = ({
-    option,
     env,
   }: {
-    option?: boolean;
     env?: Record<string, string>;
   } = {}): Inngest.Any => {
     const opts = { id: "test" } as ConstructorParameters<typeof Inngest>[0];
-
-    if (option !== undefined) {
-      (opts as { sessionPropagation?: boolean }).sessionPropagation = option;
-    }
 
     if (env) {
       for (const [key, value] of Object.entries(env)) {
@@ -1432,18 +1426,8 @@ describe("sessionPropagation toggle", () => {
     return new Inngest(opts);
   };
 
-  test("defaults to false (dark-launch OFF) when neither option nor env is set", () => {
+  test("defaults to false (dark-launch OFF) when env is not set", () => {
     const inngest = createWithSessionPropagation();
-    expect(inngest[sessionPropagationSymbol]).toBe(false);
-  });
-
-  test("is true when the internal option is set to true", () => {
-    const inngest = createWithSessionPropagation({ option: true });
-    expect(inngest[sessionPropagationSymbol]).toBe(true);
-  });
-
-  test("is false when the internal option is explicitly false", () => {
-    const inngest = createWithSessionPropagation({ option: false });
     expect(inngest[sessionPropagationSymbol]).toBe(false);
   });
 
@@ -1471,22 +1455,6 @@ describe("sessionPropagation toggle", () => {
   test("`INNGEST_SESSION_PROPAGATION=0` disables propagation", () => {
     const inngest = createWithSessionPropagation({
       env: { [envKeys.InngestSessionPropagation]: "0" },
-    });
-    expect(inngest[sessionPropagationSymbol]).toBe(false);
-  });
-
-  test("option `true` overrides env `false`", () => {
-    const inngest = createWithSessionPropagation({
-      option: true,
-      env: { [envKeys.InngestSessionPropagation]: "false" },
-    });
-    expect(inngest[sessionPropagationSymbol]).toBe(true);
-  });
-
-  test("option `false` overrides env `true`", () => {
-    const inngest = createWithSessionPropagation({
-      option: false,
-      env: { [envKeys.InngestSessionPropagation]: "true" },
     });
     expect(inngest[sessionPropagationSymbol]).toBe(false);
   });

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -14,6 +14,7 @@ import {
 import type { Logger } from "../middleware/logger.ts";
 import { createClient, nodeVersion } from "../test/helpers.ts";
 import type { SendEventResponse } from "../types.ts";
+import { sessionPropagationSymbol } from "./Inngest.ts";
 import type { createStepTools } from "./InngestStepTools.ts";
 
 const testEvent: EventPayload = {
@@ -1396,5 +1397,38 @@ describe("inngest.realtime.publish", () => {
       // @ts-expect-error intentional invalid payload
       inngest.realtime.publish(ch.status, { message: 999 }),
     ).rejects.toThrow("Schema validation failed");
+  });
+});
+
+describe("sessionPropagation toggle", () => {
+  // `sessionPropagation` is an internal, undocumented option that is
+  // intentionally kept off the public `ClientOptions` type, so it's set via a
+  // narrow cast — the same way the SDK reads it internally.
+  const createWithSessionPropagation = (
+    sessionPropagation?: boolean,
+  ): Inngest.Any => {
+    const opts = { id: "test" } as ConstructorParameters<typeof Inngest>[0];
+
+    if (sessionPropagation !== undefined) {
+      (opts as { sessionPropagation?: boolean }).sessionPropagation =
+        sessionPropagation;
+    }
+
+    return new Inngest(opts);
+  };
+
+  test("defaults to false (dark-launch OFF) when the option is omitted", () => {
+    const inngest = createWithSessionPropagation();
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+
+  test("is true when the internal option is set to true", () => {
+    const inngest = createWithSessionPropagation(true);
+    expect(inngest[sessionPropagationSymbol]).toBe(true);
+  });
+
+  test("is false when the internal option is explicitly false", () => {
+    const inngest = createWithSessionPropagation(false);
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
   });
 });

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1401,10 +1401,15 @@ describe("inngest.realtime.publish", () => {
 });
 
 describe("sessionPropagation toggle", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   // `sessionPropagation` is an internal, undocumented option that is
   // intentionally kept off the public `ClientOptions` type, so it's set via a
-  // narrow cast — the same way the SDK reads it internally. `env` stubs
-  // `process.env` for the duration of construction, restoring it afterwards.
+  // narrow cast — the same way the SDK reads it internally. `env` is applied
+  // via `vi.stubEnv` and automatically restored after each test by
+  // `vi.unstubAllEnvs`, so there's no env-var bleed between tests.
   const createWithSessionPropagation = ({
     option,
     env,
@@ -1418,28 +1423,13 @@ describe("sessionPropagation toggle", () => {
       (opts as { sessionPropagation?: boolean }).sessionPropagation = option;
     }
 
-    let ogKeys: Record<string, string | undefined> = {};
     if (env) {
-      ogKeys = Object.keys(env).reduce<Record<string, string | undefined>>(
-        (acc, key) => {
-          acc[key] = process.env[key];
-          process.env[key] = env[key];
-          return acc;
-        },
-        {},
-      );
-    }
-
-    try {
-      return new Inngest(opts);
-    } finally {
-      if (env) {
-        // biome-ignore lint/complexity/noForEach: intentional
-        Object.keys(ogKeys).forEach((key) => {
-          process.env[key] = ogKeys[key];
-        });
+      for (const [key, value] of Object.entries(env)) {
+        vi.stubEnv(key, value);
       }
     }
+
+    return new Inngest(opts);
   };
 
   test("defaults to false (dark-launch OFF) when neither option nor env is set", () => {

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -118,6 +118,16 @@ type FetchT = typeof fetch;
  */
 export const internalLoggerSymbol = Symbol.for("inngest.internalLogger");
 
+/**
+ * Symbol for accessing whether session propagation is enabled on this client.
+ * @internal
+ */
+export const sessionPropagationSymbol = Symbol.for(
+  "inngest.sessionPropagation",
+);
+
+const SESSION_PROPAGATION_DEFAULT_ENABLED = false;
+
 export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
   implements Inngest.Like
 {
@@ -162,6 +172,15 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
    * @internal
    */
   readonly [internalLoggerSymbol]: Logger;
+
+  /**
+   * Whether session propagation is enabled for this client. Resolved from
+   * `sessionPropagation` constructor option, defaulting to
+   * {@link SESSION_PROPAGATION_DEFAULT_ENABLED}.
+   *
+   * @internal
+   */
+  readonly [sessionPropagationSymbol]: boolean;
 
   private localFns: InngestFunction.Any[] = [];
 
@@ -377,6 +396,15 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
 
     this._logger = logger ?? new ConsoleLogger();
     this[internalLoggerSymbol] = this.options.internalLogger ?? this._logger;
+
+    // `sessionPropagation` is an internal, undocumented option intentionally
+    // kept off the public `ClientOptions` type, so it's read via a narrow cast.
+    const sessionPropagationOption = (
+      this.options as TClientOpts & { sessionPropagation?: boolean }
+    ).sessionPropagation;
+
+    this[sessionPropagationSymbol] =
+      sessionPropagationOption ?? SESSION_PROPAGATION_DEFAULT_ENABLED;
 
     // Warned here rather than per-function so internal SDK functions
     // inheriting this setting don't each warn.

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -173,16 +173,6 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
    */
   readonly [internalLoggerSymbol]: Logger;
 
-  /**
-   * Whether session propagation is enabled for this client. Resolved with the
-   * precedence `sessionPropagation` constructor option >
-   * `INNGEST_SESSION_PROPAGATION` env var > {@link
-   * SESSION_PROPAGATION_DEFAULT_ENABLED}.
-   *
-   * @internal
-   */
-  readonly [sessionPropagationSymbol]: boolean;
-
   private localFns: InngestFunction.Any[] = [];
 
   /**
@@ -398,29 +388,6 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     this._logger = logger ?? new ConsoleLogger();
     this[internalLoggerSymbol] = this.options.internalLogger ?? this._logger;
 
-    // Session propagation is resolved with the precedence
-    // `sessionPropagation` option > `INNGEST_SESSION_PROPAGATION` env var >
-    // default, matching the SDK's `dev`-mode resolution order.
-    let sessionPropagation = SESSION_PROPAGATION_DEFAULT_ENABLED;
-
-    const sessionPropagationEnv = parseAsBoolean(
-      this._env[envKeys.InngestSessionPropagation],
-    );
-    if (sessionPropagationEnv !== undefined) {
-      sessionPropagation = sessionPropagationEnv;
-    }
-
-    // `sessionPropagation` is an internal, undocumented option intentionally
-    // kept off the public `ClientOptions` type, so it's read via a narrow cast.
-    const sessionPropagationOption = (
-      this.options as TClientOpts & { sessionPropagation?: boolean }
-    ).sessionPropagation;
-    if (sessionPropagationOption !== undefined) {
-      sessionPropagation = sessionPropagationOption;
-    }
-
-    this[sessionPropagationSymbol] = sessionPropagation;
-
     // Warned here rather than per-function so internal SDK functions
     // inheriting this setting don't each warn.
     if (this.options.optimizeParallelism === false) {
@@ -471,6 +438,43 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     this._env = protectEnv({ ...this._env, ...env });
 
     return this;
+  }
+
+  /**
+   * Whether session propagation is enabled for this client. Resolved with the
+   * precedence `sessionPropagation` constructor option >
+   * `INNGEST_SESSION_PROPAGATION` env var > {@link
+   * SESSION_PROPAGATION_DEFAULT_ENABLED}.
+   *
+   * Resolved lazily on every access (mirroring {@link mode}) so that env vars
+   * populated after construction via {@link setEnvVars} — as happens in
+   * edge/serverless runtimes like Cloudflare Workers — are honored.
+   *
+   * @internal
+   */
+  get [sessionPropagationSymbol](): boolean {
+    // Session propagation is resolved with the precedence
+    // `sessionPropagation` option > `INNGEST_SESSION_PROPAGATION` env var >
+    // default, matching the SDK's `dev`-mode resolution order.
+    let sessionPropagation = SESSION_PROPAGATION_DEFAULT_ENABLED;
+
+    const sessionPropagationEnv = parseAsBoolean(
+      this._env[envKeys.InngestSessionPropagation],
+    );
+    if (sessionPropagationEnv !== undefined) {
+      sessionPropagation = sessionPropagationEnv;
+    }
+
+    // `sessionPropagation` is an internal, undocumented option intentionally
+    // kept off the public `ClientOptions` type, so it's read via a narrow cast.
+    const sessionPropagationOption = (
+      this.options as TClientOpts & { sessionPropagation?: boolean }
+    ).sessionPropagation;
+    if (sessionPropagationOption !== undefined) {
+      sessionPropagation = sessionPropagationOption;
+    }
+
+    return sessionPropagation;
   }
 
   get mode(): Mode {

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -174,9 +174,10 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
   readonly [internalLoggerSymbol]: Logger;
 
   /**
-   * Whether session propagation is enabled for this client. Resolved from
-   * `sessionPropagation` constructor option, defaulting to
-   * {@link SESSION_PROPAGATION_DEFAULT_ENABLED}.
+   * Whether session propagation is enabled for this client. Resolved with the
+   * precedence `sessionPropagation` constructor option >
+   * `INNGEST_SESSION_PROPAGATION` env var > {@link
+   * SESSION_PROPAGATION_DEFAULT_ENABLED}.
    *
    * @internal
    */
@@ -397,14 +398,28 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     this._logger = logger ?? new ConsoleLogger();
     this[internalLoggerSymbol] = this.options.internalLogger ?? this._logger;
 
+    // Session propagation is resolved with the precedence
+    // `sessionPropagation` option > `INNGEST_SESSION_PROPAGATION` env var >
+    // default, matching the SDK's `dev`-mode resolution order.
+    let sessionPropagation = SESSION_PROPAGATION_DEFAULT_ENABLED;
+
+    const sessionPropagationEnv = parseAsBoolean(
+      this._env[envKeys.InngestSessionPropagation],
+    );
+    if (sessionPropagationEnv !== undefined) {
+      sessionPropagation = sessionPropagationEnv;
+    }
+
     // `sessionPropagation` is an internal, undocumented option intentionally
     // kept off the public `ClientOptions` type, so it's read via a narrow cast.
     const sessionPropagationOption = (
       this.options as TClientOpts & { sessionPropagation?: boolean }
     ).sessionPropagation;
+    if (sessionPropagationOption !== undefined) {
+      sessionPropagation = sessionPropagationOption;
+    }
 
-    this[sessionPropagationSymbol] =
-      sessionPropagationOption ?? SESSION_PROPAGATION_DEFAULT_ENABLED;
+    this[sessionPropagationSymbol] = sessionPropagation;
 
     // Warned here rather than per-function so internal SDK functions
     // inheriting this setting don't each warn.

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -442,8 +442,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
 
   /**
    * Whether session propagation is enabled for this client. Resolved with the
-   * precedence `sessionPropagation` constructor option >
-   * `INNGEST_SESSION_PROPAGATION` env var > {@link
+   * precedence `INNGEST_SESSION_PROPAGATION` env var > {@link
    * SESSION_PROPAGATION_DEFAULT_ENABLED}.
    *
    * Resolved lazily on every access (mirroring {@link mode}) so that env vars
@@ -454,8 +453,8 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
    */
   get [sessionPropagationSymbol](): boolean {
     // Session propagation is resolved with the precedence
-    // `sessionPropagation` option > `INNGEST_SESSION_PROPAGATION` env var >
-    // default, matching the SDK's `dev`-mode resolution order.
+    // `INNGEST_SESSION_PROPAGATION` env var > default, matching the SDK's
+    // `dev`-mode resolution order.
     let sessionPropagation = SESSION_PROPAGATION_DEFAULT_ENABLED;
 
     const sessionPropagationEnv = parseAsBoolean(
@@ -463,15 +462,6 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     );
     if (sessionPropagationEnv !== undefined) {
       sessionPropagation = sessionPropagationEnv;
-    }
-
-    // `sessionPropagation` is an internal, undocumented option intentionally
-    // kept off the public `ClientOptions` type, so it's read via a narrow cast.
-    const sessionPropagationOption = (
-      this.options as TClientOpts & { sessionPropagation?: boolean }
-    ).sessionPropagation;
-    if (sessionPropagationOption !== undefined) {
-      sessionPropagation = sessionPropagationOption;
     }
 
     return sessionPropagation;

--- a/packages/inngest/src/helpers/consts.ts
+++ b/packages/inngest/src/helpers/consts.ts
@@ -37,6 +37,7 @@ export enum envKeys {
   InngestStreaming = "INNGEST_STREAMING",
   InngestDevMode = "INNGEST_DEV",
   InngestAllowInBandSync = "INNGEST_ALLOW_IN_BAND_SYNC",
+  InngestSessionPropagation = "INNGEST_SESSION_PROPAGATION",
   InngestEnableUnauthedSync = "INNGEST_ENABLE_UNAUTHED_SYNC",
   InngestConnectMaxWorkerConcurrency = "INNGEST_CONNECT_MAX_WORKER_CONCURRENCY",
   InngestConnectIsolateExecution = "INNGEST_CONNECT_ISOLATE_EXECUTION",


### PR DESCRIPTION
## Summary

- We're building out session propagation. Eventually this will be a configurable field.
- Let's wire up this configuration. We'll default it to off. Our future fields can honor the toggle, and we can add public access to it upon release
- We add INNGEST_SESSION_PROPAGATION as an env var to also serve as conifg. We still default to off.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>