### PR TITLE
fix(sandbox): add actionable operation errors

### DIFF
--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -917,6 +917,249 @@ describe("inngest.sandboxes", () => {
   });
 
   test.each([
+    ["destroy", "repeating Destroy is safe"],
+    ["file.upload", "Repeating the same upload is safe"],
+  ] as const)(
+    "marks %s transport failures as retryable with recovery guidance",
+    async (action, message) => {
+      let requestCount = 0;
+      const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "key",
+        headers: () => ({}),
+        fetch: () => async () => {
+          requestCount++;
+          if (requestCount === 1) {
+            return Response.json({ data: sandboxResource });
+          }
+          throw new TypeError("connection refused");
+        },
+      });
+      const sandbox = await client.get(sandboxId);
+      if (!sandbox) {
+        throw new Error("Expected sandbox");
+      }
+
+      const operation =
+        action === "destroy"
+          ? sandbox.destroy()
+          : sandbox.files.upload({
+              path: "/tmp/input.bin",
+              data: new Uint8Array([1]),
+            });
+
+      await expect(operation).rejects.toMatchObject({
+        name: "SandboxError",
+        action,
+        code: "compute_unavailable",
+        message: expect.stringContaining(message),
+        ambiguous: false,
+        retryable: true,
+      });
+    },
+  );
+
+  test.each([
+    ["exec", "Inspect its external effects"],
+    ["process.start", "List processes and reconcile"],
+    ["process.signal", "Get or wait for the process"],
+  ] as const)(
+    "marks %s transport failures as ambiguous with recovery guidance",
+    async (action, message) => {
+      let requestCount = 0;
+      const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
+      const {
+        kind: _processKind,
+        version: _processVersion,
+        sandboxId: _processSandboxId,
+        ...processResource
+      } = processRef;
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "key",
+        headers: () => ({}),
+        fetch: () => async () => {
+          requestCount++;
+          if (requestCount === 1) {
+            return Response.json({ data: sandboxResource });
+          }
+          if (action === "process.signal" && requestCount === 2) {
+            return Response.json({ data: processResource });
+          }
+          throw new TypeError("connection refused");
+        },
+      });
+      const sandbox = await client.get(sandboxId);
+      if (!sandbox) {
+        throw new Error("Expected sandbox");
+      }
+
+      let operation: Promise<unknown>;
+      switch (action) {
+        case "exec":
+          operation = sandbox.commands.run({ command: ["/bin/true"] });
+          break;
+        case "process.start":
+          operation = sandbox.processes.start({ command: ["/bin/true"] });
+          break;
+        case "process.signal": {
+          const process = await sandbox.processes.get(processId);
+          if (!process) {
+            throw new Error("Expected process");
+          }
+          operation = process.signal({ signal: 15 });
+          break;
+        }
+      }
+
+      await expect(operation).rejects.toMatchObject({
+        name: "SandboxError",
+        action,
+        code: "operation_ambiguous",
+        message: expect.stringContaining(message),
+        ambiguous: true,
+        retryable: false,
+      });
+    },
+  );
+
+  test.each([
+    ["create", 201, "compute_unavailable", false, true],
+    ["destroy", 202, "compute_unavailable", false, true],
+    ["exec", 200, "operation_ambiguous", true, false],
+    ["process.start", 201, "operation_ambiguous", true, false],
+    ["file.upload", 200, "compute_unavailable", false, true],
+  ] as const)(
+    "classifies a lost successful %s response body",
+    async (action, status, code, ambiguous, retryable) => {
+      let requestCount = 0;
+      const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "key",
+        headers: () => ({}),
+        fetch: () => async () => {
+          requestCount++;
+          if (action !== "create" && requestCount === 1) {
+            return Response.json({ data: sandboxResource });
+          }
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.error(new Error("response body lost"));
+              },
+            }),
+            { status, headers: { "Content-Type": "application/json" } },
+          );
+        },
+      });
+
+      let operation: Promise<unknown>;
+      if (action === "create") {
+        operation = client.create(createOptions);
+      } else {
+        const sandbox = await client.get(sandboxId);
+        if (!sandbox) {
+          throw new Error("Expected sandbox");
+        }
+        switch (action) {
+          case "destroy":
+            operation = sandbox.destroy();
+            break;
+          case "exec":
+            operation = sandbox.commands.run({ command: ["/bin/true"] });
+            break;
+          case "process.start":
+            operation = sandbox.processes.start({ command: ["/bin/true"] });
+            break;
+          case "file.upload":
+            operation = sandbox.files.upload({
+              path: "/tmp/input.bin",
+              data: new Uint8Array([1]),
+            });
+            break;
+        }
+      }
+
+      await expect(operation).rejects.toMatchObject({
+        name: "SandboxError",
+        action,
+        code,
+        ambiguous,
+        retryable,
+      });
+    },
+  );
+
+  test("replaces a generic ambiguous API message with action-specific guidance", async () => {
+    let requestCount = 0;
+    const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "key",
+      headers: () => ({}),
+      fetch: () => async () => {
+        requestCount++;
+        if (requestCount === 1) {
+          return Response.json({ data: sandboxResource });
+        }
+        return Response.json(
+          {
+            errors: [
+              {
+                code: "operation_ambiguous",
+                message: "Operation result is ambiguous",
+              },
+            ],
+          },
+          { status: 409 },
+        );
+      },
+    });
+    const sandbox = await client.get(sandboxId);
+    if (!sandbox) {
+      throw new Error("Expected sandbox");
+    }
+
+    await expect(
+      sandbox.processes.start({ command: ["/bin/true"] }),
+    ).rejects.toMatchObject({
+      action: "process.start",
+      code: "operation_ambiguous",
+      message: expect.stringContaining("List processes and reconcile"),
+    });
+  });
+
+  test("guides an ambiguous Create response toward reconciliation", async () => {
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "key",
+      headers: () => ({}),
+      fetch: () => async () =>
+        Response.json(
+          {
+            errors: [
+              {
+                code: "operation_ambiguous",
+                message: "Operation result is ambiguous",
+              },
+            ],
+          },
+          { status: 409 },
+        ),
+    });
+
+    await expect(client.create(createOptions)).rejects.toMatchObject({
+      action: "create",
+      code: "operation_ambiguous",
+      message: expect.stringContaining("List sandboxes and reconcile by name"),
+      ambiguous: true,
+      retryable: false,
+    });
+  });
+
+  test.each([
     "PENDING",
     "STARTING",
     "RUNNING",

--- a/packages/inngest/src/components/sandbox/client.ts
+++ b/packages/inngest/src/components/sandbox/client.ts
@@ -125,7 +125,10 @@ const waitProcessSchema = z
     }
   });
 
-const safeReadActions = new Set<SandboxAction>([
+const safeRepeatActions = new Set<SandboxAction>([
+  "create",
+  "destroy",
+  "file.upload",
   "list",
   "get",
   "waitUntilRunning",
@@ -137,6 +140,32 @@ const safeReadActions = new Set<SandboxAction>([
   "logs.stream",
   "file.download",
 ]);
+
+const sandboxTransportFailureMessage = (action: SandboxAction): string => {
+  switch (action) {
+    case "create":
+      return "The Sandbox Create response was not confirmed. Repeating the same Create request is safe";
+    case "destroy":
+      return "Sandbox teardown may have been accepted. Get the sandbox; repeating Destroy is safe";
+    case "file.upload":
+      return "The sandbox file may have been replaced. Repeating the same upload is safe";
+    case "exec":
+      return "The sandbox command may have run. Inspect its external effects before running it again";
+    case "process.start":
+      return "A sandbox process may be running. List processes and reconcile before starting another";
+    case "process.signal":
+      return "The sandbox process signal may have been delivered. Get or wait for the process before sending another";
+    default:
+      return "Compute is temporarily unavailable. Retry this operation";
+  }
+};
+
+const sandboxAmbiguousResponseMessage = (action: SandboxAction): string => {
+  if (action === "create") {
+    return "A sandbox was created, but its current resource could not be loaded. List sandboxes and reconcile by name before creating another";
+  }
+  return sandboxTransportFailureMessage(action);
+};
 
 class SandboxRestTransport {
   constructor(private readonly config: SandboxClientConfig) {}
@@ -176,11 +205,12 @@ class SandboxRestTransport {
     if (response.status === 204) {
       return { status: response.status };
     }
-    const raw = await response.json().catch((error: unknown) => {
-      throw new SandboxValidationError("Sandbox API returned invalid JSON", {
-        cause: error,
-      });
-    });
+    const raw = await this.readResponseJSON(
+      action,
+      response,
+      options.sandboxId,
+      options.processId,
+    );
     return {
       status: response.status,
       envelope: parseWithSchema(
@@ -212,6 +242,19 @@ class SandboxRestTransport {
       );
     }
     return response;
+  }
+
+  async readResponseEnvelope(
+    action: SandboxAction,
+    response: Response,
+    sandboxId?: string,
+    processId?: string,
+  ): Promise<z.infer<typeof responseEnvelopeSchema>> {
+    return parseWithSchema(
+      responseEnvelopeSchema,
+      await this.readResponseJSON(action, response, sandboxId, processId),
+      "sandbox API response",
+    );
   }
 
   async stream(
@@ -352,21 +395,46 @@ class SandboxRestTransport {
         requestInit,
       );
     } catch (error) {
-      const safeToRepeat = action === "create" || safeReadActions.has(action);
-      throw new SandboxError({
+      throw this.transportFailure(
         action,
-        code: safeToRepeat ? "compute_unavailable" : "operation_ambiguous",
-        message: safeToRepeat
-          ? "Compute is temporarily unavailable"
-          : "Sandbox operation result is ambiguous",
-        sandboxId: options.sandboxId,
-        processId: options.processId,
-        ambiguous: !safeToRepeat,
-        retryable: safeToRepeat,
-        details: [],
-        cause: error,
-      });
+        error,
+        options.sandboxId,
+        options.processId,
+      );
     }
+  }
+
+  private async readResponseJSON(
+    action: SandboxAction,
+    response: Response,
+    sandboxId?: string,
+    processId?: string,
+  ): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch (error) {
+      throw this.transportFailure(action, error, sandboxId, processId);
+    }
+  }
+
+  private transportFailure(
+    action: SandboxAction,
+    cause: unknown,
+    sandboxId?: string,
+    processId?: string,
+  ): SandboxError {
+    const safeToRepeat = safeRepeatActions.has(action);
+    return new SandboxError({
+      action,
+      code: safeToRepeat ? "compute_unavailable" : "operation_ambiguous",
+      message: sandboxTransportFailureMessage(action),
+      sandboxId,
+      processId,
+      ambiguous: !safeToRepeat,
+      retryable: safeToRepeat,
+      details: [],
+      cause,
+    });
   }
 
   private async throwResponseError(
@@ -415,7 +483,10 @@ class SandboxRestTransport {
     return new SandboxError({
       action,
       code: item.code as SandboxErrorCode,
-      message: item.message,
+      message:
+        item.code === "operation_ambiguous"
+          ? sandboxAmbiguousResponseMessage(action)
+          : item.message,
       status,
       sandboxId,
       processId,
@@ -641,10 +712,10 @@ const createDirectSandboxFacade = (
             sandboxId: ref.id,
           },
         );
-        const envelope = parseWithSchema(
-          responseEnvelopeSchema,
-          await response.json(),
-          "sandbox file upload response",
+        const envelope = await transport.readResponseEnvelope(
+          "file.upload",
+          response,
+          ref.id,
         );
         return parseWithSchema(
           fileUploadResultSchema,


### PR DESCRIPTION
- Add action-specific recovery guidance to sandbox errors.
- Classify lost successful response bodies using the operation's replay safety.
- Keep Create, Destroy, file upload, and reads retryable where replay is safe.
- Keep captured Exec, process Start, and process Signal non-retryable when dispatch may have happened.
- Preserve `action`, ambiguity, and retryability through direct and durable SDK errors.

`operation_ambiguous` describes a real case, but the generic message did not tell callers how to recover. These errors now explain whether to retry, inspect external effects, or reconcile sandbox/process state
