### PR TITLE
feat(middleware): add Middleware.isStepType type guard

### DIFF
--- a/.changeset/unlucky-turtles-cheer.md
+++ b/.changeset/unlucky-turtles-cheer.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add Middleware.isStepType, a type guard for middleware to get step-specific typing

--- a/packages/inngest/src/components/middleware/middleware.test.ts
+++ b/packages/inngest/src/components/middleware/middleware.test.ts
@@ -1,6 +1,45 @@
-import { test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 import { Inngest } from "../Inngest.ts";
 import { Middleware } from "./middleware.ts";
+
+test("isStepType narrows stepInfo to the matching step type", () => {
+  const stepInfo = {
+    stepType: "invoke" as Middleware.StepType,
+  };
+
+  if (Middleware.isStepType(stepInfo, "invoke")) {
+    expect(stepInfo.stepType).toBe("invoke");
+    expectTypeOf(stepInfo.stepType).toEqualTypeOf<"invoke">();
+  } else {
+    throw new Error("expected isStepType to match");
+  }
+
+  expect(Middleware.isStepType(stepInfo, "sendEvent")).toBe(false);
+});
+
+test("isStepType accepts open-union members not declared on StepType", () => {
+  // `StepType` is an open union; the guard must work for step types that do
+  // not yet exist as declared members, without a breaking change.
+  const stepInfo = { stepType: "group.parallel" as Middleware.StepType };
+
+  expect(Middleware.isStepType(stepInfo, "group.parallel")).toBe(true);
+
+  if (Middleware.isStepType(stepInfo, "group.parallel")) {
+    expectTypeOf(stepInfo.stepType).toEqualTypeOf<"group.parallel">();
+  }
+});
+
+test("isStepType preserves extra fields on the narrowed type", () => {
+  const stepInfo = {
+    stepType: "invoke" as Middleware.StepType,
+    hashedId: "abc",
+  };
+
+  if (Middleware.isStepType(stepInfo, "invoke")) {
+    expectTypeOf(stepInfo.hashedId).toEqualTypeOf<string>();
+    expectTypeOf(stepInfo.stepType).toEqualTypeOf<"invoke">();
+  }
+});
 
 test("stepOutputTransform does not affect step.invoke return type", () => {
   interface PreserveDate extends Middleware.StaticTransform {

--- a/packages/inngest/src/components/middleware/middleware.test.ts
+++ b/packages/inngest/src/components/middleware/middleware.test.ts
@@ -41,6 +41,49 @@ test("isStepType preserves extra fields on the narrowed type", () => {
   }
 });
 
+test("isStepType narrows transformStepInput's arg", () => {
+  const seen: string[] = [];
+
+  class MW extends Middleware.BaseMiddleware {
+    readonly id = "test";
+
+    override transformStepInput(
+      arg: Middleware.TransformStepInputArgs,
+    ): Middleware.TransformStepInputArgs {
+      expectTypeOf(arg.stepInfo.stepType).toEqualTypeOf<Middleware.StepType>();
+
+      if (!Middleware.isStepType(arg.stepInfo, "invoke")) {
+        return arg;
+      }
+
+      expectTypeOf(arg.stepInfo.stepType).toEqualTypeOf<"invoke">();
+
+      // The rest of `stepInfo` is untouched by the narrowing.
+      expectTypeOf(arg.stepInfo.hashedId).toEqualTypeOf<string>();
+      expectTypeOf(arg.stepInfo.memoized).toEqualTypeOf<boolean>();
+
+      seen.push(arg.stepInfo.stepType);
+      return arg;
+    }
+  }
+
+  const client = new Inngest({ id: "test", middleware: [MW] });
+  const mw = new MW({ client });
+
+  const arg = (stepType: Middleware.StepType) =>
+    ({
+      fn: {} as Middleware.TransformStepInputArgs["fn"],
+      stepInfo: { hashedId: "abc", memoized: false, stepType },
+      stepOptions: { id: "my-step" },
+      input: [],
+    }) satisfies Middleware.TransformStepInputArgs;
+
+  mw.transformStepInput(arg("invoke"));
+  mw.transformStepInput(arg("run"));
+
+  expect(seen).toEqual(["invoke"]);
+});
+
 test("stepOutputTransform does not affect step.invoke return type", () => {
   interface PreserveDate extends Middleware.StaticTransform {
     Out: this["In"] extends Date ? Date : this["In"];

--- a/packages/inngest/src/components/middleware/middleware.ts
+++ b/packages/inngest/src/components/middleware/middleware.ts
@@ -279,6 +279,30 @@ export namespace Middleware {
   };
 
   /**
+   * Narrows a `stepInfo` to a specific {@link StepType}, for use in step-scoped
+   * hooks (e.g. `transformStepInput`) that need to act on one kind of step:
+   *
+   * ```ts
+   * async transformStepInput(arg) {
+   *   if (!Middleware.isStepType(arg.stepInfo, "invoke")) return arg;
+   *   // arg.stepInfo.stepType is narrowed to "invoke" here
+   *   return arg;
+   * }
+   * ```
+   *
+   * This is a positive equality check, never an exhaustive match, so it works
+   * for step types that do not yet exist in {@link StepType} (which is an open
+   * union and may gain members without a breaking change) — e.g.
+   * `isStepType(stepInfo, "group.parallel")`.
+   */
+  export function isStepType<
+    S extends Pick<StepInfo, "stepType">,
+    const T extends StepType,
+  >(stepInfo: S, stepType: T): stepInfo is S & { stepType: T } {
+    return stepInfo.stepType === stepType;
+  }
+
+  /**
    * Base class for creating middleware. Extend this class to create custom
    * middleware with hooks for step execution.
    */


### PR DESCRIPTION
## Summary

- Middleware can be tricky to use due to the unknown types that vary based on the different step types
- We add a type guard to resolve typing based upon the step type
- We take special care to prevent this from causing breaking changes in the future

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~ https://linear.app/inngest/issue/EXE-2052/add-type-guard-to-middleware-docs
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2036
