### PR TITLE
feat: Drop the experimental label from the sessions propagation API

### DIFF
--- a/packages/inngest/src/types.ts
+++ b/packages/inngest/src/types.ts
@@ -825,9 +825,6 @@ export type EventMeta = {
   sessions?: EventSessions | null;
 
   /**
-   * EXPERIMENTAL: This API is not yet stable and may change in the future
-   * without a major version bump.
-   *
    * Sessions propagated from the run that emitted this event. Stamped
    * automatically from `ctx.sessions`; carried as a separate layer from manual
    * {@link EventMeta.sessions} and merged server-side (manual wins per key).
@@ -1241,9 +1238,6 @@ export interface ClientOptions {
   aiMetadata?: boolean;
 
   /**
-   * EXPERIMENTAL: This API is not yet stable and may change in the future
-   * without a major version bump.
-   *
    * Whether events spawned during a run — via `step.sendEvent`, `step.invoke`,
    * and `defer` — inherit the run's session metadata, so the resulting child
    * runs stay grouped in the same sessions as their parent.


### PR DESCRIPTION
## Summary

- We are in the process of releasing propagated sessions
- Let's transition its API out of experimental


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- ~[ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~
- ~[ ] Added unit/integration tests~
- ~[ ] Added changesets if applicable~

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>