### PR TITLE
chore(errors): remove serialize-error-cjs dependency

### DIFF
--- a/.changeset/tame-otters-unwind.md
+++ b/.changeset/tame-otters-unwind.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Remove the unmaintained `serialize-error-cjs` dependency

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -324,7 +324,6 @@
     "hash.js": "^1.1.7",
     "json-stringify-safe": "^5.0.1",
     "ms": "^2.1.3",
-    "serialize-error-cjs": "^0.1.3",
     "temporal-polyfill": "^0.2.5",
     "ulid": "^2.3.0",
     "zod": "^3.25.0"

--- a/packages/inngest/src/helpers/errors.test.ts
+++ b/packages/inngest/src/helpers/errors.test.ts
@@ -1,4 +1,9 @@
-import { isSerializedError, serializeError } from "./errors.ts";
+import { NonRetriableError } from "../components/NonRetriableError.ts";
+import {
+  deserializeError,
+  isSerializedError,
+  serializeError,
+} from "./errors.ts";
 
 interface ErrorTests {
   name: string;
@@ -101,5 +106,70 @@ describe("serializeError", () => {
     name: "Existing serialized error",
     error: serializeError(new Error("test")),
     tests: { message: "test" },
+  });
+});
+
+class MyCustomError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "MyCustomError";
+  }
+}
+
+describe("serializeError -> deserializeError round trip", () => {
+  it("round-trips a NonRetriableError", () => {
+    const err = deserializeError(serializeError(new NonRetriableError("boom")));
+
+    expect(err.name).toBe("NonRetriableError");
+    expect(err.message).toBe("boom");
+    expect(err).toBeInstanceOf(NonRetriableError);
+  });
+
+  it("round-trips a built-in TypeError", () => {
+    const err = deserializeError(serializeError(new TypeError("bad")));
+
+    expect(err.name).toBe("TypeError");
+    expect(err).toBeInstanceOf(TypeError);
+  });
+
+  it("round-trips a plain Error", () => {
+    const err = deserializeError(serializeError(new Error("plain")));
+
+    expect(err.name).toBe("Error");
+    expect(err.message).toBe("plain");
+  });
+
+  it("preserves a cause through the round trip", () => {
+    const err = deserializeError(
+      serializeError(
+        new NonRetriableError("outer", { cause: new Error("inner") }),
+      ),
+    );
+
+    expect(err.cause).toMatchObject({ message: "inner" });
+  });
+
+  it("falls back to a plain Error for an unknown custom error name", () => {
+    const err = deserializeError(serializeError(new MyCustomError("custom")));
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("custom");
+  });
+
+  it("recognizes a stringified serialized error instead of double-wrapping", () => {
+    const str = JSON.stringify(serializeError(new Error("stringified")));
+
+    const err = deserializeError(serializeError(str));
+
+    expect(err.name).toBe("Error");
+    expect(err.message).toBe("stringified");
+  });
+
+  it("preserves a code through the round trip", () => {
+    const original = Object.assign(new Error("with code"), { code: "E_TEST" });
+
+    const err = deserializeError(serializeError(original));
+
+    expect(err).toMatchObject({ message: "with code", code: "E_TEST" });
   });
 });

--- a/packages/inngest/src/helpers/errors.ts
+++ b/packages/inngest/src/helpers/errors.ts
@@ -1,16 +1,22 @@
 import stringify from "json-stringify-safe";
-import {
-  type SerializedError as CjsSerializedError,
-  deserializeError as cjsDeserializeError,
-  serializeError as cjsSerializeError,
-  errorConstructors,
-} from "serialize-error-cjs";
 import { z } from "zod/v3";
 import { NonRetriableError } from "../components/NonRetriableError.ts";
 import type { ClientOptions, OutgoingOp } from "../types.ts";
 
 const SERIALIZED_KEY = "__serialized";
 const SERIALIZED_VALUE = true;
+
+/**
+ * The properties preserved when serializing and deserializing errors, with
+ * the enumerability each has on a real `Error` instance.
+ */
+const copiedErrorProperties = [
+  { key: "name", enumerable: false },
+  { key: "message", enumerable: false },
+  { key: "stack", enumerable: false },
+  { key: "code", enumerable: true },
+  { key: "cause", enumerable: false },
+] as const;
 
 /**
  * Add first-class support for certain errors that we control, in addition to
@@ -22,30 +28,76 @@ const SERIALIZED_VALUE = true;
  *
  * Note that these errors only support `message?: string | undefined` as the
  * input; more custom errors are not supported with this current strategy.
+ *
+ * New public error classes are usually fine unregistered; deserialization
+ * falls back to `Error`. Only `name`, `message`, `stack`, `code`, and
+ * `cause` survive serialization either way, so register a factory only if
+ * users need `instanceof` checks in `onFailure` handlers.
  */
-errorConstructors.set(
-  "NonRetriableError",
-  NonRetriableError as ErrorConstructor,
-);
+const errorFactories = new Map<string, () => Error>([
+  ["EvalError", () => new EvalError()],
+  ["RangeError", () => new RangeError()],
+  ["ReferenceError", () => new ReferenceError()],
+  ["SyntaxError", () => new SyntaxError()],
+  ["TypeError", () => new TypeError()],
+  ["URIError", () => new URIError()],
+  ["NonRetriableError", () => new NonRetriableError("")],
+]);
 
-export interface SerializedError extends Readonly<CjsSerializedError> {
+// `name` and other error properties usually live on the prototype, so check
+// with `in` rather than own-property lookups.
+const pickErrorProperties = (subject: object): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  for (const { key } of copiedErrorProperties) {
+    if (Reflect.has(subject, key)) {
+      result[key] = Reflect.get(subject, key);
+    }
+  }
+
+  return result;
+};
+
+const reconstructError = (subject: object): Error => {
+  const name = Reflect.get(subject, "name");
+  const factory =
+    typeof name === "string" ? errorFactories.get(name) : undefined;
+
+  const output = factory ? factory() : new Error();
+
+  for (const { key, enumerable } of copiedErrorProperties) {
+    if (Reflect.has(subject, key)) {
+      Object.defineProperty(output, key, {
+        value: Reflect.get(subject, key),
+        enumerable,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+
+  return output;
+};
+
+export interface SerializedError {
+  readonly name: string;
+  readonly message: string;
+  readonly stack: string;
   readonly [SERIALIZED_KEY]: typeof SERIALIZED_VALUE;
 }
 
 /**
- * Serialise an error to a serialized JSON string.
+ * Serialize an error to a plain, JSON-serializable object.
  *
- * Errors do not serialise nicely to JSON, so we use this function to convert
- * them to a serialized JSON string. Doing this is also non-trivial for some
- * errors, so we use the `serialize-error` package to do it for us.
+ * Errors do not serialize nicely to JSON by default, so we use this function
+ * to convert them to a plain object, copying across the properties that
+ * matter (`name`, `message`, `stack`, and, where present, `code` and
+ * `cause`).
  *
- * See {@link https://www.npmjs.com/package/serialize-error}
+ * This function also adds a marker property to the serialized error, so that
+ * we can distinguish between serialized errors and other objects.
  *
- * This function is a small wrapper around that package to also add a `type`
- * property to the serialised error, so that we can distinguish between
- * serialised errors and other objects.
- *
- * Will not reserialise existing serialised errors.
+ * Will not reserialize existing serialized errors.
  */
 export const serializeError = <
   TAllowUnknown extends boolean = false,
@@ -75,7 +127,7 @@ export const serializeError = <
 
     if (typeof subject === "object" && subject !== null) {
       // Is an object, so let's try and serialize it.
-      const serializedErr = cjsSerializeError(subject as Error);
+      const serializedErr = pickErrorProperties(subject);
 
       // Not a proper error was caught, so give us a chance to return `unknown`.
       if (!serializedErr.name && allowUnknown) {
@@ -103,20 +155,29 @@ export const serializeError = <
       // If we have a cause, make sure we recursively serialize them too. We are
       // lighter with causes though; attempt to recursively serialize them, but
       // stop if we find something that doesn't work and just return `unknown`.
-      let target: unknown = ret;
+      // Values that come back unserialized are copied before we walk into
+      // them, so we never mutate objects the caller still holds.
+      let target: object = ret;
       const maxDepth = 5;
       for (let i = 0; i < maxDepth; i++) {
-        if (
-          typeof target === "object" &&
-          target !== null &&
-          "cause" in target &&
-          target.cause
-        ) {
-          target = target.cause = serializeError(target.cause, true);
-          continue;
+        if (!("cause" in target) || !target.cause) {
+          break;
         }
 
-        break;
+        const serializedCause = serializeError(target.cause, true);
+
+        if (typeof serializedCause !== "object" || serializedCause === null) {
+          target.cause = serializedCause;
+          break;
+        }
+
+        const next =
+          serializedCause === target.cause
+            ? { ...serializedCause }
+            : serializedCause;
+
+        target.cause = next;
+        target = next;
       }
 
       return ret as TOutput;
@@ -159,6 +220,15 @@ export const serializeError = <
   }
 };
 
+const serializedErrorSchema = z
+  .object({
+    [SERIALIZED_KEY]: z.literal(SERIALIZED_VALUE),
+    name: z.string(),
+    message: z.string(),
+    stack: z.string(),
+  })
+  .passthrough();
+
 /**
  * Check if an object or a string is a serialised error created by
  * {@link serializeError}.
@@ -168,18 +238,7 @@ export const isSerializedError = (
 ): SerializedError | undefined => {
   try {
     if (typeof value === "string") {
-      const parsed = z
-        .object({
-          [SERIALIZED_KEY]: z.literal(SERIALIZED_VALUE),
-          name: z.enum([...Array.from(errorConstructors.keys())] as [
-            string,
-            ...string[],
-          ]),
-          message: z.string(),
-          stack: z.string(),
-        })
-        .passthrough()
-        .safeParse(JSON.parse(value));
+      const parsed = serializedErrorSchema.safeParse(JSON.parse(value));
 
       if (parsed.success) {
         return parsed.data as SerializedError;
@@ -231,7 +290,7 @@ export const deserializeError = <
       throw new Error();
     }
 
-    const deserializedErr = cjsDeserializeError(subject as SerializedError);
+    const deserializedErr = reconstructError(subject);
 
     if ("cause" in deserializedErr) {
       deserializedErr.cause = deserializeError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       react:
         specifier: '>=18.0.0'
         version: 19.0.0
-      serialize-error-cjs:
-        specifier: ^0.1.3
-        version: 0.1.3
       temporal-polyfill:
         specifier: ^0.2.5
         version: 0.2.5


### PR DESCRIPTION
## Summary
Inline error serialization into `helpers/errors.ts` and drop the unmaintained `serialize-error-cjs` dependency. Behavior matches the old library (same property list, enumerability, and fallback to `Error`), with two deliberate changes: stringified serialized errors are recognized instead of double-wrapped, and the cause loop no longer mutates caller-held cause objects.

## Checklist

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A internal refactor
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- #1217 — related but not fixed: serialization still preserves only
  `name`, `message`, `stack`, `code`, and `cause`. Preserving custom
  properties is now a small local follow-up instead of a dependency swap.