### PR TITLE
fix: catch invalid propagated sessions with step.invoke and defer

### DIFF
--- a/.changeset/perfect-papayas-call.md
+++ b/.changeset/perfect-papayas-call.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Validate propagated sessions with step.invoke and defer

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -1089,11 +1089,15 @@ describe("defer session propagation", () => {
   const startDefer = async (
     enabled: boolean,
     manualMeta?: Record<string, unknown>,
+    middlewareSessions?: unknown,
   ) => {
     const client = createClient({
       id: "test",
       isDev: true,
       sessionPropagation: enabled,
+      ...(middlewareSessions === undefined
+        ? {}
+        : { middleware: [overwriteSessionsMiddleware(middlewareSessions)] }),
     });
 
     const target = createDefer(
@@ -1154,8 +1158,13 @@ describe("defer session propagation", () => {
   const runDefer = async (
     enabled: boolean,
     manualMeta?: Record<string, unknown>,
+    middlewareSessions?: unknown,
   ) => {
-    const { deferOp } = await startDefer(enabled, manualMeta);
+    const { deferOp } = await startDefer(
+      enabled,
+      manualMeta,
+      middlewareSessions,
+    );
     expect(deferOp).toBeDefined();
     return (deferOp?.opts as { meta?: Record<string, unknown> })?.meta;
   };
@@ -1202,6 +1211,23 @@ describe("defer session propagation", () => {
     expect(meta).toBeDefined();
     expect(meta?.sessions).toBeNull();
     expect(meta?.propagated_sessions).toEqual({ conv_id: "p1", org_id: "42" });
+  });
+
+  test("normalizes a sessions layer overwritten by middleware", async () => {
+    const meta = await runDefer(true, undefined, { conv_id: 123 });
+    expect(meta?.propagated_sessions).toEqual({ conv_id: "123" });
+  });
+
+  test("skips the defer on an unusable sessions layer from middleware", async () => {
+    // Same fire-and-forget contract as invalid manual meta: log and skip rather
+    // than shipping a malformed propagated layer or failing the run.
+    const { result, deferOp } = await startDefer(true, undefined, {
+      conv_id: {},
+    });
+    expect(deferOp).toBeUndefined();
+    expect(result).toMatchObject({
+      steps: [expect.objectContaining({ op: "RunComplete", data: "done" })],
+    });
   });
 
   test("skips the defer on invalid meta without derailing the run", async () => {

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { InngestApi } from "../../api/api.ts";
 import { createDefer } from "../../experimental.ts";
 import { ExecutionVersion } from "../../helpers/consts.ts";
+import { Middleware } from "../../index.ts";
 import { createClient } from "../../test/helpers.ts";
 import { type Context, StepMode, StepOpCode } from "../../types.ts";
 import { InngestFunction } from "../InngestFunction.ts";
@@ -921,19 +922,47 @@ describe("Execution engine checkpoint retry behavior", () => {
   });
 });
 
+/**
+ * Middleware that replaces `ctx.sessions` wholesale, standing in for any
+ * `transformFunctionInput` hook that writes the field. Both propagation paths
+ * read `ctx.sessions` at stamp time, so the value they ship is whatever
+ * middleware left behind — not the reduced, normalized aggregate.
+ */
+const overwriteSessionsMiddleware = (sessions: unknown) =>
+  class extends Middleware.BaseMiddleware {
+    readonly id = "overwrite-sessions";
+    override transformFunctionInput(
+      arg: Middleware.TransformFunctionInputArgs,
+    ) {
+      // Cast because the point of the test is a value `ctx.sessions` doesn't
+      // type as — middleware can still put one there at runtime.
+      return {
+        ...arg,
+        ctx: {
+          ...arg.ctx,
+          sessions,
+        } as Middleware.TransformFunctionInputArgs["ctx"],
+      };
+    }
+  };
+
 describe("step.invoke session propagation", () => {
   // Drives a real execution whose handler calls `step.invoke`, then inspects
   // the emitted InvokeFunction op to assert the engine's central stamp: the
   // run's `ctx.sessions` (aggregated from triggering events) is attached to the
   // invoke payload as `meta.propagated_sessions`, gated by the client toggle.
-  const runInvoke = async (
+  const startInvoke = async (
     enabled: boolean,
     manualMeta?: Record<string, unknown>,
+    middlewareSessions?: unknown,
   ) => {
     const client = createClient({
       id: "test",
       isDev: true,
       sessionPropagation: enabled,
+      ...(middlewareSessions === undefined
+        ? {}
+        : { middleware: [overwriteSessionsMiddleware(middlewareSessions)] }),
     });
 
     const target = new InngestFunction(
@@ -986,7 +1015,15 @@ describe("step.invoke session propagation", () => {
       },
     });
 
-    const result = await execution.start();
+    return execution.start();
+  };
+
+  // Most cases expect the invoke to be planned; assert that once here and hand
+  // back just the payload under test.
+  const runInvoke = async (
+    ...args: Parameters<typeof startInvoke>
+  ): Promise<{ meta?: Record<string, unknown> } | undefined> => {
+    const result = await startInvoke(...args);
     expect(result.type).toBe("steps-found");
     const stepsFound = result as ExecutionResults["steps-found"];
     const invokeOp = stepsFound.steps.find(
@@ -1018,6 +1055,27 @@ describe("step.invoke session propagation", () => {
     expect(payload?.meta?.propagated_sessions).toEqual({
       conv_id: "p1",
       org_id: "42",
+    });
+  });
+
+  test("normalizes a sessions layer overwritten by middleware", async () => {
+    // Middleware writes `ctx.sessions` after the engine's reduce, so the stamp
+    // can't assume the normalized shape; invoke never passes through the
+    // `sendEvent` normalization that would otherwise catch this.
+    const payload = await runInvoke(true, undefined, { conv_id: 123 });
+    expect(payload?.meta?.propagated_sessions).toEqual({ conv_id: "123" });
+  });
+
+  test("fails the run on an unusable sessions layer from middleware", async () => {
+    // `step.invoke` is user-addressable, so a malformed layer surfaces as a run
+    // failure — the same outcome `sendEvent` gives — rather than silently
+    // shipping something ingest would reject.
+    const result = await startInvoke(true, undefined, { conv_id: {} });
+    expect(result).toMatchObject({
+      type: "function-rejected",
+      error: expect.objectContaining({
+        message: expect.stringContaining("must be a string or number"),
+      }),
     });
   });
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -35,6 +35,7 @@ import {
 } from "../../helpers/promises.ts";
 import {
   normalizeEventMeta,
+  normalizePropagatedSessions,
   reduceEventsToPropagatedSessions,
   stampPropagatedSessionsOnEvent,
 } from "../../helpers/sessions.ts";
@@ -2785,15 +2786,19 @@ class InngestExecutionEngine
         let deferMeta: ReturnType<typeof normalizeEventMeta>;
         try {
           deferMeta = normalizeEventMeta(meta);
+
+          if (this.options.client[sessionPropagationSymbol]) {
+            // Normalized rather than trusted: `ctx.sessions` can be replaced by
+            // middleware or the handler, and this path never reaches the
+            // `sendEvent` normalization.
+            const propagated = normalizePropagatedSessions(this.fnArg.sessions);
+            if (propagated) {
+              deferMeta = { ...deferMeta, propagated_sessions: propagated };
+            }
+          }
         } catch (err) {
           log.error({ runId, err }, "defer skipped: invalid meta");
           return noopHandle;
-        }
-        if (this.options.client[sessionPropagationSymbol]) {
-          const propagated = this.fnArg.sessions;
-          if (propagated && Object.keys(propagated).length > 0) {
-            deferMeta = { ...deferMeta, propagated_sessions: propagated };
-          }
         }
 
         void stepHandler({

--- a/packages/inngest/src/helpers/sessions.test.ts
+++ b/packages/inngest/src/helpers/sessions.test.ts
@@ -337,6 +337,37 @@ describe("stampPropagatedSessionsOnEvent", () => {
     ).toBe(payload);
   });
 
+  // `ctx.sessions` is machine-generated, but middleware and the handler can
+  // both replace it before the stamp reads it, and only the `sendEvent` path
+  // normalizes further downstream.
+  test("normalizes the sessions it is handed", () => {
+    const payload: Payload = { data: {} };
+    expect(stampPropagatedSessionsOnEvent(payload, { conv_id: 123 })).toEqual({
+      data: {},
+      meta: { propagated_sessions: { conv_id: "123" } },
+    });
+  });
+
+  test("rejects an unusable sessions layer rather than stamping it", () => {
+    const payload: Payload = { data: {} };
+    expect(() =>
+      stampPropagatedSessionsOnEvent(payload, {
+        conv_id: null,
+      } as unknown as Record<string, string>),
+    ).toThrow(/must be a string or number/);
+    expect(() =>
+      stampPropagatedSessionsOnEvent(payload, {
+        "": "123",
+      }),
+    ).toThrow(/cannot be empty/);
+    expect(() =>
+      stampPropagatedSessionsOnEvent(
+        payload,
+        "nope" as unknown as Record<string, string>,
+      ),
+    ).toThrow(/must be an object/);
+  });
+
   test("onlyIfAbsent still stamps when there is no propagated layer", () => {
     const payload = { data: {}, meta: { sessions: { conv_id: "manual" } } };
     expect(

--- a/packages/inngest/src/helpers/sessions.ts
+++ b/packages/inngest/src/helpers/sessions.ts
@@ -299,17 +299,27 @@ export const reduceEventsToPropagatedSessions = (
  *
  * Pass `onlyIfAbsent` when stamping *downstream* of another entry point, to
  * leave the upstream stamp authoritative rather than clobbering it.
+ *
+ * The value is normalized here rather than trusted: `ctx.sessions` starts out
+ * machine-generated, but middleware (`transformFunctionInput`) and the handler
+ * itself can both replace it, and only the `sendEvent` path normalizes further
+ * downstream. Normalizing at the stamp keeps every entry point — `sendEvent`,
+ * `invoke`, and a bare `send()` — on the same wire shape and rejection rules.
  */
 export const stampPropagatedSessionsOnEvent = <T extends { meta?: EventMeta }>(
   payload: T,
-  sessions: Record<string, string> | undefined,
+  sessions: PropagatedEventSessions | undefined,
   { onlyIfAbsent = false }: { onlyIfAbsent?: boolean } = {},
 ): T => {
-  if (!sessions || Object.keys(sessions).length === 0) {
+  if (onlyIfAbsent && payload.meta?.propagated_sessions !== undefined) {
     return payload;
   }
 
-  if (onlyIfAbsent && payload.meta?.propagated_sessions !== undefined) {
+  // Returns `undefined` for an absent or empty layer, leaving the payload
+  // unstamped; the normalized object is already a fresh clone, so mutating one
+  // event's sessions in middleware can't reach another event or `ctx.sessions`.
+  const normalized = normalizePropagatedSessions(sessions);
+  if (!normalized) {
     return payload;
   }
 
@@ -317,11 +327,7 @@ export const stampPropagatedSessionsOnEvent = <T extends { meta?: EventMeta }>(
     ...payload,
     meta: {
       ...payload.meta,
-
-      // Clone so that mutating one event's sessions in middleware doesn't
-      // inadvertently mutate every other event's sessions, or `ctx.sessions`
-      // itself.
-      propagated_sessions: { ...sessions },
+      propagated_sessions: normalized,
     },
   };
 };
@@ -332,7 +338,7 @@ export const stampPropagatedSessionsOnEvent = <T extends { meta?: EventMeta }>(
  */
 export const stampPropagatedSessions = (
   payload: SendEventPayload,
-  sessions: Record<string, string> | undefined,
+  sessions: PropagatedEventSessions | undefined,
 ): SendEventPayload =>
   Array.isArray(payload)
     ? payload.map((p) => stampPropagatedSessionsOnEvent(p, sessions))


### PR DESCRIPTION
## Summary

- Step.invoke and defer attached propagated sessions to the outgoing opcode with running through normalization/validation
- This is usually fine, as propagated sessions are generated and we generate valid propagated sessions, however user middleware can transform this into invalid sessions
- Let's apply normalization before attaching to the opcode to ensure we catch these cases

## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- ~[ ] Added a [docs PR](https://github.com/inngest/website) that references this PR~
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->
- EXE-2135
