### PR TITLE
fix(sessions): expose ctx.sessions on the triggers context

### DIFF
--- a/packages/inngest/src/components/triggers/trigger.test.ts
+++ b/packages/inngest/src/components/triggers/trigger.test.ts
@@ -783,3 +783,28 @@ describe("staticSchema", () => {
     });
   });
 });
+
+describe("ctx.sessions", () => {
+  test("is present and typed on the triggers-path context", () => {
+    const inngest = new Inngest({ id: "app" });
+    inngest.createFunction(
+      { id: "fn", triggers: [{ event: "user/created" }] },
+      (ctx) => {
+        expectTypeOf(ctx.sessions).not.toBeAny();
+        expectTypeOf(ctx.sessions).toEqualTypeOf<
+          Record<string, string> | undefined
+        >();
+      },
+    );
+  });
+
+  test("is writable, so a handler can override what gets propagated", () => {
+    const inngest = new Inngest({ id: "app" });
+    inngest.createFunction(
+      { id: "fn", triggers: [{ event: "user/created" }] },
+      (ctx) => {
+        ctx.sessions = { conversation_id: "conv_123" };
+      },
+    );
+  });
+});

--- a/packages/inngest/src/components/triggers/typeHelpers.ts
+++ b/packages/inngest/src/components/triggers/typeHelpers.ts
@@ -304,6 +304,18 @@ export type BaseContextWithTriggers<
   events: AsTuple<ReceivedEventTupleToUnion<ToReceivedEvent<TTriggers>>>;
 
   /**
+   * The run's effective sessions, aggregated from its triggering event(s).
+   *
+   * When session propagation is active, these are propagated onto events
+   * emitted during the run via `step.sendEvent`, so child runs stay grouped
+   * in the same sessions. Mutating this in the handler overrides what is
+   * propagated for the remainder of the run.
+   *
+   * Kept in sync with `BaseContext.sessions`.
+   */
+  sessions?: Record<string, string>;
+
+  /**
    * The run ID for the current function execution
    */
   runId: string;


### PR DESCRIPTION
## Summary

- Add sessions on to BaseContextWithTrigger so that `createFunction` can touch sessions with typing

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- ~[ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~
- [x] Added unit/integration tests
- ~[ ] Added changesets if applicable~

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- INN-
