### PR TITLE
feat(sandbox): support create environment variables

### DIFF
--- a/.changeset/fuzzy-dingos-build.md
+++ b/.changeset/fuzzy-dingos-build.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Allow sandbox Create to configure environment variables inherited by commands and managed processes.

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -12,6 +12,7 @@ import { Inngest } from "./Inngest.ts";
 import {
   createSandboxClient,
   createSandboxTools,
+  parseSandboxOperation,
   SandboxError,
   type SandboxOperationResultV1,
   type SandboxOperationV1,
@@ -55,6 +56,10 @@ const createOptions = {
   name: sandboxRef.name,
   vcpu: 2,
   memoryMb: 2048,
+  environment: {
+    "1.WITH-DOT": "allowed",
+    SHARED: "sandbox",
+  },
 };
 
 const resultForOperation = (
@@ -294,6 +299,20 @@ describe("step.sandbox", () => {
       throw new Error("Expected sandbox");
     }
     rawTool.mockClear();
+
+    await expect(
+      createSandboxTools(() => rawTool).create("create", {
+        ...createOptions,
+        environment: { "": "invalid" },
+      }),
+    ).rejects.toBeInstanceOf(SandboxValidationError);
+    expect(() =>
+      parseSandboxOperation({
+        protocolVersion: 1,
+        action: "create",
+        input: [{ ...createOptions, environment: { "": "invalid" } }],
+      }),
+    ).toThrow(SandboxValidationError);
 
     await expect(
       sandbox.commands.run("exec", {
@@ -897,6 +916,31 @@ describe("step.sandbox", () => {
 });
 
 describe("inngest.sandboxes", () => {
+  test("validates Create environment before transport", async () => {
+    const fetchMock: typeof fetch = vi.fn();
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+    const tooMany = Object.fromEntries(
+      Array.from({ length: 257 }, (_, index) => [`KEY_${index}`, "value"]),
+    );
+
+    for (const environment of [
+      { "": "invalid" },
+      { KEY: "value\0" },
+      tooMany,
+      { KEY: "x".repeat(64 * 1_024) },
+    ]) {
+      await expect(
+        client.create({ ...createOptions, environment }),
+      ).rejects.toBeInstanceOf(SandboxValidationError);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("marks Create transport failures as retryable", async () => {
     const client = createSandboxClient({
       baseUrl: () => "https://api.example.test",

--- a/packages/inngest/src/components/sandbox/protocol.ts
+++ b/packages/inngest/src/components/sandbox/protocol.ts
@@ -10,6 +10,7 @@ import {
 } from "./types.ts";
 import {
   canonicalUuidSchema,
+  normalizeSandboxCreateOptions,
   normalizeSandboxProcessStartOptions,
   parseWithSchema,
   sandboxProcessRefSchema,
@@ -38,9 +39,27 @@ const createInputSchema = z
     name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
     vcpu: z.number().int().positive().max(0xffffffff),
     memoryMb: z.number().int().positive().max(0xffffffff),
+    environment: z.record(z.string()).optional(),
     runningTimeoutMs: z.number().int().positive().max(300_000).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, ctx) => {
+    try {
+      const { runningTimeoutMs, ...options } = value;
+      normalizeSandboxCreateOptions({
+        ...options,
+        ...(runningTimeoutMs !== undefined && {
+          runningTimeout: runningTimeoutMs,
+        }),
+      });
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          error instanceof Error ? error.message : "invalid create options",
+      });
+    }
+  });
 const listInputSchema = z
   .object({
     cursor: z.string().min(1).optional(),

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -40,11 +40,19 @@ export interface SandboxRef extends SandboxResource {
 export interface SandboxCreateOptions {
   /**
    * Stable identity for an active sandbox. Creating the same name again with
-   * the same resources returns the existing sandbox.
+   * the same configuration returns the existing sandbox.
    */
   name: string;
   vcpu: number;
   memoryMb: number;
+
+  /**
+   * Environment inherited by commands and managed processes. Values are
+   * persisted as literal sandbox configuration; this is not a secrets
+   * mechanism, so do not use this field for secrets. Guest defaults are
+   * retained, and operation-specific values override matching keys.
+   */
+  environment?: Record<string, string>;
 
   /**
    * Wait up to this duration for the sandbox to reach RUNNING.
@@ -80,8 +88,8 @@ export interface SandboxCommandOptions {
   command: readonly string[];
 
   /**
-   * Replaces the sandbox environment for this command. It is not merged.
-   * Omitted or empty uses the guest's default environment.
+   * Overrides matching sandbox environment values for this command.
+   * Omitted or empty inherits the sandbox environment unchanged.
    */
   environment?: Record<string, string>;
   cwd?: string;
@@ -151,8 +159,8 @@ export interface SandboxProcessStartOptions {
   command: readonly string[];
 
   /**
-   * Replaces the sandbox environment for this process. It is not merged.
-   * Omitted or empty uses the guest's default environment.
+   * Overrides matching sandbox environment values for this process.
+   * Omitted or empty inherits the sandbox environment unchanged.
    */
   environment?: Record<string, string>;
   cwd?: string;

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -44,6 +44,64 @@ const goJSONBytes = (value: unknown): number => {
   return textEncoder.encode(encoded).byteLength;
 };
 
+const assertNoNul = (value: string, context: string): void => {
+  if (value.includes("\0")) {
+    throw new SandboxValidationError(`${context} must not contain NUL`);
+  }
+};
+
+const assertValidUnicode = (value: string, context: string): void => {
+  for (let index = 0; index < value.length; index++) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        throw new SandboxValidationError(
+          `${context} must not contain an unpaired surrogate`,
+        );
+      }
+      index++;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw new SandboxValidationError(
+        `${context} must not contain an unpaired surrogate`,
+      );
+    }
+  }
+};
+
+const validateSandboxEnvironment = (
+  environment: Record<string, string> | undefined,
+): Array<[string, string]> => {
+  const entries = Object.entries(environment ?? {});
+  if (entries.length > maxProcessEnvCount) {
+    throw new SandboxValidationError(
+      `environment must not contain more than ${maxProcessEnvCount} entries`,
+    );
+  }
+  let environmentBytes = 0;
+  for (const [key, value] of entries) {
+    if (!key || key.includes("=")) {
+      throw new SandboxValidationError(
+        "environment keys must be nonempty and must not contain '='",
+      );
+    }
+    assertNoNul(key, `environment key ${key}`);
+    assertNoNul(value, `environment.${key}`);
+    assertValidUnicode(key, `environment key ${key}`);
+    assertValidUnicode(value, `environment.${key}`);
+    environmentBytes +=
+      textEncoder.encode(key).byteLength +
+      1 +
+      textEncoder.encode(value).byteLength;
+  }
+  if (environmentBytes > maxProcessEnvBytes) {
+    throw new SandboxValidationError(
+      `environment must not exceed ${maxProcessEnvBytes} bytes`,
+    );
+  }
+  return entries;
+};
+
 export const canonicalUuidSchema = z
   .string()
   .regex(
@@ -284,12 +342,14 @@ export const normalizeSandboxCreateOptions = (
         name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
         vcpu: z.number().int().positive().max(0xffffffff),
         memoryMb: z.number().int().positive().max(0xffffffff),
+        environment: z.record(z.string()).optional(),
         runningTimeout: z.unknown().optional(),
       })
       .strict(),
     options,
     "sandbox create options",
   );
+  validateSandboxEnvironment(parsed.environment);
   const { runningTimeout, ...create } = parsed;
   return {
     ...create,
@@ -339,31 +399,6 @@ export const normalizeSandboxListOptions = (
 
 export const normalizeSandboxProcessListOptions = normalizeSandboxListOptions;
 
-const assertNoNul = (value: string, context: string): void => {
-  if (value.includes("\0")) {
-    throw new SandboxValidationError(`${context} must not contain NUL`);
-  }
-};
-
-const assertValidUnicode = (value: string, context: string): void => {
-  for (let index = 0; index < value.length; index++) {
-    const codeUnit = value.charCodeAt(index);
-    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (next < 0xdc00 || next > 0xdfff) {
-        throw new SandboxValidationError(
-          `${context} must not contain an unpaired surrogate`,
-        );
-      }
-      index++;
-    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
-      throw new SandboxValidationError(
-        `${context} must not contain an unpaired surrogate`,
-      );
-    }
-  }
-};
-
 const normalizeProcessSpec = <
   T extends SandboxCommandOptions | SandboxProcessStartOptions,
 >(
@@ -400,34 +435,7 @@ const normalizeProcessSpec = <
     );
   }
 
-  const environment = parsed.environment ?? {};
-  const entries = Object.entries(environment);
-  if (entries.length > maxProcessEnvCount) {
-    throw new SandboxValidationError(
-      `environment must not contain more than ${maxProcessEnvCount} entries`,
-    );
-  }
-  let environmentBytes = 0;
-  for (const [key, value] of entries) {
-    if (!key || key.includes("=")) {
-      throw new SandboxValidationError(
-        "environment keys must be nonempty and must not contain '='",
-      );
-    }
-    assertNoNul(key, `environment key ${key}`);
-    assertNoNul(value, `environment.${key}`);
-    assertValidUnicode(key, `environment key ${key}`);
-    assertValidUnicode(value, `environment.${key}`);
-    environmentBytes +=
-      textEncoder.encode(key).byteLength +
-      1 +
-      textEncoder.encode(value).byteLength;
-  }
-  if (environmentBytes > maxProcessEnvBytes) {
-    throw new SandboxValidationError(
-      `environment must not exceed ${maxProcessEnvBytes} bytes`,
-    );
-  }
+  const entries = validateSandboxEnvironment(parsed.environment);
 
   if (parsed.cwd !== undefined) {
     assertNoNul(parsed.cwd, "cwd");


### PR DESCRIPTION
## Summary

- add environment to sandbox Create for both direct and durable clients
- validate direct and serialized middleware calls against the canonical Simcity limits before dispatch
- document sandbox inheritance, per-command/process overrides, and that Create environment values are persisted configuration—not secrets
- add a release changeset

This is stacked on #1664.

## Tests

- pnpm run test src/components/InngestSandbox.test.ts
- Biome check
- pnpm build
