### PR TITLE
fix: lazily initialize execution streams

### DIFF
--- a/.changeset/lazy-stream-tools.md
+++ b/.changeset/lazy-stream-tools.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Create execution streams lazily to avoid unused Web Streams allocations.

--- a/packages/inngest/src/components/StreamTools.test.ts
+++ b/packages/inngest/src/components/StreamTools.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { Stream } from "./StreamTools.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function trackTransformStreamConstruction() {
+  const OriginalTransformStream = globalThis.TransformStream;
+  const constructed = vi.fn();
+
+  class TrackedTransformStream extends OriginalTransformStream {
+    constructor(
+      ...args: ConstructorParameters<typeof OriginalTransformStream>
+    ) {
+      constructed();
+      super(...args);
+    }
+  }
+
+  vi.stubGlobal("TransformStream", TrackedTransformStream);
+  return constructed;
+}
 
 async function drain(s: Stream): Promise<string> {
   const reader = s.readable.getReader();
@@ -15,16 +37,51 @@ async function drain(s: Stream): Promise<string> {
   return result;
 }
 
+describe("Stream lifecycle", () => {
+  test("creates the underlying stream only when readable is accessed", async () => {
+    const transformStream = trackTransformStreamConstruction();
+    const s = new Stream();
+
+    s.end();
+
+    expect(transformStream).not.toHaveBeenCalled();
+    await expect(drain(s)).resolves.toBe("");
+    expect(transformStream).toHaveBeenCalledTimes(1);
+  });
+
+  test("delivers a terminal event when readable is accessed after close", async () => {
+    const transformStream = trackTransformStreamConstruction();
+    const s = new Stream();
+
+    s.closeSucceeded({
+      body: '"done"',
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(transformStream).not.toHaveBeenCalled();
+    const raw = await drain(s);
+
+    expect(transformStream).toHaveBeenCalledTimes(1);
+    expect(raw).toContain("event: inngest.response");
+    expect(raw).toContain('"status":"succeeded"');
+    expect(raw).toContain('"body":"\\"done\\""');
+  });
+});
+
 describe("Stream.push", () => {
   test("writes SSE stream events", async () => {
+    const transformStream = trackTransformStreamConstruction();
     const s = new Stream();
 
     s.push("hello");
     s.push("world");
     s.end();
 
+    expect(transformStream).toHaveBeenCalledTimes(1);
     const raw = await drain(s);
 
+    expect(transformStream).toHaveBeenCalledTimes(1);
     expect(raw).toContain("event: inngest.stream");
     expect(raw).toContain('"hello"');
     expect(raw).toContain('"world"');

--- a/packages/inngest/src/components/StreamTools.ts
+++ b/packages/inngest/src/components/StreamTools.ts
@@ -55,12 +55,15 @@ export interface StreamTools {
  * @internal
  */
 export class Stream implements StreamTools {
-  private transform: TransformStream<Uint8Array, Uint8Array>;
-  private writer: WritableStreamDefaultWriter<Uint8Array>;
+  private stream?: {
+    transform: TransformStream<Uint8Array, Uint8Array>;
+    writer: WritableStreamDefaultWriter<Uint8Array>;
+  };
   private encoder = new TextEncoder();
   private _activated = false;
   private _errored = false;
   private writeChain: Promise<void> = Promise.resolve();
+  private pendingClose: string | null | undefined;
 
   /**
    * Optional callback invoked the first time `push` or `pipe` is called.
@@ -82,6 +85,15 @@ export class Stream implements StreamTools {
   }) {
     this.onActivated = opts?.onActivated;
     this.onWriteError = opts?.onWriteError;
+  }
+
+  private ensureStream(): {
+    transform: TransformStream<Uint8Array, Uint8Array>;
+    writer: WritableStreamDefaultWriter<Uint8Array>;
+  } {
+    if (this.stream) {
+      return this.stream;
+    }
 
     let readableStrategy: QueuingStrategy<Uint8Array> | undefined;
 
@@ -98,12 +110,23 @@ export class Stream implements StreamTools {
       // Leave `readableStrategy` undefined
     }
 
-    this.transform = new TransformStream<Uint8Array, Uint8Array>(
+    const transform = new TransformStream<Uint8Array, Uint8Array>(
       undefined,
       undefined,
       readableStrategy,
     );
-    this.writer = this.transform.writable.getWriter();
+    this.stream = {
+      transform,
+      writer: transform.writable.getWriter(),
+    };
+
+    if (this.pendingClose !== undefined) {
+      const finalEvent = this.pendingClose ?? undefined;
+      this.pendingClose = undefined;
+      this.scheduleClose(finalEvent);
+    }
+
+    return this.stream;
   }
 
   /**
@@ -118,7 +141,7 @@ export class Stream implements StreamTools {
    * HTTP response) read SSE events from here.
    */
   get readable(): ReadableStream<Uint8Array> {
-    return this.transform.readable;
+    return this.ensureStream().transform.readable;
   }
 
   /**
@@ -131,6 +154,7 @@ export class Stream implements StreamTools {
 
   private activate(): void {
     if (!this._activated) {
+      this.ensureStream();
       this._activated = true;
       this.onActivated?.();
     }
@@ -140,7 +164,7 @@ export class Stream implements StreamTools {
    * Encode and write an SSE event string to the underlying writer.
    */
   private writeEncoded(sseEvent: string): Promise<void> {
-    return this.writer.write(this.encoder.encode(sseEvent));
+    return this.ensureStream().writer.write(this.encoder.encode(sseEvent));
   }
 
   /**
@@ -149,6 +173,7 @@ export class Stream implements StreamTools {
   private enqueue(sseEvent: string): void {
     if (this._errored) return;
 
+    this.ensureStream();
     this.writeChain = this.writeChain
       .then(() => this.writeEncoded(sseEvent))
       .catch((err) => {
@@ -302,12 +327,23 @@ export class Stream implements StreamTools {
    * Optionally write a final SSE event, then close the writer.
    */
   private closeWriter(finalEvent?: string): void {
+    if (!this.stream) {
+      if (this.pendingClose === undefined) {
+        this.pendingClose = finalEvent ?? null;
+      }
+      return;
+    }
+
+    this.scheduleClose(finalEvent);
+  }
+
+  private scheduleClose(finalEvent?: string): void {
     this.writeChain = this.writeChain
       .then(async () => {
         if (finalEvent) {
           await this.writeEncoded(finalEvent);
         }
-        await this.writer.close();
+        await this.ensureStream().writer.close();
       })
       .catch((err) => {
         this.onWriteError?.(err);

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -24,7 +24,25 @@ describe("Execution engine checkpoint retry behavior", () => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
+
+  const trackTransformStreamConstruction = () => {
+    const OriginalTransformStream = globalThis.TransformStream;
+    const constructed = vi.fn();
+
+    class TrackedTransformStream extends OriginalTransformStream {
+      constructor(
+        ...args: ConstructorParameters<typeof OriginalTransformStream>
+      ) {
+        constructed();
+        super(...args);
+      }
+    }
+
+    vi.stubGlobal("TransformStream", TrackedTransformStream);
+    return constructed;
+  };
 
   /**
    * Helper to advance timers through all retry delays.
@@ -820,6 +838,31 @@ describe("Execution engine checkpoint retry behavior", () => {
   });
 
   describe("StepMode.Sync with steps", () => {
+    test("does not allocate a stream for non-streaming executions", async () => {
+      const transformStream = trackTransformStreamConstruction();
+
+      const { result } = await runExecution({
+        mockApi: {
+          checkpointNewRun: vi.fn().mockResolvedValue({
+            data: {
+              app_id: "app-123",
+              fn_id: "fn-456",
+              token: "token-789",
+            },
+          }),
+          checkpointSteps: vi.fn().mockResolvedValue(undefined),
+        },
+        handler: async ({ step }) => {
+          await step.run("step-1", () => "result-1");
+          return "done";
+        },
+        stepMode: StepMode.Sync,
+      });
+
+      expect(result.type).toBe("function-resolved");
+      expect(transformStream).not.toHaveBeenCalled();
+    });
+
     test("checkpoints steps via checkpointSteps after initial run", async () => {
       const mockCheckpointNewRun = vi.fn().mockResolvedValue({
         data: { app_id: "app-123", fn_id: "fn-456", token: "token-789" },

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -1763,7 +1763,9 @@ class InngestExecutionEngine
         await this.middlewareManager.onStepComplete(stepInfo, serverData);
 
         // Emit inngest.commit — step data is finalized.
-        this.streamTools.commit(hashedId);
+        if (this.streamTools.activated) {
+          this.streamTools.commit(hashedId);
+        }
 
         return {
           ...outgoingOp,
@@ -1909,7 +1911,9 @@ class InngestExecutionEngine
     );
 
     // Step's stream should be rolled back
-    this.streamTools.rollback(outgoingOp.id);
+    if (this.streamTools.activated) {
+      this.streamTools.rollback(outgoingOp.id);
+    }
 
     // `transformOutput` runs `retriability(error)` then serializes — pre-serializing
     // here drops `RetryAfterError.retryAfter` (custom property) and breaks the check.


### PR DESCRIPTION
## Summary

- lazily create the `TransformStream` and writer when streaming is activated or `readable` is requested
- preserve terminal events when a durable response closes before its readable stream is consumed
- skip engine commit and rollback stream events until user streaming is active

This removes the per-execution Web Streams allocation for executions that do not stream while preserving activated and SSE response behavior.

## Checklist

- [x] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Internal allocation fix with no API change.
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Testing

- `pnpm --filter inngest test` (167 files, 4,927 passed, 2 skipped)
- `pnpm --filter inngest test:types`
- `pnpm --filter inngest exec tsc -p tsconfig.build.json`
- `pnpm --filter inngest exec biome check src/components/StreamTools.ts src/components/StreamTools.test.ts src/components/execution/engine.ts src/components/execution/engine.test.ts`

The package-wide Biome command is blocked by CRLF formatting in the Windows checkout; the changed files pass targeted Biome checks. The full build reaches and passes TypeScript compilation, but bundling cannot start because the filtered install omitted Rolldown's Windows optional native binding.

## Related

- Fixes #1624
