### PR TITLE
feat(sessions): add a client toggle to control sessions propagation

### DIFF
--- a/.changeset/grumpy-news-hide.md
+++ b/.changeset/grumpy-news-hide.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add a toggle to clients to control sessions propagation

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1219,8 +1219,12 @@ export interface ClientOptions {
    * EXPERIMENTAL: This API is not yet stable and may change in the future
    * without a major version bump.
    *
-   * Whether events sent during a run inherit the run's session metadata, so
-   * the resulting child runs stay grouped in the same sessions as their parent.
+   * Whether events spawned during a run — via `step.sendEvent`, `step.invoke`,
+   * and `defer` — inherit the run's session metadata, so the resulting child
+   * runs stay grouped in the same sessions as their parent.
+   *
+   * Sessions set manually always take precedence. Setting a key to null will
+   * remove that session from propagated sessions.
    *
    * This option takes precedence over the `INNGEST_SESSION_PROPAGATION`
    * environment variable, which in turn takes precedence over the SDK's


### PR DESCRIPTION
## Summary

- We've introduced sessions propagation
- Add a toggle to clients that will disable sessions propagation on that client
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2031

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>