### PR TITLE
fix: sub-second sleep/timeout durations being dropped

### DIFF
--- a/.changeset/tidy-camels-sleep.md
+++ b/.changeset/tidy-camels-sleep.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Sub-second durations no longer get dropped. `step.sleep("id", 500)` used to resolve immediately; it now rounds up and sleeps a full second, the minimum resolution of a durable wait. The same rounding applies to `waitForEvent`, `invoke`, `waitForSignal`, and `cancelOn` timeouts.

--- a/packages/inngest/src/components/InngestFunction.ts
+++ b/packages/inngest/src/components/InngestFunction.ts
@@ -208,7 +208,7 @@ export class InngestFunction<
         };
 
         if (timeout) {
-          ret.timeout = timeStr(timeout);
+          ret.timeout = timeStr(timeout, this.client[internalLoggerSymbol]);
         }
 
         if (match) {

--- a/packages/inngest/src/components/InngestStepTools.test.ts
+++ b/packages/inngest/src/components/InngestStepTools.test.ts
@@ -83,6 +83,16 @@ describe("waitForEvent", () => {
     });
   });
 
+  test("round sub-second number `timeout` up to 1s", async () => {
+    await expect(
+      step.waitForEvent("id", { event: "event", timeout: 500 }),
+    ).resolves.toMatchObject({
+      opts: {
+        timeout: "1s",
+      },
+    });
+  });
+
   test("return TTL if date `timeout` given", async () => {
     const upcoming = new Date();
     upcoming.setDate(upcoming.getDate() + 6);
@@ -720,6 +730,12 @@ describe("sleep", () => {
   test("parses number of milliseconds", async () => {
     await expect(step.sleep("id", 60000)).resolves.toMatchObject({
       name: "1m",
+    });
+  });
+
+  test("rounds sub-second number of milliseconds up to 1s", async () => {
+    await expect(step.sleep("id", 500)).resolves.toMatchObject({
+      name: "1s",
     });
   });
 

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -532,7 +532,7 @@ export const createStepTools = <
         displayName: name ?? id,
         opts: {
           signal: opts.signal,
-          timeout: timeStr(opts.timeout),
+          timeout: timeStr(opts.timeout, client[internalLoggerSymbol]),
           conflict: opts.onConflict,
         },
         userland: { id },
@@ -671,6 +671,9 @@ export const createStepTools = <
            * `"2.5d"`, a `Date`, a `Temporal.Duration` (relative wait), or a
            * `Temporal.Instant` / `Temporal.ZonedDateTime` (absolute deadline).
            *
+           * Durations of less than 1 second round up to `1s`, the minimum
+           * resolution of a durable wait.
+           *
            * {@link https://npm.im/ms}
            */
           timeout:
@@ -695,7 +698,10 @@ export const createStepTools = <
         opts,
       ) => {
         const matchOpts: { timeout: string; if?: string } = {
-          timeout: timeStr(typeof opts === "string" ? opts : opts.timeout),
+          timeout: timeStr(
+            typeof opts === "string" ? opts : opts.timeout,
+            client[internalLoggerSymbol],
+          ),
         };
 
         if (typeof opts !== "string") {
@@ -804,6 +810,9 @@ export const createStepTools = <
      * The time to wait can be specified using a `number` of milliseconds or an
      * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`.
      *
+     * Durations of less than 1 second round up to `1s`, the minimum
+     * resolution of a durable wait.
+     *
      * {@link https://npm.im/ms}
      *
      * To wait until a particular date, use `sleepUntil` instead.
@@ -822,7 +831,7 @@ export const createStepTools = <
        * The presence of this operation in the returned stack indicates that the
        * sleep is over and we should continue execution.
        */
-      const msTimeStr: string = timeStr(time);
+      const msTimeStr: string = timeStr(time, client[internalLoggerSymbol]);
 
       return {
         id,
@@ -956,7 +965,10 @@ export const createStepTools = <
       } = {
         payload,
         function_id: "",
-        timeout: typeof timeout === "undefined" ? undefined : timeStr(timeout),
+        timeout:
+          typeof timeout === "undefined"
+            ? undefined
+            : timeStr(timeout, client[internalLoggerSymbol]),
       };
 
       switch (_type) {
@@ -1222,6 +1234,9 @@ type InvocationOpts<TFunction extends InvokeTargetFunctionDefinition> =
        * a `Date`, a `Temporal.Duration` (relative wait), or a `Temporal.Instant`
        * / `Temporal.ZonedDateTime` (absolute deadline).
        *
+       * Durations of less than 1 second round up to `1s`, the minimum
+       * resolution of a durable wait.
+       *
        * {@link https://npm.im/ms}
        */
       timeout?:
@@ -1266,6 +1281,9 @@ type WaitForSignalOpts = {
    * `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, a
    * `Date`, a `Temporal.Duration` (relative wait), or a `Temporal.Instant` /
    * `Temporal.ZonedDateTime` (absolute deadline).
+   *
+   * Durations of less than 1 second round up to `1s`, the minimum
+   * resolution of a durable wait.
    *
    * {@link https://npm.im/ms}
    */

--- a/packages/inngest/src/helpers/strings.test.ts
+++ b/packages/inngest/src/helpers/strings.test.ts
@@ -44,6 +44,76 @@ describe("timeStr", () => {
     expect(timeStr("1 day")).toEqual("1d");
   });
 
+  describe("sub-second durations", () => {
+    test("rounds sub-second values up to 1s instead of dropping them", () => {
+      expect(timeStr(1)).toEqual("1s");
+      expect(timeStr(500)).toEqual("1s");
+      expect(timeStr("500ms")).toEqual("1s");
+      expect(timeStr(999)).toEqual("1s");
+    });
+
+    test("floors sub-second remainders on durations of at least 1s", () => {
+      expect(timeStr(1500)).toEqual("1s");
+      expect(timeStr(65500)).toEqual("1m5s");
+    });
+
+    test("whole-second values are unchanged", () => {
+      expect(timeStr(1000)).toEqual("1s");
+      expect(timeStr(60000)).toEqual("1m");
+    });
+
+    test("fractional sub-second durations also round up to 1s", () => {
+      expect(timeStr(999.6)).toEqual("1s");
+      expect(timeStr(0.4)).toEqual("1s");
+    });
+
+    test("Temporal.Duration sub-second components floor as on any input", () => {
+      expect(
+        timeStr(Temporal.Duration.from({ hours: 1, nanoseconds: 1 })),
+      ).toEqual("1h");
+
+      expect(
+        timeStr(
+          Temporal.Duration.from({
+            hours: 1,
+            milliseconds: 999,
+            nanoseconds: 999999,
+          }),
+        ),
+      ).toEqual("1h");
+    });
+
+    test("zero and negative durations still return an empty string", () => {
+      expect(timeStr(0)).toEqual("");
+      expect(timeStr(-500)).toEqual("");
+    });
+
+    test("never returns an empty string for durations of at least 1ms", () => {
+      for (const value of [1, 10, 100, 500, 999, 1001, 1500]) {
+        expect(timeStr(value)).not.toEqual("");
+      }
+    });
+
+    test("warns once per process when a logger is given and the clamp fires", () => {
+      const mockLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      expect(timeStr(500, mockLogger)).toEqual("1s");
+      expect(timeStr(700, mockLogger)).toEqual("1s");
+      expect(timeStr(1500, mockLogger)).toEqual("1s");
+
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        { requestedMs: 500 },
+        expect.stringContaining("round up to 1s"),
+      );
+    });
+  });
+
   test("converts a date to an ISO string", () => {
     expect(timeStr(new Date(0))).toEqual("1970-01-01T00:00:00.000Z");
   });

--- a/packages/inngest/src/helpers/strings.ts
+++ b/packages/inngest/src/helpers/strings.ts
@@ -2,7 +2,8 @@ import hashjs from "hash.js";
 import { default as safeStringify } from "json-stringify-safe";
 import ms from "ms";
 import { Temporal } from "temporal-polyfill";
-import type { TimeStr } from "../types.ts";
+import type { Logger } from "../middleware/logger.ts";
+import { warnOnce } from "./log.ts";
 import {
   type DurationLike,
   getISOString,
@@ -88,7 +89,7 @@ const periods = [
 
 /**
  * Convert a given `Date`, `number`, or `ms`-compatible `string` to a
- * Inngest sleep-compatible time string (e.g. `"1d"` or `"2h3010s"`).
+ * Inngest sleep-compatible time string (e.g. `"1d"` or `"2h30m10s"`).
  */
 export const timeStr = (
   /**
@@ -101,6 +102,12 @@ export const timeStr = (
     | DurationLike
     | InstantLike
     | ZonedDateTimeLike,
+
+  /**
+   * If given, used to warn (once per process) when a sub-second duration is
+   * rounded up to 1s.
+   */
+  logger?: Logger,
 ): string => {
   if (input instanceof Date) {
     return input.toISOString();
@@ -128,6 +135,21 @@ export const timeStr = (
     milliseconds = input as number;
   }
 
+  // Purely sub-second durations round up to 1s: the round-trip latency of a
+  // durable wait dwarfs them, and flooring would serialize to "", which the
+  // server treats as a 0-duration wait.
+  if (milliseconds > 0 && milliseconds < second) {
+    if (logger) {
+      warnOnce(
+        logger,
+        "sub-second-duration-clamp",
+        { requestedMs: milliseconds },
+        "Durable waits have a minimum resolution of 1s; durations under 1s round up to 1s",
+      );
+    }
+    milliseconds = second;
+  }
+
   const [, timeStr] = periods.reduce<[number, string]>(
     ([num, str], [suffix, period]) => {
       const numPeriods = Math.floor(num / period);
@@ -141,7 +163,7 @@ export const timeStr = (
     [milliseconds, ""],
   );
 
-  return timeStr as TimeStr;
+  return timeStr;
 };
 
 /**

--- a/packages/inngest/src/test/integration/subSecondDurations.test.ts
+++ b/packages/inngest/src/test/integration/subSecondDurations.test.ts
@@ -1,0 +1,102 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { expect, test } from "vitest";
+import { Inngest } from "../../index.ts";
+import { createServer } from "../../node.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+test("step.sleep with a 500ms numeric duration rounds up and sleeps 1s", async () => {
+  // Sub-second numeric durations used to serialize to "" (floored to whole
+  // seconds), which the server treated as a 0-duration sleep. They now round
+  // up to 1s, the wire format's resolution.
+
+  const state = createState({ beforeSleep: 0, afterSleep: 0 });
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      state.beforeSleep ||= Date.now();
+      await step.sleep("sleep", 500);
+      state.afterSleep ||= Date.now();
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  expect(result).toBe("done");
+  const elapsed = state.afterSleep - state.beforeSleep;
+  expect(elapsed).toBeGreaterThanOrEqual(900);
+});
+
+test("step.sleep with a 1500ms numeric duration floors to 1s", async () => {
+  // Durations of at least 1s floor to whole seconds, matching long-standing
+  // behavior; only purely sub-second durations round up.
+
+  const state = createState({ beforeSleep: 0, afterSleep: 0 });
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      state.beforeSleep ||= Date.now();
+      await step.sleep("sleep", 1500);
+      state.afterSleep ||= Date.now();
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  expect(result).toBe("done");
+  const elapsed = state.afterSleep - state.beforeSleep;
+  expect(elapsed).toBeGreaterThanOrEqual(900);
+});
+
+test("step.waitForEvent with a sub-second numeric timeout times out with null", async () => {
+  const state = createState<{ waitResult: unknown }>({ waitResult: "unset" });
+
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const eventName = randomSuffix("evt");
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      state.waitResult = await step.waitForEvent("wait", {
+        event: randomSuffix("never"),
+        timeout: 500,
+      });
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  await client.send({ name: eventName });
+  const result = await state.waitForRunComplete();
+
+  expect(result).toBe("done");
+  expect(state.waitResult).toBeNull();
+});

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -1495,6 +1495,9 @@ export type Cancellation = {
    * `Date`, a `Temporal.Duration` (relative wait), or a `Temporal.Instant` /
    * `Temporal.ZonedDateTime` (absolute deadline).
    *
+   * Durations of less than 1 second round up to `1s`, the minimum
+   * resolution of a durable wait.
+   *
    * {@link https://npm.im/ms}
    */
   timeout?:


### PR DESCRIPTION
## Summary

Durable waits have a 1s minimum resolution: sub-second durations now round up to 1s instead of serializing to "" (an instant resolve), warning once per process when the round-up fires. Durations of 1s and up floor to whole seconds, unchanged.

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

* [EXE-1994](https://linear.app/inngest/issue/EXE-1994/stepsleep-stepwaitforevent-silently-drop-sub-second-durations-empty)
* #1619 
* #1644 
* #1653 
* #1641 
* #1642 
