### PR TITLE
internal: inngest.send supports session propagation

### DIFF
--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -14,6 +14,8 @@ import {
 import type { Logger } from "../middleware/logger.ts";
 import { createClient, nodeVersion } from "../test/helpers.ts";
 import type { SendEventResponse } from "../types.ts";
+import type { AsyncContext } from "./execution/als.ts";
+import { getAsyncLocalStorage } from "./execution/als.ts";
 import { sessionPropagationSymbol } from "./Inngest.ts";
 import type { createStepTools } from "./InngestStepTools.ts";
 
@@ -1500,5 +1502,144 @@ describe("sessionPropagation toggle", () => {
       env: { [envKeys.InngestSessionPropagation]: "true" },
     });
     expect(inngest[sessionPropagationSymbol]).toBe(false);
+  });
+});
+
+describe("session propagation (bare inngest.send)", () => {
+  const originalFetch = global.fetch;
+
+  const setFetch = () => {
+    return vi.fn((_url: string, opts: { body: string }) => {
+      const ids = (JSON.parse(opts.body) as EventPayload[]).map(
+        () => "test-id",
+      );
+      const json = { status: 200, ids };
+      return Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve(json),
+        text: () => Promise.resolve(JSON.stringify(json)),
+      });
+    }) as unknown as typeof fetch;
+  };
+
+  beforeAll(() => {
+    Object.defineProperties(global, {
+      fetch: { value: setFetch(), configurable: true },
+    });
+  });
+
+  beforeEach(() => {
+    (global.fetch as Mock).mockClear();
+  });
+
+  afterAll(() => {
+    Object.defineProperties(global, {
+      fetch: { value: originalFetch, configurable: true },
+    });
+  });
+
+  const createClientWithPropagation = (
+    sessionPropagation: boolean,
+  ): Inngest.Any =>
+    createClient({
+      id: "test",
+      eventKey: testEventKey,
+      // Internal, undocumented option kept off the public `ClientOptions` type.
+      ...({ sessionPropagation } as { sessionPropagation: boolean }),
+    });
+
+  /**
+   * Run `fn` as if it were executing inside a run owned by `app`, with the
+   * given `ctx.sessions`, by seeding the AsyncLocalStorage store the same way
+   * the execution engine does.
+   */
+  const runInAmbientRun = async <T>(
+    app: Inngest.Like,
+    sessions: Record<string, string> | undefined,
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    const als = await getAsyncLocalStorage();
+    const store = {
+      app,
+      execution: {
+        instance: {} as never,
+        ctx: { sessions } as never,
+      },
+    } as AsyncContext;
+    return als.run(store, fn);
+  };
+
+  /** The `propagated_sessions` of the single event in the last fetch call. */
+  const sentPropagatedSessions = () => {
+    const call = (global.fetch as Mock).mock.calls.at(-1);
+    const payloads = JSON.parse(call?.[1].body as string) as EventPayload[];
+    return payloads[0]?.meta?.propagated_sessions;
+  };
+
+  test("stamps ctx.sessions onto a bare send inside a run", async () => {
+    const inngest = createClientWithPropagation(true);
+
+    await runInAmbientRun(inngest, { conv: "123" }, () =>
+      inngest.send({ name: "test", data: {} }),
+    );
+
+    expect(sentPropagatedSessions()).toEqual({ conv: "123" });
+  });
+
+  test("does not stamp when sent outside a run", async () => {
+    const inngest = createClientWithPropagation(true);
+
+    await inngest.send({ name: "test", data: {} });
+
+    expect(sentPropagatedSessions()).toBeUndefined();
+  });
+
+  test("does not stamp when the run is owned by a different client", async () => {
+    const runningClient = createClientWithPropagation(true);
+    const sendingClient = createClientWithPropagation(true);
+
+    // The ambient run belongs to `runningClient`; the send is made through a
+    // different client, so it must not inherit the run's sessions.
+    await runInAmbientRun(runningClient, { conv: "123" }, () =>
+      sendingClient.send({ name: "test", data: {} }),
+    );
+
+    expect(sentPropagatedSessions()).toBeUndefined();
+  });
+
+  test("does not stamp when propagation is disabled", async () => {
+    const inngest = createClientWithPropagation(false);
+
+    await runInAmbientRun(inngest, { conv: "123" }, () =>
+      inngest.send({ name: "test", data: {} }),
+    );
+
+    expect(sentPropagatedSessions()).toBeUndefined();
+  });
+
+  test("does not stamp when ctx.sessions is empty", async () => {
+    const inngest = createClientWithPropagation(true);
+
+    await runInAmbientRun(inngest, {}, () =>
+      inngest.send({ name: "test", data: {} }),
+    );
+
+    expect(sentPropagatedSessions()).toBeUndefined();
+  });
+
+  test("leaves an already-stamped payload untouched", async () => {
+    const inngest = createClientWithPropagation(true);
+
+    // A payload arriving with `propagated_sessions` already set (e.g. stamped
+    // upstream by `step.sendEvent`) must remain authoritative.
+    await runInAmbientRun(inngest, { conv: "123" }, () =>
+      inngest.send({
+        name: "test",
+        data: {},
+        meta: { propagated_sessions: { fromStep: "abc" } },
+      }),
+    );
+
+    expect(sentPropagatedSessions()).toEqual({ fromStep: "abc" });
   });
 });

--- a/packages/inngest/src/components/Inngest.test.ts
+++ b/packages/inngest/src/components/Inngest.test.ts
@@ -1544,8 +1544,7 @@ describe("session propagation (bare inngest.send)", () => {
     createClient({
       id: "test",
       eventKey: testEventKey,
-      // Internal, undocumented option kept off the public `ClientOptions` type.
-      ...({ sessionPropagation } as { sessionPropagation: boolean }),
+      sessionPropagation,
     });
 
   /**

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -993,6 +993,36 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
         ? ([payload] as [EventPayload])
         : [];
 
+    // Best-effort session propagation for bare `inngest.send()` calls made
+    // *inside* a run. Unlike `step.sendEvent`/`step.invoke` (which stamp
+    // synchronously from their direct `ctx`), a bare send has no `ctx`, so we
+    // read the ambient run context from AsyncLocalStorage.
+    //
+    // This is best-effort by construction: on runtimes without
+    // `node:async_hooks` the ALS store is empty and propagation silently no-ops.
+    //
+    // Outside a run there is no execution context, so nothing is stamped.
+    if (this[sessionPropagationSymbol]) {
+      const asyncCtx = await getAsyncCtx();
+
+      // Client-identity guard: only inherit when *this* client owns the
+      // ambient run. A bare send through a different client (possibly a
+      // different environment) must never pick up this run's sessions.
+      if (asyncCtx?.app === this) {
+        const sessions = asyncCtx.execution?.ctx.sessions;
+        if (sessions && Object.keys(sessions).length > 0) {
+          payloads = payloads.map((p) =>
+            // Leave payloads already stamped upstream by `step.sendEvent`
+            // authoritative; it stamps from its direct `ctx` before reaching
+            // `_send`.
+            p.meta?.propagated_sessions === undefined
+              ? { ...p, meta: { ...p.meta, propagated_sessions: sessions } }
+              : p,
+          );
+        }
+      }
+    }
+
     // Instantiate fresh middleware per send() call.
     const mwInstances = [...this.middleware, ...fnMiddleware].map(
       (Cls) => new Cls({ client: this }),

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -933,10 +933,8 @@ describe("step.invoke session propagation", () => {
     const client = createClient({
       id: "test",
       isDev: true,
-      // `sessionPropagation` is internal/undocumented (off the public
-      // ClientOptions), so it's set via the same cast the SDK reads it with.
       sessionPropagation: enabled,
-    } as Parameters<typeof createClient>[0]);
+    });
 
     const target = new InngestFunction(
       client,


### PR DESCRIPTION
## Summary
 
- `inngest.send` should support session propagation
- Unlike `step.sendEvent` and `step.Invoke`, `inngest.send` doesn't have ctx. We instead rely upon async local storage to determine when we're in the context of a run.
- Async local storage is not available in all runtimes, such as some of cloudflare workers. We will call this out in the docs.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~ docs later
- [x] Added unit/integration tests
~- [ ] Added changesets if applicable~ unreleased 

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2044

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>