### PR TITLE
feat(sandbox): optionally wait for running

### DIFF
--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -73,6 +73,12 @@ const resultForOperation = (
       };
     case "get":
       return { protocolVersion: 1, action: "get", sandbox: sandboxRef };
+    case "waitUntilRunning":
+      return {
+        protocolVersion: 1,
+        action: "waitUntilRunning",
+        sandbox: sandboxRef,
+      };
     case "exec":
       return {
         protocolVersion: 1,
@@ -160,7 +166,10 @@ describe("step.sandbox", () => {
     });
     const tools = createSandboxTools(() => rawTool);
 
-    const created = await tools.create("create", createOptions);
+    const created = await tools.create("create", {
+      ...createOptions,
+      runningTimeout: "5s",
+    });
     const listed = await tools.list("list", { limit: 10 });
     const fetched = await tools.get("get", sandboxId);
     const command = await created.commands.run("exec", {
@@ -181,6 +190,9 @@ describe("step.sandbox", () => {
     await process.signal("signal", { signal: 15, includeChildren: true });
     const waited = await process.wait("wait", { timeout: "5s" });
     const output = await process.getOutput("output", { tailBytes: 123 });
+    const running = await created.waitUntilRunning("wait-running", {
+      timeout: "5s",
+    });
     const destroyed = await created.destroy("destroy");
 
     expect(created).toMatchObject(sandboxRef);
@@ -215,6 +227,7 @@ describe("step.sandbox", () => {
     expect(Object.isFrozen(waited)).toBe(true);
     expect(Object.isFrozen(waited.command)).toBe(true);
     expect(output.chunks[0]?.data).toEqual(new Uint8Array([0, 255]));
+    expect(running).toMatchObject({ id: sandboxId, status: "RUNNING" });
     expect(destroyed).toMatchObject({ status: "TERMINATING" });
 
     expect(operations.map(({ action }) => action)).toEqual([
@@ -228,6 +241,7 @@ describe("step.sandbox", () => {
       "process.signal",
       "process.wait",
       "process.output",
+      "waitUntilRunning",
       "destroy",
     ]);
     expect(operations[3]).toMatchObject({
@@ -240,6 +254,10 @@ describe("step.sandbox", () => {
           timeoutMs: 1000,
         },
       ],
+    });
+    expect(operations[0]).toMatchObject({
+      action: "create",
+      input: [{ ...createOptions, runningTimeoutMs: 5000 }],
     });
     expect(operations[4]).toMatchObject({
       action: "process.start",
@@ -256,6 +274,11 @@ describe("step.sandbox", () => {
         process: { sandboxId, id: processId },
       },
       input: [{ signal: 15, includeChildren: true }],
+    });
+    expect(operations[10]).toMatchObject({
+      action: "waitUntilRunning",
+      target: { sandbox: { id: sandboxId } },
+      input: [{ timeoutMs: 5000 }],
     });
   });
 
@@ -367,6 +390,123 @@ describe("step.sandbox", () => {
     ).resolves.toMatchObject({
       type: "function-resolved",
       data: processId,
+    });
+  });
+
+  test("suspends waitUntilRunning and rehydrates its RUNNING result on replay", async () => {
+    const startingSandboxRef = {
+      ...sandboxRef,
+      status: "STARTING",
+      startedAt: undefined,
+    } satisfies SandboxRef;
+    const client = new Inngest({
+      id: testClientId,
+      isDev: true,
+      middleware: [sandboxMiddleware()],
+    });
+    const fn = client.createFunction(
+      {
+        id: "sandbox-wait-until-running",
+        triggers: [{ event: "sandbox/wait-until-running" }],
+      },
+      async ({ step }) => {
+        const sandbox = await step.sandbox.get("get", sandboxId);
+        if (!sandbox) {
+          throw new Error("Expected sandbox");
+        }
+        return (
+          await sandbox.waitUntilRunning("wait-running", { timeout: "5s" })
+        ).status;
+      },
+    );
+
+    const getInvocation = await runFnWithStack(
+      fn,
+      {},
+      {
+        disableImmediateExecution: true,
+      },
+    );
+    expect(getInvocation).toMatchObject({
+      type: "steps-found",
+      steps: [
+        {
+          opts: {
+            input: [{ protocolVersion: 1, action: "get" }],
+          },
+        },
+      ],
+    });
+    if (getInvocation.type !== "steps-found" || !getInvocation.steps[0]) {
+      throw new Error("Expected Get step");
+    }
+
+    const getStep = getInvocation.steps[0];
+    const waitInvocation = await runFnWithStack(
+      fn,
+      {
+        [getStep.id]: {
+          id: getStep.id,
+          data: {
+            protocolVersion: 1,
+            action: "get",
+            sandbox: startingSandboxRef,
+          },
+        },
+      },
+      {
+        stackOrder: [getStep.id],
+        disableImmediateExecution: true,
+      },
+    );
+    expect(waitInvocation).toMatchObject({
+      type: "steps-found",
+      steps: [
+        {
+          opts: {
+            input: [
+              {
+                protocolVersion: 1,
+                action: "waitUntilRunning",
+                target: { sandbox: { id: sandboxId, status: "STARTING" } },
+                input: [{ timeoutMs: 5000 }],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    if (waitInvocation.type !== "steps-found" || !waitInvocation.steps[0]) {
+      throw new Error("Expected waitUntilRunning step");
+    }
+
+    const waitStep = waitInvocation.steps[0];
+    await expect(
+      runFnWithStack(
+        fn,
+        {
+          [getStep.id]: {
+            id: getStep.id,
+            data: {
+              protocolVersion: 1,
+              action: "get",
+              sandbox: startingSandboxRef,
+            },
+          },
+          [waitStep.id]: {
+            id: waitStep.id,
+            data: {
+              protocolVersion: 1,
+              action: "waitUntilRunning",
+              sandbox: sandboxRef,
+            },
+          },
+        },
+        { stackOrder: [getStep.id, waitStep.id] },
+      ),
+    ).resolves.toMatchObject({
+      type: "function-resolved",
+      data: "RUNNING",
     });
   });
 
@@ -810,6 +950,209 @@ describe("inngest.sandboxes", () => {
     expect(sandbox.id).toBe(sandboxId);
     expect(sandbox.status).toBe(status);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("makes readiness waiting opt-in on Create", async () => {
+    const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+    const startingResource = {
+      ...runningResource,
+      status: "STARTING",
+      startedAt: undefined,
+    };
+    const calls: Array<{ url: URL; init?: RequestInit }> = [];
+    const fetchMock: typeof fetch = vi.fn(async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      calls.push({ url, init });
+      if (init?.method === "POST") {
+        return Response.json({ data: startingResource }, { status: 202 });
+      }
+      return Response.json({ data: runningResource });
+    });
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+
+    const immediate = await client.create(createOptions);
+    expect(immediate.status).toBe("STARTING");
+    expect(calls).toHaveLength(1);
+
+    const running = await client.create({
+      ...createOptions,
+      runningTimeout: "5s",
+    });
+    expect(running.status).toBe("RUNNING");
+    expect(calls).toHaveLength(3);
+    expect(calls.map(({ init }) => init?.method)).toEqual([
+      "POST",
+      "POST",
+      "GET",
+    ]);
+    for (const call of calls.filter(({ init }) => init?.method === "POST")) {
+      expect(JSON.parse(String(call.init?.body))).toEqual(createOptions);
+    }
+  });
+
+  test("waitUntilRunning reloads a STARTING sandbox", async () => {
+    const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+    const startingResource = {
+      ...runningResource,
+      status: "STARTING",
+      startedAt: undefined,
+    };
+    let requestCount = 0;
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => async () => {
+        requestCount++;
+        return requestCount === 1
+          ? Response.json({ data: startingResource }, { status: 202 })
+          : Response.json({ data: runningResource });
+      },
+    });
+
+    const starting = await client.create(createOptions);
+    const running = await starting.waitUntilRunning({ timeout: "5s" });
+
+    expect(starting.status).toBe("STARTING");
+    expect(running.status).toBe("RUNNING");
+    expect(requestCount).toBe(2);
+  });
+
+  test("reports terminal startup failure without retrying", async () => {
+    const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+    const startingResource = {
+      ...runningResource,
+      status: "STARTING",
+      startedAt: undefined,
+    };
+    let requestCount = 0;
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => async () => {
+        requestCount++;
+        return requestCount === 1
+          ? Response.json({ data: startingResource }, { status: 202 })
+          : Response.json({
+              data: {
+                ...startingResource,
+                status: "FAILED",
+                endedAt: now,
+                error: "guest failed to start",
+              },
+            });
+      },
+    });
+
+    await expect(
+      client.create({ ...createOptions, runningTimeout: "5s" }),
+    ).rejects.toMatchObject({
+      name: "SandboxError",
+      action: "create",
+      code: "sandbox_start_failed",
+      sandboxId,
+      retryable: false,
+      details: [
+        {
+          status: "FAILED",
+          error: "guest failed to start",
+        },
+      ],
+    });
+    expect(requestCount).toBe(2);
+  });
+
+  test("reports readiness timeout without retrying Create", async () => {
+    vi.useFakeTimers();
+    try {
+      const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+      const startingResource = {
+        ...runningResource,
+        status: "STARTING",
+        startedAt: undefined,
+      };
+      const fetchMock: typeof fetch = vi.fn(async (_input, init) =>
+        Response.json(
+          { data: startingResource },
+          { status: init?.method === "POST" ? 202 : 200 },
+        ),
+      );
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "signkey-test",
+        headers: () => ({}),
+        fetch: () => fetchMock,
+      });
+
+      const result = client.create({
+        ...createOptions,
+        runningTimeout: "1s",
+      });
+      const assertion = expect(result).rejects.toMatchObject({
+        name: "SandboxError",
+        action: "create",
+        code: "sandbox_start_timed_out",
+        sandboxId,
+        retryable: false,
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await assertion;
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("retries transient readiness reads without redispatching Create", async () => {
+    vi.useFakeTimers();
+    try {
+      const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+      const startingResource = {
+        ...runningResource,
+        status: "STARTING",
+        startedAt: undefined,
+      };
+      const methods: string[] = [];
+      let requestCount = 0;
+      const fetchMock: typeof fetch = vi.fn(async (_input, init) => {
+        requestCount++;
+        methods.push(init?.method ?? "GET");
+        if (requestCount === 1) {
+          return Response.json({ data: startingResource }, { status: 202 });
+        }
+        if (requestCount === 2) {
+          throw new TypeError("connection reset");
+        }
+        return Response.json({ data: runningResource });
+      });
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "signkey-test",
+        headers: () => ({}),
+        fetch: () => fetchMock,
+      });
+
+      const result = client.create({
+        ...createOptions,
+        runningTimeout: "5s",
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(result).resolves.toMatchObject({
+        id: sandboxId,
+        status: "RUNNING",
+      });
+      expect(methods).toEqual(["POST", "GET", "GET"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("forwards the complete direct REST lifecycle", async () => {

--- a/packages/inngest/src/components/InngestSandbox.ts
+++ b/packages/inngest/src/components/InngestSandbox.ts
@@ -62,6 +62,7 @@ export type {
   SandboxResource,
   SandboxResources,
   SandboxStatus,
+  SandboxWaitUntilRunningOptions,
 } from "./sandbox/types.ts";
 export {
   SandboxError,

--- a/packages/inngest/src/components/sandbox/client.ts
+++ b/packages/inngest/src/components/sandbox/client.ts
@@ -11,6 +11,8 @@ import {
   type SandboxFileUploadResult,
   type SandboxOutputChunk,
   type SandboxProcess,
+  type SandboxRef,
+  type SandboxStatus,
   SandboxValidationError,
 } from "./types.ts";
 import {
@@ -27,6 +29,7 @@ import {
   normalizeSandboxProcessSignalOptions,
   normalizeSandboxProcessStartOptions,
   normalizeSandboxProcessWaitOptions,
+  normalizeSandboxWaitUntilRunningOptions,
   parseWithSchema,
   restOutputChunkSchema,
   sandboxProcessRefFromResource,
@@ -125,6 +128,7 @@ const waitProcessSchema = z
 const safeReadActions = new Set<SandboxAction>([
   "list",
   "get",
+  "waitUntilRunning",
   "process.list",
   "process.get",
   "process.wait",
@@ -426,6 +430,44 @@ class SandboxRestTransport {
 const processPath = (sandboxId: string, processId: string): string =>
   `/v2/sandboxes/${encodeURIComponent(sandboxId)}/processes/${encodeURIComponent(processId)}`;
 
+const sandboxStartingStatuses = new Set<SandboxStatus>(["PENDING", "STARTING"]);
+const sandboxRunningPollIntervalMs = 1_000;
+
+const delay = async (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const sandboxStartFailedError = (
+  action: "create" | "waitUntilRunning",
+  sandbox: SandboxRef,
+): SandboxError =>
+  new SandboxError({
+    action,
+    code: "sandbox_start_failed",
+    message: `Sandbox entered ${sandbox.status} before reaching RUNNING`,
+    sandboxId: sandbox.id,
+    retryable: false,
+    details: [
+      {
+        status: sandbox.status,
+        ...(sandbox.error !== undefined && { error: sandbox.error }),
+      },
+    ],
+  });
+
+const sandboxStartTimedOutError = (
+  action: "create" | "waitUntilRunning",
+  sandbox: SandboxRef,
+  timeoutMs: number,
+): SandboxError =>
+  new SandboxError({
+    action,
+    code: "sandbox_start_timed_out",
+    message: `Sandbox did not reach RUNNING within ${timeoutMs} milliseconds`,
+    sandboxId: sandbox.id,
+    retryable: false,
+    details: [{ status: sandbox.status, timeoutMs }],
+  });
+
 const createDirectProcessFacade = (
   rawRef: unknown,
   transport: SandboxRestTransport,
@@ -719,6 +761,13 @@ const createDirectSandboxFacade = (
         }
       },
     }),
+    waitUntilRunning: async (options) =>
+      waitUntilSandboxRunning(
+        ref,
+        normalizeSandboxWaitUntilRunningOptions(options).timeoutMs,
+        transport,
+        "waitUntilRunning",
+      ),
     destroy: async (): Promise<SandboxDestroyResult> => {
       const { status, envelope } = await transport.json(
         "destroy",
@@ -742,6 +791,54 @@ const createDirectSandboxFacade = (
     },
   };
   return Object.freeze(facade);
+};
+
+const waitUntilSandboxRunning = async (
+  initialSandbox: SandboxRef,
+  timeoutMs: number,
+  transport: SandboxRestTransport,
+  action: "create" | "waitUntilRunning",
+): Promise<Sandbox> => {
+  let sandbox = initialSandbox;
+  if (sandbox.status === "RUNNING") {
+    return createDirectSandboxFacade(sandbox, transport);
+  }
+  if (!sandboxStartingStatuses.has(sandbox.status)) {
+    throw sandboxStartFailedError(action, sandbox);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  const path = `/v2/sandboxes/${encodeURIComponent(sandbox.id)}`;
+  for (;;) {
+    if (deadline - Date.now() <= 0) {
+      throw sandboxStartTimedOutError(action, sandbox, timeoutMs);
+    }
+
+    try {
+      const { envelope } = await transport.json(action, "GET", path, {
+        statuses: [200],
+        sandboxId: sandbox.id,
+      });
+      sandbox = sandboxRefFromResource(envelope?.data);
+    } catch (error) {
+      if (!(error instanceof SandboxError && error.retryable)) {
+        throw error;
+      }
+    }
+
+    if (sandbox.status === "RUNNING") {
+      return createDirectSandboxFacade(sandbox, transport);
+    }
+    if (!sandboxStartingStatuses.has(sandbox.status)) {
+      throw sandboxStartFailedError(action, sandbox);
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw sandboxStartTimedOutError(action, sandbox, timeoutMs);
+    }
+    await delay(Math.min(sandboxRunningPollIntervalMs, remainingMs));
+  }
 };
 
 const sandboxClientTransports = new WeakMap<
@@ -779,7 +876,8 @@ export const createSandboxClient = (
   const transport = new SandboxRestTransport(config);
   const client: SandboxClient = {
     create: async (options) => {
-      const body = normalizeSandboxCreateOptions(options);
+      const { runningTimeoutMs, ...body } =
+        normalizeSandboxCreateOptions(options);
       const { status, envelope } = await transport.json(
         "create",
         "POST",
@@ -795,7 +893,14 @@ export const createSandboxClient = (
           `Sandbox Create returned HTTP ${status} with status ${sandbox.status}`,
         );
       }
-      return createDirectSandboxFacade(sandbox, transport);
+      return runningTimeoutMs === undefined
+        ? createDirectSandboxFacade(sandbox, transport)
+        : waitUntilSandboxRunning(
+            sandbox,
+            runningTimeoutMs,
+            transport,
+            "create",
+          );
     },
     list: async (options) => {
       const normalized = normalizeSandboxListOptions(options);

--- a/packages/inngest/src/components/sandbox/durable.ts
+++ b/packages/inngest/src/components/sandbox/durable.ts
@@ -43,6 +43,7 @@ import {
   normalizeSandboxProcessSignalOptions,
   normalizeSandboxProcessStartOptions,
   normalizeSandboxProcessWaitOptions,
+  normalizeSandboxWaitUntilRunningOptions,
   parseWithSchema,
   sandboxProcessRefSchema,
   sandboxRefSchema,
@@ -160,7 +161,13 @@ export const executeSandboxOperation = async (
 
   switch (operation.action) {
     case "create": {
-      const sandbox = await client.create(operation.input[0]);
+      const { runningTimeoutMs, ...options } = operation.input[0];
+      const sandbox = await client.create({
+        ...options,
+        ...(runningTimeoutMs !== undefined && {
+          runningTimeout: runningTimeoutMs,
+        }),
+      });
       return {
         protocolVersion: sandboxProtocolVersion,
         action: operation.action,
@@ -183,6 +190,19 @@ export const executeSandboxOperation = async (
         protocolVersion: sandboxProtocolVersion,
         action: operation.action,
         sandbox: sandbox ? sandboxRefForWire(sandbox) : null,
+      };
+    }
+    case "waitUntilRunning": {
+      const sandbox = await sandboxForOperation(
+        client,
+        operation.target.sandbox,
+      ).waitUntilRunning({
+        timeout: operation.input[0].timeoutMs,
+      });
+      return {
+        protocolVersion: sandboxProtocolVersion,
+        action: operation.action,
+        sandbox: sandboxRefForWire(sandbox),
       };
     }
     case "exec": {
@@ -505,6 +525,16 @@ export const createDurableSandboxFacade = (
           : null;
       },
     }),
+    waitUntilRunning: async (idOrOptions, options) => {
+      const operation = parseSandboxOperationForAction("waitUntilRunning", {
+        protocolVersion: sandboxProtocolVersion,
+        action: "waitUntilRunning",
+        target: sandboxTarget(ref),
+        input: [normalizeSandboxWaitUntilRunningOptions(options)],
+      });
+      const result = await callRawTool(rawToolResolver, idOrOptions, operation);
+      return createDurableSandboxFacade(result.sandbox, rawToolResolver);
+    },
     destroy: async (idOrOptions): Promise<SandboxDestroyResult> => {
       const operation = parseSandboxOperationForAction("destroy", {
         protocolVersion: sandboxProtocolVersion,

--- a/packages/inngest/src/components/sandbox/protocol.ts
+++ b/packages/inngest/src/components/sandbox/protocol.ts
@@ -38,6 +38,7 @@ const createInputSchema = z
     name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
     vcpu: z.number().int().positive().max(0xffffffff),
     memoryMb: z.number().int().positive().max(0xffffffff),
+    runningTimeoutMs: z.number().int().positive().max(300_000).optional(),
   })
   .strict();
 const listInputSchema = z
@@ -130,6 +131,14 @@ export const sandboxOperationSchema = z.discriminatedUnion("action", [
       ...operationBase,
       action: z.literal("get"),
       input: z.tuple([getInputSchema]),
+    })
+    .strict(),
+  z
+    .object({
+      ...operationBase,
+      action: z.literal("waitUntilRunning"),
+      target: sandboxTargetSchema,
+      input: z.tuple([waitInputSchema]),
     })
     .strict(),
   z
@@ -341,6 +350,16 @@ export const sandboxOperationResultSchema = z.discriminatedUnion("action", [
   z
     .object({
       ...operationBase,
+      action: z.literal("waitUntilRunning"),
+      sandbox: sandboxRefSchema.refine(
+        (sandbox) => sandbox.status === "RUNNING",
+        "waitUntilRunning sandbox must be RUNNING",
+      ),
+    })
+    .strict(),
+  z
+    .object({
+      ...operationBase,
       action: z.literal("exec"),
       result: wireCommandResultSchema,
     })
@@ -405,6 +424,7 @@ const sandboxErrorPayloadSchema = z
       "create",
       "list",
       "get",
+      "waitUntilRunning",
       "exec",
       "destroy",
       "process.start",

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -45,6 +45,18 @@ export interface SandboxCreateOptions {
   name: string;
   vcpu: number;
   memoryMb: number;
+
+  /**
+   * Wait up to this duration for the sandbox to reach RUNNING.
+   *
+   * Omit this to return as soon as Create is accepted, with either STARTING or
+   * RUNNING status.
+   */
+  runningTimeout?: SandboxDuration;
+}
+
+export interface SandboxWaitUntilRunningOptions {
+  timeout: SandboxDuration;
 }
 
 export interface SandboxListOptions {
@@ -196,6 +208,7 @@ export type SandboxAction =
   | "create"
   | "list"
   | "get"
+  | "waitUntilRunning"
   | "exec"
   | "destroy"
   | "process.start"
@@ -222,6 +235,8 @@ export type SandboxErrorCode =
   | "sandbox_exec_timed_out"
   | "sandbox_name_taken"
   | "sandbox_not_found"
+  | "sandbox_start_failed"
+  | "sandbox_start_timed_out"
   | "sandbox_process_not_found"
   | "sandbox_process_output_not_retained"
   | "sandbox_process_wait_timed_out"
@@ -315,6 +330,7 @@ export interface Sandbox {
     ): Promise<SandboxProcessListResult<SandboxProcess>>;
     get(processId: string): Promise<SandboxProcess | null>;
   };
+  waitUntilRunning(options: SandboxWaitUntilRunningOptions): Promise<Sandbox>;
   destroy(): Promise<SandboxDestroyResult>;
 }
 
@@ -379,6 +395,10 @@ export interface DurableSandbox {
       processId: string,
     ): Promise<DurableSandboxProcess | null>;
   };
+  waitUntilRunning(
+    idOrOptions: StepOptionsOrId,
+    options: SandboxWaitUntilRunningOptions,
+  ): Promise<DurableSandbox>;
   destroy(idOrOptions: StepOptionsOrId): Promise<SandboxDestroyResult>;
 }
 

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -17,10 +17,12 @@ import {
   type SandboxProcessWaitOptions,
   type SandboxRef,
   SandboxValidationError,
+  type SandboxWaitUntilRunningOptions,
 } from "./types.ts";
 
 export const maxSandboxProcessTimeoutMs = 5 * 60 * 1_000;
 export const defaultSandboxProcessTimeoutMs = 30 * 1_000;
+export const maxSandboxRunningTimeoutMs = 5 * 60 * 1_000;
 export const maxSandboxProcessTailBytes = 512 * 1_024;
 
 const maxProcessArgvCount = 128;
@@ -273,18 +275,50 @@ export const sandboxProcessRefFromResource = (
 
 export const normalizeSandboxCreateOptions = (
   options: SandboxCreateOptions,
-): SandboxCreateOptions =>
-  parseWithSchema(
+): Omit<SandboxCreateOptions, "runningTimeout"> & {
+  runningTimeoutMs?: number;
+} => {
+  const parsed = parseWithSchema(
     z
       .object({
         name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
         vcpu: z.number().int().positive().max(0xffffffff),
         memoryMb: z.number().int().positive().max(0xffffffff),
+        runningTimeout: z.unknown().optional(),
       })
       .strict(),
     options,
     "sandbox create options",
   );
+  const { runningTimeout, ...create } = parsed;
+  return {
+    ...create,
+    ...(runningTimeout !== undefined && {
+      runningTimeoutMs: normalizeDurationMs(
+        runningTimeout as SandboxDuration,
+        maxSandboxRunningTimeoutMs,
+        "runningTimeout",
+      ),
+    }),
+  };
+};
+
+export const normalizeSandboxWaitUntilRunningOptions = (
+  options: SandboxWaitUntilRunningOptions,
+): { timeoutMs: number } => {
+  const parsed = parseWithSchema(
+    z.object({ timeout: z.unknown() }).strict(),
+    options,
+    "sandbox waitUntilRunning options",
+  );
+  return {
+    timeoutMs: normalizeDurationMs(
+      parsed.timeout as SandboxDuration,
+      maxSandboxRunningTimeoutMs,
+      "timeout",
+    ),
+  };
+};
 
 export const normalizeSandboxListOptions = (
   options: SandboxListOptions = {},

--- a/packages/inngest/src/experimental.ts
+++ b/packages/inngest/src/experimental.ts
@@ -51,6 +51,7 @@ export type {
   SandboxResource,
   SandboxResources,
   SandboxStatus,
+  SandboxWaitUntilRunningOptions,
 } from "./components/InngestSandbox.ts";
 export {
   SandboxError,


### PR DESCRIPTION
Adds opt-in startup waiting without changing the current async Create behavior.

- `runningTimeout` on Create waits for `RUNNING` when supplied; undefined still returns `STARTING` or `RUNNING` immediately
- adds `sandbox.waitUntilRunning({ timeout })` to the direct client and the durable step surface
- retries transient readiness reads within the deadline without redispatching Create
- returns explicit startup failure and timeout errors

This is stacked on #1659 because durable Create-and-wait relies on active-name Create reuse when a step is retried