### PR TITLE
fix: step.sleep/waitForEvent silently dropping sub-second durations

### DIFF
--- a/.changeset/quick-plums-relax.md
+++ b/.changeset/quick-plums-relax.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `step.sleep()` and `step.waitForEvent()` timeout silently dropping sub-second durations (e.g. `500` or `1500` milliseconds), which previously produced an empty/invalid duration string or lost the fractional second. Sub-second durations are now rounded up to the nearest whole second.

--- a/packages/inngest/src/helpers/strings.test.ts
+++ b/packages/inngest/src/helpers/strings.test.ts
@@ -44,6 +44,39 @@ describe("timeStr", () => {
     expect(timeStr("1 day")).toEqual("1d");
   });
 
+  describe("sub-second durations are rounded up, never dropped (inngest-js#1619)", () => {
+    test("500ms rounds up to a valid non-empty duration", () => {
+      expect(timeStr(500)).toEqual("1s");
+    });
+
+    test('"500ms" ms-string rounds up the same as the equivalent number', () => {
+      expect(timeStr("500ms")).toEqual("1s");
+    });
+
+    test("999ms rounds up to 1s", () => {
+      expect(timeStr(999)).toEqual("1s");
+    });
+
+    test("1500ms preserves the sub-second remainder by rounding up, not truncating it away", () => {
+      expect(timeStr(1500)).toEqual("2s");
+    });
+
+    test("an exact whole-second value is unaffected by rounding", () => {
+      expect(timeStr(1000)).toEqual("1s");
+    });
+
+    test("a sub-second remainder on a larger duration rounds the whole value up", () => {
+      // 1m5.5s -> previously floored to "1m5s", dropping 500ms.
+      expect(timeStr(65500)).toEqual("1m6s");
+    });
+
+    test("never returns an empty string for a positive duration", () => {
+      for (const value of [1, 10, 100, 500, 999, 1001, 1500]) {
+        expect(timeStr(value)).not.toEqual("");
+      }
+    });
+  });
+
   test("converts a date to an ISO string", () => {
     expect(timeStr(new Date(0))).toEqual("1970-01-01T00:00:00.000Z");
   });

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -128,6 +128,16 @@ export const timeStr = (
     milliseconds = input as number;
   }
 
+  // `periods`' smallest unit is whole seconds, so a sub-second remainder
+  // (e.g. the 500 in 1500ms, or the entirety of a 500ms duration) would
+  // otherwise be floored away by the reduce below -- silently shortening
+  // the sleep/timeout, or, for inputs under 1000ms, leaving the result as
+  // an empty (invalid) string. Round positive durations up to the nearest
+  // second so we never resolve in less time than requested and never emit
+  // "" for a positive duration. See inngest/inngest-js#1619.
+  const roundedMilliseconds =
+    milliseconds > 0 ? Math.ceil(milliseconds / second) * second : milliseconds;
+
   const [, timeStr] = periods.reduce<[number, string]>(
     ([num, str], [suffix, period]) => {
       const numPeriods = Math.floor(num / period);
@@ -138,7 +148,7 @@ export const timeStr = (
 
       return [num, str];
     },
-    [milliseconds, ""],
+    [roundedMilliseconds, ""],
   );
 
   return timeStr as TimeStr;


### PR DESCRIPTION
## Summary

`step.sleep()` and `step.waitForEvent()`'s `timeout` silently drop sub-second durations. Under the hood both go through `timeStr()` (`packages/inngest/src/helpers/strings.ts`), whose `periods` lookup table stops at whole seconds:

```js
const periods = [
  ["w", week],
  ["d", day],
  ["h", hour],
  ["m", minute],
  ["s", second],
] as const;
```

Any input under 1000ms floors to an empty accumulator, so `timeStr(500)` returns `""` — an empty, invalid duration that gets sent straight through to the executor as the op's `name` (no validation exists at the `sleep`/`waitForEvent` call sites in `InngestStepTools.ts`). Larger values also silently lose their sub-second remainder: `timeStr(1500)` returns `"1s"`, quietly dropping 500ms.

```js
timeStr(500)   // ""     (step.sleep("id", 500) — documented as 500ms)
timeStr(1500)  // "1s"   (loses 500ms)
```

## Root cause

`packages/inngest/src/helpers/strings.ts` — `timeStr()`'s `periods.reduce` only descends to seconds, so the accumulator for any sub-second remainder is silently discarded.

I also checked whether the fix should instead preserve exact millisecond precision on the wire. It can't: the `TimeStr` type (`packages/inngest/src/types.ts:498`) is a template-literal type whose smallest unit is whole seconds (`` `${number}s` ``) — there's no ms suffix in the wire format by design. So sub-second precision genuinely isn't representable client-side without a server-side format change, which is out of scope here.

## Fix

Round positive durations up to the nearest whole second before the `periods` reduce, so:
- A sleep/timeout never resolves in *less* time than requested (rounds up, not down).
- A positive duration never produces the empty/invalid `""` string.
- Exact whole-second inputs are unaffected.
- `0`/negative inputs are unchanged (out of scope — not a "dropped sub-second precision" case, and their intended semantics are a separate design question).

```js
timeStr(500)    // "1s"  (was "")
timeStr(1500)   // "2s"  (was "1s", silently dropping 500ms)
timeStr(1000)   // "1s"  (unchanged)
```

## Testing

Added test cases to `packages/inngest/src/helpers/strings.test.ts` reproducing the exact scenarios from the issue (`timeStr(500)`, `timeStr("500ms")`, `timeStr(1500)`, a mixed `1m5.5s` value, and a sweep asserting no positive input ever returns `""`).

Revert-proofed locally: reverting just the implementation change while keeping the new tests causes 6 of them to fail with exactly the reported symptoms (`''` instead of `'1s'`, `'1s'` instead of `'2s'`, etc.); restoring the fix makes them pass again.

- `pnpm test` (packages/inngest, `strings.test.ts` + `InngestStepTools.test.ts` for the `sleep`/`waitForEvent` call sites) — all passing, no regressions.
- `pnpm lint` (Biome) — clean.

Fixes #1619. Thanks to @tsushanth for the clear, well-diagnosed report — the root cause and reduce-table explanation in the issue matches what I found.

## Test plan
- [ ] `pnpm test` in `packages/inngest/` passes
- [ ] `pnpm lint` passes
- [ ] Manually verify `step.sleep("id", 500)` no longer sends an empty duration string to the executor
