### PR TITLE
fix(sandbox): relax name validation

### DIFF
--- a/.changeset/brave-ulids-smile.md
+++ b/.changeset/brave-ulids-smile.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow sandbox names up to 255 characters, including uppercase ULIDs and human-readable names.

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -916,6 +916,95 @@ describe("step.sandbox", () => {
 });
 
 describe("inngest.sandboxes", () => {
+  test("accepts uppercase ULIDs and human-readable sandbox names", async () => {
+    const { kind: _kind, version: _version, ...resource } = sandboxRef;
+    const sentNames: string[] = [];
+    const fetchMock: typeof fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { name: string };
+      sentNames.push(body.name);
+      return Response.json(
+        { data: { ...resource, name: body.name } },
+        { status: 201 },
+      );
+    });
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+    const names = [
+      "01J4Z3R7M8N9P0Q1S2T3V4W5XY",
+      "Repo Build / 01J4Z3R7M8N9P0Q1S2T3V4W5XY",
+      "my.sandbox",
+      "déploiement-🚀",
+      "🚀".repeat(255),
+    ];
+
+    for (const name of names) {
+      await expect(
+        client.create({ ...createOptions, name }),
+      ).resolves.toMatchObject({ name });
+      expect(() =>
+        parseSandboxOperation({
+          protocolVersion: 1,
+          action: "create",
+          input: [{ ...createOptions, name }],
+        }),
+      ).not.toThrow();
+    }
+
+    expect(sentNames).toEqual(names);
+  });
+
+  test.each([
+    ["empty", "", "must not be empty"],
+    ["too long", "a".repeat(256), "must not exceed 255 characters"],
+    [
+      "too many Unicode characters",
+      "🚀".repeat(256),
+      "must not exceed 255 characters",
+    ],
+    [
+      "leading whitespace",
+      " sandbox",
+      "must not contain leading or trailing whitespace",
+    ],
+    [
+      "trailing whitespace",
+      "sandbox ",
+      "must not contain leading or trailing whitespace",
+    ],
+    [
+      "control character",
+      "sandbox\nname",
+      "must not contain control characters",
+    ],
+  ] as const)(
+    "rejects a sandbox name that is %s",
+    async (_case, name, message) => {
+      const fetchMock: typeof fetch = vi.fn();
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "signkey-test",
+        headers: () => ({}),
+        fetch: () => fetchMock,
+      });
+
+      await expect(client.create({ ...createOptions, name })).rejects.toThrow(
+        message,
+      );
+      expect(() =>
+        parseSandboxOperation({
+          protocolVersion: 1,
+          action: "create",
+          input: [{ ...createOptions, name }],
+        }),
+      ).toThrow(message);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
   test("validates Create environment before transport", async () => {
     const fetchMock: typeof fetch = vi.fn();
     const client = createSandboxClient({

--- a/packages/inngest/src/components/sandbox/protocol.ts
+++ b/packages/inngest/src/components/sandbox/protocol.ts
@@ -13,6 +13,7 @@ import {
   normalizeSandboxCreateOptions,
   normalizeSandboxProcessStartOptions,
   parseWithSchema,
+  sandboxNameSchema,
   sandboxProcessRefSchema,
   sandboxRefSchema,
   wireOutputChunkSchema,
@@ -36,7 +37,7 @@ const processTargetSchema = sandboxTargetSchema
 
 const createInputSchema = z
   .object({
-    name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
+    name: sandboxNameSchema,
     vcpu: z.number().int().positive().max(0xffffffff),
     memoryMb: z.number().int().positive().max(0xffffffff),
     environment: z.record(z.string()).optional(),

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -40,7 +40,8 @@ export interface SandboxRef extends SandboxResource {
 export interface SandboxCreateOptions {
   /**
    * Stable identity for an active sandbox. Creating the same name again with
-   * the same configuration returns the existing sandbox.
+   * the same configuration returns the existing sandbox. Names are
+   * case-sensitive and may contain up to 255 characters.
    */
   name: string;
   vcpu: number;

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -31,7 +31,36 @@ const maxProcessEnvCount = 256;
 const maxProcessEnvBytes = 64 * 1_024;
 const maxProcessCwdBytes = 4_096;
 const maxProcessWireBytes = 96 * 1_024;
+const maxSandboxNameCharacters = 255;
+const sandboxNameControlCharacterPattern = /\p{Cc}/u;
+const sandboxNameEdgeWhitespacePattern = /^\p{White_Space}|\p{White_Space}$/u;
 const textEncoder = new TextEncoder();
+
+export const sandboxNameSchema = z.string().superRefine((name, ctx) => {
+  if (name.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must not be empty",
+    });
+  } else if ([...name].length > maxSandboxNameCharacters) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `must not exceed ${maxSandboxNameCharacters} characters`,
+    });
+  }
+  if (sandboxNameEdgeWhitespacePattern.test(name)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must not contain leading or trailing whitespace",
+    });
+  }
+  if (sandboxNameControlCharacterPattern.test(name)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must not contain control characters",
+    });
+  }
+});
 
 const goJSONBytes = (value: unknown): number => {
   // encoding/json escapes these runes by default. Simcity measures the
@@ -142,7 +171,7 @@ const sandboxResourcesSchema = z
 export const sandboxResourceSchema = z
   .object({
     id: canonicalUuidSchema,
-    name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
+    name: sandboxNameSchema,
     status: sandboxStatusSchema,
     vpcId: canonicalUuidSchema,
     imageRef: z.string().min(1),
@@ -339,7 +368,7 @@ export const normalizeSandboxCreateOptions = (
   const parsed = parseWithSchema(
     z
       .object({
-        name: z.string().regex(/^[a-z0-9_-]{1,63}$/),
+        name: sandboxNameSchema,
         vcpu: z.number().int().positive().max(0xffffffff),
         memoryMb: z.number().int().positive().max(0xffffffff),
         environment: z.record(z.string()).optional(),


### PR DESCRIPTION
Matches the sandbox SDK to the API name contract.

Sandbox names can now be up to 255 characters and can include uppercase ULIDs, spaces, punctuation, and Unicode. We still reject empty names, leading or trailing whitespace, and control characters
