### PR TITLE
feat: batched events use the intersection of their sessions

### DIFF
--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -955,11 +955,20 @@ describe("step.invoke session propagation", () => {
       },
     );
 
-    // Two triggering events carrying sessions — exercises the run-level
-    // aggregation that produces `ctx.sessions`.
+    // Two triggering events whose sessions only partly overlap — exercises the
+    // run-level aggregation that produces `ctx.sessions`, and pins that only
+    // the shared pairs survive it.
     const events = [
-      { name: "test/event", data: {}, meta: { sessions: { conv_id: "p1" } } },
-      { name: "test/event", data: {}, meta: { sessions: { org_id: "42" } } },
+      {
+        name: "test/event",
+        data: {},
+        meta: { sessions: { conv_id: "p1", org_id: "42", only_a: "1" } },
+      },
+      {
+        name: "test/event",
+        data: {},
+        meta: { sessions: { conv_id: "p1", org_id: "42", only_b: "2" } },
+      },
     ];
 
     const execution = fn["createExecution"]({

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -24,51 +24,44 @@ describe("reduceEventsToPropagatedSessions", () => {
     expect(reduceEventsToPropagatedSessions([{ meta: null }])).toEqual({});
   });
 
-  test("batch unions sessions across all triggering events", () => {
-    expect(
-      reduceEventsToPropagatedSessions([evt({ a: "1" }), evt({ b: "2" })]),
-    ).toEqual({
-      a: "1",
-      b: "2",
-    });
-  });
-
-  test("exact (key,id) duplicate across the batch dedupes", () => {
-    expect(
-      reduceEventsToPropagatedSessions([evt({ a: "1" }), evt({ a: "1" })]),
-    ).toEqual({
-      a: "1",
-    });
-  });
-
   test("a key with conflicting ids across the batch is dropped entirely", () => {
     expect(
       reduceEventsToPropagatedSessions([evt({ a: "1" }), evt({ a: "2" })]),
     ).toEqual({});
   });
 
-  test("only the conflicting key is dropped; the rest survive", () => {
+  test("batch keeps only the (key,id) pairs every event shares", () => {
     expect(
       reduceEventsToPropagatedSessions([
         evt({ a: "1", b: "9" }),
-        evt({ a: "2" }),
+        evt({ a: "1", c: "9" }),
       ]),
-    ).toEqual({ b: "9" });
+    ).toEqual({ a: "1" });
   });
 
-  test("a duplicate id does not mask a genuine conflict", () => {
-    // ids seen for `a` are {1, 2} even though (a,1) appears twice.
+  test("a key held by most of the batch still needs every event", () => {
     expect(
       reduceEventsToPropagatedSessions([
         evt({ a: "1" }),
         evt({ a: "1" }),
-        evt({ a: "2" }),
+        evt({ b: "2" }),
       ]),
     ).toEqual({});
   });
 
+  test("an event with no sessions empties the intersection, either side", () => {
+    // Leading empty seeds an empty intersection; trailing empty narrows a
+    // non-empty one to nothing. Both paths must agree.
+    expect(
+      reduceEventsToPropagatedSessions([evt({ a: "1" }), evt(undefined)]),
+    ).toEqual({});
+    expect(
+      reduceEventsToPropagatedSessions([evt(undefined), evt({ a: "1" })]),
+    ).toEqual({});
+  });
+
   test("numeric and string ids for a key canonicalize equal (no false conflict)", () => {
-    // Guards the String() coercion: {a:1} and {a:"1"} dedupe, not conflict.
+    // Guards the String() coercion: {a:1} and {a:"1"} match, not conflict.
     // The numeric id is a deliberate type violation, hence the cast.
     const numericEvt = {
       meta: { sessions: { a: 1 } },
@@ -91,13 +84,13 @@ describe("reduceEventsToPropagatedSessions", () => {
     });
   });
 
-  test("conflict drop happens BEFORE truncation", () => {
-    // Six keys a..f; `a` conflicts and is dropped, leaving exactly b..f (5).
-    // If truncation ran first we would keep a..e, then drop conflicting a,
-    // yielding only b..e (4) — this pins the ordering.
+  test("intersection happens BEFORE truncation", () => {
+    // Six keys a..f on both events; `a` conflicts and is dropped, leaving
+    // exactly b..f (5). If truncation ran first we would keep a..e, then drop
+    // conflicting a, yielding only b..e (4) — this pins the ordering.
     const events = [
       evt({ a: "1", b: "1", c: "1", d: "1", e: "1", f: "1" }),
-      evt({ a: "2" }),
+      evt({ a: "2", b: "1", c: "1", d: "1", e: "1", f: "1" }),
     ];
     expect(reduceEventsToPropagatedSessions(events)).toEqual({
       b: "1",

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -182,8 +182,46 @@ export const compareUtf8 = (a: string, b: string): number => {
 };
 
 /**
- * Reduces a run's triggering events to `≤5` deterministic sessions that
- * become the propagated sessions.
+ * Collects one event's sessions into a Map, which (unlike a plain object)
+ * sidesteps `__proto__`/prototype-key footguns.
+ */
+const ownSessions = (
+  sessions: EventMeta["sessions"] | undefined,
+): Map<string, string> => {
+  const own = new Map<string, string>();
+  if (!sessions) {
+    return own;
+  }
+
+  for (const [key, id] of Object.entries(sessions)) {
+    if (!key) {
+      continue; // defensive: the server rejects empty keys at ingest
+    }
+    if (id === null) {
+      // A run's triggering events are already-resolved (received) events, so
+      // their sessions never hold tombstones; guard defensively since the
+      // send-time EventSessionValue type now admits null.
+      continue;
+    }
+    // Canonicalize to string so a numeric id and its string form match rather
+    // than diverge (ids are already strings when received; this guards against
+    // runtime type violations).
+    own.set(key, String(id));
+  }
+
+  return own;
+};
+
+/**
+ * Reduces a run's triggering events to the deterministic set of sessions that
+ * become the propagated sessions: the intersection of every triggering event's
+ * `(key, id)` pairs.
+ *
+ * A key must be present with the same id on *all* the events to survive, so a
+ * key missing from any one event — or disagreeing on its id — is dropped. The
+ * server caps a single event at `MAX_EVENT_SESSIONS`, which bounds the
+ * intersection at that too; the truncation below is a backstop for an event
+ * that somehow arrives over the cap.
  */
 export const reduceEventsToPropagatedSessions = (
   // Accepts the send-time EventMeta shape (numeric ids permitted) since that is
@@ -191,60 +229,35 @@ export const reduceEventsToPropagatedSessions = (
   // to strings below, so received string ids pass through unchanged.
   events: ReadonlyArray<{ meta?: EventMeta | null }>,
 ): Record<string, string> => {
-  // Group the sessions by key
-
-  // A Map (not a plain object) sidesteps `__proto__`/prototype-key footguns
-  // while collecting.
-  const idsByKey = new Map<string, Set<string>>();
+  // Seed from the first event, then narrow against each of the rest.
+  let shared: Map<string, string> | undefined;
   for (const event of events) {
-    const sessions = event?.meta?.sessions;
-    if (!sessions) {
-      continue;
+    const own = ownSessions(event?.meta?.sessions);
+    if (!shared) {
+      shared = own;
+    } else {
+      // Deleting during iteration is well-defined: entries removed before they
+      // are reached are not visited.
+      for (const [key, id] of shared) {
+        if (own.get(key) !== id) {
+          shared.delete(key);
+        }
+      }
     }
-    for (const [key, id] of Object.entries(sessions)) {
-      if (!key) {
-        continue; // defensive: the server rejects empty keys at ingest
-      }
-      if (id === null) {
-        // A run's triggering events are already-resolved (received) events, so
-        // their sessions never hold tombstones; guard defensively since the
-        // send-time EventSessionValue type now admits null.
-        continue;
-      }
-      let ids = idsByKey.get(key);
-      if (!ids) {
-        ids = new Set();
-        idsByKey.set(key, ids);
-      }
-      // Canonicalize to string so a numeric id and its string form dedupe
-      // rather than register as a conflict (ids are already strings when
-      // received; this guards against runtime type violations).
-      ids.add(String(id));
+    if (shared.size === 0) {
+      break;
     }
   }
 
-  // Keep only keys with a single distinct id across the batch.
-  //
-  // A key that disagrees on its id (e.g. a batch carrying conv_id:1 and
-  // conv_id:2) is dropped entirely rather than resolved to one id, for
-  // predictability.
-  const keys: string[] = [];
-  for (const [key, ids] of idsByKey) {
-    if (ids.size === 1) {
-      keys.push(key);
-    }
+  if (!shared || shared.size === 0) {
+    return {};
   }
 
   // Deterministic `≤5`: sort by UTF-8 byte order (matching the server) and
   // take the first MAX_EVENT_SESSIONS keys.
-  keys.sort(compareUtf8);
-
-  const entries = keys
-    .slice(0, MAX_EVENT_SESSIONS)
-    .map((key): [string, string] => {
-      const [id] = idsByKey.get(key)!;
-      return [key, id as string];
-    });
+  const entries = [...shared.entries()]
+    .sort(([a], [b]) => compareUtf8(a, b))
+    .slice(0, MAX_EVENT_SESSIONS);
 
   // Object.fromEntries so keys like "__proto__" land as own properties.
   return Object.fromEntries(entries);

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -580,7 +580,8 @@ export type BaseContext<TClient extends Inngest.Any> = {
   events: AsTuple<Simplify<EventPayload>>;
 
   /**
-   * The run's effective sessions, aggregated from its triggering event(s).
+   * The run's effective sessions: those shared by all of its triggering
+   * events.
    *
    * When session propagation is active, these are propagated onto events
    * emitted during the run via `step.sendEvent`, so child runs stay grouped


### PR DESCRIPTION
## Summary

- Batched events can have very many triggering events
- Previously we set propagated sessions with ~ the first five key values where different events did not have conflicts values for a given key
- Let's move to a much simpler algorithm: the intersection of sessions in the event. All events must share the same key
- This is simpler to reason about and thus more predictable



## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests
- [ ] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
