### PR TITLE
fix(lambda): preserve query string so function-level middleware runs

### DIFF
--- a/.changeset/fix-lambda-url-query-string.md
+++ b/.changeset/fix-lambda-url-query-string.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Preserve the query string in the AWS Lambda adapter's `url()` so function-level middleware can resolve `fnId`

--- a/packages/inngest/src/lambda.test.ts
+++ b/packages/inngest/src/lambda.test.ts
@@ -1,5 +1,7 @@
 import type { APIGatewayProxyResult } from "aws-lambda";
+import { describe, expect, test } from "vitest";
 import * as LambdaHandler from "./lambda.ts";
+import { buildLambdaUrl } from "./lambda.ts";
 import { testFramework } from "./test/helpers.ts";
 
 testFramework("AWS Lambda", LambdaHandler, {
@@ -34,4 +36,67 @@ testFramework("AWS Lambda", LambdaHandler, {
       headers: (ret.headers || {}) as Record<string, string>,
     };
   },
+});
+
+describe("buildLambdaUrl query string preservation", () => {
+  const getHeader = (key: string) =>
+    key.toLowerCase() === "host" ? "example.execute-api.us-east-1.amazonaws.com" : undefined;
+
+  test("API Gateway v2 keeps rawQueryString so fnId is on url.searchParams", () => {
+    const url = buildLambdaUrl(
+      {
+        version: "2.0",
+        rawQueryString: "fnId=my-app-my-fn&stepId=step",
+        headers: { host: "example.execute-api.us-east-1.amazonaws.com" },
+        requestContext: {
+          http: {
+            method: "POST",
+            path: "/api/inngest",
+          },
+        },
+      } as Parameters<typeof buildLambdaUrl>[0],
+      getHeader,
+    );
+
+    expect(url.pathname).toBe("/api/inngest");
+    expect(url.searchParams.get("fnId")).toBe("my-app-my-fn");
+    expect(url.searchParams.get("stepId")).toBe("step");
+  });
+
+  test("API Gateway v1 keeps queryStringParameters on url.searchParams", () => {
+    const url = buildLambdaUrl(
+      {
+        path: "/api/inngest",
+        httpMethod: "POST",
+        headers: { host: "example.execute-api.us-east-1.amazonaws.com" },
+        queryStringParameters: {
+          fnId: "my-app-my-fn",
+          stepId: "step",
+        },
+      } as Parameters<typeof buildLambdaUrl>[0],
+      getHeader,
+    );
+
+    expect(url.searchParams.get("fnId")).toBe("my-app-my-fn");
+    expect(url.searchParams.get("stepId")).toBe("step");
+  });
+
+  test("omits search when the event has no query string", () => {
+    const url = buildLambdaUrl(
+      {
+        version: "2.0",
+        rawQueryString: "",
+        headers: { host: "example.execute-api.us-east-1.amazonaws.com" },
+        requestContext: {
+          http: {
+            method: "GET",
+            path: "/api/inngest",
+          },
+        },
+      } as Parameters<typeof buildLambdaUrl>[0],
+      getHeader,
+    );
+
+    expect(url.search).toBe("");
+  });
 });

--- a/packages/inngest/src/lambda.ts
+++ b/packages/inngest/src/lambda.ts
@@ -43,6 +43,46 @@ import type { SupportedFrameworkName } from "./types.ts";
 export const frameworkName: SupportedFrameworkName = "aws-lambda";
 
 /**
+ * Build the request URL for a Lambda/API Gateway event, preserving the query
+ * string so function-level middleware can resolve `fnId` from `url.searchParams`.
+ *
+ * @internal Exported for unit tests.
+ */
+export const buildLambdaUrl = (
+  event: Either<APIGatewayEvent, APIGatewayProxyEventV2>,
+  getHeader: (key: string) => string | undefined,
+): URL => {
+  const eventIsV2 = (event as APIGatewayProxyEventV2).version === "2.0";
+  const path = eventIsV2
+    ? (event as APIGatewayProxyEventV2).requestContext.http.path
+    : (event as APIGatewayEvent).path;
+  const proto = getHeader("x-forwarded-proto") || "https";
+  const url = new URL(path, `${proto}://${getHeader("host") || ""}`);
+
+  // Must preserve the query string: InngestCommHandler matches function-level
+  // middleware via `url.searchParams.get(fnId)`. Execution itself reads fnId
+  // from `queryString` / queryStringParameters, so dropping the query here
+  // silently skips function middleware only.
+  // See https://github.com/inngest/inngest-js/issues/1673
+  if (eventIsV2) {
+    const rawQueryString = (event as APIGatewayProxyEventV2).rawQueryString;
+    if (rawQueryString) {
+      url.search = rawQueryString;
+    }
+  } else if ((event as APIGatewayEvent).queryStringParameters) {
+    for (const [key, value] of Object.entries(
+      (event as APIGatewayEvent).queryStringParameters ?? {},
+    )) {
+      if (typeof value === "string") {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  return url;
+};
+
+/**
  * With AWS Lambda, serve and register any declared functions with Inngest,
  * making them available to be triggered by events.
  *
@@ -120,13 +160,7 @@ export const serve = (
             ? event.requestContext.http.method
             : event.httpMethod;
         },
-        url: () => {
-          const path = eventIsV2 ? event.requestContext.http.path : event.path;
-          const proto = getHeader("x-forwarded-proto") || "https";
-          const url = new URL(path, `${proto}://${getHeader("host") || ""}`);
-
-          return url;
-        },
+        url: () => buildLambdaUrl(event, getHeader),
         queryString: (key) => {
           return event.queryStringParameters?.[key];
         },


### PR DESCRIPTION
## Summary
- The AWS Lambda adapter's `url()` rebuilt the request URL from the path only, dropping the query string.
- `InngestCommHandler` attaches function-level middleware by reading `fnId` from `url.searchParams`, so those hooks never ran on Lambda (client middleware still worked; execution still worked via `queryString`).
- Preserve `rawQueryString` (API Gateway v2) / `queryStringParameters` (v1) on the constructed URL.

Fixes #1673

## Test plan
- [x] Unit tests for `buildLambdaUrl` covering v1 + v2 query preservation
- [x] A/B: without the query-preservation block, `url.searchParams.get("fnId")` is `null`; with the fix it returns the expected id
- [x] Existing Lambda framework suite still passes (`vitest run src/lambda.test.ts`)


Made with [Cursor](https://cursor.com)