### PR TITLE
feat(defer): propagate sessions through defer meta

### DIFF
--- a/.changeset/thirty-eggs-rule.md
+++ b/.changeset/thirty-eggs-rule.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add sessions support to deferred runs

--- a/packages/inngest/src/components/execution/defer.md
+++ b/packages/inngest/src/components/execution/defer.md
@@ -83,6 +83,30 @@ Without a schema, `data` falls back to `Record<string, any>`.
 
 Receiver-side schema failures (the deferred run reading invalid `event.data`) are not in this category: they fail the deferred run itself, with normal retry semantics.
 
+## Sessions
+
+A deferred run supports sessions, similar to `step.sendEvent` and `step.invoke`.
+
+```ts
+defer("send", {
+  function: sendEmail,
+  data: { ... },
+  meta: { sessions: { conv_id: "abc" } }, // add or override a session
+});
+```
+
+Pass `meta.sessions` to add or override sessions on the deferred run.
+
+The two layers travel separately on the `DeferAdd` op's `meta` blob (manual
+`meta.sessions` normalized with tombstones preserved; propagated stamped from
+`ctx.sessions`). The SDK does not merge them — the server folds them at finalize
+in `buildDeferEvents` before emitting `inngest/deferred.schedule`. This mirrors the
+`step.invoke` and `step.sendEvent` session paths.
+
+Session propagation is gated by the public `sessionPropagation` client option
+(off by default). While disabled, the propagated layer is not stamped; manual
+`meta.sessions` still travels.
+
 ## Sharing across parents
 
 A defer function is one Inngest function in the backend. Multiple parent functions can hold a reference to it and each call to `defer(...)` triggers an independent run.

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -1021,3 +1021,116 @@ describe("step.invoke session propagation", () => {
     });
   });
 });
+
+describe("defer session propagation", () => {
+  // Drives a real execution whose handler calls `defer(...)`, then inspects the
+  // buffered `DeferAdd` op's `opts.meta`. Asserts the engine resolves the
+  // defer's session layers: the manual `meta.sessions` layer is normalized, and
+  // the run's `ctx.sessions` (aggregated from triggering events) is stamped as
+  // the separate `meta.propagated_sessions` layer, gated by the client toggle.
+  const runDefer = async (
+    enabled: boolean,
+    manualMeta?: Record<string, unknown>,
+  ) => {
+    const client = createClient({
+      id: "test",
+      isDev: true,
+      sessionPropagation: enabled,
+    });
+
+    const target = createDefer(
+      client,
+      { id: "target-defer" },
+      () => "target-result",
+    );
+
+    const fn = new InngestFunction(
+      client,
+      { id: "caller-fn", triggers: [{ event: "test/event" }] },
+      ({
+        defer,
+      }: Context.Any & { defer: (id: string, opts: unknown) => unknown }) => {
+        defer("d", {
+          function: target,
+          data: { foo: "bar" },
+          ...(manualMeta ? { meta: manualMeta } : {}),
+        });
+        return "done";
+      },
+    );
+
+    // Two triggering events carrying sessions — exercises the run-level
+    // aggregation that produces `ctx.sessions`.
+    const events = [
+      { name: "test/event", data: {}, meta: { sessions: { conv_id: "p1" } } },
+      { name: "test/event", data: {}, meta: { sessions: { org_id: "42" } } },
+    ];
+
+    const execution = fn["createExecution"]({
+      partialOptions: {
+        client,
+        data: fromPartial({ event: events[0], events }),
+        runId: "test-run-id",
+        stepState: {},
+        stepCompletionOrder: [],
+        reqArgs: [],
+        headers: {},
+        stepMode: StepMode.AsyncCheckpointing,
+        queueItemId: "queue-item-123",
+        internalFnId: "internal-fn-456",
+      },
+    });
+
+    const result = await execution.start();
+    // The defer op is a lazy op shipped alongside the terminal response.
+    const steps =
+      (result as { steps?: { op?: string; opts?: unknown }[] }).steps ?? [];
+    const deferOp = steps.find((s) => s.op === StepOpCode.DeferAdd);
+    expect(deferOp).toBeDefined();
+    return (deferOp?.opts as { meta?: Record<string, unknown> })?.meta;
+  };
+
+  test("stamps propagated_sessions from ctx.sessions when the toggle is on", async () => {
+    const meta = await runDefer(true);
+    expect(meta?.propagated_sessions).toEqual({ conv_id: "p1", org_id: "42" });
+  });
+
+  test("does not stamp when the toggle is off", async () => {
+    const meta = await runDefer(false);
+    expect(meta).toBeUndefined();
+  });
+
+  test("stamps manual sessions even when the toggle is off", async () => {
+    const meta = await runDefer(false, { sessions: { conv_id: "manual" } });
+    // Manual sessions are explicit user intent and always travel; the toggle
+    // only gates the inherited (propagated) layer, never the manual one.
+    expect(meta?.sessions).toEqual({ conv_id: "manual" });
+    expect(meta?.propagated_sessions).toBeUndefined();
+  });
+
+  test("keeps the manual sessions layer distinct from propagated", async () => {
+    const meta = await runDefer(true, { sessions: { conv_id: "manual" } });
+    // Manual and propagated travel as separate layers; the server merges them
+    // (manual wins). The SDK must not merge them itself.
+    expect(meta?.sessions).toEqual({ conv_id: "manual" });
+    expect(meta?.propagated_sessions).toEqual({ conv_id: "p1", org_id: "42" });
+  });
+
+  test("preserves a null tombstone on the manual sessions layer", async () => {
+    const meta = await runDefer(true, { sessions: { conv_id: null } });
+    // The tombstone must survive to finalize so the server can cut the matching
+    // inherited (propagated) session.
+    expect(meta?.sessions).toEqual({ conv_id: null });
+    expect(meta?.propagated_sessions).toEqual({ conv_id: "p1", org_id: "42" });
+  });
+
+  test("preserves a whole-field null (clear all inherited sessions)", async () => {
+    const meta = await runDefer(true, { sessions: null });
+    // `sessions: null` is the RFC 7386 whole-document tombstone: clear every
+    // inherited session. It must ship verbatim alongside the still-stamped
+    // propagated layer — the server folds/clears at finalize, not the SDK.
+    expect(meta).toBeDefined();
+    expect(meta?.sessions).toBeNull();
+    expect(meta?.propagated_sessions).toEqual({ conv_id: "p1", org_id: "42" });
+  });
+});

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -1028,7 +1028,7 @@ describe("defer session propagation", () => {
   // defer's session layers: the manual `meta.sessions` layer is normalized, and
   // the run's `ctx.sessions` (aggregated from triggering events) is stamped as
   // the separate `meta.propagated_sessions` layer, gated by the client toggle.
-  const runDefer = async (
+  const startDefer = async (
     enabled: boolean,
     manualMeta?: Record<string, unknown>,
   ) => {
@@ -1060,10 +1060,12 @@ describe("defer session propagation", () => {
     );
 
     // Two triggering events carrying sessions — exercises the run-level
-    // aggregation that produces `ctx.sessions`.
+    // intersection that produces `ctx.sessions`, so both must agree on every
+    // key for it to survive.
+    const sessions = { conv_id: "p1", org_id: "42" };
     const events = [
-      { name: "test/event", data: {}, meta: { sessions: { conv_id: "p1" } } },
-      { name: "test/event", data: {}, meta: { sessions: { org_id: "42" } } },
+      { name: "test/event", data: {}, meta: { sessions } },
+      { name: "test/event", data: {}, meta: { sessions } },
     ];
 
     const execution = fn["createExecution"]({
@@ -1086,6 +1088,16 @@ describe("defer session propagation", () => {
     const steps =
       (result as { steps?: { op?: string; opts?: unknown }[] }).steps ?? [];
     const deferOp = steps.find((s) => s.op === StepOpCode.DeferAdd);
+    return { result, deferOp };
+  };
+
+  // Most cases expect the defer to be buffered; assert that once here and hand
+  // back just the `meta` blob under test.
+  const runDefer = async (
+    enabled: boolean,
+    manualMeta?: Record<string, unknown>,
+  ) => {
+    const { deferOp } = await startDefer(enabled, manualMeta);
     expect(deferOp).toBeDefined();
     return (deferOp?.opts as { meta?: Record<string, unknown> })?.meta;
   };
@@ -1132,5 +1144,18 @@ describe("defer session propagation", () => {
     expect(meta).toBeDefined();
     expect(meta?.sessions).toBeNull();
     expect(meta?.propagated_sessions).toEqual({ conv_id: "p1", org_id: "42" });
+  });
+
+  test("skips the defer on invalid meta without derailing the run", async () => {
+    // `defer()` is fire-and-forget: normalization failures are logged and the
+    // call silently skipped, so no `DeferAdd` is buffered but the parent
+    // handler still runs to completion.
+    const { result, deferOp } = await startDefer(true, {
+      sessions: { conv_id: {} },
+    });
+    expect(deferOp).toBeUndefined();
+    expect(result).toMatchObject({
+      steps: [expect.objectContaining({ op: "RunComplete", data: "done" })],
+    });
   });
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -34,6 +34,7 @@ import {
   runAsPromise,
 } from "../../helpers/promises.ts";
 import {
+  normalizeEventMeta,
   reduceEventsToPropagatedSessions,
   stampPropagatedSessionsOnEvent,
 } from "../../helpers/sessions.ts";
@@ -2729,7 +2730,7 @@ class InngestExecutionEngine
    * schema mismatch) are logged and the call is silently skipped.
    */
   private buildDefer(stepHandler: StepHandler): DeferFn {
-    return (idOrOptions, { function: deferFn, data, experiment }) => {
+    return (idOrOptions, { function: deferFn, data, experiment, meta }) => {
       const log = this.options.client[internalLoggerSymbol];
       const runId = this.fnArg.runId;
       const noopHandle: DeferHandle = { abort: () => {} };
@@ -2775,6 +2776,26 @@ class InngestExecutionEngine
             ? { ...input, [deferExperimentKey]: experiment }
             : input;
 
+        // Resolve the defer's session layers into the `meta` blob the deferred
+        // run inherits. The manual `meta.sessions` layer (tombstones preserved)
+        // is always normalized; the run's propagated sessions (`ctx.sessions`)
+        // are stamped as the separate `meta.propagated_sessions` layer, gated by
+        // the client toggle, mirroring `step.invoke`/`step.sendEvent`. The
+        // server folds the two at finalize.
+        let deferMeta: ReturnType<typeof normalizeEventMeta>;
+        try {
+          deferMeta = normalizeEventMeta(meta);
+        } catch (err) {
+          log.error({ runId, err }, "defer skipped: invalid meta.sessions");
+          return noopHandle;
+        }
+        if (this.options.client[sessionPropagationSymbol]) {
+          const propagated = this.fnArg.sessions;
+          if (propagated && Object.keys(propagated).length > 0) {
+            deferMeta = { ...deferMeta, propagated_sessions: propagated };
+          }
+        }
+
         void stepHandler({
           args: [stepOptions, finalInput],
           matchOp: (stepOptions, inputArg) => ({
@@ -2783,7 +2804,11 @@ class InngestExecutionEngine
             op: StepOpCode.DeferAdd,
             name: stepOptions.name ?? stepOptions.id,
             displayName: stepOptions.name ?? stepOptions.id,
-            opts: { fn_slug: deferFnSlug, input: inputArg },
+            opts: {
+              fn_slug: deferFnSlug,
+              input: inputArg,
+              ...(deferMeta ? { meta: deferMeta } : {}),
+            },
             userland: { id: stepOptions.id },
           }),
         }).catch((err: unknown) => {

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2786,7 +2786,7 @@ class InngestExecutionEngine
         try {
           deferMeta = normalizeEventMeta(meta);
         } catch (err) {
-          log.error({ runId, err }, "defer skipped: invalid meta.sessions");
+          log.error({ runId, err }, "defer skipped: invalid meta");
           return noopHandle;
         }
         if (this.options.client[sessionPropagationSymbol]) {

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -545,6 +545,21 @@ export type DeferFn = <TFn extends DeferredFunction.Any>(
         Record<string, any>;
     /** Attribute the deferred scorer's result to this experiment variant. */
     experiment?: ExperimentRef;
+    /**
+     * Event meta shared with the deferred run.
+     *
+     * By default the deferred run inherits the calling run's sessions: the
+     * `meta.propagated_sessions` layer is stamped automatically from
+     * `ctx.sessions`.
+     *
+     * Pass `meta.sessions` to add or override sessions on the deferred run; a
+     * `null` value cuts an inherited session (RFC 7386), and a whole-field
+     * `null` clears all inherited sessions. Values are normalized to strings
+     * before sending, as with `inngest.send()`.
+     *
+     * Inheritance can be disabled at the client level.
+     */
+    meta?: EventMeta;
   },
 ) => DeferHandle;
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->
- Adds support for sessions to deferred functions. Also adds support for propagated sessions to deferred runs
- We add additional server side support in oss and monorepo

Rebased onto `main` now that the rest of the stack has landed; this PR is no longer stacked. Note the run-level `ctx.sessions` is now the *intersection* of the triggering events' sessions (#1668), which the defer tests reflect.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

~- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2035
