### PR TITLE
fix: step.ai.wrap reported as unknown step type to middleware

### DIFF
--- a/.changeset/chubby-streets-sip.md
+++ b/.changeset/chubby-streets-sip.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix errant `step.ai.wrap` warning

--- a/packages/inngest/src/components/middleware/utils.test.ts
+++ b/packages/inngest/src/components/middleware/utils.test.ts
@@ -21,6 +21,16 @@ describe("stepTypeFromOpCode", () => {
     ).toBe("run");
   });
 
+  test("StepPlanned with type 'step.ai.wrap' returns 'ai.wrap'", () => {
+    expect(
+      stepTypeFromOpCode(
+        StepOpCode.StepPlanned,
+        { type: "step.ai.wrap" },
+        logger,
+      ),
+    ).toBe("ai.wrap");
+  });
+
   test("StepPlanned with type 'step.sendEvent' returns 'sendEvent'", () => {
     expect(
       stepTypeFromOpCode(
@@ -85,16 +95,6 @@ describe("stepTypeFromOpCode", () => {
         logger,
       ),
     ).toBe("ai.infer");
-  });
-
-  test("AiGateway with type 'step.ai.wrap' returns 'ai.wrap'", () => {
-    expect(
-      stepTypeFromOpCode(
-        StepOpCode.AiGateway,
-        { type: "step.ai.wrap" },
-        logger,
-      ),
-    ).toBe("ai.wrap");
   });
 
   test("AiGateway with unknown type returns 'unknown'", () => {

--- a/packages/inngest/src/components/middleware/utils.ts
+++ b/packages/inngest/src/components/middleware/utils.ts
@@ -93,9 +93,6 @@ export function stepTypeFromOpCode(
     if (opts?.type === "step.ai.infer") {
       return "ai.infer";
     }
-    if (opts?.type === "step.ai.wrap") {
-      return "ai.wrap";
-    }
   } else if (op === StepOpCode.Gateway) {
     return "fetch";
   } else if (op === StepOpCode.InvokeFunction) {
@@ -103,6 +100,9 @@ export function stepTypeFromOpCode(
   } else if (op === StepOpCode.StepPlanned) {
     if (opts?.type === undefined) {
       return "run";
+    }
+    if (opts?.type === "step.ai.wrap") {
+      return "ai.wrap";
     }
     if (opts?.type === "step.sendEvent") {
       return "sendEvent";


### PR DESCRIPTION
## Summary
Fix a bug where `step.ai.wrap` reports as an unknown step type.

<img width="490" height="261" alt="Screenshot 2026-07-23 at 12 32 27 PM" src="https://github.com/user-attachments/assets/eae7f2b5-4f5e-4e84-a725-4e731fdbb063" />

## Checklist

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
[EXE-2062: TS SDK: step.ai.wrap logs "Unknown step type" warning and reports stepType "unknown" to middleware](https://linear.app/inngest/issue/EXE-2062/ts-sdk-stepaiwrap-logs-unknown-step-type-warning-and-reports-steptype)
