### PR TITLE
feat: add marker to identify the OTel provider

### DIFF
--- a/.changeset/red-fishes-try.md
+++ b/.changeset/red-fishes-try.md
@@ -1,0 +1,5 @@
+---
+"@inngest/otel": patch
+---
+
+feat: add marker to identify the OTel provider

--- a/packages/otel/src/instrument.ts
+++ b/packages/otel/src/instrument.ts
@@ -12,6 +12,8 @@ import { type MaybeError, toError } from "./types.ts";
 
 const debug = Debug("inngest:otel:instrumentTracing");
 
+export const providerMarker = Symbol.for("inngest.otel.provider");
+
 let isTraceInstrumentationHookRegistered = false;
 let isTraceInstrumentationStarted = false;
 
@@ -100,6 +102,11 @@ function ensureTraceProvider(): MaybeError<void> {
       // Reachable when a provider already exists
       return;
     }
+
+    Object.defineProperty(provider, providerMarker, {
+      value: true,
+      enumerable: false,
+    });
 
     context.setGlobalContextManager(
       new AsyncLocalStorageContextManager().enable(),

--- a/packages/otel/tests/providerMarker.test.ts
+++ b/packages/otel/tests/providerMarker.test.ts
@@ -1,0 +1,62 @@
+import { context, type TracerProvider, trace } from "@opentelemetry/api";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const unwrapProvider = (): object => {
+  const provider = trace.getTracerProvider();
+  if ("getDelegate" in provider && typeof provider.getDelegate === "function") {
+    return provider.getDelegate();
+  }
+
+  return provider;
+};
+
+describe("provider marker", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    trace.disable();
+    context.disable();
+  });
+
+  afterEach(() => {
+    trace.disable();
+    context.disable();
+  });
+
+  test("uses the shared global symbol key", async () => {
+    const { providerMarker } = await import("../src/instrument.ts");
+
+    expect(providerMarker).toBe(Symbol.for("inngest.otel.provider"));
+  });
+
+  test("marks providers it creates", async () => {
+    const { instrumentTracing, providerMarker } = await import(
+      "../src/instrument.ts"
+    );
+
+    instrumentTracing();
+
+    const provider = unwrapProvider();
+    expect((provider as Record<symbol, unknown>)[providerMarker]).toBe(true);
+    expect(
+      Object.getOwnPropertyDescriptor(provider, providerMarker)?.enumerable,
+    ).toBe(false);
+  });
+
+  test("does not mark pre-existing providers", async () => {
+    const existingProvider = new BasicTracerProvider();
+    trace.setGlobalTracerProvider(
+      existingProvider as unknown as TracerProvider,
+    );
+
+    const { instrumentTracing, providerMarker } = await import(
+      "../src/instrument.ts"
+    );
+
+    instrumentTracing();
+
+    expect(
+      (existingProvider as unknown as Record<symbol, unknown>)[providerMarker],
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add a marker that allows the `inngest` package to identify the OpenTelemetry provider created by the `@inngest/otel` package.

## Checklist

- [x] Added unit/integration tests
- [x] Added changesets if applicable
