### PR TITLE
internal: invoke propagates sessions

### DIFF
--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -15,6 +15,7 @@ import { referenceFunction } from "./InngestFunctionReference.ts";
 import {
   createStepTools,
   stampPropagatedSessions,
+  stampPropagatedSessionsOnInvoke,
 } from "./InngestStepTools.ts";
 import { realtime } from "./realtime/index.ts";
 
@@ -1164,6 +1165,36 @@ describe("invoke", () => {
         });
       });
 
+      test("preserves a whole-field null sessions tombstone in the payload", async () => {
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            meta: { sessions: null },
+          }),
+        ).resolves.toMatchObject({
+          opts: {
+            payload: {
+              meta: { sessions: null },
+            },
+          },
+        });
+      });
+
+      test("rejects non-string propagated session values", async () => {
+        await expect(
+          step.invoke("id", {
+            function: fn,
+            data: { foo: "foo" },
+            meta: {
+              propagated_sessions: {
+                conversation_id: true,
+              } as unknown as Record<string, string>,
+            },
+          }),
+        ).rejects.toThrowError("Invalid invocation options");
+      });
+
       test("omits meta from the payload if none given", async () => {
         const op = (await step.invoke("id", {
           function: fn,
@@ -1480,6 +1511,41 @@ describe("stampPropagatedSessions", () => {
     const payload = { name: "app/event", data: {} };
     stampPropagatedSessions(payload, sessions);
     expect(payload).toEqual({ name: "app/event", data: {} });
+  });
+});
+
+describe("stampPropagatedSessionsOnInvoke", () => {
+  const sessions = { conv_id: "123", org_id: "42" };
+
+  test("returns payload unchanged when there are no sessions", () => {
+    const payload = { data: {} };
+    expect(stampPropagatedSessionsOnInvoke(payload, undefined)).toBe(payload);
+    expect(stampPropagatedSessionsOnInvoke(payload, {})).toBe(payload);
+  });
+
+  test("stamps propagated_sessions onto the invoke payload", () => {
+    const payload = { data: { foo: "bar" } };
+    expect(stampPropagatedSessionsOnInvoke(payload, sessions)).toEqual({
+      data: { foo: "bar" },
+      meta: { propagated_sessions: sessions },
+    });
+  });
+
+  test("preserves the manual sessions layer alongside propagated", () => {
+    const payload = { data: {}, meta: { sessions: { conv_id: "manual" } } };
+    expect(stampPropagatedSessionsOnInvoke(payload, sessions)).toEqual({
+      data: {},
+      meta: {
+        sessions: { conv_id: "manual" },
+        propagated_sessions: sessions,
+      },
+    });
+  });
+
+  test("does not mutate the input payload", () => {
+    const payload = { data: {} };
+    stampPropagatedSessionsOnInvoke(payload, sessions);
+    expect(payload).toEqual({ data: {} });
   });
 });
 

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -256,6 +256,25 @@ export const stampPropagatedSessions = (
 };
 
 /**
+ * Stamps the run's propagated sessions onto a `step.invoke` payload as the
+ * separate `meta.propagated_sessions` layer, mirroring
+ * {@link stampPropagatedSessions} for `step.sendEvent`.
+ */
+export const stampPropagatedSessionsOnInvoke = (
+  payload: MinimalEventPayload,
+  sessions: Record<string, string> | undefined,
+): MinimalEventPayload => {
+  if (!sessions || Object.keys(sessions).length === 0) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    meta: { ...payload.meta, propagated_sessions: sessions },
+  };
+};
+
+/**
  * Suffix used to namespace steps that are automatically indexed.
  */
 export const STEP_INDEXING_SUFFIX = ":";
@@ -1238,7 +1257,16 @@ export const invokePayloadSchema = z.object({
   v: z.string().optional(),
   meta: z
     .object({
-      sessions: z.record(z.any()).optional(),
+      // Manual layer: RFC 7386 patch — a whole-field `null` clears all
+      // inherited sessions, so it must parse. Values stay loose here because
+      // `normalizeEventSessions` validates them right after the parse with
+      // precise per-key errors; tightening them in zod would mask those behind
+      // the generic invoke-options error.
+      sessions: z.record(z.any()).nullable().optional(),
+      // Machine-stamped layer: string/number ids only, never tombstones.
+      propagated_sessions: z
+        .record(z.union([z.string(), z.number()]))
+        .optional(),
     })
     .optional(),
 });
@@ -1253,9 +1281,16 @@ type InvocationOpts<TFunction extends InvokeTargetFunctionDefinition> =
       /**
        * Event meta shared with the invoked run.
        *
-       * Meta is not inherited from the calling run; pass `meta.sessions`
-       * explicitly to group the invoked run. Values are normalized to strings
-       * before sending, as with `inngest.send()`.
+       * By default the invoked run inherits the calling run's sessions. The
+       * `meta.propagated_sessions` layer is stamped automatically from
+       * `ctx.sessions`.
+       *
+       * Pass `meta.sessions` to add or override sessions on the invocation.
+       *
+       * Inheritance can be disabled at the client level.
+       *
+       * Values are normalized to strings before sending, as with
+       * `inngest.send()`.
        */
       meta?: EventMeta;
 

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -920,3 +920,97 @@ describe("Execution engine checkpoint retry behavior", () => {
     });
   });
 });
+
+describe("step.invoke session propagation", () => {
+  // Drives a real execution whose handler calls `step.invoke`, then inspects
+  // the emitted InvokeFunction op to assert the engine's central stamp: the
+  // run's `ctx.sessions` (aggregated from triggering events) is attached to the
+  // invoke payload as `meta.propagated_sessions`, gated by the client toggle.
+  const runInvoke = async (
+    enabled: boolean,
+    manualMeta?: Record<string, unknown>,
+  ) => {
+    const client = createClient({
+      id: "test",
+      isDev: true,
+      // `sessionPropagation` is internal/undocumented (off the public
+      // ClientOptions), so it's set via the same cast the SDK reads it with.
+      sessionPropagation: enabled,
+    } as Parameters<typeof createClient>[0]);
+
+    const target = new InngestFunction(
+      client,
+      { id: "target-fn", triggers: [{ event: "target/event" }] },
+      () => "target-result",
+    );
+
+    const fn = new InngestFunction(
+      client,
+      { id: "caller-fn", triggers: [{ event: "test/event" }] },
+      async ({ step }: Context.Any & { step: GenericStepTools }) => {
+        await step.invoke("inv", {
+          function: target,
+          data: { foo: "bar" },
+          ...(manualMeta ? { meta: manualMeta } : {}),
+        });
+        return "done";
+      },
+    );
+
+    // Two triggering events carrying sessions — exercises the run-level
+    // aggregation that produces `ctx.sessions`.
+    const events = [
+      { name: "test/event", data: {}, meta: { sessions: { conv_id: "p1" } } },
+      { name: "test/event", data: {}, meta: { sessions: { org_id: "42" } } },
+    ];
+
+    const execution = fn["createExecution"]({
+      partialOptions: {
+        client,
+        data: fromPartial({ event: events[0], events }),
+        runId: "test-run-id",
+        stepState: {},
+        stepCompletionOrder: [],
+        reqArgs: [],
+        headers: {},
+        stepMode: StepMode.AsyncCheckpointing,
+        queueItemId: "queue-item-123",
+        internalFnId: "internal-fn-456",
+      },
+    });
+
+    const result = await execution.start();
+    expect(result.type).toBe("steps-found");
+    const stepsFound = result as ExecutionResults["steps-found"];
+    const invokeOp = stepsFound.steps.find(
+      (s) => s.op === StepOpCode.InvokeFunction,
+    );
+    expect(invokeOp).toBeDefined();
+    return (invokeOp?.opts as { payload?: { meta?: Record<string, unknown> } })
+      ?.payload;
+  };
+
+  test("stamps propagated_sessions from ctx.sessions when the toggle is on", async () => {
+    const payload = await runInvoke(true);
+    expect(payload?.meta?.propagated_sessions).toEqual({
+      conv_id: "p1",
+      org_id: "42",
+    });
+  });
+
+  test("does not stamp when the toggle is off", async () => {
+    const payload = await runInvoke(false);
+    expect(payload?.meta).toBeUndefined();
+  });
+
+  test("keeps the manual sessions layer distinct from propagated", async () => {
+    const payload = await runInvoke(true, { sessions: { conv_id: "manual" } });
+    // Manual and propagated travel as separate layers; the server merges them
+    // (manual wins). The SDK must not merge them itself.
+    expect(payload?.meta?.sessions).toEqual({ conv_id: "manual" });
+    expect(payload?.meta?.propagated_sessions).toEqual({
+      conv_id: "p1",
+      org_id: "42",
+    });
+  });
+});

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2407,7 +2407,7 @@ class InngestExecutionEngine
         opId.opts?.payload
       ) {
         opId.opts.payload = stampPropagatedSessionsOnInvoke(
-          opId.opts.payload as MinimalEventPayload,
+          opId.opts.payload,
           this.fnArg.sessions,
         );
       }

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -51,6 +51,7 @@ import {
   type Handler,
   type HashedOp,
   jsonErrorSchema,
+  type MinimalEventPayload,
   type OutgoingOp,
   StepMode,
   StepOpCode,
@@ -72,6 +73,7 @@ import {
   getStepOptions,
   STEP_INDEXING_SUFFIX,
   type StepHandler,
+  stampPropagatedSessionsOnInvoke,
 } from "../InngestStepTools.ts";
 import { MiddlewareManager } from "../middleware/index.ts";
 import type { Middleware } from "../middleware/middleware.ts";
@@ -2386,6 +2388,29 @@ class InngestExecutionEngine
     }): Promise<unknown> => {
       const stepOptions = getStepOptions(args[0]);
       const opId = matchOp(stepOptions, ...args.slice(1));
+
+      // Central stamp for `step.invoke`: attach the run's propagated sessions
+      // (`ctx.sessions`) onto the invocation payload as the separate
+      // `meta.propagated_sessions` layer, mirroring `step.sendEvent`.
+      //
+      // Done here — before middleware and memoization — so
+      // `transformStepInput` sees the propagated layer and the server merges the
+      // two layers (manual wins).
+      //
+      // The invoke tool's `matchOp` has no `ctx`, so the stamp lives in the engine
+      // where `this.fnArg` is in scope, avoiding an ALS read on the send path.
+      //
+      // Gated by the client-level session-propagation toggle.
+      if (
+        opId.op === StepOpCode.InvokeFunction &&
+        this.options.client[sessionPropagationSymbol] &&
+        opId.opts?.payload
+      ) {
+        opId.opts.payload = stampPropagatedSessionsOnInvoke(
+          opId.opts.payload as MinimalEventPayload,
+          this.fnArg.sessions,
+        );
+      }
 
       // Opcode-only sync ops (e.g. `DeferAdd`) are fire-and-forget and
       // not user-addressable as steps: they have no handler, no


### PR DESCRIPTION
## Summary

- step.invoke should also propagate sessions

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2034

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>