### PR TITLE
internal: support null tombstones in sessions

### DIFF
--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -565,23 +565,33 @@ describe("send", () => {
       ).rejects.toThrowError("Event session keys cannot be empty");
     });
 
-    test("should reject event session values with unsupported runtime types", async () => {
+    test("should carry a null session tombstone through on the wire", async () => {
       const inngest = createClient({ id: "test", eventKey: testEventKey });
 
+      const mockedFetch = vi.mocked(global.fetch);
+
+      // A null value is an RFC 7386 tombstone (cut the inherited key), not an
+      // invalid id — it is accepted and preserved so the server can consume it.
       await expect(
         inngest.send({
           name: "test.sessions",
           data: {},
           meta: {
-            sessions: { conversation_id: null } as unknown as Record<
-              string,
-              string
-            >,
+            sessions: { conversation_id: null, keep: "1" },
           },
         }),
-      ).rejects.toThrowError(
-        'Event session "conversation_id" must be a string or number',
+      ).resolves.toMatchObject({
+        ids: Array(1).fill(expect.any(String)),
+      });
+
+      const body: Array<Record<string, unknown>> = JSON.parse(
+        mockedFetch.mock.calls[0]?.[1]?.body as string,
       );
+
+      expect((body[0]?.meta as Record<string, unknown>)?.sessions).toEqual({
+        conversation_id: null,
+        keep: "1",
+      });
     });
 
     test("should reject boolean event session values", async () => {
@@ -596,7 +606,7 @@ describe("send", () => {
           },
         }),
       ).rejects.toThrowError(
-        'Event session "active" must be a string or number',
+        'Event session "active" must be a string, number, or null',
       );
     });
 

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "vitest";
 import {
   compareUtf8,
   normalizeEventMeta,
-  normalizeEventSessions,
+  normalizeManualSessions,
+  normalizePropagatedSessions,
   reduceEventsToPropagatedSessions,
 } from "./sessions.ts";
 
@@ -166,39 +167,52 @@ describe("compareUtf8", () => {
   });
 });
 
-describe("normalizeEventSessions (tombstones)", () => {
+describe("normalizePropagatedSessions", () => {
   test("normalizes string/number ids, absent when empty", () => {
-    expect(normalizeEventSessions({ a: "1", b: 2 }, false)).toEqual({
+    expect(normalizePropagatedSessions({ a: "1", b: 2 })).toEqual({
       a: "1",
       b: "2",
     });
-    expect(normalizeEventSessions(undefined, false)).toBeUndefined();
-    expect(normalizeEventSessions({}, false)).toBeUndefined();
+    expect(normalizePropagatedSessions(undefined)).toBeUndefined();
+    expect(normalizePropagatedSessions({})).toBeUndefined();
   });
 
-  test("rejects null on the propagated layer (allowCut: false)", () => {
-    expect(() => normalizeEventSessions({ a: null }, false)).toThrow(
+  test("rejects a per-key null, since the layer carries no tombstones", () => {
+    expect(() => normalizePropagatedSessions({ a: null })).toThrow(
       /must be a string or number/,
     );
-    // Whole-field null on the propagated layer is dropped, not preserved.
-    expect(normalizeEventSessions(null, false)).toBeUndefined();
   });
 
-  test("manual layer preserves a per-key null tombstone", () => {
-    expect(normalizeEventSessions({ conv_id: null, keep: "1" }, true)).toEqual({
+  test("drops whole-field null rather than preserving it", () => {
+    expect(normalizePropagatedSessions(null)).toBeUndefined();
+  });
+});
+
+describe("normalizeManualSessions (tombstones)", () => {
+  test("normalizes string/number ids, absent when empty", () => {
+    expect(normalizeManualSessions({ a: "1", b: 2 })).toEqual({
+      a: "1",
+      b: "2",
+    });
+    expect(normalizeManualSessions(undefined)).toBeUndefined();
+    expect(normalizeManualSessions({})).toBeUndefined();
+  });
+
+  test("preserves a per-key null tombstone", () => {
+    expect(normalizeManualSessions({ conv_id: null, keep: "1" })).toEqual({
       conv_id: null,
       keep: "1",
     });
   });
 
-  test("manual layer preserves whole-field null (clear all)", () => {
-    expect(normalizeEventSessions(null, true)).toBeNull();
+  test("preserves whole-field null (clear all)", () => {
+    expect(normalizeManualSessions(null)).toBeNull();
   });
 
-  test("manual layer still rejects non-string/number/null values", () => {
+  test("still rejects non-string/number/null values", () => {
     expect(() =>
       // @ts-expect-error runtime guard for a value the type forbids
-      normalizeEventSessions({ a: true }, true),
+      normalizeManualSessions({ a: true }),
     ).toThrow(/must be a string, number, or null/);
   });
 });

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { compareUtf8, reduceEventsToPropagatedSessions } from "./sessions.ts";
+import {
+  compareUtf8,
+  normalizeEventMeta,
+  normalizeEventSessions,
+  reduceEventsToPropagatedSessions,
+} from "./sessions.ts";
 
 /** Build a triggering event carrying the given session map. */
 const evt = (sessions?: Record<string, string>) => ({ meta: { sessions } });
@@ -158,5 +163,70 @@ describe("compareUtf8", () => {
     expect(compareUtf8("￿", "\u{1F600}")).toBeLessThan(0);
     // Sanity: JS's native UTF-16 comparison disagrees (proves we diverge from it).
     expect("￿" < "\u{1F600}").toBe(false);
+  });
+});
+
+describe("normalizeEventSessions (tombstones)", () => {
+  test("normalizes string/number ids, absent when empty", () => {
+    expect(normalizeEventSessions({ a: "1", b: 2 }, false)).toEqual({
+      a: "1",
+      b: "2",
+    });
+    expect(normalizeEventSessions(undefined, false)).toBeUndefined();
+    expect(normalizeEventSessions({}, false)).toBeUndefined();
+  });
+
+  test("rejects null on the propagated layer (allowCut: false)", () => {
+    expect(() => normalizeEventSessions({ a: null }, false)).toThrow(
+      /must be a string or number/,
+    );
+    // Whole-field null on the propagated layer is dropped, not preserved.
+    expect(normalizeEventSessions(null, false)).toBeUndefined();
+  });
+
+  test("manual layer preserves a per-key null tombstone", () => {
+    expect(normalizeEventSessions({ conv_id: null, keep: "1" }, true)).toEqual({
+      conv_id: null,
+      keep: "1",
+    });
+  });
+
+  test("manual layer preserves whole-field null (clear all)", () => {
+    expect(normalizeEventSessions(null, true)).toBeNull();
+  });
+
+  test("manual layer still rejects non-string/number/null values", () => {
+    expect(() =>
+      // @ts-expect-error runtime guard for a value the type forbids
+      normalizeEventSessions({ a: true }, true),
+    ).toThrow(/must be a string, number, or null/);
+  });
+});
+
+describe("normalizeEventMeta (tombstones)", () => {
+  test("carries a per-key tombstone on the manual layer through", () => {
+    expect(
+      normalizeEventMeta({
+        sessions: { conv_id: null },
+        propagated_sessions: { conv_id: "123", org_id: "42" },
+      }),
+    ).toEqual({
+      sessions: { conv_id: null },
+      propagated_sessions: { conv_id: "123", org_id: "42" },
+    });
+  });
+
+  test("carries whole-field null (clear all) through, keeping propagated", () => {
+    expect(
+      normalizeEventMeta({
+        sessions: null,
+        propagated_sessions: { a: "1" },
+      }),
+    ).toEqual({ sessions: null, propagated_sessions: { a: "1" } });
+  });
+
+  test("drops the meta entirely when nothing is set", () => {
+    expect(normalizeEventMeta({})).toBeUndefined();
+    expect(normalizeEventMeta(undefined)).toBeUndefined();
   });
 });

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -178,9 +178,11 @@ describe("normalizePropagatedSessions", () => {
   });
 
   test("rejects a per-key null, since the layer carries no tombstones", () => {
-    expect(() => normalizePropagatedSessions({ a: null })).toThrow(
-      /must be a string or number/,
-    );
+    expect(() =>
+      // @ts-expect-error the type forbids tombstones here; this guards the
+      // runtime path against JS callers and payloads rebuilt from untyped data
+      normalizePropagatedSessions({ a: null }),
+    ).toThrow(/must be a string or number/);
   });
 
   test("drops whole-field null rather than preserving it", () => {

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -8,26 +8,20 @@ import type { EventMeta, EventSessions } from "../types.ts";
 type NormalizedSessions = Record<string, string | null>;
 
 /**
- * Validates event sessions and normalizes their values to strings, matching
- * the shape stored by the Inngest server.
- *
- * When `allowCut` is `true` (the manual layer), `null` values are preserved as
- * RFC 7386 tombstones rather than rejected, and a whole-field `null` is
- * preserved (as `null`) to mean "clear all inherited sessions". Tombstones are
- * consumed server-side and never count against the per-event session limit.
- * When `allowCut` is `false` (the propagated layer) `null` values are rejected
- * and a whole-field `null` is dropped, since it is machine-stamped and carries
- * no tombstones. The flag is required so each call site declares which side of
- * this trust boundary it is on rather than relying on a default.
+ * Validates event sessions and normalizes their values to strings, matching the
+ * shape stored by the Inngest server. Shared by the two layer-specific entry
+ * points below; `layer` selects how `null` is treated.
  *
  * Returns `undefined` if no sessions were given (an absent field, or an empty
  * object — an empty RFC 7386 patch leaves the inherited layer untouched);
  * returns `null` for a preserved "clear all" tombstone.
  */
-export const normalizeEventSessions = (
+const normalizeSessions = (
   sessions: EventSessions | null | undefined,
-  allowCut: boolean,
+  layer: "manual" | "propagated",
 ): NormalizedSessions | null | undefined => {
+  const allowCut = layer === "manual";
+
   if (sessions === undefined) {
     return undefined;
   }
@@ -83,6 +77,35 @@ export const normalizeEventSessions = (
   return Object.fromEntries(normalized);
 };
 
+/**
+ * Normalizes the manual `meta.sessions` layer, which is user-authored and so
+ * admits RFC 7386 tombstones: a `null` value is preserved as a per-key cut of
+ * the inherited session, and a whole-field `null` is preserved (as `null`) to
+ * mean "clear all inherited sessions". Tombstones are consumed server-side and
+ * never count against the per-event session limit.
+ */
+export const normalizeManualSessions = (
+  sessions: EventSessions | null | undefined,
+): NormalizedSessions | null | undefined =>
+  normalizeSessions(sessions, "manual");
+
+/**
+ * Normalizes the `meta.propagated_sessions` layer, which is machine-stamped from
+ * `ctx.sessions` and carries no tombstones — so `null` values are rejected and a
+ * whole-field `null` is dropped. The layer is typed `@internal`, but a hand-set
+ * value can still reach here (a direct `inngest.send()` is never stamped, and
+ * `step.sendEvent` leaves the payload untouched when there is nothing to
+ * propagate), so the rejection is a real trust boundary rather than a
+ * formality.
+ */
+export const normalizePropagatedSessions = (
+  sessions: EventSessions | null | undefined,
+): Record<string, string> | undefined =>
+  // The "propagated" layer never returns tombstones, so narrow the value type.
+  normalizeSessions(sessions, "propagated") as
+    | Record<string, string>
+    | undefined;
+
 export const normalizeEventMeta = (
   meta: EventMeta | null | undefined,
 ): NormalizedEventMeta | undefined => {
@@ -93,12 +116,9 @@ export const normalizeEventMeta = (
     throw new Error("Event meta must be an object");
   }
 
-  // The manual layer preserves tombstones (`allowCut`); the propagated layer is
-  // machine-stamped and rejects them.
-  const sessions = normalizeEventSessions(meta.sessions, true);
-  const propagatedSessions = normalizeEventSessions(
+  const sessions = normalizeManualSessions(meta.sessions);
+  const propagatedSessions = normalizePropagatedSessions(
     meta.propagated_sessions,
-    false,
   );
   if (sessions === undefined && propagatedSessions === undefined) {
     return undefined;
@@ -111,8 +131,7 @@ export const normalizeEventMeta = (
     out.sessions = sessions;
   }
   if (propagatedSessions !== undefined) {
-    // Propagated never carries tombstones; narrow away the `null` value type.
-    out.propagated_sessions = propagatedSessions as Record<string, string>;
+    out.propagated_sessions = propagatedSessions;
   }
 
   return out;

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -1,4 +1,8 @@
-import type { EventMeta, EventSessions } from "../types.ts";
+import type {
+  EventMeta,
+  EventSessions,
+  PropagatedEventSessions,
+} from "../types.ts";
 
 /**
  * A normalized session layer as carried on the wire. Values are session-id
@@ -99,7 +103,7 @@ export const normalizeManualSessions = (
  * formality.
  */
 export const normalizePropagatedSessions = (
-  sessions: EventSessions | null | undefined,
+  sessions: PropagatedEventSessions | null | undefined,
 ): Record<string, string> | undefined =>
   // The "propagated" layer never returns tombstones, so narrow the value type.
   normalizeSessions(sessions, "propagated") as

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -1,16 +1,40 @@
 import type { EventMeta, EventSessions } from "../types.ts";
 
 /**
+ * A normalized session layer as carried on the wire. Values are session-id
+ * strings; `null` is a per-key tombstone (RFC 7386) preserved so the server can
+ * cut the matching inherited session. Only the manual layer admits tombstones.
+ */
+type NormalizedSessions = Record<string, string | null>;
+
+/**
  * Validates event sessions and normalizes their values to strings, matching
  * the shape stored by the Inngest server.
  *
- * Returns `undefined` if no sessions were given.
+ * When `allowCut` is `true` (the manual layer), `null` values are preserved as
+ * RFC 7386 tombstones rather than rejected, and a whole-field `null` is
+ * preserved (as `null`) to mean "clear all inherited sessions". Tombstones are
+ * consumed server-side and never count against the per-event session limit.
+ * When `allowCut` is `false` (the propagated layer) `null` values are rejected
+ * and a whole-field `null` is dropped, since it is machine-stamped and carries
+ * no tombstones. The flag is required so each call site declares which side of
+ * this trust boundary it is on rather than relying on a default.
+ *
+ * Returns `undefined` if no sessions were given (an absent field, or an empty
+ * object — an empty RFC 7386 patch leaves the inherited layer untouched);
+ * returns `null` for a preserved "clear all" tombstone.
  */
 export const normalizeEventSessions = (
   sessions: EventSessions | null | undefined,
-): Record<string, string> | undefined => {
-  if (sessions === undefined || sessions === null) {
+  allowCut: boolean,
+): NormalizedSessions | null | undefined => {
+  if (sessions === undefined) {
     return undefined;
+  }
+  if (sessions === null) {
+    // Whole-field null: on the manual layer this is the "clear all inherited"
+    // tombstone, preserved on the wire; on the propagated layer it is a no-op.
+    return allowCut ? null : undefined;
   }
   if (typeof sessions !== "object" || Array.isArray(sessions)) {
     throw new Error("Event sessions must be an object");
@@ -24,13 +48,25 @@ export const normalizeEventSessions = (
   // Collected as entries and built with Object.fromEntries so that special
   // keys like "__proto__" become own properties instead of being silently
   // dropped by a plain object assignment.
-  const normalized: [string, string][] = [];
+  const normalized: [string, string | null][] = [];
   for (const [key, value] of entries) {
     if (!key) {
       throw new Error("Event session keys cannot be empty");
     }
+    if (value === null) {
+      if (!allowCut) {
+        throw new Error(`Event session "${key}" must be a string or number`);
+      }
+      // Per-key tombstone: preserved on the wire, consumed server-side.
+      normalized.push([key, null]);
+      continue;
+    }
     if (typeof value !== "string" && typeof value !== "number") {
-      throw new Error(`Event session "${key}" must be a string or number`);
+      throw new Error(
+        allowCut
+          ? `Event session "${key}" must be a string, number, or null`
+          : `Event session "${key}" must be a string or number`,
+      );
     }
     if (typeof value === "number" && !Number.isFinite(value)) {
       throw new Error(`Event session "${key}" must be a finite number`);
@@ -57,25 +93,33 @@ export const normalizeEventMeta = (
     throw new Error("Event meta must be an object");
   }
 
-  const sessions = normalizeEventSessions(meta.sessions);
-  const propagatedSessions = normalizeEventSessions(meta.propagated_sessions);
+  // The manual layer preserves tombstones (`allowCut`); the propagated layer is
+  // machine-stamped and rejects them.
+  const sessions = normalizeEventSessions(meta.sessions, true);
+  const propagatedSessions = normalizeEventSessions(
+    meta.propagated_sessions,
+    false,
+  );
   if (sessions === undefined && propagatedSessions === undefined) {
     return undefined;
   }
 
   const out: NormalizedEventMeta = {};
+  // `sessions` may be `null` (whole-field "clear all inherited" tombstone),
+  // which must survive on the wire — so distinguish it from `undefined`.
   if (sessions !== undefined) {
     out.sessions = sessions;
   }
   if (propagatedSessions !== undefined) {
-    out.propagated_sessions = propagatedSessions;
+    // Propagated never carries tombstones; narrow away the `null` value type.
+    out.propagated_sessions = propagatedSessions as Record<string, string>;
   }
 
   return out;
 };
 
 type NormalizedEventMeta = {
-  sessions?: Record<string, string>;
+  sessions?: NormalizedSessions | null;
   propagated_sessions?: Record<string, string>;
 };
 
@@ -137,6 +181,12 @@ export const reduceEventsToPropagatedSessions = (
     for (const [key, id] of Object.entries(sessions)) {
       if (!key) {
         continue; // defensive: the server rejects empty keys at ingest
+      }
+      if (id === null) {
+        // A run's triggering events are already-resolved (received) events, so
+        // their sessions never hold tombstones; guard defensively since the
+        // send-time EventSessionValue type now admits null.
+        continue;
       }
       let ids = idsByKey.get(key);
       if (!ids) {

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -115,6 +115,8 @@ export type {
   JsonError,
   LogLevel,
   OutgoingOp,
+  PropagatedEventSessions,
+  PropagatedEventSessionValue,
   ReceivedEventMeta,
   RegisterOptions,
   ScheduledTimerEventPayload,

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -767,6 +767,28 @@ export type EventSessionValue = string | number | null;
 export type EventSessions = Record<string, EventSessionValue>;
 
 /**
+ * Primitive values accepted for session IDs on the propagated layer. Unlike
+ * {@link EventSessionValue} this excludes `null`: the propagated layer is the
+ * base that manual tombstones are applied *against*, so it carries session ids
+ * only and a `null` there is meaningless.
+ *
+ * @public
+ */
+export type PropagatedEventSessionValue = Exclude<EventSessionValue, null>;
+
+/**
+ * Session meta on the propagated layer — see
+ * {@link EventMeta.propagated_sessions}. Same shape as {@link EventSessions} but
+ * without tombstones.
+ *
+ * @public
+ */
+export type PropagatedEventSessions = Record<
+  string,
+  PropagatedEventSessionValue
+>;
+
+/**
  * Event meta accepted when sending an event.
  *
  * @public
@@ -796,7 +818,7 @@ export type EventMeta = {
    *
    * Not intended to be set by hand.
    */
-  propagated_sessions?: EventSessions;
+  propagated_sessions?: PropagatedEventSessions;
 };
 
 /**

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -745,13 +745,22 @@ export interface EventPayload<TData = any> extends MinimalEventPayload<TData> {
  * Primitive values accepted for event session IDs when sending an
  * event. Numbers are normalized to strings before sending.
  *
+ * `null` is a tombstone (RFC 7386 JSON Merge Patch), not a session id: on the
+ * manual {@link EventMeta.sessions} layer it cuts the inherited (propagated)
+ * session of the same key. It is consumed server-side and never counts against
+ * the per-event session limit. Received events never carry `null` — see
+ * {@link ReceivedEventMeta}.
+ *
  * @public
  */
-export type EventSessionValue = string | number;
+export type EventSessionValue = string | number | null;
 
 /**
  * Session meta accepted when sending an event. Values are normalized to
  * strings before sending; received events carry `Record<string, string>`.
+ *
+ * A `null` value cuts the inherited session of that key; setting the whole
+ * field to `null` clears all inherited sessions (see {@link EventMeta.sessions}).
  *
  * @public
  */
@@ -768,8 +777,14 @@ export type EventMeta = {
    *
    * Keys are session keys, values are session IDs. Values are
    * normalized to strings before the event is sent.
+   *
+   * Follows RFC 7386 (JSON Merge Patch) against the inherited
+   * {@link EventMeta.propagated_sessions} layer: a `null` value cuts the
+   * inherited session of that key, and setting the whole field to `null`
+   * clears all inherited sessions. Tombstones are consumed server-side and do
+   * not count against the per-event session limit.
    */
-  sessions?: EventSessions;
+  sessions?: EventSessions | null;
 
   /**
    * EXPERIMENTAL: This API is not yet stable and may change in the future


### PR DESCRIPTION
## Summary

- Users should be able to override propagated sessions
- Setting an individual key will clear the propagated session
- Setting the entire sessions object to null will clear all propagated sessions

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2034

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>