### PR TITLE
feat(sandbox): support shell command strings

### DIFF
--- a/.changeset/fuzzy-shells-run.md
+++ b/.changeset/fuzzy-shells-run.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Support shell command strings in the experimental sandbox command and managed process APIs.

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -178,13 +178,13 @@ describe("step.sandbox", () => {
     });
     const listed = await tools.list("list", { limit: 10 });
     const fetched = await tools.get("get", sandboxId);
-    const command = await created.commands.run("exec", {
-      command: ["/bin/sh", "-lc", "printf ok"],
+    const shellCommand = `cd /workspace && printf '%s\n' "$HOME" | grep workspace > output.txt`;
+    const command = await created.commands.run("exec", shellCommand, {
       environment: { "WITH.DOT": "allowed" },
       timeout: Temporal.Duration.from({ seconds: 1 }),
     });
     const process = await created.processes.start("start", {
-      command: processRef.command,
+      command: "sleep 30",
       environment: { "1_NUMERIC": "also-allowed" },
       cwd: "/workspace",
     });
@@ -255,7 +255,7 @@ describe("step.sandbox", () => {
       target: { sandbox: { id: sandboxId } },
       input: [
         {
-          command: ["/bin/sh", "-lc", "printf ok"],
+          command: ["/bin/sh", "-c", shellCommand],
           environment: { "WITH.DOT": "allowed" },
           timeoutMs: 1000,
         },
@@ -268,6 +268,7 @@ describe("step.sandbox", () => {
     expect(operations[4]).toMatchObject({
       action: "process.start",
       target: { sandbox: { id: sandboxId } },
+      input: [{ command: ["/bin/sh", "-c", "sleep 30"] }],
     });
     expect(operations[5]).toMatchObject({
       action: "process.list",
@@ -315,11 +316,42 @@ describe("step.sandbox", () => {
       }),
     ).toThrow(SandboxValidationError);
 
-    await expect(
-      sandbox.commands.run("exec", {
-        command: ["npm", "test"],
+    await expect(sandbox.commands.run("exec", ["npm", "test"])).rejects.toThrow(
+      "absolute executable path",
+    );
+    await expect(sandbox.commands.run("exec", "npm test")).resolves.toEqual({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      output: { truncated: false },
+    });
+    await sandbox.commands.run("argv", [
+      "/usr/bin/git",
+      "commit",
+      "-m",
+      "hello world",
+    ]);
+    expect(rawTool).toHaveBeenLastCalledWith(
+      "argv",
+      expect.objectContaining({
+        action: "exec",
+        input: [
+          expect.objectContaining({
+            command: ["/usr/bin/git", "commit", "-m", "hello world"],
+          }),
+        ],
       }),
-    ).rejects.toThrow("absolute executable path");
+    );
+    rawTool.mockClear();
+    await expect(sandbox.commands.run("empty", "")).rejects.toThrow(
+      "command must not be empty",
+    );
+    await expect(sandbox.commands.run("nul", "printf \0")).rejects.toThrow(
+      "must not contain NUL",
+    );
+    await expect(
+      sandbox.commands.run("too-large", "x".repeat(32_760)),
+    ).rejects.toThrow("must not exceed 32768 bytes");
     await expect(
       sandbox.processes.start("start", {
         command: ["/bin/true"],
@@ -351,7 +383,7 @@ describe("step.sandbox", () => {
       async ({ step }) => {
         const sandbox = await step.sandbox.create("create", createOptions);
         const process = await sandbox.processes.start("start", {
-          command: processRef.command,
+          command: "sleep 30",
         });
         await process.signal("signal", { signal: 15 });
         return process.id;
@@ -398,6 +430,13 @@ describe("step.sandbox", () => {
           input: [{ protocolVersion: 1, action }],
         },
       });
+      if (action === "process.start") {
+        expect(outgoing).toMatchObject({
+          opts: {
+            input: [{ input: [{ command: ["/bin/sh", "-c", "sleep 30"] }] }],
+          },
+        });
+      }
       state[outgoing.id] = { id: outgoing.id, data: results[index] };
       stackOrder.push(outgoing.id);
     }
@@ -578,6 +617,7 @@ describe("step.sandbox", () => {
     const threeMiBBase64 = encodeBase64(stdoutBytes);
     const oneMiBBase64 = encodeBase64(stderrBytes);
     const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
+    const execBodies: unknown[] = [];
     const fetchMock: typeof fetch = vi.fn(async (input, init) => {
       const url = new URL(input instanceof Request ? input.url : input);
       if (
@@ -585,6 +625,9 @@ describe("step.sandbox", () => {
         (init?.method ?? "GET") === "GET"
       ) {
         return Response.json({ data: sandboxResource });
+      }
+      if (url.pathname.endsWith("/exec")) {
+        execBodies.push(JSON.parse(String(init?.body)));
       }
       return Response.json({
         data: {
@@ -607,8 +650,10 @@ describe("step.sandbox", () => {
     if (!directSandbox) {
       throw new Error("Expected sandbox");
     }
-    const direct = await directSandbox.commands.run({
-      command: ["/bin/true"],
+    const direct = await directSandbox.commands.run("printf ok", {
+      cwd: "/workspace",
+      environment: { CI: "true" },
+      timeout: "5m",
     });
     expect(direct.stdout.startsWith("\u0001\u0002\u0003")).toBe(true);
     expect(direct.stdout).toContain("€");
@@ -622,8 +667,10 @@ describe("step.sandbox", () => {
         if (!sandbox) {
           throw new Error("Expected sandbox");
         }
-        const result = await sandbox.commands.run("exec", {
-          command: ["/bin/true"],
+        const result = await sandbox.commands.run("exec", "printf ok", {
+          cwd: "/workspace",
+          environment: { CI: "true" },
+          timeout: "5m",
         });
         return {
           stdoutStartsWithReplacement: result.stdout.startsWith("\uFFFD"),
@@ -717,6 +764,20 @@ describe("step.sandbox", () => {
       },
     });
     expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(execBodies).toEqual([
+      {
+        command: ["/bin/sh", "-c", "printf ok"],
+        cwd: "/workspace",
+        environment: { CI: "true" },
+        timeout: "300000ms",
+      },
+      {
+        command: ["/bin/sh", "-c", "printf ok"],
+        cwd: "/workspace",
+        environment: { CI: "true" },
+        timeout: "300000ms",
+      },
+    ]);
   });
 
   test("retries a structured Create availability failure", async () => {
@@ -1041,9 +1102,7 @@ describe("inngest.sandboxes", () => {
     if (!sandbox) {
       throw new Error("Expected sandbox");
     }
-    await expect(
-      sandbox.commands.run({ command: ["/bin/true"] }),
-    ).resolves.toEqual({
+    await expect(sandbox.commands.run(["/bin/true"])).resolves.toEqual({
       stdout: "hello π 🚀�",
       stderr: "�",
       exitCode: 0,
@@ -1078,9 +1137,7 @@ describe("inngest.sandboxes", () => {
     if (!sandbox) {
       throw new Error("Expected sandbox");
     }
-    await expect(
-      sandbox.commands.run({ command: ["/bin/true"] }),
-    ).resolves.toEqual({
+    await expect(sandbox.commands.run(["/bin/true"])).resolves.toEqual({
       stdout: "",
       stderr: "",
       exitCode: 0,
@@ -1215,7 +1272,7 @@ describe("inngest.sandboxes", () => {
       let operation: Promise<unknown>;
       switch (action) {
         case "exec":
-          operation = sandbox.commands.run({ command: ["/bin/true"] });
+          operation = sandbox.commands.run(["/bin/true"]);
           break;
         case "process.start":
           operation = sandbox.processes.start({ command: ["/bin/true"] });
@@ -1285,7 +1342,7 @@ describe("inngest.sandboxes", () => {
             operation = sandbox.destroy();
             break;
           case "exec":
-            operation = sandbox.commands.run({ command: ["/bin/true"] });
+            operation = sandbox.commands.run(["/bin/true"]);
             break;
           case "process.start":
             operation = sandbox.processes.start({ command: ["/bin/true"] });
@@ -1773,8 +1830,7 @@ describe("inngest.sandboxes", () => {
     if (!sandbox) {
       throw new Error("Expected sandbox");
     }
-    const command = await sandbox.commands.run({
-      command: ["/bin/sh", "-lc", "printf ok"],
+    const command = await sandbox.commands.run("printf ok", {
       timeout: "1s",
     });
     const logReader = (await sandbox.logs.stream({ follow: true })).getReader();
@@ -1788,7 +1844,7 @@ describe("inngest.sandboxes", () => {
       path: "/tmp/result.bin",
     });
     const started = await sandbox.processes.start({
-      command: processRef.command,
+      command: "sleep 30",
     });
     const processes = await sandbox.processes.list({
       cursor: "process-cursor",
@@ -1862,6 +1918,26 @@ describe("inngest.sandboxes", () => {
       Authorization: `Bearer ${hashSigningKey("signkey-test")}`,
       "x-inngest-env": "branch",
     });
+    expect(
+      JSON.parse(
+        String(
+          calls.find(({ url }) => url.pathname.endsWith("/exec"))?.init?.body,
+        ),
+      ),
+    ).toMatchObject({
+      command: ["/bin/sh", "-c", "printf ok"],
+      timeout: "1000ms",
+    });
+    expect(
+      JSON.parse(
+        String(
+          calls.find(
+            ({ url, init }) =>
+              url.pathname.endsWith("/processes") && init?.method === "POST",
+          )?.init?.body,
+        ),
+      ),
+    ).toEqual({ command: ["/bin/sh", "-c", "sleep 30"] });
   });
 
   test("uses the REST v2 resource shape and decodes byte-safe streams", async () => {
@@ -1973,11 +2049,7 @@ describe("inngest.sandboxes", () => {
       if (!sandbox) {
         throw new Error("Expected sandbox");
       }
-      await expect(
-        sandbox.commands.run({
-          command: ["/bin/true"],
-        }),
-      ).rejects.toMatchObject({
+      await expect(sandbox.commands.run(["/bin/true"])).rejects.toMatchObject({
         name: "SandboxError",
         action: "exec",
         code,

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -458,6 +458,13 @@ describe("step.sandbox", () => {
           },
         });
       }
+      if (action === "process.signal") {
+        expect(outgoing).toMatchObject({
+          opts: {
+            input: [{ input: [{ signal: 15, includeChildren: true }] }],
+          },
+        });
+      }
       state[outgoing.id] = { id: outgoing.id, data: results[index] };
       stackOrder.push(outgoing.id);
     }
@@ -1872,7 +1879,8 @@ describe("inngest.sandboxes", () => {
       limit: 25,
     });
     const fetchedProcess = await sandbox.processes.get(processId);
-    await started.signal({ signal: 15, includeChildren: true });
+    await started.signal({ signal: 15 });
+    await started.signal({ signal: 9, includeChildren: false });
     const waited = await started.wait({ timeout: "2s" });
     const output = await started.getOutput({ tailBytes: 64 });
     const destroyed = await sandbox.destroy();
@@ -1959,6 +1967,14 @@ describe("inngest.sandboxes", () => {
         ),
       ),
     ).toEqual({ command: ["/bin/sh", "-c", "sleep 30"] });
+    expect(
+      calls
+        .filter(({ url }) => url.pathname.endsWith("/signals"))
+        .map(({ init }) => JSON.parse(String(init?.body))),
+    ).toEqual([
+      { signal: 15, includeChildren: true },
+      { signal: 9, includeChildren: false },
+    ]);
   });
 
   test("uses the REST v2 resource shape and decodes byte-safe streams", async () => {

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -342,6 +342,27 @@ describe("step.sandbox", () => {
         ],
       }),
     );
+    const widerOptions = {
+      command: "printf overridden",
+      cwd: "/workspace",
+    };
+    await sandbox.commands.run(
+      "explicit-command",
+      "printf explicit",
+      widerOptions,
+    );
+    expect(rawTool).toHaveBeenLastCalledWith(
+      "explicit-command",
+      expect.objectContaining({
+        action: "exec",
+        input: [
+          expect.objectContaining({
+            command: ["/bin/sh", "-c", "printf explicit"],
+            cwd: "/workspace",
+          }),
+        ],
+      }),
+    );
     rawTool.mockClear();
     await expect(sandbox.commands.run("empty", "")).rejects.toThrow(
       "command must not be empty",

--- a/packages/inngest/src/components/InngestSandbox.ts
+++ b/packages/inngest/src/components/InngestSandbox.ts
@@ -30,6 +30,7 @@ export type {
   Sandbox,
   SandboxAction,
   SandboxClient,
+  SandboxCommand,
   SandboxCommandOptions,
   SandboxCommandOutputMetadata,
   SandboxCommandResult,

--- a/packages/inngest/src/components/sandbox/client.ts
+++ b/packages/inngest/src/components/sandbox/client.ts
@@ -4,6 +4,7 @@ import {
   type Sandbox,
   type SandboxAction,
   type SandboxClient,
+  type SandboxCommand,
   type SandboxCommandOptions,
   type SandboxCommandOutputMetadata,
   type SandboxDestroyResult,
@@ -648,7 +649,8 @@ interface SandboxCommandByteResult {
 }
 
 type DirectSandboxCommandRunner = (
-  options: SandboxCommandOptions,
+  command: SandboxCommand,
+  options?: SandboxCommandOptions,
 ) => Promise<SandboxCommandByteResult>;
 
 const directSandboxCommandRunners = new WeakMap<
@@ -659,7 +661,8 @@ const directSandboxCommandRunners = new WeakMap<
 /** Internal byte-preserving command execution used by the durable adapter. */
 export const runSandboxCommandForOperation = (
   sandbox: Sandbox,
-  options: SandboxCommandOptions,
+  command: SandboxCommand,
+  options?: SandboxCommandOptions,
 ): Promise<SandboxCommandByteResult> => {
   const run = directSandboxCommandRunners.get(sandbox);
   if (!run) {
@@ -667,7 +670,7 @@ export const runSandboxCommandForOperation = (
       "Sandbox commands can only run on an SDK sandbox resource",
     );
   }
-  return run(options);
+  return run(command, options);
 };
 
 const createDirectSandboxFacade = (
@@ -677,9 +680,10 @@ const createDirectSandboxFacade = (
   const ref = parseWithSchema(sandboxRefSchema, rawRef, "sandbox reference");
   const basePath = `/v2/sandboxes/${encodeURIComponent(ref.id)}`;
   const runCommand = async (
-    options: SandboxCommandOptions,
+    command: SandboxCommand,
+    options: SandboxCommandOptions = {},
   ): Promise<SandboxCommandByteResult> => {
-    const normalized = normalizeSandboxCommandOptions(options);
+    const normalized = normalizeSandboxCommandOptions(command, options);
     const { timeout: _timeout, timeoutMs, ...spec } = normalized;
     const { envelope } = await transport.json(
       "exec",
@@ -710,8 +714,8 @@ const createDirectSandboxFacade = (
     ...ref,
     resources: Object.freeze({ ...ref.resources }),
     commands: Object.freeze({
-      run: async (options) => {
-        const result = await runCommand(options);
+      run: async (command, options) => {
+        const result = await runCommand(command, options);
         return {
           stdout: decodeUtf8(result.stdout),
           stderr: decodeUtf8(result.stderr),

--- a/packages/inngest/src/components/sandbox/durable.ts
+++ b/packages/inngest/src/components/sandbox/durable.ts
@@ -215,9 +215,9 @@ export const executeSandboxOperation = async (
       };
     }
     case "exec": {
-      const { timeoutMs, ...options } = operation.input[0];
+      const { command, timeoutMs, ...options } = operation.input[0];
       const sandbox = sandboxForOperation(client, operation.target.sandbox);
-      const result = await runSandboxCommandForOperation(sandbox, {
+      const result = await runSandboxCommandForOperation(sandbox, command, {
         ...options,
         timeout: timeoutMs,
       });
@@ -447,8 +447,8 @@ export const createDurableSandboxFacade = (
     ...ref,
     resources: Object.freeze({ ...ref.resources }),
     commands: Object.freeze({
-      run: async (idOrOptions, options) => {
-        const normalized = normalizeSandboxCommandOptions(options);
+      run: async (idOrOptions, command, options) => {
+        const normalized = normalizeSandboxCommandOptions(command, options);
         const { timeout: _timeout, ...input } = normalized;
         const operation = parseSandboxOperationForAction("exec", {
           protocolVersion: sandboxProtocolVersion,

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -185,6 +185,10 @@ export interface SandboxProcessStartOptions {
 
 export interface SandboxProcessSignalOptions {
   signal: number;
+  /**
+   * Also signal the process's descendants. Defaults to `true` so shell-backed
+   * commands do not leave their child processes running.
+   */
   includeChildren?: boolean;
 }
 

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -85,9 +85,17 @@ export interface SandboxListResult<TSandbox = SandboxRef> {
   fetchedAt: string;
 }
 
-export interface SandboxCommandOptions {
-  command: readonly string[];
+/**
+ * A shell command string or an argv array for direct execution.
+ *
+ * Strings run as `["/bin/sh", "-c", command]`. They are passed to the shell
+ * unchanged, so normal shell quoting, variables, pipes, redirects, and
+ * chaining apply. Arrays bypass the shell and must begin with an absolute
+ * executable path.
+ */
+export type SandboxCommand = string | readonly string[];
 
+export interface SandboxCommandOptions {
   /**
    * Overrides matching sandbox environment values for this command.
    * Omitted or empty inherits the sandbox environment unchanged.
@@ -165,7 +173,7 @@ export interface SandboxProcessRef extends SandboxProcessResource {
 }
 
 export interface SandboxProcessStartOptions {
-  command: readonly string[];
+  command: SandboxCommand;
 
   /**
    * Overrides matching sandbox environment values for this process.
@@ -329,7 +337,10 @@ export interface Sandbox {
   readonly endedAt?: string;
   readonly error?: string;
   readonly commands: {
-    run(options: SandboxCommandOptions): Promise<SandboxCommandResult>;
+    run(
+      command: SandboxCommand,
+      options?: SandboxCommandOptions,
+    ): Promise<SandboxCommandResult>;
   };
   readonly logs: {
     stream(
@@ -395,7 +406,8 @@ export interface DurableSandbox {
   readonly commands: {
     run(
       idOrOptions: StepOptionsOrId,
-      options: SandboxCommandOptions,
+      command: SandboxCommand,
+      options?: SandboxCommandOptions,
     ): Promise<SandboxCommandResult>;
   };
   readonly processes: {

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -510,7 +510,7 @@ export const normalizeSandboxCommandOptions = (
   command: SandboxCommand,
   options: SandboxCommandOptions = {},
 ): SandboxCommandOptions & { command: string[]; timeoutMs: number } => {
-  const parsed = normalizeProcessSpec({ command, ...options }, true);
+  const parsed = normalizeProcessSpec({ ...options, command }, true);
   return {
     ...parsed,
     timeoutMs:

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v3";
 
 import { isTemporalDuration } from "../../helpers/temporal.ts";
 import {
+  type SandboxCommand,
   type SandboxCommandOptions,
   type SandboxCreateOptions,
   type SandboxDuration,
@@ -428,16 +429,23 @@ export const normalizeSandboxListOptions = (
 
 export const normalizeSandboxProcessListOptions = normalizeSandboxListOptions;
 
+type SandboxProcessSpecOptions = SandboxCommandOptions & {
+  command: SandboxCommand;
+};
+
 const normalizeProcessSpec = <
-  T extends SandboxCommandOptions | SandboxProcessStartOptions,
+  T extends SandboxProcessSpecOptions | SandboxProcessStartOptions,
 >(
   options: T,
   includeTimeout: boolean,
-): T => {
+): Omit<T, "command"> & { command: string[] } => {
   const parsed = parseWithSchema(
     z
       .object({
-        command: z.array(z.string()).min(1).max(maxProcessArgvCount),
+        command: z.union([
+          z.string().min(1, "command must not be empty"),
+          z.array(z.string()).min(1).max(maxProcessArgvCount),
+        ]),
         environment: z.record(z.string()).optional(),
         cwd: z.string().optional(),
         ...(includeTimeout && { timeout: z.unknown().optional() }),
@@ -447,15 +455,21 @@ const normalizeProcessSpec = <
     "sandbox command options",
   ) as unknown as T;
 
-  if (!parsed.command[0]?.startsWith("/")) {
+  if (Array.isArray(parsed.command) && !parsed.command[0]?.startsWith("/")) {
     throw new SandboxValidationError(
       "command must begin with an absolute executable path",
     );
   }
+  const argv =
+    typeof parsed.command === "string"
+      ? ["/bin/sh", "-c", parsed.command]
+      : parsed.command;
   let argvBytes = 0;
-  parsed.command.forEach((argument, index) => {
-    assertNoNul(argument, `command[${index}]`);
-    assertValidUnicode(argument, `command[${index}]`);
+  argv.forEach((argument, index) => {
+    const context =
+      typeof parsed.command === "string" ? "command" : `command[${index}]`;
+    assertNoNul(argument, context);
+    assertValidUnicode(argument, context);
     argvBytes += textEncoder.encode(argument).byteLength;
   });
   if (argvBytes > maxProcessArgvBytes) {
@@ -477,7 +491,7 @@ const normalizeProcessSpec = <
   }
 
   const wireBytes = goJSONBytes({
-    argv: parsed.command,
+    argv,
     ...(entries.length > 0 && { env: parsed.environment }),
     ...(parsed.cwd !== undefined && parsed.cwd !== "" && { cwd: parsed.cwd }),
   });
@@ -486,13 +500,17 @@ const normalizeProcessSpec = <
       `command, environment, and cwd must not exceed ${maxProcessWireBytes} encoded bytes`,
     );
   }
-  return parsed;
+  return {
+    ...parsed,
+    command: [...argv],
+  } as Omit<T, "command"> & { command: string[] };
 };
 
 export const normalizeSandboxCommandOptions = (
-  options: SandboxCommandOptions,
-): SandboxCommandOptions & { timeoutMs: number } => {
-  const parsed = normalizeProcessSpec(options, true);
+  command: SandboxCommand,
+  options: SandboxCommandOptions = {},
+): SandboxCommandOptions & { command: string[]; timeoutMs: number } => {
+  const parsed = normalizeProcessSpec({ command, ...options }, true);
   return {
     ...parsed,
     timeoutMs:
@@ -508,7 +526,8 @@ export const normalizeSandboxCommandOptions = (
 
 export const normalizeSandboxProcessStartOptions = (
   options: SandboxProcessStartOptions,
-): SandboxProcessStartOptions => normalizeProcessSpec(options, false);
+): Omit<SandboxProcessStartOptions, "command"> & { command: string[] } =>
+  normalizeProcessSpec(options, false);
 
 export const normalizeSandboxProcessSignalOptions = (
   options: SandboxProcessSignalOptions,

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -544,7 +544,7 @@ export const normalizeSandboxProcessSignalOptions = (
   );
   return {
     signal: parsed.signal,
-    includeChildren: parsed.includeChildren ?? false,
+    includeChildren: parsed.includeChildren ?? true,
   };
 };
 


### PR DESCRIPTION
Lets sandbox commands accept shell strings, so the common case is just:

```ts
await sandbox.commands.run("git status && npm test");
```

Options still work:

```ts
await sandbox.commands.run("npm test", {
  cwd: "/workspace",
  environment: { CI: "true" },
  timeout: "5m",
});
```

And the API works the same way with a step ID:

```ts
await sandbox.commands.run("run-tests", "npm test", {
  cwd: "/workspace",
  timeout: "5m",
});
```

The SDK turns a string into `["/bin/sh", "-c", command]`. It does not split or parse it, so pipes, redirects, variables, quoting, and chained commands work normally. Existing argv arrays are passed through unchanged.

Managed process start accepts the same command strings:

```ts
await sandbox.processes.start({
  command: "npm run dev",
  cwd: "/workspace",
});
```

This is SDK-only. REST, middleware, and Simcity still receive argv arrays