### PR TITLE
fix: wrapStep middleware hook sometimes skipped for parallel steps

### DIFF
--- a/.changeset/rotten-snails-punch.md
+++ b/.changeset/rotten-snails-punch.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix wrapStep middleware hook sometimes skipped for parallel steps

--- a/packages/inngest/src/components/execution/als.mocked.test.ts
+++ b/packages/inngest/src/components/execution/als.mocked.test.ts
@@ -86,6 +86,28 @@ describe("getAsyncCtx", () => {
     const store = await externalP;
     expect(store).toBeUndefined();
   });
+
+  test("should execute step tooling if node:async_hooks is not supported", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { Inngest } = await import("../../index.ts");
+
+    const inngest = new Inngest({ id: "test" });
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "" }] },
+      async ({ step }) => {
+        return await step.run("step", () => "done");
+      },
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: intentional
+    const t = new InngestTestEngine({ function: fn as any });
+
+    const { result, error } = await t.execute();
+
+    expect(error).toBeUndefined();
+    expect(result).toBe("done");
+  });
 });
 
 describe("getAsyncCtxSync", () => {

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -168,6 +168,15 @@ export const getAsyncCtxSync = (): AsyncContext | undefined => {
   return getCache().resolved?.getStore();
 };
 
+export function mustGetAsyncContextSync(): AsyncContext {
+  const asyncContext = getAsyncCtxSync();
+  if (!asyncContext) {
+    throw new Error("Runtime does not support AsyncLocalStorage");
+  }
+
+  return asyncContext;
+}
+
 /**
  * Run a function within a specific async context if AsyncLocalStorage has
  * already been initialized.

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -168,15 +168,6 @@ export const getAsyncCtxSync = (): AsyncContext | undefined => {
   return getCache().resolved?.getStore();
 };
 
-export function mustGetAsyncContextSync(): AsyncContext {
-  const asyncContext = getAsyncCtxSync();
-  if (!asyncContext) {
-    throw new Error("Runtime does not support AsyncLocalStorage");
-  }
-
-  return asyncContext;
-}
-
 /**
  * Run a function within a specific async context if AsyncLocalStorage has
  * already been initialized.

--- a/packages/inngest/src/components/execution/als.ts
+++ b/packages/inngest/src/components/execution/als.ts
@@ -169,6 +169,19 @@ export const getAsyncCtxSync = (): AsyncContext | undefined => {
 };
 
 /**
+ * Run a function within a specific async context if AsyncLocalStorage has
+ * already been initialized.
+ */
+export const runWithAsyncCtx = <R>(store: AsyncContext, fn: () => R): R => {
+  const als = getCache().resolved;
+  if (!als) {
+    return fn();
+  }
+
+  return als.run(store, fn);
+};
+
+/**
  * Get a singleton instance of `AsyncLocalStorage` used to store and retrieve
  * async context for the current execution.
  */

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -82,8 +82,8 @@ import { Stream } from "../StreamTools.ts";
 import { validateEvents } from "../triggers/utils.js";
 import {
   getAsyncCtx,
+  getAsyncCtxSync,
   getAsyncLocalStorage,
-  mustGetAsyncContextSync,
   runWithAsyncCtx,
 } from "./als.ts";
 import {
@@ -2493,7 +2493,7 @@ class InngestExecutionEngine
         fnArgs = [...args.slice(0, 2), ...stepInfo.input];
       }
 
-      const asyncContext = mustGetAsyncContextSync();
+      const asyncContext = getAsyncCtxSync();
 
       const step: FoundStep = {
         ...opId,
@@ -2625,6 +2625,10 @@ class InngestExecutionEngine
 
             return true;
           };
+
+          if (!asyncContext) {
+            return runHandle();
+          }
 
           return runWithAsyncCtx(asyncContext, runHandle);
         },

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -80,7 +80,12 @@ import { RetryAfterError } from "../RetryAfterError.ts";
 import { StepError } from "../StepError.ts";
 import { Stream } from "../StreamTools.ts";
 import { validateEvents } from "../triggers/utils.js";
-import { getAsyncCtx, getAsyncLocalStorage } from "./als.ts";
+import {
+  getAsyncCtx,
+  getAsyncLocalStorage,
+  mustGetAsyncContextSync,
+  runWithAsyncCtx,
+} from "./als.ts";
 import {
   type BasicFoundStep,
   type ExecutionResult,
@@ -851,12 +856,10 @@ class InngestExecutionEngine
       return transformResult;
     };
 
-    const maybeReturnNewSteps = async (): Promise<
-      ExecutionResult | undefined
-    > => {
-      const newSteps = await this.filterNewSteps(
-        Array.from(this.state.steps.values()),
-      );
+    const maybeReturnNewSteps = async (
+      foundSteps = Array.from(this.state.steps.values()),
+    ): Promise<ExecutionResult | undefined> => {
+      const newSteps = await this.filterNewSteps(foundSteps);
 
       const allSteps: OutgoingOp[] = [
         ...(newSteps ?? []),
@@ -1296,7 +1299,7 @@ class InngestExecutionEngine
       "steps-found": async ({ steps }) => {
         const stepResult = await this.tryExecuteStep(steps);
         if (!stepResult) {
-          return maybeReturnNewSteps();
+          return maybeReturnNewSteps(steps);
         }
 
         // If the step's handler buffered any lazy ops (e.g. `defer` calls),
@@ -1513,7 +1516,7 @@ class InngestExecutionEngine
               }
             }
 
-            return maybeReturnNewSteps();
+            return maybeReturnNewSteps(steps);
           }
 
           // If we have stepsToResume, resume as many as possible and resume execution
@@ -2490,6 +2493,8 @@ class InngestExecutionEngine
         fnArgs = [...args.slice(0, 2), ...stepInfo.input];
       }
 
+      const asyncContext = mustGetAsyncContextSync();
+
       const step: FoundStep = {
         ...opId,
         opts: { ...opId.opts, ...extraOpts },
@@ -2512,112 +2517,116 @@ class InngestExecutionEngine
         },
 
         handle: () => {
-          if (step.handled) {
-            return false;
-          }
+          const runHandle = () => {
+            if (step.handled) {
+              return false;
+            }
 
-          this.devDebug(`handling step "${hashedId}"`);
+            this.devDebug(`handling step "${hashedId}"`);
 
-          step.handled = true;
+            step.handled = true;
 
-          // Refetch step state because it may have been changed since we found
-          // the step. This could be due to checkpointing, where we run this
-          // live and then return to the function.
-          const result = this.state.stepState[hashedId];
+            // Refetch step state because it may have been changed since we found
+            // the step. This could be due to checkpointing, where we run this
+            // live and then return to the function.
+            const result = this.state.stepState[hashedId];
 
-          if (step.fulfilled && result) {
-            result.fulfilled = true;
+            if (step.fulfilled && result) {
+              result.fulfilled = true;
 
-            // For some execution scenarios such as testing, `data`, `error`,
-            // and `input` may be `Promises`. This could also be the case for
-            // future middleware applications. For this reason, we'll make sure
-            // the values are fully resolved before continuing.
-            void Promise.all([result.data, result.error, result.input]).then(
-              async () => {
-                // If the wrapStep chain already ran during discovery in this
-                // same request (checkpointing), reuse its result instead of
-                // firing wrappedHandler() again. This prevents middleware from
-                // seeing a duplicate wrapStep call per step per request.
-                if (step.transformedResultPromise) {
-                  // Resolve the memoization deferred so wrapStep's next()
-                  // unblocks. The step data is now confirmed memoized.
-                  if (step.memoizationDeferred) {
-                    if (typeof result.data !== "undefined") {
-                      step.memoizationDeferred.resolve(await result.data);
-                    } else {
-                      const stepError = new StepError(opId.id, result.error);
-                      this.state.recentlyRejectedStepError = stepError;
-                      step.memoizationDeferred.reject(stepError);
+              // For some execution scenarios such as testing, `data`, `error`,
+              // and `input` may be `Promises`. This could also be the case for
+              // future middleware applications. For this reason, we'll make sure
+              // the values are fully resolved before continuing.
+              void Promise.all([result.data, result.error, result.input]).then(
+                async () => {
+                  // If the wrapStep chain already ran during discovery in this
+                  // same request (checkpointing), reuse its result instead of
+                  // firing wrappedHandler() again. This prevents middleware from
+                  // seeing a duplicate wrapStep call per step per request.
+                  if (step.transformedResultPromise) {
+                    // Resolve the memoization deferred so wrapStep's next()
+                    // unblocks. The step data is now confirmed memoized.
+                    if (step.memoizationDeferred) {
+                      if (typeof result.data !== "undefined") {
+                        step.memoizationDeferred.resolve(await result.data);
+                      } else {
+                        const stepError = new StepError(opId.id, result.error);
+                        this.state.recentlyRejectedStepError = stepError;
+                        step.memoizationDeferred.reject(stepError);
+                      }
                     }
+
+                    step.transformedResultPromise.then(resolve, reject);
+                    return;
                   }
 
-                  step.transformedResultPromise.then(resolve, reject);
-                  return;
-                }
+                  // The wrapStep chain is about to fire again to resolve the
+                  // step promise through middleware (e.g. deserialization).
+                  // Mark the step as memoized so middleware can distinguish
+                  // this from the original execution call.
+                  //
+                  // This need for this change was discovered when checkpointing +
+                  // middleware's "double `wrapStep` call" behavior had `memoized:
+                  // false` on the 2nd call
+                  step.middleware.stepInfo.memoized = true;
 
-                // The wrapStep chain is about to fire again to resolve the
-                // step promise through middleware (e.g. deserialization).
-                // Mark the step as memoized so middleware can distinguish
-                // this from the original execution call.
-                //
-                // This need for this change was discovered when checkpointing +
-                // middleware's "double `wrapStep` call" behavior had `memoized:
-                // false` on the 2nd call
-                step.middleware.stepInfo.memoized = true;
+                  if (typeof result.data !== "undefined") {
+                    // Validate waitForEvent results against the schema if present
+                    // Skip validation if result.data is null (timeout case)
+                    if (
+                      opId.op === StepOpCode.WaitForEvent &&
+                      result.data !== null
+                    ) {
+                      const { event } = (step.rawArgs?.[1] ?? {}) as {
+                        event: unknown;
+                      };
+                      if (!event) {
+                        // Unreachable
+                        throw new Error("Missing event option in waitForEvent");
+                      }
+                      try {
+                        await validateEvents(
+                          [result.data],
 
-                if (typeof result.data !== "undefined") {
-                  // Validate waitForEvent results against the schema if present
-                  // Skip validation if result.data is null (timeout case)
-                  if (
-                    opId.op === StepOpCode.WaitForEvent &&
-                    result.data !== null
-                  ) {
-                    const { event } = (step.rawArgs?.[1] ?? {}) as {
-                      event: unknown;
-                    };
-                    if (!event) {
-                      // Unreachable
-                      throw new Error("Missing event option in waitForEvent");
+                          // @ts-expect-error - This is a full event object at runtime
+                          [{ event }],
+                        );
+                      } catch (err) {
+                        this.state.recentlyRejectedStepError = new StepError(
+                          opId.id,
+                          err,
+                        );
+                        reject(this.state.recentlyRejectedStepError);
+                        return;
+                      }
                     }
-                    try {
-                      await validateEvents(
-                        [result.data],
 
-                        // @ts-expect-error - This is a full event object at runtime
-                        [{ event }],
-                      );
-                    } catch (err) {
-                      this.state.recentlyRejectedStepError = new StepError(
-                        opId.id,
-                        err,
-                      );
-                      reject(this.state.recentlyRejectedStepError);
-                      return;
-                    }
+                    // Set inner handler to return memoized data
+                    step.middleware.setActualHandler(() =>
+                      Promise.resolve(result.data),
+                    );
+
+                    step.middleware.wrappedHandler().then(resolve);
+                  } else {
+                    const stepError = new StepError(opId.id, result.error);
+                    this.state.recentlyRejectedStepError = stepError;
+
+                    // Set inner handler to reject with step error
+                    step.middleware.setActualHandler(() =>
+                      Promise.reject(stepError),
+                    );
+
+                    step.middleware.wrappedHandler().catch(reject);
                   }
+                },
+              );
+            }
 
-                  // Set inner handler to return memoized data
-                  step.middleware.setActualHandler(() =>
-                    Promise.resolve(result.data),
-                  );
+            return true;
+          };
 
-                  step.middleware.wrappedHandler().then(resolve);
-                } else {
-                  const stepError = new StepError(opId.id, result.error);
-                  this.state.recentlyRejectedStepError = stepError;
-
-                  // Set inner handler to reject with step error
-                  step.middleware.setActualHandler(() =>
-                    Promise.reject(stepError),
-                  );
-
-                  step.middleware.wrappedHandler().catch(reject);
-                }
-              },
-            );
-          }
-
-          return true;
+          return runWithAsyncCtx(asyncContext, runHandle);
         },
       };
 

--- a/packages/inngest/src/components/middleware/AGENTS.md
+++ b/packages/inngest/src/components/middleware/AGENTS.md
@@ -1,0 +1,1 @@
+Read `ARCHITECTURE.md` before making middleware changes.

--- a/packages/inngest/src/components/middleware/ARCHITECTURE.md
+++ b/packages/inngest/src/components/middleware/ARCHITECTURE.md
@@ -7,3 +7,5 @@ The most complicated hook (by far) is `wrapStep`. It wraps every step, which nec
 ## `MiddlewareManager`
 
 `MiddlewareManager` is an abstraction layer between execution and middleware. It's sole purpose is to minimize polluting execution code with excessive middleware concerns.
+
+A `MiddlewareManager` is created once per execution request by the execution engine. Fields on the manager should be treated as request-scoped state.

--- a/packages/inngest/src/components/middleware/CLAUDE.md
+++ b/packages/inngest/src/components/middleware/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -3,7 +3,7 @@ import type { Logger } from "../../middleware/logger.ts";
 import type { Context, StepOpCode } from "../../types.ts";
 import {
   type AsyncContext,
-  mustGetAsyncContextSync,
+  getAsyncCtxSync,
   runWithAsyncCtx,
 } from "../execution/als.ts";
 import type { MemoizedOp } from "../execution/InngestExecution.ts";
@@ -95,6 +95,16 @@ export class MiddlewareManager {
     ExecutionContext,
     Set<Middleware.BaseMiddleware>
   >();
+
+  /**
+   * Fallback recursion guard for runtimes without AsyncLocalStorage. This
+   * preserves the legacy best-effort behavior for edge runtimes that cannot
+   * isolate concurrent async branches.
+   *
+   * TODO: Remove this when we have a hard requirement for AsyncLocalStorage
+   * (i.e. no fallbacks).
+   */
+  private readonly activeWrapStep = new Set<Middleware.BaseMiddleware>();
 
   constructor(
     fnArg: Context.Any,
@@ -326,23 +336,24 @@ export class MiddlewareManager {
             throw new UnreachableError("wrapStep is undefined");
           }
 
-          const asyncContext = mustGetAsyncContextSync();
-          const asyncExecution = asyncContext.execution;
-          if (!asyncExecution) {
-            throw new Error("Inngest execution async context is required");
-          }
+          const asyncContext = getAsyncCtxSync();
+          const asyncExecution = asyncContext?.execution;
 
           // Use the current async execution branch as the guard boundary: it
           // lets parallel sibling steps each run through this middleware, while
           // steps created inside this middleware's own wrapStep inherit the
           // branch and skip this middleware to avoid recursive planning.
           let activeWrapStep: Set<Middleware.BaseMiddleware>;
-          const storedActiveWrapStep =
-            this.activeWrapStepByExecution.get(asyncExecution);
-          if (storedActiveWrapStep) {
-            activeWrapStep = storedActiveWrapStep;
+          if (asyncExecution) {
+            const storedActiveWrapStep =
+              this.activeWrapStepByExecution.get(asyncExecution);
+            if (storedActiveWrapStep) {
+              activeWrapStep = storedActiveWrapStep;
+            } else {
+              activeWrapStep = new Set<Middleware.BaseMiddleware>();
+            }
           } else {
-            activeWrapStep = new Set<Middleware.BaseMiddleware>();
+            activeWrapStep = this.activeWrapStep;
           }
 
           // Infinite recursion guard: skip if this middleware is already
@@ -354,7 +365,12 @@ export class MiddlewareManager {
           // Clone guard state for ALS-backed executions before entering this
           // middleware. That preserves recursion history for this branch
           // without sharing in-flight middleware state with sibling branches.
-          const branchActiveWrapStep = new Set(activeWrapStep);
+          let branchActiveWrapStep: Set<Middleware.BaseMiddleware>;
+          if (asyncExecution) {
+            branchActiveWrapStep = new Set(activeWrapStep);
+          } else {
+            branchActiveWrapStep = activeWrapStep;
+          }
 
           const runWrapStep = () => {
             branchActiveWrapStep.add(mw);
@@ -381,6 +397,10 @@ export class MiddlewareManager {
           // Give this wrapStep call its own ALS execution object. Async work
           // spawned from here, including ctx.step.run() before next(), sees
           // this branch's guard state.
+          if (!asyncContext || !asyncExecution) {
+            return runWrapStep();
+          }
+
           const branchExecution = { ...asyncExecution };
           this.activeWrapStepByExecution.set(
             branchExecution,

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -1,6 +1,11 @@
 import { timeStr } from "../../helpers/strings.ts";
 import type { Logger } from "../../middleware/logger.ts";
 import type { Context, StepOpCode } from "../../types.ts";
+import {
+  type AsyncContext,
+  getAsyncCtxSync,
+  runWithAsyncCtx,
+} from "../execution/als.ts";
 import type { MemoizedOp } from "../execution/InngestExecution.ts";
 import type { InngestFunction } from "../InngestFunction.ts";
 import type { Middleware } from "./middleware.ts";
@@ -11,6 +16,8 @@ import {
   stepTypeFromOpCode,
   UnreachableError,
 } from "./utils.ts";
+
+type ExecutionContext = NonNullable<AsyncContext["execution"]>;
 
 export interface StepInfoOptions {
   hashedId: string;
@@ -53,6 +60,9 @@ export interface PreparedStep {
 /**
  * Manages middleware. Hides middleware complexity from elsewhere in the
  * codebase. Not for for public use.
+ *
+ * A MiddlewareManager is created once per execution request by the execution
+ * engine, so fields on this class should be treated as request-scoped state.
  */
 export class MiddlewareManager {
   private readonly fnArg: Context.Any;
@@ -77,8 +87,20 @@ export class MiddlewareManager {
   /**
    * Infinite recursion guard for `wrapStep`. Prevents a middleware from
    * wrapping steps it creates inside its own `wrapStep` via `ctx.step.run`.
+   * Only used when AsyncLocalStorage isn't available. This fallback is best
+   * effort and cannot isolate concurrent async branches.
    */
   private readonly activeWrapStep = new Set<Middleware.BaseMiddleware>();
+
+  /**
+   * Tracks recursion guard state per async execution branch. Parallel memoized
+   * sibling steps get separate branches, so one step's wrapStep does not hide
+   * another step's middleware.
+   */
+  private readonly activeWrapStepByExecution = new WeakMap<
+    ExecutionContext,
+    Set<Middleware.BaseMiddleware>
+  >();
 
   constructor(
     fnArg: Context.Any,
@@ -289,6 +311,12 @@ export class MiddlewareManager {
   /**
    * Wrap a step handler with wrapStep middlewares (reverse order for
    * onion layering). Returns the wrapped handler.
+   *
+   * Build the wrapStep onion around the resolver for the value returned to user
+   * code for this step. Keep recursion protection scoped to the current async
+   * branch so parallel steps work properly: a step created by middleware before
+   * it calls next() skips that same middleware, but unrelated parallel steps
+   * still run through it.
    */
   buildWrapStepChain(
     handler: () => Promise<unknown>,
@@ -304,31 +332,86 @@ export class MiddlewareManager {
             throw new UnreachableError("wrapStep is undefined");
           }
 
+          const asyncContext = getAsyncCtxSync();
+          const asyncExecution = asyncContext?.execution;
+          let activeWrapStep: Set<Middleware.BaseMiddleware>;
+          if (asyncExecution) {
+            const storedActiveWrapStep =
+              this.activeWrapStepByExecution.get(asyncExecution);
+            if (storedActiveWrapStep) {
+              activeWrapStep = storedActiveWrapStep;
+            } else {
+              activeWrapStep = new Set<Middleware.BaseMiddleware>();
+            }
+          } else {
+            // No ALS means no branch-local state. Keep the legacy global guard
+            // so recursive ctx.step.run() calls still get best-effort
+            // protection.
+            activeWrapStep = this.activeWrapStep;
+          }
+
           // Infinite recursion guard: skip if this middleware is already
-          // executing
-          if (this.activeWrapStep.has(mw)) {
+          // executing in this async branch.
+          if (activeWrapStep.has(mw)) {
             return next();
           }
 
-          this.activeWrapStep.add(mw);
+          // Clone guard state for ALS-backed executions before entering this
+          // middleware. That preserves recursion history for this branch
+          // without sharing in-flight middleware state with sibling branches.
+          let branchActiveWrapStep: Set<Middleware.BaseMiddleware>;
+          if (asyncExecution) {
+            branchActiveWrapStep = new Set(activeWrapStep);
+          } else {
+            // Without ALS this shares state across branches, matching the
+            // previous behavior in runtimes that cannot carry async context.
+            branchActiveWrapStep = activeWrapStep;
+          }
 
-          // Remove from active while inside next() so only the middleware
-          // that directly calls ctx.step.run() is guarded.
-          const guardedNext = () => {
-            this.activeWrapStep.delete(mw);
-            return next().finally(() => {
-              this.activeWrapStep.add(mw);
+          const runWrapStep = () => {
+            branchActiveWrapStep.add(mw);
+
+            // Remove from active while inside next() so only the middleware
+            // that directly calls ctx.step.run() is guarded.
+            const guardedNext = () => {
+              branchActiveWrapStep.delete(mw);
+              return next().finally(() => {
+                branchActiveWrapStep.add(mw);
+              });
+            };
+
+            return mw.wrapStep!({
+              ctx: this.fnArg,
+              fn: this.fn,
+              next: guardedNext,
+              stepInfo,
+            }).finally(() => {
+              branchActiveWrapStep.delete(mw);
             });
           };
 
-          return mw.wrapStep!({
-            ctx: this.fnArg,
-            fn: this.fn,
-            next: guardedNext,
-            stepInfo,
-          }).finally(() => {
-            this.activeWrapStep.delete(mw);
-          });
+          if (!asyncContext || !asyncExecution) {
+            // No ALS-backed execution context exists, so run with the legacy
+            // manager-scoped guard.
+            return runWrapStep();
+          }
+
+          // Give this wrapStep call its own ALS execution object. Async work
+          // spawned from here, including ctx.step.run() before next(), sees
+          // this branch's guard state.
+          const branchExecution = { ...asyncExecution };
+          this.activeWrapStepByExecution.set(
+            branchExecution,
+            branchActiveWrapStep,
+          );
+
+          return runWithAsyncCtx(
+            {
+              ...asyncContext,
+              execution: branchExecution,
+            },
+            runWrapStep,
+          );
         };
       }
     }

--- a/packages/inngest/src/components/middleware/manager.ts
+++ b/packages/inngest/src/components/middleware/manager.ts
@@ -3,7 +3,7 @@ import type { Logger } from "../../middleware/logger.ts";
 import type { Context, StepOpCode } from "../../types.ts";
 import {
   type AsyncContext,
-  getAsyncCtxSync,
+  mustGetAsyncContextSync,
   runWithAsyncCtx,
 } from "../execution/als.ts";
 import type { MemoizedOp } from "../execution/InngestExecution.ts";
@@ -85,17 +85,11 @@ export class MiddlewareManager {
   private readonly internalLogger: Logger;
 
   /**
-   * Infinite recursion guard for `wrapStep`. Prevents a middleware from
-   * wrapping steps it creates inside its own `wrapStep` via `ctx.step.run`.
-   * Only used when AsyncLocalStorage isn't available. This fallback is best
-   * effort and cannot isolate concurrent async branches.
-   */
-  private readonly activeWrapStep = new Set<Middleware.BaseMiddleware>();
-
-  /**
    * Tracks recursion guard state per async execution branch. Parallel memoized
    * sibling steps get separate branches, so one step's wrapStep does not hide
-   * another step's middleware.
+   * another step's middleware. Steps created by a middleware inside its own
+   * wrapStep keep the declaring branch, so that same middleware is skipped for
+   * those nested steps instead of recursively prepending/planning forever.
    */
   private readonly activeWrapStepByExecution = new WeakMap<
     ExecutionContext,
@@ -332,22 +326,23 @@ export class MiddlewareManager {
             throw new UnreachableError("wrapStep is undefined");
           }
 
-          const asyncContext = getAsyncCtxSync();
-          const asyncExecution = asyncContext?.execution;
+          const asyncContext = mustGetAsyncContextSync();
+          const asyncExecution = asyncContext.execution;
+          if (!asyncExecution) {
+            throw new Error("Inngest execution async context is required");
+          }
+
+          // Use the current async execution branch as the guard boundary: it
+          // lets parallel sibling steps each run through this middleware, while
+          // steps created inside this middleware's own wrapStep inherit the
+          // branch and skip this middleware to avoid recursive planning.
           let activeWrapStep: Set<Middleware.BaseMiddleware>;
-          if (asyncExecution) {
-            const storedActiveWrapStep =
-              this.activeWrapStepByExecution.get(asyncExecution);
-            if (storedActiveWrapStep) {
-              activeWrapStep = storedActiveWrapStep;
-            } else {
-              activeWrapStep = new Set<Middleware.BaseMiddleware>();
-            }
+          const storedActiveWrapStep =
+            this.activeWrapStepByExecution.get(asyncExecution);
+          if (storedActiveWrapStep) {
+            activeWrapStep = storedActiveWrapStep;
           } else {
-            // No ALS means no branch-local state. Keep the legacy global guard
-            // so recursive ctx.step.run() calls still get best-effort
-            // protection.
-            activeWrapStep = this.activeWrapStep;
+            activeWrapStep = new Set<Middleware.BaseMiddleware>();
           }
 
           // Infinite recursion guard: skip if this middleware is already
@@ -359,14 +354,7 @@ export class MiddlewareManager {
           // Clone guard state for ALS-backed executions before entering this
           // middleware. That preserves recursion history for this branch
           // without sharing in-flight middleware state with sibling branches.
-          let branchActiveWrapStep: Set<Middleware.BaseMiddleware>;
-          if (asyncExecution) {
-            branchActiveWrapStep = new Set(activeWrapStep);
-          } else {
-            // Without ALS this shares state across branches, matching the
-            // previous behavior in runtimes that cannot carry async context.
-            branchActiveWrapStep = activeWrapStep;
-          }
+          const branchActiveWrapStep = new Set(activeWrapStep);
 
           const runWrapStep = () => {
             branchActiveWrapStep.add(mw);
@@ -389,12 +377,6 @@ export class MiddlewareManager {
               branchActiveWrapStep.delete(mw);
             });
           };
-
-          if (!asyncContext || !asyncExecution) {
-            // No ALS-backed execution context exists, so run with the legacy
-            // manager-scoped guard.
-            return runWrapStep();
-          }
 
           // Give this wrapStep call its own ALS execution object. Async work
           // spawned from here, including ctx.step.run() before next(), sees

--- a/packages/inngest/src/test/integration/middleware/parallelSteps.test.ts
+++ b/packages/inngest/src/test/integration/middleware/parallelSteps.test.ts
@@ -8,6 +8,7 @@ import {
 import { expect, test } from "vitest";
 import { Inngest, Middleware } from "../../../index.ts";
 import { createServer } from "../../../node.ts";
+import { matrixCheckpointing } from "../utils.ts";
 
 const testFileName = testNameFromFileUrl(import.meta.url);
 
@@ -148,51 +149,77 @@ test("info hooks for parallel steps", async () => {
   ]);
 });
 
-test("wrapStep runs for every memoized sibling parallel step", async () => {
-  // Regression test for a bug, where wrapStep wasn't respecting parallel steps.
+matrixCheckpointing(
+  "wrapStep runs for every memoized sibling parallel step",
+  async (checkpointing) => {
+    // Regression test for a bug, where wrapStep wasn't respecting parallel steps.
 
-  const state = createState({
-    output: null as unknown,
-  });
+    const state = createState({
+      // Used to assert steps return the output modified by middleware.
+      parallelOutput: null as unknown,
 
-  class TagMiddleware extends Middleware.BaseMiddleware {
-    readonly id = "tag";
+      // Used to assert we run each prepend step exactly once.
+      prependStepIds: [] as string[],
+    });
 
-    override async wrapStep({ next }: Middleware.WrapStepArgs) {
-      await sleep(10);
-      const value = await next();
-      return { tagged: true, value };
+    class TagMiddleware extends Middleware.BaseMiddleware {
+      readonly id = "tag";
+
+      override async wrapStep({
+        ctx,
+        next,
+        stepInfo,
+      }: Middleware.WrapStepArgs) {
+        const prependStepId = `${stepInfo.options.id}-prepend`;
+
+        // Runs before every step.
+        await ctx.step.run(prependStepId, () => {
+          state.prependStepIds.push(prependStepId);
+          return null;
+        });
+
+        // Sleep to give things time to mess up.
+        await sleep(10);
+
+        const value = await next();
+        return { tagged: true, value };
+      }
     }
-  }
 
-  const client = new Inngest({
-    id: randomSuffix(testFileName),
-    isDev: true,
-    middleware: [TagMiddleware],
-  });
-  const eventName = randomSuffix("evt");
-  const fn = client.createFunction(
-    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
-    async ({ step, runId }) => {
-      const [a, b] = await Promise.all([
-        step.run("step-a", () => ({ from: "a" })),
-        step.run("step-b", () => ({ from: "b" })),
-      ]);
+    const client = new Inngest({
+      checkpointing,
+      id: randomSuffix(testFileName),
+      isDev: true,
+      middleware: [TagMiddleware],
+    });
+    const eventName = randomSuffix("evt");
+    const fn = client.createFunction(
+      { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+      async ({ step, runId }) => {
+        state.runId = runId;
+        state.parallelOutput = await Promise.all([
+          step.run("step-a", () => {
+            return { from: "a" };
+          }),
+          step.run("step-b", () => {
+            return { from: "b" };
+          }),
+        ]);
+      },
+    );
+    await createTestApp({ client, functions: [fn], serve: createServer });
 
-      state.output = { a, b };
-      state.runId = runId;
-      return state.output;
-    },
-  );
-  await createTestApp({ client, functions: [fn], serve: createServer });
+    await client.send({ name: eventName });
+    const result = await state.waitForRunComplete();
 
-  await client.send({ name: eventName });
-  const result = await state.waitForRunComplete();
-
-  const expected = {
-    a: { tagged: true, value: { from: "a" } },
-    b: { tagged: true, value: { from: "b" } },
-  };
-  expect(state.output).toEqual(expected);
-  expect(result).toEqual(expected);
-});
+    const expected = [
+      { tagged: true, value: { from: "a" } },
+      { tagged: true, value: { from: "b" } },
+    ];
+    expect(state.parallelOutput).toEqual(expected);
+    expect(state.prependStepIds).toEqual(
+      expect.arrayContaining(["step-a-prepend", "step-b-prepend"]),
+    );
+    expect(state.prependStepIds).toHaveLength(2);
+  },
+);

--- a/packages/inngest/src/test/integration/middleware/parallelSteps.test.ts
+++ b/packages/inngest/src/test/integration/middleware/parallelSteps.test.ts
@@ -147,3 +147,52 @@ test("info hooks for parallel steps", async () => {
     "onRunComplete",
   ]);
 });
+
+test("wrapStep runs for every memoized sibling parallel step", async () => {
+  // Regression test for a bug, where wrapStep wasn't respecting parallel steps.
+
+  const state = createState({
+    output: null as unknown,
+  });
+
+  class TagMiddleware extends Middleware.BaseMiddleware {
+    readonly id = "tag";
+
+    override async wrapStep({ next }: Middleware.WrapStepArgs) {
+      await sleep(10);
+      const value = await next();
+      return { tagged: true, value };
+    }
+  }
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [TagMiddleware],
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ step, runId }) => {
+      const [a, b] = await Promise.all([
+        step.run("step-a", () => ({ from: "a" })),
+        step.run("step-b", () => ({ from: "b" })),
+      ]);
+
+      state.output = { a, b };
+      state.runId = runId;
+      return state.output;
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  const expected = {
+    a: { tagged: true, value: { from: "a" } },
+    b: { tagged: true, value: { from: "b" } },
+  };
+  expect(state.output).toEqual(expected);
+  expect(result).toEqual(expected);
+});

--- a/packages/test-harness/src/devServer.ts
+++ b/packages/test-harness/src/devServer.ts
@@ -26,6 +26,7 @@ export async function startDevServer(): Promise<void> {
     devServerProcess = spawn(
       "npx",
       [
+        "--ignore-scripts=false",
         "inngest-cli@latest",
         "dev",
         "--no-discovery",


### PR DESCRIPTION
## Summary

Fixes a `wrapStep` middleware bug where async middleware could be skipped for one of multiple parallel `step.run()` calls during memoized replay.

The recursion guard for `wrapStep` is now scoped to the current async execution branch when `AsyncLocalStorage` is available. This keeps the intended protection for steps created inside a middleware's own `wrapStep`, while still allowing unrelated sibling steps in `Promise.all()` to run through the same middleware.

Also adds middleware architecture notes and AGENTS/CLAUDE routing files so future middleware changes have clearer lifecycle context.

Also add `--ignore-script=false` to the Dev Server test harness command, since the Dev Server uses a post install script.

Closes #1656.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable
