### PR TITLE
internal: send propagated sessions with step.sendEvent

### DIFF
--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1405,9 +1405,11 @@ describe("sessionPropagation toggle", () => {
     vi.unstubAllEnvs();
   });
 
-  // Session propagation is resolved from the `INNGEST_SESSION_PROPAGATION` env
-  // var (there's no public/internal client option yet — that arrives with
-  // client-side configuration). `env` is applied via `vi.stubEnv` and
+  // Session propagation resolves with precedence: explicit `sessionPropagation`
+  // client option > `INNGEST_SESSION_PROPAGATION` env var > default. This block
+  // covers the env-var path and the default; the option path is exercised by
+  // the behavior tests (send/invoke/defer). Option-vs-env precedence lands with
+  // the public client-side toggle. `env` is applied via `vi.stubEnv` and
   // automatically restored after each test by `vi.unstubAllEnvs`, so there's no
   // env-var bleed between tests.
   const createWithSessionPropagation = ({

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1407,17 +1407,22 @@ describe("sessionPropagation toggle", () => {
 
   // Session propagation resolves with precedence: explicit `sessionPropagation`
   // client option > `INNGEST_SESSION_PROPAGATION` env var > default. This block
-  // covers the env-var path and the default; the option path is exercised by
-  // the behavior tests (send/invoke/defer). Option-vs-env precedence lands with
-  // the public client-side toggle. `env` is applied via `vi.stubEnv` and
-  // automatically restored after each test by `vi.unstubAllEnvs`, so there's no
-  // env-var bleed between tests.
+  // covers all three levels, including option-vs-env precedence in both
+  // directions. `env` is applied via `vi.stubEnv` and automatically restored
+  // after each test by `vi.unstubAllEnvs`, so there's no env-var bleed between
+  // tests.
   const createWithSessionPropagation = ({
     env,
+    sessionPropagation,
   }: {
     env?: Record<string, string>;
+    sessionPropagation?: boolean;
   } = {}): Inngest.Any => {
-    const opts = { id: "test" } as ConstructorParameters<typeof Inngest>[0];
+    const opts: ConstructorParameters<typeof Inngest>[0] = { id: "test" };
+
+    if (typeof sessionPropagation === "boolean") {
+      opts.sessionPropagation = sessionPropagation;
+    }
 
     if (env) {
       for (const [key, value] of Object.entries(env)) {
@@ -1457,6 +1462,32 @@ describe("sessionPropagation toggle", () => {
   test("`INNGEST_SESSION_PROPAGATION=0` disables propagation", () => {
     const inngest = createWithSessionPropagation({
       env: { [envKeys.InngestSessionPropagation]: "0" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+
+  test("`sessionPropagation: true` option enables propagation", () => {
+    const inngest = createWithSessionPropagation({ sessionPropagation: true });
+    expect(inngest[sessionPropagationSymbol]).toBe(true);
+  });
+
+  test("`sessionPropagation: false` option disables propagation", () => {
+    const inngest = createWithSessionPropagation({ sessionPropagation: false });
+    expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+
+  test("`sessionPropagation: true` option overrides a conflicting env var", () => {
+    const inngest = createWithSessionPropagation({
+      sessionPropagation: true,
+      env: { [envKeys.InngestSessionPropagation]: "false" },
+    });
+    expect(inngest[sessionPropagationSymbol]).toBe(true);
+  });
+
+  test("`sessionPropagation: false` option overrides a conflicting env var", () => {
+    const inngest = createWithSessionPropagation({
+      sessionPropagation: false,
+      env: { [envKeys.InngestSessionPropagation]: "true" },
     });
     expect(inngest[sessionPropagationSymbol]).toBe(false);
   });

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -460,8 +460,9 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
 
   /**
    * Whether session propagation is enabled for this client. Resolved with the
-   * precedence `INNGEST_SESSION_PROPAGATION` env var > {@link
-   * SESSION_PROPAGATION_DEFAULT_ENABLED}.
+   * precedence explicit `sessionPropagation` option > `INNGEST_SESSION_PROPAGATION`
+   * env var > {@link SESSION_PROPAGATION_DEFAULT_ENABLED}, mirroring how
+   * {@link mode} resolves the `isDev` option ahead of the env var.
    *
    * Resolved lazily on every access (mirroring {@link mode}) so that env vars
    * populated after construction via {@link setEnvVars} — as happens in
@@ -470,19 +471,25 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
    * @internal
    */
   get [sessionPropagationSymbol](): boolean {
-    // Session propagation is resolved with the precedence
-    // `INNGEST_SESSION_PROPAGATION` env var > default, matching the SDK's
-    // `dev`-mode resolution order.
-    let sessionPropagation = SESSION_PROPAGATION_DEFAULT_ENABLED;
+    // An explicit boolean option wins outright (like `isDev` in `mode`); it is
+    // internal/undocumented, so it lives off the public `ClientOptions` type
+    // and is read via a cast.
+    const sessionPropagationOption = (
+      this.options as { sessionPropagation?: unknown }
+    ).sessionPropagation;
+    if (typeof sessionPropagationOption === "boolean") {
+      return sessionPropagationOption;
+    }
 
+    // Otherwise fall back to the env var, then the default.
     const sessionPropagationEnv = parseAsBoolean(
       this._env[envKeys.InngestSessionPropagation],
     );
     if (sessionPropagationEnv !== undefined) {
-      sessionPropagation = sessionPropagationEnv;
+      return sessionPropagationEnv;
     }
 
-    return sessionPropagation;
+    return SESSION_PROPAGATION_DEFAULT_ENABLED;
   }
 
   get mode(): Mode {

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -471,14 +471,9 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
    * @internal
    */
   get [sessionPropagationSymbol](): boolean {
-    // An explicit boolean option wins outright (like `isDev` in `mode`); it is
-    // internal/undocumented, so it lives off the public `ClientOptions` type
-    // and is read via a cast.
-    const sessionPropagationOption = (
-      this.options as { sessionPropagation?: unknown }
-    ).sessionPropagation;
-    if (typeof sessionPropagationOption === "boolean") {
-      return sessionPropagationOption;
+    // An explicit boolean option wins outright (like `isDev` in `mode`).
+    if (typeof this.options.sessionPropagation === "boolean") {
+      return this.options.sessionPropagation;
     }
 
     // Otherwise fall back to the env var, then the default.

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -1490,14 +1490,11 @@ describe("step.sendEvent session propagation gating", () => {
     enabled: boolean,
     ctxSessions: Record<string, string> | undefined,
   ) => {
-    const clientOpts = {
+    const client = createClient({
       id: testClientId,
       isDev: true,
-      // `sessionPropagation` is internal/undocumented (off the public
-      // ClientOptions), so it's set via the same cast the SDK reads it with.
       sessionPropagation: enabled,
-    } as Parameters<typeof createClient>[0];
-    const client = createClient(clientOpts);
+    });
 
     const sendSpy = vi
       .spyOn(

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -12,7 +12,10 @@ import {
 import { type InvocationResult, StepOpCode } from "../types.ts";
 import { InngestFunction } from "./InngestFunction.ts";
 import { referenceFunction } from "./InngestFunctionReference.ts";
-import { createStepTools } from "./InngestStepTools.ts";
+import {
+  createStepTools,
+  stampPropagatedSessions,
+} from "./InngestStepTools.ts";
 import { realtime } from "./realtime/index.ts";
 
 describe("waitForEvent", () => {
@@ -1422,5 +1425,121 @@ describe("invoke", () => {
       type Actual = GetTestReturn<typeof _test>;
       assertType<IsEqual<Actual, null>>(true);
     });
+  });
+});
+
+describe("stampPropagatedSessions", () => {
+  const sessions = { conv_id: "123", org_id: "42" };
+
+  test("returns payload unchanged when there are no sessions", () => {
+    const payload = { name: "app/event", data: {} };
+    expect(stampPropagatedSessions(payload, undefined)).toBe(payload);
+    expect(stampPropagatedSessions(payload, {})).toBe(payload);
+  });
+
+  test("stamps propagated_sessions onto a single payload", () => {
+    const payload = { name: "app/event", data: {} };
+    expect(stampPropagatedSessions(payload, sessions)).toEqual({
+      name: "app/event",
+      data: {},
+      meta: { propagated_sessions: sessions },
+    });
+  });
+
+  test("stamps each payload in an array", () => {
+    const result = stampPropagatedSessions(
+      [
+        { name: "app/a", data: {} },
+        { name: "app/b", data: {} },
+      ],
+      sessions,
+    );
+    expect(result).toEqual([
+      { name: "app/a", data: {}, meta: { propagated_sessions: sessions } },
+      { name: "app/b", data: {}, meta: { propagated_sessions: sessions } },
+    ]);
+  });
+
+  test("preserves the manual sessions layer alongside propagated", () => {
+    const payload = {
+      name: "app/event",
+      data: {},
+      meta: { sessions: { conv_id: "manual" } },
+    };
+    expect(stampPropagatedSessions(payload, sessions)).toEqual({
+      name: "app/event",
+      data: {},
+      meta: {
+        sessions: { conv_id: "manual" },
+        propagated_sessions: sessions,
+      },
+    });
+  });
+
+  test("does not mutate the input payload", () => {
+    const payload = { name: "app/event", data: {} };
+    stampPropagatedSessions(payload, sessions);
+    expect(payload).toEqual({ name: "app/event", data: {} });
+  });
+});
+
+describe("step.sendEvent session propagation gating", () => {
+  // Drives the real sendEvent tool fn with a mocked client._send so we can
+  // assert what actually reaches the wire given the client-level toggle.
+  const runSendEvent = async (
+    enabled: boolean,
+    ctxSessions: Record<string, string> | undefined,
+  ) => {
+    const clientOpts = {
+      id: testClientId,
+      isDev: true,
+      // `sessionPropagation` is internal/undocumented (off the public
+      // ClientOptions), so it's set via the same cast the SDK reads it with.
+      sessionPropagation: enabled,
+    } as Parameters<typeof createClient>[0];
+    const client = createClient(clientOpts);
+
+    const sendSpy = vi
+      .spyOn(
+        client as unknown as {
+          _send: (arg: { payload: unknown }) => Promise<unknown>;
+        },
+        "_send",
+      )
+      .mockResolvedValue({ ids: [] });
+
+    const execution = {
+      options: { fn: { opts: {} }, headers: {} },
+    } as never;
+
+    const step = createStepTools(client, execution, async ({ args, opts }) => {
+      if (!opts?.fn) {
+        throw new Error("Expected tool fn");
+      }
+      return opts.fn(
+        { sessions: ctxSessions } as never,
+        ...(args as unknown[]),
+      );
+    });
+
+    await step.sendEvent("send-child", { name: "app/child", data: {} });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    return sendSpy.mock.calls[0]?.[0]?.payload;
+  };
+
+  test("stamps propagated_sessions from ctx.sessions when the toggle is on", async () => {
+    const payload = await runSendEvent(true, { conv_id: "p1" });
+    expect(payload).toEqual({
+      name: "app/child",
+      data: {},
+      meta: { propagated_sessions: { conv_id: "p1" } },
+    });
+  });
+
+  test("leaves the send untouched when the toggle is off", async () => {
+    // Even with ctx.sessions populated, an off toggle must not stamp.
+    const payload = await runSendEvent(false, { conv_id: "p1" });
+    expect(payload).toEqual({ name: "app/child", data: {} });
   });
 });

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -242,7 +242,14 @@ export const stampPropagatedSessions = (
 
   const stamp = <T extends { meta?: EventMeta }>(p: T): T => ({
     ...p,
-    meta: { ...p.meta, propagated_sessions: sessions },
+    meta: {
+      ...p.meta,
+
+      // Clone so that mutating one event's sessions in middleware doesn't
+      // inadvertently mutate every other event's sessions, or `ctx.sessions`
+      // itself.
+      propagated_sessions: { ...sessions },
+    },
   });
 
   return Array.isArray(payload) ? payload.map(stamp) : stamp(payload);

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -39,6 +39,7 @@ import {
   type GetStepTools,
   type Inngest,
   internalLoggerSymbol,
+  sessionPropagationSymbol,
 } from "./Inngest.ts";
 import { InngestFunction } from "./InngestFunction.ts";
 import { InngestFunctionReference } from "./InngestFunctionReference.ts";
@@ -219,6 +220,32 @@ export const getStepOptions = (options: StepOptionsOrId): StepOptions => {
   }
 
   return options;
+};
+
+/**
+ * Stamps the run's propagated sessions onto each outgoing `step.sendEvent`
+ * payload as the separate `meta.propagated_sessions` layer, so child runs stay
+ * grouped in the parent's sessions. The manual `meta.sessions` layer is left
+ * untouched — the server merges the two (manual wins per key).
+ *
+ * `sessions` is `ctx.sessions`, read at send time so a run-level override
+ * (mutating `ctx.sessions` in the handler) is reflected. When there is nothing
+ * to propagate the payload is returned unchanged.
+ */
+export const stampPropagatedSessions = (
+  payload: SendEventPayload,
+  sessions: Record<string, string> | undefined,
+): SendEventPayload => {
+  if (!sessions || Object.keys(sessions).length === 0) {
+    return payload;
+  }
+
+  const stamp = <T extends { meta?: EventMeta }>(p: T): T => ({
+    ...p,
+    meta: { ...p.meta, propagated_sessions: sessions },
+  });
+
+  return Array.isArray(payload) ? payload.map(stamp) : stamp(payload);
 };
 
 /**
@@ -499,10 +526,14 @@ export const createStepTools = <
         };
       },
       {
-        fn: (_ctx, _idOrOptions, payload) => {
+        fn: (ctx, _idOrOptions, payload) => {
           const fn = execution["options"]["fn"];
+          // Only stamp inherited sessions when the client-level toggle is on.
+          const payloadToSend = client[sessionPropagationSymbol]
+            ? stampPropagatedSessions(payload, ctx.sessions)
+            : payload;
           return client["_send"]({
-            payload,
+            payload: payloadToSend,
             headers: execution["options"]["headers"],
             fnMiddleware: fn.opts.middleware ?? [],
             fn,

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -33,6 +33,7 @@ import {
   retryWithBackoff,
   runAsPromise,
 } from "../../helpers/promises.ts";
+import { aggregateMetadata } from "../../helpers/sessions.ts";
 import { stringify } from "../../helpers/strings.ts";
 import * as Temporal from "../../helpers/temporal.ts";
 import {
@@ -55,7 +56,7 @@ import {
   StepOpCode,
 } from "../../types.ts";
 import { version } from "../../version.ts";
-import { internalLoggerSymbol } from "../Inngest.ts";
+import { internalLoggerSymbol, sessionPropagationSymbol } from "../Inngest.ts";
 import { createGroupTools } from "../InngestGroupTools.ts";
 import type {
   MetadataKind,
@@ -2155,6 +2156,22 @@ class InngestExecutionEngine
       group: createGroupTools({ experimentStepRun }),
       defer,
     } as unknown as Context.Any;
+
+    // Aggregate the run's triggering events into its propagated sessions in
+    // `ctx.sessions`
+    //
+    // Gated by the client-level session-propagation toggle so that,
+    // while disabled, `ctx.sessions` stays unset and no new surface appears
+    // on the handler context.
+    if (this.options.client[sessionPropagationSymbol]) {
+      // Best-effort: session grouping must never crash a run, so a failure here
+      // degrades to no propagation rather than throwing.
+      try {
+        fnArg.sessions = aggregateMetadata(fnArg.events ?? []);
+      } catch {
+        fnArg.sessions = undefined;
+      }
+    }
 
     /**
      * Handle use of the `onFailure` option by deserializing the error.

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -33,7 +33,7 @@ import {
   retryWithBackoff,
   runAsPromise,
 } from "../../helpers/promises.ts";
-import { aggregateMetadata } from "../../helpers/sessions.ts";
+import { reduceEventsToPropagatedSessions } from "../../helpers/sessions.ts";
 import { stringify } from "../../helpers/strings.ts";
 import * as Temporal from "../../helpers/temporal.ts";
 import {
@@ -2167,7 +2167,7 @@ class InngestExecutionEngine
       // Best-effort: session grouping must never crash a run, so a failure here
       // degrades to no propagation rather than throwing.
       try {
-        fnArg.sessions = aggregateMetadata(fnArg.events ?? []);
+        fnArg.sessions = reduceEventsToPropagatedSessions(fnArg.events ?? []);
       } catch {
         fnArg.sessions = undefined;
       }

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2167,9 +2167,12 @@ class InngestExecutionEngine
       // Best-effort: session grouping must never crash a run, so a failure here
       // degrades to no propagation rather than throwing.
       try {
-        fnArg.sessions = reduceEventsToPropagatedSessions(fnArg.events ?? []);
+        const sessions = reduceEventsToPropagatedSessions(fnArg.events ?? []);
+        if (Object.keys(sessions).length > 0) {
+          fnArg.sessions = sessions;
+        }
       } catch {
-        fnArg.sessions = undefined;
+        // Best-effort: leave `ctx.sessions` absent on failure.
       }
     }
 

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { reduceEventsToPropagatedSessions, compareUtf8 } from "./sessions.ts";
+import { compareUtf8, reduceEventsToPropagatedSessions } from "./sessions.ts";
 
 /** Build a triggering event carrying the given session map. */
 const evt = (sessions?: Record<string, string>) => ({ meta: { sessions } });

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -1,48 +1,63 @@
 import { describe, expect, test } from "vitest";
-import { aggregateMetadata, compareUtf8 } from "./sessions.ts";
+import { reduceEventsToPropagatedSessions, compareUtf8 } from "./sessions.ts";
 
 /** Build a triggering event carrying the given session map. */
 const evt = (sessions?: Record<string, string>) => ({ meta: { sessions } });
 
-describe("aggregateMetadata", () => {
+describe("reduceEventsToPropagatedSessions", () => {
   test("single event, single session passes through", () => {
-    expect(aggregateMetadata([evt({ a: "1" })])).toEqual({ a: "1" });
+    expect(reduceEventsToPropagatedSessions([evt({ a: "1" })])).toEqual({
+      a: "1",
+    });
   });
 
   test("no events / no sessions yields an empty map (no-run safety)", () => {
-    expect(aggregateMetadata([])).toEqual({});
-    expect(aggregateMetadata([evt(undefined)])).toEqual({});
-    expect(aggregateMetadata([evt({})])).toEqual({});
-    expect(aggregateMetadata([{ meta: null }])).toEqual({});
+    expect(reduceEventsToPropagatedSessions([])).toEqual({});
+    expect(reduceEventsToPropagatedSessions([evt(undefined)])).toEqual({});
+    expect(reduceEventsToPropagatedSessions([evt({})])).toEqual({});
+    expect(reduceEventsToPropagatedSessions([{ meta: null }])).toEqual({});
   });
 
   test("batch unions sessions across all triggering events", () => {
-    expect(aggregateMetadata([evt({ a: "1" }), evt({ b: "2" })])).toEqual({
+    expect(
+      reduceEventsToPropagatedSessions([evt({ a: "1" }), evt({ b: "2" })]),
+    ).toEqual({
       a: "1",
       b: "2",
     });
   });
 
   test("exact (key,id) duplicate across the batch dedupes", () => {
-    expect(aggregateMetadata([evt({ a: "1" }), evt({ a: "1" })])).toEqual({
+    expect(
+      reduceEventsToPropagatedSessions([evt({ a: "1" }), evt({ a: "1" })]),
+    ).toEqual({
       a: "1",
     });
   });
 
   test("a key with conflicting ids across the batch is dropped entirely", () => {
-    expect(aggregateMetadata([evt({ a: "1" }), evt({ a: "2" })])).toEqual({});
+    expect(
+      reduceEventsToPropagatedSessions([evt({ a: "1" }), evt({ a: "2" })]),
+    ).toEqual({});
   });
 
   test("only the conflicting key is dropped; the rest survive", () => {
     expect(
-      aggregateMetadata([evt({ a: "1", b: "9" }), evt({ a: "2" })]),
+      reduceEventsToPropagatedSessions([
+        evt({ a: "1", b: "9" }),
+        evt({ a: "2" }),
+      ]),
     ).toEqual({ b: "9" });
   });
 
   test("a duplicate id does not mask a genuine conflict", () => {
     // ids seen for `a` are {1, 2} even though (a,1) appears twice.
     expect(
-      aggregateMetadata([evt({ a: "1" }), evt({ a: "1" }), evt({ a: "2" })]),
+      reduceEventsToPropagatedSessions([
+        evt({ a: "1" }),
+        evt({ a: "1" }),
+        evt({ a: "2" }),
+      ]),
     ).toEqual({});
   });
 
@@ -52,14 +67,16 @@ describe("aggregateMetadata", () => {
     const numericEvt = {
       meta: { sessions: { a: 1 } },
     } as unknown as ReturnType<typeof evt>;
-    expect(aggregateMetadata([numericEvt, evt({ a: "1" })])).toEqual({
+    expect(
+      reduceEventsToPropagatedSessions([numericEvt, evt({ a: "1" })]),
+    ).toEqual({
       a: "1",
     });
   });
 
   test("more than five keys truncate to the first five by key", () => {
     const events = [evt({ a: "1", b: "1", c: "1", d: "1", e: "1", f: "1" })];
-    expect(aggregateMetadata(events)).toEqual({
+    expect(reduceEventsToPropagatedSessions(events)).toEqual({
       a: "1",
       b: "1",
       c: "1",
@@ -76,7 +93,7 @@ describe("aggregateMetadata", () => {
       evt({ a: "1", b: "1", c: "1", d: "1", e: "1", f: "1" }),
       evt({ a: "2" }),
     ];
-    expect(aggregateMetadata(events)).toEqual({
+    expect(reduceEventsToPropagatedSessions(events)).toEqual({
       b: "1",
       c: "1",
       d: "1",
@@ -100,7 +117,7 @@ describe("aggregateMetadata", () => {
         "\u{1F600}": "x",
       }),
     ];
-    const got = aggregateMetadata(events);
+    const got = reduceEventsToPropagatedSessions(events);
     expect(Object.keys(got).sort()).toEqual(["1", "2", "3", "4", "￿"]);
     expect(got).not.toHaveProperty("\u{1F600}");
   });
@@ -109,7 +126,7 @@ describe("aggregateMetadata", () => {
     // Received events are JSON-parsed, which makes __proto__ an own property
     // (unlike an object literal, which would invoke the prototype setter).
     const sessions = JSON.parse('{"__proto__":"1"}') as Record<string, string>;
-    const got = aggregateMetadata([{ meta: { sessions } }]);
+    const got = reduceEventsToPropagatedSessions([{ meta: { sessions } }]);
     expect(Object.hasOwn(got, "__proto__")).toBe(true);
     expect(got["__proto__"]).toBe("1");
   });

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import { aggregateMetadata, compareUtf8 } from "./sessions.ts";
+
+/** Build a triggering event carrying the given session map. */
+const evt = (sessions?: Record<string, string>) => ({ meta: { sessions } });
+
+describe("aggregateMetadata", () => {
+  test("single event, single session passes through", () => {
+    expect(aggregateMetadata([evt({ a: "1" })])).toEqual({ a: "1" });
+  });
+
+  test("no events / no sessions yields an empty map (no-run safety)", () => {
+    expect(aggregateMetadata([])).toEqual({});
+    expect(aggregateMetadata([evt(undefined)])).toEqual({});
+    expect(aggregateMetadata([evt({})])).toEqual({});
+    expect(aggregateMetadata([{ meta: null }])).toEqual({});
+  });
+
+  test("batch unions sessions across all triggering events", () => {
+    expect(aggregateMetadata([evt({ a: "1" }), evt({ b: "2" })])).toEqual({
+      a: "1",
+      b: "2",
+    });
+  });
+
+  test("exact (key,id) duplicate across the batch dedupes", () => {
+    expect(aggregateMetadata([evt({ a: "1" }), evt({ a: "1" })])).toEqual({
+      a: "1",
+    });
+  });
+
+  test("a key with conflicting ids across the batch is dropped entirely", () => {
+    expect(aggregateMetadata([evt({ a: "1" }), evt({ a: "2" })])).toEqual({});
+  });
+
+  test("only the conflicting key is dropped; the rest survive", () => {
+    expect(
+      aggregateMetadata([evt({ a: "1", b: "9" }), evt({ a: "2" })]),
+    ).toEqual({ b: "9" });
+  });
+
+  test("a duplicate id does not mask a genuine conflict", () => {
+    // ids seen for `a` are {1, 2} even though (a,1) appears twice.
+    expect(
+      aggregateMetadata([evt({ a: "1" }), evt({ a: "1" }), evt({ a: "2" })]),
+    ).toEqual({});
+  });
+
+  test("numeric and string ids for a key canonicalize equal (no false conflict)", () => {
+    // Guards the String() coercion: {a:1} and {a:"1"} dedupe, not conflict.
+    // The numeric id is a deliberate type violation, hence the cast.
+    const numericEvt = {
+      meta: { sessions: { a: 1 } },
+    } as unknown as ReturnType<typeof evt>;
+    expect(aggregateMetadata([numericEvt, evt({ a: "1" })])).toEqual({
+      a: "1",
+    });
+  });
+
+  test("more than five keys truncate to the first five by key", () => {
+    const events = [evt({ a: "1", b: "1", c: "1", d: "1", e: "1", f: "1" })];
+    expect(aggregateMetadata(events)).toEqual({
+      a: "1",
+      b: "1",
+      c: "1",
+      d: "1",
+      e: "1",
+    });
+  });
+
+  test("conflict drop happens BEFORE truncation", () => {
+    // Six keys a..f; `a` conflicts and is dropped, leaving exactly b..f (5).
+    // If truncation ran first we would keep a..e, then drop conflicting a,
+    // yielding only b..e (4) — this pins the ordering.
+    const events = [
+      evt({ a: "1", b: "1", c: "1", d: "1", e: "1", f: "1" }),
+      evt({ a: "2" }),
+    ];
+    expect(aggregateMetadata(events)).toEqual({
+      b: "1",
+      c: "1",
+      d: "1",
+      e: "1",
+      f: "1",
+    });
+  });
+
+  test("truncation uses UTF-8 byte order, not UTF-16 code-unit order", () => {
+    // Byte order of the first byte: digits 0x31.. < U+FFFF (0xEF..) < 😀 (0xF0..).
+    // So the ≤5 cut keeps "￿" and drops "😀".
+    // UTF-16 code-unit order would rank 😀 (lead surrogate 0xD83D) *before*
+    // "￿", keeping 😀 and dropping "￿" — the opposite survivor.
+    const events = [
+      evt({
+        "1": "x",
+        "2": "x",
+        "3": "x",
+        "4": "x",
+        "￿": "x",
+        "\u{1F600}": "x",
+      }),
+    ];
+    const got = aggregateMetadata(events);
+    expect(Object.keys(got).sort()).toEqual(["1", "2", "3", "4", "￿"]);
+    expect(got).not.toHaveProperty("\u{1F600}");
+  });
+
+  test("__proto__ is collected as an own property, not the prototype", () => {
+    // Received events are JSON-parsed, which makes __proto__ an own property
+    // (unlike an object literal, which would invoke the prototype setter).
+    const sessions = JSON.parse('{"__proto__":"1"}') as Record<string, string>;
+    const got = aggregateMetadata([{ meta: { sessions } }]);
+    expect(Object.hasOwn(got, "__proto__")).toBe(true);
+    expect(got["__proto__"]).toBe("1");
+  });
+});
+
+describe("compareUtf8", () => {
+  test("equal strings compare equal", () => {
+    expect(compareUtf8("abc", "abc")).toBe(0);
+  });
+
+  test("orders ASCII by byte value", () => {
+    expect(compareUtf8("a", "b")).toBeLessThan(0);
+    // Uppercase 'Z' (0x5A) sorts before lowercase 'a' (0x61).
+    expect(compareUtf8("Z", "a")).toBeLessThan(0);
+  });
+
+  test("a prefix sorts before its extension", () => {
+    expect(compareUtf8("a", "ab")).toBeLessThan(0);
+    expect(compareUtf8("ab", "a")).toBeGreaterThan(0);
+  });
+
+  test("multi-byte characters sort after ASCII", () => {
+    // 'z' is 0x7A; 'é' begins 0xC3.
+    expect(compareUtf8("z", "é")).toBeLessThan(0);
+  });
+
+  test("astral char ordering matches UTF-8 bytes, not UTF-16 code units", () => {
+    // U+FFFF encodes to 0xEF..; U+1F600 (😀) encodes to 0xF0.. → "￿" first.
+    expect(compareUtf8("￿", "\u{1F600}")).toBeLessThan(0);
+    // Sanity: JS's native UTF-16 comparison disagrees (proves we diverge from it).
+    expect("￿" < "\u{1F600}").toBe(false);
+  });
+});

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -118,7 +118,7 @@ export const compareUtf8 = (a: string, b: string): number => {
  * Reduces a run's triggering events to `≤5` deterministic sessions that
  * become the propagated sessions.
  */
-export const aggregateMetadata = (
+export const reduceEventsToPropagatedSessions = (
   // Accepts the send-time EventMeta shape (numeric ids permitted) since that is
   // how a run's triggering events are statically typed; ids are canonicalized
   // to strings below, so received string ids pass through unchanged.

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -49,7 +49,7 @@ export const normalizeEventSessions = (
 
 export const normalizeEventMeta = (
   meta: EventMeta | null | undefined,
-): { sessions?: Record<string, string> } | undefined => {
+): NormalizedEventMeta | undefined => {
   if (meta === undefined || meta === null) {
     return undefined;
   }
@@ -58,9 +58,121 @@ export const normalizeEventMeta = (
   }
 
   const sessions = normalizeEventSessions(meta.sessions);
-  if (sessions === undefined) {
+  const propagatedSessions = normalizeEventSessions(meta.propagated_sessions);
+  if (sessions === undefined && propagatedSessions === undefined) {
     return undefined;
   }
 
-  return { sessions };
+  const out: NormalizedEventMeta = {};
+  if (sessions !== undefined) {
+    out.sessions = sessions;
+  }
+  if (propagatedSessions !== undefined) {
+    out.propagated_sessions = propagatedSessions;
+  }
+
+  return out;
+};
+
+type NormalizedEventMeta = {
+  sessions?: Record<string, string>;
+  propagated_sessions?: Record<string, string>;
+};
+
+/**
+ * Maximum sessions carried on a single event. Mirrors the server's
+ * `consts.MaxEventSessions`; the propagated aggregate is truncated to this so
+ * the emitted event passes ingest validation.
+ */
+const MAX_EVENT_SESSIONS = 5;
+
+const utf8Encoder = new TextEncoder();
+
+/**
+ * Compares two strings by their UTF-8 byte sequences, matching the server's
+ * native string ordering (Go's `cmp.Compare`, which is byte-wise over UTF-8).
+ *
+ * JavaScript's default `<` / `Array.prototype.sort` compares UTF-16 code units,
+ * which diverges from UTF-8 byte order for characters outside the BMP (surrogate
+ * pairs sort below `U+E000..U+FFFF` by code unit but above them by code point).
+ * Session keys have no charset restriction server-side, so we encode and compare
+ * bytes to stay byte-for-byte identical to server-side truncation. See the
+ * session-propagation design (collation decision).
+ */
+export const compareUtf8 = (a: string, b: string): number => {
+  if (a === b) {
+    return 0;
+  }
+  const ab = utf8Encoder.encode(a);
+  const bb = utf8Encoder.encode(b);
+  const len = Math.min(ab.length, bb.length);
+  for (let i = 0; i < len; i++) {
+    if (ab[i] !== bb[i]) {
+      return ab[i]! - bb[i]!;
+    }
+  }
+  return ab.length - bb.length;
+};
+
+/**
+ * Reduces a run's triggering events to `≤5` deterministic sessions that
+ * become the propagated sessions.
+ */
+export const aggregateMetadata = (
+  // Accepts the send-time EventMeta shape (numeric ids permitted) since that is
+  // how a run's triggering events are statically typed; ids are canonicalized
+  // to strings below, so received string ids pass through unchanged.
+  events: ReadonlyArray<{ meta?: EventMeta | null }>,
+): Record<string, string> => {
+  // Group the sessions by key
+
+  // A Map (not a plain object) sidesteps `__proto__`/prototype-key footguns
+  // while collecting.
+  const idsByKey = new Map<string, Set<string>>();
+  for (const event of events) {
+    const sessions = event?.meta?.sessions;
+    if (!sessions) {
+      continue;
+    }
+    for (const [key, id] of Object.entries(sessions)) {
+      if (!key) {
+        continue; // defensive: the server rejects empty keys at ingest
+      }
+      let ids = idsByKey.get(key);
+      if (!ids) {
+        ids = new Set();
+        idsByKey.set(key, ids);
+      }
+      // Canonicalize to string so a numeric id and its string form dedupe
+      // rather than register as a conflict (ids are already strings when
+      // received; this guards against runtime type violations).
+      ids.add(String(id));
+    }
+  }
+
+  // Keep only keys with a single distinct id across the batch.
+  //
+  // A key that disagrees on its id (e.g. a batch carrying conv_id:1 and
+  // conv_id:2) is dropped entirely rather than resolved to one id, for
+  // predictability.
+  const keys: string[] = [];
+  for (const [key, ids] of idsByKey) {
+    if (ids.size === 1) {
+      keys.push(key);
+    }
+  }
+
+  // Deterministic `≤5`: sort by UTF-8 byte order (matching the server) and
+  // take the first MAX_EVENT_SESSIONS keys.
+  keys.sort(compareUtf8);
+
+  const entries = keys
+    .slice(0, MAX_EVENT_SESSIONS)
+    .map((key): [string, string] => {
+      const [id] = idsByKey.get(key)!;
+      return [key, id as string];
+    });
+
+  // Object.fromEntries so keys like "__proto__" land as own properties.
+  return Object.fromEntries(entries);
 };

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -772,13 +772,14 @@ export type EventMeta = {
   sessions?: EventSessions;
 
   /**
+   * EXPERIMENTAL: This API is not yet stable and may change in the future
+   * without a major version bump.
+   *
    * Sessions propagated from the run that emitted this event. Stamped
    * automatically from `ctx.sessions`; carried as a separate layer from manual
-   * {@link EventMeta.sessions} and merged server-side.
+   * {@link EventMeta.sessions} and merged server-side (manual wins per key).
    *
    * Not intended to be set by hand.
-   *
-   * @internal
    */
   propagated_sessions?: EventSessions;
 };

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -580,6 +580,14 @@ export type BaseContext<TClient extends Inngest.Any> = {
   events: AsTuple<Simplify<EventPayload>>;
 
   /**
+   * The run's effective sessions, aggregated from its triggering event(s).
+   *
+   * By default these are propagated onto events emitted during the run via
+   * `step.sendEvent`, so child runs stay grouped in the same sessions.
+   */
+  sessions?: Record<string, string>;
+
+  /**
    * The run ID for the current function execution
    */
   runId: string;
@@ -761,6 +769,17 @@ export type EventMeta = {
    * normalized to strings before the event is sent.
    */
   sessions?: EventSessions;
+
+  /**
+   * Sessions propagated from the run that emitted this event. Stamped
+   * automatically from `ctx.sessions`; carried as a separate layer from manual
+   * {@link EventMeta.sessions} and merged server-side.
+   *
+   * Not intended to be set by hand.
+   *
+   * @internal
+   */
+  propagated_sessions?: EventSessions;
 };
 
 /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1177,6 +1177,19 @@ export interface ClientOptions {
   aiMetadata?: boolean;
 
   /**
+   * EXPERIMENTAL: This API is not yet stable and may change in the future
+   * without a major version bump.
+   *
+   * Whether events sent during a run inherit the run's session metadata, so
+   * the resulting child runs stay grouped in the same sessions as their parent.
+   *
+   * This option takes precedence over the `INNGEST_SESSION_PROPAGATION`
+   * environment variable, which in turn takes precedence over the SDK's
+   * default. When left unset, the feature is off by default.
+   */
+  sessionPropagation?: boolean;
+
+  /**
    * Whether or not to use checkpointing by default for executions of functions
    * created using this client.
    *

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -582,8 +582,9 @@ export type BaseContext<TClient extends Inngest.Any> = {
   /**
    * The run's effective sessions, aggregated from its triggering event(s).
    *
-   * By default these are propagated onto events emitted during the run via
-   * `step.sendEvent`, so child runs stay grouped in the same sessions.
+   * When session propagation is active, these are propagated onto events
+   * emitted during the run via `step.sendEvent`, so child runs stay grouped
+   * in the same sessions.
    */
   sessions?: Record<string, string>;
 


### PR DESCRIPTION
## Summary

- step.sendEvent derives propagated sessions from its triggering events and sends them along during step.sendEvent
- Gated behind the internal session propagation toggle

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- https://linear.app/inngest/issue/EXE-2033/stepsendevent-propagates-sessions

---
