### PR TITLE
fix: await Promise-shaped waitForEvent mocks before validation

### DIFF
--- a/.changeset/wait-for-event-mock-promise.md
+++ b/.changeset/wait-for-event-mock-promise.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `InngestTestEngine` mocks for `step.waitForEvent`: memoized step data that is a `Promise` is now awaited before schema validation, so the documented `steps` handler pattern no longer throws `EventValidationError: Event not found in triggers: undefined`.

--- a/packages/inngest/src/components/InngestFunction.test.ts
+++ b/packages/inngest/src/components/InngestFunction.test.ts
@@ -598,6 +598,42 @@ describe("runFn", () => {
             },
             expectedStepsRun: ["A"],
           },
+          // InngestTestEngine stores mocked step results as Promises. Validation
+          // must await them or event.name is undefined (#1652).
+          "request with Promise-shaped waitForEvent data runs A step": {
+            stack: {
+              [foo]: {
+                id: foo,
+                data: Promise.resolve({
+                  name: "foo",
+                  data: { foo: "foo" },
+                }),
+              },
+            },
+            expectedReturn: {
+              type: "step-ran",
+              step: expect.objectContaining({
+                id: A,
+                name: "A",
+                op: StepOpCode.StepRun,
+                data: "A",
+                displayName: "A",
+              }),
+            },
+            expectedStepsRun: ["A"],
+          },
+          "request with Promise-shaped waitForEvent timeout (null) resolves": {
+            stack: {
+              [foo]: {
+                id: foo,
+                data: Promise.resolve(null),
+              },
+            },
+            expectedReturn: {
+              type: "function-resolved",
+              data: null,
+            },
+          },
           "request with event foo.data.foo:bar runs B step": {
             stack: {
               [foo]: { id: foo, data: { name: "foo", data: { foo: "bar" } } },

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -2531,9 +2531,11 @@ class InngestExecutionEngine
             // For some execution scenarios such as testing, `data`, `error`,
             // and `input` may be `Promises`. This could also be the case for
             // future middleware applications. For this reason, we'll make sure
-            // the values are fully resolved before continuing.
+            // the values are fully resolved before continuing — and use those
+            // resolved values below (passing the Promise into validateEvents
+            // would read `.name` as undefined; see #1652).
             void Promise.all([result.data, result.error, result.input]).then(
-              async () => {
+              async ([resolvedData, resolvedError]) => {
                 // If the wrapStep chain already ran during discovery in this
                 // same request (checkpointing), reuse its result instead of
                 // firing wrappedHandler() again. This prevents middleware from
@@ -2542,10 +2544,10 @@ class InngestExecutionEngine
                   // Resolve the memoization deferred so wrapStep's next()
                   // unblocks. The step data is now confirmed memoized.
                   if (step.memoizationDeferred) {
-                    if (typeof result.data !== "undefined") {
-                      step.memoizationDeferred.resolve(await result.data);
+                    if (typeof resolvedData !== "undefined") {
+                      step.memoizationDeferred.resolve(resolvedData);
                     } else {
-                      const stepError = new StepError(opId.id, result.error);
+                      const stepError = new StepError(opId.id, resolvedError);
                       this.state.recentlyRejectedStepError = stepError;
                       step.memoizationDeferred.reject(stepError);
                     }
@@ -2565,12 +2567,12 @@ class InngestExecutionEngine
                 // false` on the 2nd call
                 step.middleware.stepInfo.memoized = true;
 
-                if (typeof result.data !== "undefined") {
+                if (typeof resolvedData !== "undefined") {
                   // Validate waitForEvent results against the schema if present
-                  // Skip validation if result.data is null (timeout case)
+                  // Skip validation if resolvedData is null (timeout case)
                   if (
                     opId.op === StepOpCode.WaitForEvent &&
-                    result.data !== null
+                    resolvedData !== null
                   ) {
                     const { event } = (step.rawArgs?.[1] ?? {}) as {
                       event: unknown;
@@ -2581,7 +2583,7 @@ class InngestExecutionEngine
                     }
                     try {
                       await validateEvents(
-                        [result.data],
+                        [resolvedData],
 
                         // @ts-expect-error - This is a full event object at runtime
                         [{ event }],
@@ -2598,12 +2600,12 @@ class InngestExecutionEngine
 
                   // Set inner handler to return memoized data
                   step.middleware.setActualHandler(() =>
-                    Promise.resolve(result.data),
+                    Promise.resolve(resolvedData),
                   );
 
                   step.middleware.wrappedHandler().then(resolve);
                 } else {
-                  const stepError = new StepError(opId.id, result.error);
+                  const stepError = new StepError(opId.id, resolvedError);
                   this.state.recentlyRejectedStepError = stepError;
 
                   // Set inner handler to reject with step error

--- a/packages/inngest/src/components/execution/waitForEventMock.test.ts
+++ b/packages/inngest/src/components/execution/waitForEventMock.test.ts
@@ -1,0 +1,76 @@
+import { InngestTestEngine } from "@inngest/test";
+import { expect, it } from "vitest";
+import { Inngest } from "../../index.ts";
+
+/**
+ * Regression for #1652: InngestTestEngine stores mocked step results as
+ * Promises. waitForEvent schema validation must await them before reading
+ * `event.name`, otherwise it throws `Event not found in triggers: undefined`.
+ */
+it("resolves a mocked waitForEvent step via the documented steps option", async () => {
+  const inngest = new Inngest({ id: "repro", isDev: true });
+
+  const fn = inngest.createFunction(
+    { id: "wait-repro", triggers: [{ event: "demo/started" }] },
+    async ({ step }) => {
+      const approval = await step.waitForEvent("wait-for-approval", {
+        event: "demo/approved",
+        timeout: "1d",
+      });
+      return { approved: approval !== null, data: approval?.data };
+    },
+  );
+
+  const t = new InngestTestEngine({
+    function: fn,
+    steps: [
+      {
+        id: "wait-for-approval",
+        handler() {
+          return { name: "demo/approved", data: { ok: true } };
+        },
+      },
+    ],
+  });
+
+  const { result, error } = await t.execute({
+    events: [{ name: "demo/started", data: { id: "1" } }],
+  });
+
+  expect(error).toBeUndefined();
+  expect(result).toEqual({ approved: true, data: { ok: true } });
+});
+
+it("treats a mocked waitForEvent null result as a timeout", async () => {
+  const inngest = new Inngest({ id: "repro", isDev: true });
+
+  const fn = inngest.createFunction(
+    { id: "wait-timeout", triggers: [{ event: "demo/started" }] },
+    async ({ step }) => {
+      const approval = await step.waitForEvent("wait-for-approval", {
+        event: "demo/approved",
+        timeout: "1d",
+      });
+      return { approved: approval !== null };
+    },
+  );
+
+  const t = new InngestTestEngine({
+    function: fn,
+    steps: [
+      {
+        id: "wait-for-approval",
+        handler() {
+          return null;
+        },
+      },
+    ],
+  });
+
+  const { result, error } = await t.execute({
+    events: [{ name: "demo/started", data: { id: "1" } }],
+  });
+
+  expect(error).toBeUndefined();
+  expect(result).toEqual({ approved: false });
+});


### PR DESCRIPTION
InngestTestEngine stores mocked step results as Promises; use the resolved values in validateEvents so documented steps mocks no longer throw EventValidationError (#1652).

## Summary
`InngestTestEngine` stores mocked step results as Promises. The execution engine awaited those Promises but still passed the unresolved Promise into `validateEvents` for `step.waitForEvent`, so `event.name` was `undefined` and validation threw `EventValidationError: Event not found in triggers: undefined`.

This change uses the resolved values from `Promise.all` for waitForEvent validation and memoized step handling, so the documented `steps` mock pattern works again.

## Checklist
- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Bug fix; no docs change needed — existing testing docs already describe this API
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
- Fixes #1652
- EXE-2070