### PR TITLE
fix(types): export SendSignalResponse

### DIFF
--- a/.changeset/busy-drinks-drop.md
+++ b/.changeset/busy-drinks-drop.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Fix `TS2742` errors in projects that use `declaration` or `composite` `true` by exporting `SendSignalResponse` appropriately.

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -12,6 +12,7 @@ import {
   type OutgoingOp,
   ok,
   type Result,
+  type SendSignalResponse,
 } from "../types.ts";
 import {
   type BatchResponse,
@@ -78,15 +79,6 @@ export namespace InngestApi {
   export interface SendSignalOptions {
     signal: string;
     data?: unknown;
-  }
-
-  export interface SendSignalResponse {
-    /**
-     * The ID of the run that was signaled.
-     *
-     * If this is undefined, the signal could not be matched to a run.
-     */
-    runId: string | undefined;
   }
 }
 
@@ -267,7 +259,7 @@ export class InngestApi {
     options?: {
       headers?: Record<string, string>;
     },
-  ): Promise<Result<InngestApi.SendSignalResponse, ErrorResponse>> {
+  ): Promise<Result<SendSignalResponse, ErrorResponse>> {
     const url = await this.getTargetUrl("/v1/signals");
 
     const body = {
@@ -292,7 +284,7 @@ export class InngestApi {
       .then(async (res) => {
         // A 404 is valid if the signal was not found.
         if (res.status === 404) {
-          return ok<InngestApi.SendSignalResponse>({
+          return ok<SendSignalResponse>({
             runId: undefined,
           });
         }

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -53,6 +53,7 @@ import {
   type MetadataTarget,
   type SendEventOutput,
   type SendEventResponse,
+  type SendSignalResponse,
   sendEventResponseSchema,
 } from "../types.ts";
 import { getAsyncCtx } from "./execution/als.ts";
@@ -585,7 +586,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
      * multiple systems together using branch names.
      */
     env?: string;
-  }): Promise<InngestApi.SendSignalResponse> {
+  }): Promise<SendSignalResponse> {
     const headers: Record<string, string> = {
       ...(env ? { [headerKeys.Environment]: env } : {}),
     };
@@ -601,7 +602,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
     signal: string;
     data?: unknown;
     headers?: Record<string, string>;
-  }): Promise<InngestApi.SendSignalResponse> {
+  }): Promise<SendSignalResponse> {
     const res = await this.inngestApi.sendSignal(
       { signal, data },
       { ...this.headers, ...headers },

--- a/packages/inngest/src/components/InngestStepTools.ts
+++ b/packages/inngest/src/components/InngestStepTools.ts
@@ -2,7 +2,6 @@ import { type AiAdapter, models } from "@inngest/ai";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { z } from "zod/v3";
 
-import type { InngestApi } from "../api/api.ts";
 import type { Jsonify } from "../helpers/jsonify.ts";
 import { normalizeEventMeta } from "../helpers/sessions.ts";
 import { timeStr } from "../helpers/strings.ts";
@@ -24,6 +23,7 @@ import {
   type OutgoingOp,
   type ReceivedEventMeta,
   type SendEventOutput,
+  type SendSignalResponse,
   StepMode,
   StepOpCode,
   type StepOptions,
@@ -614,7 +614,7 @@ export const createStepTools = <
       (
         idOrOptions: StepOptionsOrId,
         opts: SendSignalOpts,
-      ) => Promise<InngestApi.SendSignalResponse>
+      ) => Promise<SendSignalResponse>
     >(
       ({ id, name }, opts) => {
         return {

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -119,6 +119,7 @@ export type {
   RegisterOptions,
   ScheduledTimerEventPayload,
   SendEventBaseOutput,
+  SendSignalResponse,
   StepOptions,
   StepOptionsOrId,
   TimeStr,

--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -818,6 +818,15 @@ export type SendEventOutput<TOpts extends ClientOptions> = Omit<
 export type SendEventOutputWithMiddleware<_TOpts extends ClientOptions> =
   SendEventBaseOutput;
 
+export interface SendSignalResponse {
+  /**
+   * The ID of the run that was signaled.
+   *
+   * If this is undefined, the signal could not be matched to a run.
+   */
+  runId: string | undefined;
+}
+
 /**
  * Discriminator for which output transform to extract from middleware.
  */

--- a/packages/inngest/test/composite_project/src/index.ts
+++ b/packages/inngest/test/composite_project/src/index.ts
@@ -149,6 +149,15 @@ export const fnWithStepRun = inngest.createFunction(
   },
 );
 
+// Exercise step.sendSignal to ensure SendSignalResponse is portable in
+// declaration emit.
+export const fnWithSendSignal = inngest.createFunction(
+  { id: "my-fn-send-signal", triggers: [{ event: "foo" }] },
+  async ({ step }) => {
+    return step.sendSignal("signal", { signal: "foo", data: { foo: "bar" } });
+  },
+);
+
 // Exercise eventType and typed event schemas to ensure StandardSchemaV1
 // and related trigger types are portable.
 export const myEventType = Inngest.eventType("app/user.created", {

--- a/packages/inngest/test/composite_project/tsconfig.json
+++ b/packages/inngest/test/composite_project/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "es5",
     "forceConsistentCasingInFileNames": true,
     "composite": true,


### PR DESCRIPTION
## Summary

Fixes #1510: `step.sendSignal`'s return type referenced the internal `InngestApi` namespace, causing `TS2742` for consumers with declaration emit ([#1479](https://github.com/inngest/inngest-js/pull/1479) regression). `SendSignalResponse` is now in `types.ts` and exported from the entry point; a composite-project test locks it in.

## Checklist

- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Type export only.
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related

- [EXE-1731](https://linear.app/inngest/issue/EXE-1731/bug-stepsendsignal-return-type-leaks-internal-inngestapi-namespace-and)
- [inngest/inngest-js#1510](https://github.com/inngest/inngest-js/issues/1510)
