### PR TITLE
feat(metadata): Extract AI call latency

### DIFF
--- a/.changeset/all-bushes-raise.md
+++ b/.changeset/all-bushes-raise.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+feat(metadata): Extract AI call latency

--- a/.changeset/all-bushes-raise.md
+++ b/.changeset/all-bushes-raise.md
@@ -1,5 +1,5 @@
 ---
-"inngest": patch
+"inngest": minor
 ---
 
 feat(metadata): Extract AI call latency

--- a/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.test.ts
@@ -2,11 +2,12 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Attributes, AttributeValue } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { describe, expect, test } from "vitest";
 import type { AIMetadata } from "./aiExtractor.ts";
 import {
   aggregate,
-  extractAIMetadataFromAttributes,
+  extractAIMetadataFromSpan,
   FIELD_SPECS,
   toInngestAIMetadataValues,
 } from "./aiExtractor.ts";
@@ -43,9 +44,22 @@ const unwrapOtlpValue = (v: OtlpAnyValue): AttributeValue | undefined => {
   return undefined;
 };
 
+/** An OTel `HrTime` tuple: `[seconds, remaining nanoseconds]`. */
+type HrTime = [number, number];
+
+/** Converts an OTLP/JSON `UnixNano` timestamp (a quoted int64) to an `HrTime`. */
+const unixNanoToHrTime = (unixNano: string): HrTime => {
+  const nanos = BigInt(unixNano);
+  const seconds = nanos / 1_000_000_000n;
+  const remainder = nanos % 1_000_000_000n;
+  return [Number(seconds), Number(remainder)];
+};
+
 interface OtlpSpan {
   name: string;
   attributes: Attributes;
+  startTime: HrTime;
+  endTime: HrTime;
 }
 
 interface OtlpTraceRequest {
@@ -54,6 +68,8 @@ interface OtlpTraceRequest {
       spans?: {
         name: string;
         attributes?: { key: string; value: OtlpAnyValue }[];
+        startTimeUnixNano?: string;
+        endTimeUnixNano?: string;
       }[];
     }[];
   }[];
@@ -61,8 +77,8 @@ interface OtlpTraceRequest {
 
 /**
  * Parse an OTLP/JSON `ExportTraceServiceRequest` fixture into a flat list of
- * spans (in document order), each with its attributes converted to the
- * `Attributes` record shape the SDK exposes via `ReadableSpan.attributes`.
+ * spans (in document order), each with its attributes and timing converted to
+ * the shape the SDK exposes via `ReadableSpan`.
  */
 const loadOtlpSpans = (fixturePath: string): OtlpSpan[] => {
   const req: OtlpTraceRequest = JSON.parse(readFileSync(fixturePath, "utf8"));
@@ -78,7 +94,12 @@ const loadOtlpSpans = (fixturePath: string): OtlpSpan[] => {
             attributes[attr.key] = value;
           }
         }
-        spans.push({ name: span.name, attributes });
+        spans.push({
+          name: span.name,
+          attributes,
+          startTime: unixNanoToHrTime(span.startTimeUnixNano ?? "0"),
+          endTime: unixNanoToHrTime(span.endTimeUnixNano ?? "0"),
+        });
       }
     }
   }
@@ -106,7 +127,22 @@ const discoverFixtures = (): {
   return out;
 };
 
-describe("extractAIMetadataFromAttributes", () => {
+/**
+ * Builds a fake `ReadableSpan` carrying just the fields
+ * {@link extractAIMetadataFromSpan} reads: attributes and timing. Defaults to
+ * a zero-length span (`latencyMs: 0`) unless explicit timing is given.
+ */
+const fakeSpan = (
+  attributes: Attributes,
+  timing?: { startTime: HrTime; endTime: HrTime },
+): ReadableSpan =>
+  ({
+    attributes,
+    startTime: timing?.startTime ?? [0, 0],
+    endTime: timing?.endTime ?? [0, 0],
+  }) as unknown as ReadableSpan;
+
+describe("extractAIMetadataFromSpan", () => {
   describe("captured OTLP fixtures", () => {
     const fixtures = discoverFixtures();
 
@@ -122,7 +158,7 @@ describe("extractAIMetadataFromAttributes", () => {
         // canonical metadata this extractor produces for it.
         const extracted = spans.map((span) => ({
           span: span.name,
-          metadata: extractAIMetadataFromAttributes(span.attributes),
+          metadata: extractAIMetadataFromSpan(fakeSpan(span.attributes, span)),
         }));
 
         await expect(
@@ -134,16 +170,18 @@ describe("extractAIMetadataFromAttributes", () => {
 
   test("maps allowlisted gen_ai keys to canonical fields", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.request.model": "gpt-4.1-nano",
-        "gen_ai.response.model": "gpt-4.1-nano-2025-04-14",
-        "gen_ai.provider.name": "openai",
-        "gen_ai.operation.name": "chat",
-        "gen_ai.response.id": "chatcmpl-abc",
-        "gen_ai.usage.input_tokens": 17,
-        "gen_ai.usage.output_tokens": 41,
-        "gen_ai.usage.total_tokens": 58,
-      }),
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.request.model": "gpt-4.1-nano",
+          "gen_ai.response.model": "gpt-4.1-nano-2025-04-14",
+          "gen_ai.provider.name": "openai",
+          "gen_ai.operation.name": "chat",
+          "gen_ai.response.id": "chatcmpl-abc",
+          "gen_ai.usage.input_tokens": 17,
+          "gen_ai.usage.output_tokens": 41,
+          "gen_ai.usage.total_tokens": 58,
+        }),
+      ),
     ).toEqual({
       requestModel: "gpt-4.1-nano",
       responseModel: "gpt-4.1-nano-2025-04-14",
@@ -153,19 +191,22 @@ describe("extractAIMetadataFromAttributes", () => {
       inputTokens: 17,
       outputTokens: 41,
       totalTokens: 58,
+      latencyMs: 0,
     });
   });
 
   describe("operationName", () => {
     test("reads gen_ai.operation.name", () => {
       expect(
-        extractAIMetadataFromAttributes({ "gen_ai.operation.name": "chat" }),
-      ).toEqual({ operationName: "chat" });
+        extractAIMetadataFromSpan(
+          fakeSpan({ "gen_ai.operation.name": "chat" }),
+        ),
+      ).toEqual({ operationName: "chat", latencyMs: 0 });
     });
 
     test("drops an empty gen_ai.operation.name", () => {
       expect(
-        extractAIMetadataFromAttributes({ "gen_ai.operation.name": "" }),
+        extractAIMetadataFromSpan(fakeSpan({ "gen_ai.operation.name": "" })),
       ).toEqual({});
     });
   });
@@ -173,49 +214,57 @@ describe("extractAIMetadataFromAttributes", () => {
   describe("provider", () => {
     test("reads the deprecated gen_ai.system when the canonical key is absent", () => {
       expect(
-        extractAIMetadataFromAttributes({ "gen_ai.system": "anthropic" }),
-      ).toEqual({ provider: "anthropic" });
+        extractAIMetadataFromSpan(fakeSpan({ "gen_ai.system": "anthropic" })),
+      ).toEqual({ provider: "anthropic", latencyMs: 0 });
     });
 
     test("prefers gen_ai.provider.name over the deprecated gen_ai.system", () => {
       expect(
-        extractAIMetadataFromAttributes({
-          "gen_ai.provider.name": "openai",
-          "gen_ai.system": "anthropic",
-        }),
-      ).toEqual({ provider: "openai" });
+        extractAIMetadataFromSpan(
+          fakeSpan({
+            "gen_ai.provider.name": "openai",
+            "gen_ai.system": "anthropic",
+          }),
+        ),
+      ).toEqual({ provider: "openai", latencyMs: 0 });
     });
 
     test("falls back to gen_ai.system when the canonical key is empty", () => {
       expect(
-        extractAIMetadataFromAttributes({
-          "gen_ai.provider.name": "",
-          "gen_ai.system": "anthropic",
-        }),
-      ).toEqual({ provider: "anthropic" });
+        extractAIMetadataFromSpan(
+          fakeSpan({
+            "gen_ai.provider.name": "",
+            "gen_ai.system": "anthropic",
+          }),
+        ),
+      ).toEqual({ provider: "anthropic", latencyMs: 0 });
     });
   });
 
   test("reports only the provider-supplied total; never derives one", () => {
     // With input + output but no total, the total field is simply absent.
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.usage.input_tokens": 17,
-        "gen_ai.usage.output_tokens": 41,
-      }),
-    ).toEqual({ inputTokens: 17, outputTokens: 41 });
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.usage.input_tokens": 17,
+          "gen_ai.usage.output_tokens": 41,
+        }),
+      ),
+    ).toEqual({ inputTokens: 17, outputTokens: 41, latencyMs: 0 });
   });
 
   test("extracts request parameters", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.request.temperature": 0.7,
-        "gen_ai.request.top_p": 0.9,
-        "gen_ai.request.max_tokens": 64,
-        "gen_ai.request.frequency_penalty": 0.2,
-        "gen_ai.request.presence_penalty": 0.1,
-        "gen_ai.request.seed": 42,
-      }),
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.request.temperature": 0.7,
+          "gen_ai.request.top_p": 0.9,
+          "gen_ai.request.max_tokens": 64,
+          "gen_ai.request.frequency_penalty": 0.2,
+          "gen_ai.request.presence_penalty": 0.1,
+          "gen_ai.request.seed": 42,
+        }),
+      ),
     ).toEqual({
       temperature: 0.7,
       topP: 0.9,
@@ -223,84 +272,122 @@ describe("extractAIMetadataFromAttributes", () => {
       frequencyPenalty: 0.2,
       presencePenalty: 0.1,
       seed: 42,
+      latencyMs: 0,
     });
   });
 
   test("keeps a zero-valued temperature rather than dropping it", () => {
     expect(
-      extractAIMetadataFromAttributes({ "gen_ai.request.temperature": 0 }),
-    ).toEqual({ temperature: 0 });
+      extractAIMetadataFromSpan(fakeSpan({ "gen_ai.request.temperature": 0 })),
+    ).toEqual({ temperature: 0, latencyMs: 0 });
   });
 
   test("extracts finish reasons as a list of strings", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.response.finish_reasons": ["stop", "tool_calls"],
-      }),
-    ).toEqual({ finishReasons: ["stop", "tool_calls"] });
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.response.finish_reasons": ["stop", "tool_calls"],
+        }),
+      ),
+    ).toEqual({ finishReasons: ["stop", "tool_calls"], latencyMs: 0 });
   });
 
   test("drops empty and non-string finish-reason entries", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.response.finish_reasons": ["", "stop"],
-      }),
-    ).toEqual({ finishReasons: ["stop"] });
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.response.finish_reasons": ["", "stop"],
+        }),
+      ),
+    ).toEqual({ finishReasons: ["stop"], latencyMs: 0 });
   });
 
   test("drops finish reasons when the list reduces to nothing", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.response.finish_reasons": [],
-      }),
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.response.finish_reasons": [],
+        }),
+      ),
     ).toEqual({});
   });
 
   test("ignores unmapped, content, and sensitive keys", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.tool.name": "search",
-        "gen_ai.prompt": "secret prompt",
-        "gen_ai.completion": "secret completion",
-        "gen_ai.input.messages": "secret",
-        "http.method": "GET",
-        "gen_ai.usage.input_tokens": 17,
-      }),
-    ).toEqual({ inputTokens: 17 });
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.tool.name": "search",
+          "gen_ai.prompt": "secret prompt",
+          "gen_ai.completion": "secret completion",
+          "gen_ai.input.messages": "secret",
+          "http.method": "GET",
+          "gen_ai.usage.input_tokens": 17,
+        }),
+      ),
+    ).toEqual({ inputTokens: 17, latencyMs: 0 });
   });
 
   test("coerces quoted-string int64 counts to numbers", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.usage.input_tokens": "17",
-      }),
-    ).toEqual({ inputTokens: 17 });
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.usage.input_tokens": "17",
+        }),
+      ),
+    ).toEqual({ inputTokens: 17, latencyMs: 0 });
   });
 
   test("drops empty-string text fields", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.request.model": "",
-      }),
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.request.model": "",
+        }),
+      ),
     ).toEqual({});
   });
 
   test("drops non-numeric values for numeric fields", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.usage.input_tokens": "not-a-number",
-        "gen_ai.usage.output_tokens": true,
-        "gen_ai.usage.total_tokens": "",
-      }),
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.usage.input_tokens": "not-a-number",
+          "gen_ai.usage.output_tokens": true,
+          "gen_ai.usage.total_tokens": "",
+        }),
+      ),
     ).toEqual({});
   });
 
   test("drops undefined values", () => {
     expect(
-      extractAIMetadataFromAttributes({
-        "gen_ai.request.model": undefined,
-      }),
+      extractAIMetadataFromSpan(
+        fakeSpan({
+          "gen_ai.request.model": undefined,
+        }),
+      ),
     ).toEqual({});
+  });
+
+  describe("latencyMs", () => {
+    test("computes the span's duration from its start/end time", () => {
+      expect(
+        extractAIMetadataFromSpan(
+          fakeSpan(
+            { "gen_ai.request.model": "gpt-4.1-nano" },
+            { startTime: [10, 0], endTime: [10, 500_000_000] },
+          ),
+        ),
+      ).toEqual({ requestModel: "gpt-4.1-nano", latencyMs: 500 });
+    });
+
+    test("is never populated on its own, without a recognised gen_ai attribute", () => {
+      expect(
+        extractAIMetadataFromSpan(
+          fakeSpan({}, { startTime: [0, 0], endTime: [10, 0] }),
+        ),
+      ).toEqual({});
+    });
   });
 });
 
@@ -359,6 +446,12 @@ describe("aggregate", () => {
     ).toEqual({ finishReasons: ["tool_calls"] });
   });
 
+  test("sums latencyMs across calls", () => {
+    expect(aggregate({ latencyMs: 100 }, { latencyMs: 50 })).toEqual({
+      latencyMs: 150,
+    });
+  });
+
   test("returns an empty object when both inputs are empty", () => {
     expect(aggregate({}, {})).toEqual({});
   });
@@ -386,6 +479,7 @@ describe("toInngestAIMetadataValues", () => {
         frequencyPenalty: 0.2,
         presencePenalty: 0.1,
         seed: 42,
+        latencyMs: 123,
       }),
     ).toEqual({
       request_model: "gpt-4o",
@@ -406,6 +500,7 @@ describe("toInngestAIMetadataValues", () => {
       frequency_penalty: 0.2,
       presence_penalty: 0.1,
       seed: 42,
+      latency_ms: 123,
     });
   });
 
@@ -415,19 +510,15 @@ describe("toInngestAIMetadataValues", () => {
 });
 
 describe("FIELD_SPECS", () => {
-  test("every source key is a gen_ai.* semantic convention attribute", () => {
-    // Guards the allowlist against typos: every source must live in the
-    // OpenTelemetry GenAI (`gen_ai.*`) namespace.
-    const nonGenAi = FIELD_SPECS.flatMap((spec) => [
-      spec.source,
-      ...(spec.fallbackSources ?? []),
-    ]).filter((source) => !source.startsWith("gen_ai."));
-
-    expect(nonGenAi).toEqual([]);
-  });
-
   test("each canonical field is mapped at most once", () => {
     const fields = FIELD_SPECS.map((spec) => spec.field);
     expect(new Set(fields).size).toBe(fields.length);
+  });
+
+  test("only latencyMs is optional", () => {
+    const optionalFields = FIELD_SPECS.filter((spec) => spec.optional).map(
+      (spec) => spec.field,
+    );
+    expect(optionalFields).toEqual(["latencyMs"]);
   });
 });

--- a/packages/inngest/src/components/execution/otel/aiExtractor.ts
+++ b/packages/inngest/src/components/execution/otel/aiExtractor.ts
@@ -1,4 +1,5 @@
 import type { Attributes } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
 /**
  * Canonical AI metadata extracted from a span's OpenTelemetry GenAI semantic
@@ -74,9 +75,12 @@ export interface AIMetadata {
   presencePenalty?: number;
   /** Sampling seed requested, when the emitter reports it. */
   seed?: number;
+
+  // Span-derived metadata (summed). These are not reported by the provider, but are derived from the span itself.
+  // They are stored raw as the emitter reports them.
+  latencyMs?: number; // The latency of the request in milliseconds.
 }
 
-type ValueType = "text" | "number" | "stringList";
 type MergeStrategy = "replace" | "sum";
 
 /**
@@ -100,56 +104,88 @@ type TextField = FieldsWithValue<string>;
 type NumberField = FieldsWithValue<number>;
 type StringListField = FieldsWithValue<string[]>;
 
-interface BaseFieldSpec {
-  /** The canonical (preferred) source `gen_ai.*` attribute key. */
-  source: string;
+interface FieldSpecBase {
   /**
-   * Deprecated source keys to read when {@link BaseFieldSpec.source} is absent
-   * or carries no usable value, in descending precedence. The preferred
-   * {@link BaseFieldSpec.source} always wins when it supplies a value; these are
-   * only consulted as fallbacks.
+   * When true, this field's `compute` only runs once at least one
+   * non-optional field has already produced a value for the same span (see
+   * {@link extractAIMetadataFromSpan}). Marks fields whose value is defined
+   * for virtually any span regardless of whether it's AI-related (e.g.
+   * `latencyMs`, derived from span timing that every span has), so a lone
+   * optional field can't make an unrelated span look like it carries AI
+   * metadata.
    */
-  fallbackSources?: readonly string[];
-  valueType: ValueType;
+  optional?: boolean;
   merge: MergeStrategy;
 }
 
-interface TextFieldSpec extends BaseFieldSpec {
+interface TextFieldSpec extends FieldSpecBase {
   /** The canonical {@link AIMetadata} field this populates. */
   field: TextField;
   valueType: "text";
   merge: "replace";
+  /** Derives this field's value from the span. */
+  compute: (span: ReadableSpan) => string | undefined;
 }
 
-interface NumberFieldSpec extends BaseFieldSpec {
+interface NumberFieldSpec extends FieldSpecBase {
   /** The canonical {@link AIMetadata} field this populates. */
   field: NumberField;
   valueType: "number";
+  /** Derives this field's value from the span. */
+  compute: (span: ReadableSpan) => number | undefined;
 }
 
-interface StringListFieldSpec extends BaseFieldSpec {
+interface StringListFieldSpec extends FieldSpecBase {
   /** The canonical {@link AIMetadata} field this populates. */
   field: StringListField;
   valueType: "stringList";
   merge: "replace";
+  /** Derives this field's value from the span. */
+  compute: (span: ReadableSpan) => string[] | undefined;
 }
 
 type FieldSpec = TextFieldSpec | NumberFieldSpec | StringListFieldSpec;
 
+/**
+ * Reads the first source (the canonical key, then any fallbacks in order)
+ * that yields a non-empty value, coercing non-string attribute values to
+ * text.
+ */
+function readTextAttribute(
+  attributes: Attributes,
+  sources: readonly string[],
+): string | undefined {
+  for (const source of sources) {
+    const value = attributes[source];
+    if (value === undefined) {
+      continue;
+    }
+
+    const text = typeof value === "string" ? value : String(value);
+    if (text !== "") {
+      return text;
+    }
+  }
+
+  return undefined;
+}
+
+/** A field read out of one of the span's `gen_ai.*` attributes, as text. */
 function textField(
   field: TextField,
   source: string,
   fallbackSources?: readonly string[],
 ): TextFieldSpec {
+  const sources = [source, ...(fallbackSources ?? [])];
   return {
     field,
-    source,
-    fallbackSources,
     valueType: "text",
     merge: "replace",
+    compute: (span) => readTextAttribute(span.attributes, sources),
   };
 }
 
+/** A field read out of one of the span's `gen_ai.*` attributes, as a number. */
 function numberField(
   field: NumberField,
   source: string,
@@ -157,21 +193,44 @@ function numberField(
 ): NumberFieldSpec {
   return {
     field,
-    source,
     valueType: "number",
     merge,
+    compute: (span) => parseNumericAttribute(span.attributes[source]),
   };
 }
 
+/**
+ * A field read out of one of the span's `gen_ai.*` attributes, as a list of
+ * strings.
+ */
 function stringListField(
   field: StringListField,
   source: string,
 ): StringListFieldSpec {
   return {
     field,
-    source,
     valueType: "stringList",
     merge: "replace",
+    compute: (span) => parseStringListAttribute(span.attributes[source]),
+  };
+}
+
+/**
+ * A field derived from the span itself via custom logic (e.g. timing, kind,
+ * status), rather than a direct attribute read.
+ */
+function computedNumberField(
+  field: NumberField,
+  merge: MergeStrategy,
+  compute: (span: ReadableSpan) => number | undefined,
+  optional?: boolean,
+): NumberFieldSpec {
+  return {
+    field,
+    valueType: "number",
+    merge,
+    compute,
+    optional,
   };
 }
 
@@ -216,6 +275,20 @@ export const FIELD_SPECS = [
   ),
   numberField("presencePenalty", "gen_ai.request.presence_penalty", "replace"),
   numberField("seed", "gen_ai.request.seed", "replace"),
+
+  // Span-derived metadata. Not reported by the provider, but computed from the
+  // span's own start/end time. Marked optional: it resolves for virtually any
+  // span, so it must not by itself make an unrelated span look AI-related.
+  computedNumberField(
+    "latencyMs",
+    "sum",
+    (span) => {
+      const startMs = span.startTime[0] * 1000 + span.startTime[1] / 1e6;
+      const endMs = span.endTime[0] * 1000 + span.endTime[1] / 1e6;
+      return endMs - startMs;
+    },
+    true,
+  ),
 ] as const satisfies readonly FieldSpec[];
 
 function parseNumericAttribute(value: unknown): number | undefined {
@@ -245,55 +318,62 @@ function parseStringListAttribute(value: unknown): string[] | undefined {
 }
 
 /**
- * Extracts {@link AIMetadata} from a span's attributes.
+ * Extracts {@link AIMetadata} from a span.
  *
- * Only the allowlisted {@link FIELD_SPECS} are read. Every other attribute is
- * ignored. Numeric fields accept numbers and quoted numeric strings and are
- * otherwise dropped, as OTLP/JSON may encode int64 as a quoted string. Text
- * fields are dropped when empty. String-list fields keep only non-empty string
- * entries and are dropped when none remain.
+ * Only the allowlisted {@link FIELD_SPECS} are read; every other attribute or
+ * span field is ignored. Each spec derives its value from the span via its
+ * `compute` function — most read a `gen_ai.*` attribute (numeric fields
+ * accept numbers and quoted numeric strings, as OTLP/JSON may encode int64 as
+ * a quoted string; text and string-list fields are dropped when empty), but a
+ * field can define arbitrary custom logic instead (e.g. `latencyMs`, derived
+ * from the span's start/end time).
  *
- * Returns an empty object for spans carrying no recognised `gen_ai.*`
- * attributes.
+ * Fields marked {@link FieldSpecBase.optional} only run once at least one
+ * non-optional field has already produced a value, so a span carrying no
+ * recognised `gen_ai.*` attributes still yields an empty object rather than
+ * picking up e.g. `latencyMs` on its own.
  *
- * @param attributes - The span attributes, as exposed by
- * `ReadableSpan.attributes`.
+ * @param span - The span, as exposed by the OTel SDK's `ReadableSpan`.
  */
-export const extractAIMetadataFromAttributes = (
-  attributes: Attributes,
-): AIMetadata => {
+export const extractAIMetadataFromSpan = (span: ReadableSpan): AIMetadata => {
   const metadata: AIMetadata = {};
 
+  const applySpec = (spec: FieldSpec): void => {
+    if (spec.valueType === "text") {
+      const text = spec.compute(span);
+      if (text !== undefined && text !== "") {
+        metadata[spec.field] = text;
+      }
+    } else if (spec.valueType === "stringList") {
+      const list = spec.compute(span);
+      if (list !== undefined && list.length > 0) {
+        metadata[spec.field] = list;
+      }
+    } else {
+      const num = spec.compute(span);
+      if (num !== undefined && Number.isFinite(num)) {
+        metadata[spec.field] = num;
+      }
+    }
+  };
+
   for (const spec of FIELD_SPECS) {
-    // Read the canonical key first, then any deprecated fallbacks in order,
-    // taking the first that yields a usable value.
-    const sources = [spec.source, ...(spec.fallbackSources ?? [])];
+    if (!spec.optional) {
+      applySpec(spec);
+    }
+  }
 
-    for (const source of sources) {
-      const value = attributes[source];
-      if (value === undefined) {
-        continue;
-      }
+  // No non-optional field matched, so this isn't a span we recognise as
+  // AI-related. Skip optional fields entirely rather than let one (e.g.
+  // latencyMs, which resolves for virtually every span) make an unrelated
+  // span look like it carries AI metadata.
+  if (Object.keys(metadata).length === 0) {
+    return metadata;
+  }
 
-      if (spec.valueType === "text") {
-        const text = typeof value === "string" ? value : String(value);
-        if (text !== "") {
-          metadata[spec.field] = text;
-          break;
-        }
-      } else if (spec.valueType === "stringList") {
-        const list = parseStringListAttribute(value);
-        if (list !== undefined) {
-          metadata[spec.field] = list;
-          break;
-        }
-      } else {
-        const num = parseNumericAttribute(value);
-        if (num !== undefined) {
-          metadata[spec.field] = num;
-          break;
-        }
-      }
+  for (const spec of FIELD_SPECS) {
+    if (spec.optional) {
+      applySpec(spec);
     }
   }
 

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -91,7 +91,13 @@ describe("InngestMetadataSpanProcessor", () => {
       "gen_ai.usage.input_tokens": 42,
     });
 
-    expect(pushed).toEqual([{ requestModel: "gpt-4.1-nano", inputTokens: 42 }]);
+    expect(pushed).toEqual([
+      {
+        requestModel: "gpt-4.1-nano",
+        inputTokens: 42,
+        latencyMs: expect.any(Number),
+      },
+    ]);
   });
 
   test("captures only allowlisted fields; content never reaches the sink", () => {
@@ -107,7 +113,13 @@ describe("InngestMetadataSpanProcessor", () => {
     });
 
     // Only the allowlisted signal reaches the sink; content is never captured.
-    expect(pushed).toEqual([{ requestModel: "gpt-4.1-nano", inputTokens: 42 }]);
+    expect(pushed).toEqual([
+      {
+        requestModel: "gpt-4.1-nano",
+        inputTokens: 42,
+        latencyMs: expect.any(Number),
+      },
+    ]);
   });
 
   test("does not call the sink when a span carries only content attributes", () => {
@@ -136,8 +148,16 @@ describe("InngestMetadataSpanProcessor", () => {
     });
 
     expect(pushed).toEqual([
-      { requestModel: "gpt-4.1-nano", inputTokens: 10 },
-      { requestModel: "gpt-4.1-mini", inputTokens: 5 },
+      {
+        requestModel: "gpt-4.1-nano",
+        inputTokens: 10,
+        latencyMs: expect.any(Number),
+      },
+      {
+        requestModel: "gpt-4.1-mini",
+        inputTokens: 5,
+        latencyMs: expect.any(Number),
+      },
     ]);
   });
 
@@ -165,7 +185,13 @@ describe("InngestMetadataSpanProcessor", () => {
     });
     mid.end();
 
-    expect(pushed).toEqual([{ requestModel: "gpt-4.1-nano", inputTokens: 7 }]);
+    expect(pushed).toEqual([
+      {
+        requestModel: "gpt-4.1-nano",
+        inputTokens: 7,
+        latencyMs: expect.any(Number),
+      },
+    ]);
   });
 
   test("ignores spans that are not part of a declared run", () => {

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -5,10 +5,7 @@ import type {
 } from "@opentelemetry/sdk-trace-base";
 import Debug from "debug";
 import { isRecord } from "../../../helpers/types.ts";
-import {
-  type AIMetadata,
-  extractAIMetadataFromAttributes,
-} from "./aiExtractor.ts";
+import { type AIMetadata, extractAIMetadataFromSpan } from "./aiExtractor.ts";
 import { debugPrefix } from "./consts.ts";
 
 const processorDevDebug = Debug(`${debugPrefix}:InngestMetadataSpanProcessor`);
@@ -277,7 +274,7 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
         return;
       }
 
-      const aiMetadata = extractAIMetadataFromAttributes(span.attributes);
+      const aiMetadata = extractAIMetadataFromSpan(span);
       if (Object.keys(aiMetadata).length === 0) {
         return;
       }

--- a/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/cache_messages.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/cache_messages.otlp.json.snap
@@ -14,7 +14,8 @@
       "totalTokens": 17,
       "cacheReadTokens": 0,
       "cacheCreationTokens": 2463,
-      "maxTokens": 16
+      "maxTokens": 16,
+      "latencyMs": 1224.886962890625
     }
   },
   {
@@ -32,7 +33,8 @@
       "totalTokens": 7,
       "cacheReadTokens": 2463,
       "cacheCreationTokens": 10,
-      "maxTokens": 16
+      "maxTokens": 16,
+      "latencyMs": 1118.367919921875
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.snap
@@ -14,7 +14,8 @@
       "totalTokens": 502,
       "cacheReadTokens": 0,
       "cacheCreationTokens": 0,
-      "maxTokens": 4096
+      "maxTokens": 4096,
+      "latencyMs": 6643.09375
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_langsmith_otel/basic_responses.otlp.json.snap
@@ -9,7 +9,8 @@
       "responseId": "resp_0b898006b71f980e006a30976c7ae8819a9f9dfe79dd711f39",
       "inputTokens": 17,
       "outputTokens": 46,
-      "totalTokens": 63
+      "totalTokens": 63,
+      "latencyMs": 794
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/embeddings.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/embeddings.otlp.json.snap
@@ -6,7 +6,8 @@
       "responseModel": "text-embedding-3-small",
       "provider": "openai",
       "operationName": "embeddings",
-      "inputTokens": 10
+      "inputTokens": 10,
+      "latencyMs": 393.735107421875
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/params_chat.otlp.json.snap
@@ -16,7 +16,8 @@
       "topP": 0.9,
       "maxTokens": 64,
       "frequencyPenalty": 0.2,
-      "presencePenalty": 0.1
+      "presencePenalty": 0.1,
+      "latencyMs": 1286.23828125
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/stream_chat.otlp.json.snap
@@ -11,7 +11,8 @@
         "stop"
       ],
       "inputTokens": 11,
-      "outputTokens": 10
+      "outputTokens": 10,
+      "latencyMs": 592.650146484375
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_official/tools_chat.otlp.json.snap
@@ -11,7 +11,8 @@
         "tool_calls"
       ],
       "inputTokens": 56,
-      "outputTokens": 30
+      "outputTokens": 30,
+      "latencyMs": 984.809814453125
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/basic_responses.otlp.json.snap
@@ -12,7 +12,8 @@
       ],
       "inputTokens": 17,
       "outputTokens": 43,
-      "totalTokens": 60
+      "totalTokens": 60,
+      "latencyMs": 1115.421142578125
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/params_chat.otlp.json.snap
@@ -17,7 +17,8 @@
       "topP": 0.9,
       "maxTokens": 64,
       "frequencyPenalty": 0.2,
-      "presencePenalty": 0.1
+      "presencePenalty": 0.1,
+      "latencyMs": 680.310302734375
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/stream_chat.otlp.json.snap
@@ -9,7 +9,8 @@
       "responseId": "chatcmpl-DrBrdQ2FLoMqEewTueUxqUnAaRTTA",
       "finishReasons": [
         "stop"
-      ]
+      ],
+      "latencyMs": 263.97802734375
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_otel_traceloop/tools_chat.otlp.json.snap
@@ -12,7 +12,8 @@
       ],
       "inputTokens": 56,
       "outputTokens": 14,
-      "totalTokens": 70
+      "totalTokens": 70,
+      "latencyMs": 711.927001953125
     }
   }
 ]

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/basic_responses.otlp.json.snap
@@ -10,7 +10,8 @@
         "stop"
       ],
       "inputTokens": 17,
-      "outputTokens": 40
+      "outputTokens": 40,
+      "latencyMs": 944.0263671875
     }
   },
   {

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/params_chat.otlp.json.snap
@@ -15,7 +15,8 @@
       "topP": 0.9,
       "maxTokens": 64,
       "frequencyPenalty": 0.2,
-      "presencePenalty": 0.1
+      "presencePenalty": 0.1,
+      "latencyMs": 434.149169921875
     }
   },
   {

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/stream_chat.otlp.json.snap
@@ -10,7 +10,8 @@
         "stop"
       ],
       "inputTokens": 11,
-      "outputTokens": 14
+      "outputTokens": 14,
+      "latencyMs": 283.82470703125
     }
   },
   {

--- a/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
+++ b/packages/inngest/src/components/execution/otel/testdata/openai_vercel_aisdk/tools_chat.otlp.json.snap
@@ -10,7 +10,8 @@
         "tool-calls"
       ],
       "inputTokens": 56,
-      "outputTokens": 30
+      "outputTokens": 30,
+      "latencyMs": 575.1591796875
     }
   },
   {

--- a/packages/inngest/src/test/integration/traces/stepMetadata.test.ts
+++ b/packages/inngest/src/test/integration/traces/stepMetadata.test.ts
@@ -30,7 +30,8 @@ const testFileName = testNameFromFileUrl(import.meta.url);
 // The fields the extractor lifts from `simulateOpenAICall`'s span, mapped to
 // the server's snake_case `inngest.ai` schema. Content attributes are never
 // extracted, and `total_tokens` is absent because the span carries no provider
-// total (we never derive one).
+// total (we never derive one). `latency_ms` is derived from span timing, so
+// its exact value is non-deterministic and only asserted to be a number.
 const expectedAIMetadata = {
   kind: "inngest.ai",
   scope: "step",
@@ -41,6 +42,7 @@ const expectedAIMetadata = {
     provider: "openai",
     input_tokens: 18,
     output_tokens: 39,
+    latency_ms: expect.any(Number),
   },
 };
 


### PR DESCRIPTION
## Summary
<!-- Succinctly describe your change, providing context, what you've changed, and why. -->

This extracts latency from the span start/end times for AI calls as AI metadata. Also refactors the field specs to be able to reference non-attribute span data. Multiple AI spans in the same step are summed.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
