### PR TITLE
feat: add aiMiddleware

### DIFF
--- a/.changeset/clear-ravens-cut.md
+++ b/.changeset/clear-ravens-cut.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+`extendedTracesMiddleware()` no longer replaces your app's global OpenTelemetry diagnostic logger when it has no span processor of its own — with `behaviour: "off"`, or when `"extendProvider"` finds no provider to extend. It previously swallowed diagnostics from your own exporters in those cases.

--- a/.changeset/famous-beers-mix.md
+++ b/.changeset/famous-beers-mix.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Add experimental `aiMiddleware()`, a single bundle that enables scoring (`step.score()`), metadata (`step.metadata()`), and extended traces (`ctx.tracer`) together. Spread it to compose with your own middleware, or pass `traces: { behaviour: "off" }` to leave your OpenTelemetry provider untouched.

--- a/packages/inngest/src/components/ai/middleware.test.ts
+++ b/packages/inngest/src/components/ai/middleware.test.ts
@@ -1,0 +1,94 @@
+import type { Tracer } from "@opentelemetry/api";
+import { assertType, describe, expect, expectTypeOf, test } from "vitest";
+import { dependencyInjectionMiddleware } from "../../middleware/dependencyInjection.ts";
+import { ExtendedTracesBehavior } from "../../proto/src/components/sdkFeatureObservations/protobuf/feature_observations.ts";
+import { Inngest } from "../Inngest.ts";
+import type { metadataSymbol } from "../InngestMetadata.ts";
+import type { scoreSymbol } from "../InngestScore.ts";
+import type { ExperimentalStepTools } from "../InngestStepTools.ts";
+import { sdkFeatureObservations } from "../sdkFeatureObservations.ts";
+import { type AiMiddlewareOptions, aiMiddleware } from "./middleware.ts";
+
+const assertAiContext = (ctx: {
+  tracer: Tracer;
+  step: {
+    metadata: ExperimentalStepTools[typeof metadataSymbol];
+    score: ExperimentalStepTools[typeof scoreSymbol];
+  };
+}) => {
+  assertType<Tracer>(ctx.tracer);
+  assertType<ExperimentalStepTools[typeof metadataSymbol]>(ctx.step.metadata);
+  assertType<ExperimentalStepTools[typeof scoreSymbol]>(ctx.step.score);
+};
+
+describe("aiMiddleware", () => {
+  test("score, metadata, and tracer are only present if the middleware is used", () => {
+    const inngestWithoutMiddleware = new Inngest({
+      id: "test",
+      eventKey: "test-key-123",
+    });
+
+    inngestWithoutMiddleware.createFunction(
+      { id: "test", triggers: [{ event: "foo" }] },
+      (ctx) => {
+        expectTypeOf(ctx).not.toHaveProperty("tracer");
+        expectTypeOf(ctx.step).not.toHaveProperty("score");
+        expectTypeOf(ctx.step).not.toHaveProperty("metadata");
+      },
+    );
+
+    const inngestWithMiddleware = new Inngest({
+      id: "test",
+      eventKey: "test-key-123",
+      middleware: aiMiddleware({ traces: { behaviour: "off" } }),
+    });
+
+    inngestWithMiddleware.createFunction(
+      { id: "test", triggers: [{ event: "foo" }] },
+      (ctx) => {
+        assertAiContext(ctx);
+      },
+    );
+
+    // The docs tell users to spread the bundle alongside their own middleware.
+    // The ctx extensions only survive while that spread stays a tuple.
+    const inngestWithComposedMiddleware = new Inngest({
+      id: "test",
+      eventKey: "test-key-123",
+      middleware: [
+        ...aiMiddleware({ traces: { behaviour: "off" } }),
+        dependencyInjectionMiddleware({ greeting: "hello" }),
+      ],
+    });
+
+    inngestWithComposedMiddleware.createFunction(
+      { id: "test", triggers: [{ event: "foo" }] },
+      (ctx) => {
+        assertAiContext(ctx);
+        assertType<string>(ctx.greeting);
+      },
+    );
+  });
+
+  test("onRegister enables score and metadata, and passes traces through", () => {
+    const client = new Inngest({
+      id: "test",
+      middleware: aiMiddleware({ traces: { behaviour: "off" } }),
+    });
+
+    expect(client["experimentalScoreEnabled"]).toBe(true);
+    expect(client["experimentalMetadataEnabled"]).toBe(true);
+
+    const behaviourOf = (options?: AiMiddlewareOptions) =>
+      sdkFeatureObservations.extendedTraces.get(
+        new Inngest({ id: "test", middleware: aiMiddleware(options) }),
+      )?.behavior;
+
+    expect(behaviourOf()).toBe(
+      ExtendedTracesBehavior.EXTENDED_TRACES_BEHAVIOR_EXTEND_PROVIDER,
+    );
+    expect(behaviourOf({ traces: { behaviour: "off" } })).toBe(
+      ExtendedTracesBehavior.EXTENDED_TRACES_BEHAVIOR_OFF,
+    );
+  });
+});

--- a/packages/inngest/src/components/ai/middleware.ts
+++ b/packages/inngest/src/components/ai/middleware.ts
@@ -1,0 +1,77 @@
+import {
+  type ExtendedTracesMiddlewareOptions,
+  extendedTracesMiddleware,
+} from "../execution/otel/middleware.ts";
+import { metadataMiddleware } from "../InngestMetadata.ts";
+import { scoreMiddleware } from "../InngestScore.ts";
+
+/**
+ * A set of options for the AI middleware bundle.
+ */
+export interface AiMiddlewareOptions {
+  /**
+   * Options passed to the bundled Extended Traces middleware.
+   *
+   * Mirrors `ExtendedTracesMiddlewareOptions` minus the deprecated
+   * provider-creation path, which this bundle never takes: `instrumentations`
+   * is only read when creating a provider, and `behaviour` drops `"auto"` and
+   * `"createProvider"`.
+   *
+   * `behaviour: "off"` stops Inngest attaching its span processor to your
+   * OpenTelemetry provider. `ctx.tracer` is there either way; with `"off"` its
+   * spans reach your own provider but not Inngest.
+   *
+   * Defaults to `{ behaviour: "extendProvider" }`.
+   */
+  traces?: Omit<
+    ExtendedTracesMiddlewareOptions,
+    "behaviour" | "instrumentations"
+  > & {
+    behaviour?: "extendProvider" | "off";
+  };
+}
+
+/**
+ * Middleware that enables all experimental AI features in one place:
+ * scoring (`step.score()`), metadata (`step.metadata()`, `inngest.metadata`),
+ * and extended traces (`ctx.tracer`).
+ *
+ * Returns a tuple of the three middlewares; spread it to combine the bundle
+ * with your own. Using the bundle is equivalent to passing
+ * `extendedTracesMiddleware({ behaviour: "extendProvider" })`,
+ * `metadataMiddleware()`, and `scoreMiddleware()` yourself.
+ *
+ * Extended traces attach to your app's existing OpenTelemetry provider. If
+ * you don't already have one, install `@inngest/otel` and load it before any
+ * app code (e.g. `node --import @inngest/otel/node ./app.js`, or
+ * `NODE_OPTIONS="--import @inngest/otel/node"` when a framework CLI owns the
+ * node process), or pass `traces: { behaviour: "off" }` to stop Inngest
+ * attaching to your provider. See
+ * https://www.inngest.com/docs/examples/open-telemetry.
+ *
+ * @example
+ * ```ts
+ * import { aiMiddleware } from "inngest/experimental";
+ *
+ * const inngest = new Inngest({
+ *   id: "my-app",
+ *   middleware: aiMiddleware(),
+ * });
+ * ```
+ */
+export const aiMiddleware = ({
+  traces,
+}: AiMiddlewareOptions = {}): [
+  // The client only picks up ctx/step type extensions from a tuple, never from
+  // an array, so this annotation is load-bearing.
+  ReturnType<typeof extendedTracesMiddleware>,
+  ReturnType<typeof metadataMiddleware>,
+  ReturnType<typeof scoreMiddleware>,
+] => [
+  extendedTracesMiddleware({
+    ...traces,
+    behaviour: traces?.behaviour ?? "extendProvider",
+  }),
+  metadataMiddleware(),
+  scoreMiddleware(),
+];

--- a/packages/inngest/src/components/ai/middleware.ts
+++ b/packages/inngest/src/components/ai/middleware.ts
@@ -55,7 +55,7 @@ export interface AiMiddlewareOptions {
  *
  * const inngest = new Inngest({
  *   id: "my-app",
- *   middleware: aiMiddleware(),
+ *   middleware: [...aiMiddleware()],
  * });
  * ```
  */

--- a/packages/inngest/src/components/execution/otel/middleware.test.ts
+++ b/packages/inngest/src/components/execution/otel/middleware.test.ts
@@ -1,0 +1,38 @@
+import { DiagLogLevel, diag } from "@opentelemetry/api";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Inngest } from "../../Inngest.ts";
+import { extendedTracesMiddleware } from "./middleware.ts";
+
+describe("extendedTracesMiddleware", () => {
+  afterEach(() => {
+    diag.disable();
+  });
+
+  // Inngest only has diagnostics worth reading when it owns a span processor.
+  // Installing its logger otherwise would swallow the host app's own OTel
+  // diagnostics for no gain. "extendProvider" finds no provider here, and
+  // "nonsense" stands in for a plain-JS caller passing an unknown behaviour,
+  // which warns that it defaults to "off".
+  test.for(["off", "extendProvider", "nonsense"])(
+    "behaviour %s leaves the host app's diag logger in place",
+    (behaviour) => {
+      const logger = {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        verbose: vi.fn(),
+        warn: vi.fn(),
+      };
+      diag.setLogger(logger, DiagLogLevel.ALL);
+
+      new Inngest({
+        id: "test",
+        // @ts-expect-error `string` is wider than `Behaviour`
+        middleware: [extendedTracesMiddleware({ behaviour })],
+      });
+
+      diag.error("from the host app");
+      expect(logger.error).toHaveBeenCalledWith("from the host app");
+    },
+  );
+});

--- a/packages/inngest/src/components/execution/otel/middleware.ts
+++ b/packages/inngest/src/components/execution/otel/middleware.ts
@@ -68,7 +68,8 @@ export interface ExtendedTracesMiddlewareOptions {
    * The log level for the Extended Traces middleware, specifically a diagnostic logger
    * attached to the global OpenTelemetry provider.
    *
-   * Defaults to `DiagLogLevel.ERROR`.
+   * Defaults to `DiagLogLevel.ERROR`. Ignored when Inngest has no span
+   * processor of its own, as it then registers no diagnostic logger.
    */
   logLevel?: DiagLogLevel;
 }
@@ -165,9 +166,6 @@ export const extendedTracesMiddleware = ({
       }
 
       setup = extended.setup;
-      console.warn(
-        "unable to extend provider, Extended Traces middleware will not work. Use @inngest/otel, or make sure that the provider is created and imported before the middleware is used.",
-      );
 
       break;
     }
@@ -192,12 +190,16 @@ export const extendedTracesMiddleware = ({
     static override onRegister({ client }: Middleware.OnRegisterArgs) {
       replaceExtendedTracesObservation(client);
 
-      // Set the logger for our otel processors and exporters.
-      // If this is called multiple times, only the first call is set.
-      devDebug(
-        "set otel diagLogger:",
-        diag.setLogger(new InngestTracesLogger(), logLevel),
-      );
+      // Set the logger for our otel processors and exporters. `diag.setLogger`
+      // overwrites any logger already registered, so skip it when we have no
+      // processor of our own to diagnose and would only be swallowing the host
+      // app's OTel diagnostics.
+      if (processor || processorReady) {
+        devDebug(
+          "set otel diagLogger:",
+          diag.setLogger(new InngestTracesLogger(), logLevel),
+        );
+      }
 
       if (processor) {
         clientProcessorMap.set(client, processor);

--- a/packages/inngest/src/components/execution/otel/util.ts
+++ b/packages/inngest/src/components/execution/otel/util.ts
@@ -135,7 +135,15 @@ export const extendProvider = (
   if (!setup.providerFound) {
     if (behaviour !== "auto") {
       console.warn(
-        'No existing OTel provider found and behaviour is "extendProvider". Inngest\'s OTel middleware will not work. Use @inngest/otel instead, or make sure that the provider is created and imported before the middleware is used.',
+        [
+          "Inngest extended traces are disabled: no OpenTelemetry provider was registered before the middleware initialized.",
+          "To fix, install @inngest/otel and load it before any app code:",
+          "  npm install @inngest/otel",
+          "  node --import @inngest/otel/node ./app.js",
+          'If a framework CLI owns the node process (Next.js, Vite, etc.), set NODE_OPTIONS="--import @inngest/otel/node" or add `import "@inngest/otel/node"` as the first import of your entrypoint.',
+          'Alternatively, register your own OpenTelemetry provider before creating the Inngest client, or silence this by setting the behaviour to "off".',
+          "Docs: https://www.inngest.com/docs/examples/open-telemetry",
+        ].join("\n"),
       );
     }
 
@@ -150,7 +158,8 @@ export const extendProvider = (
     console.warn(
       "Unable to add InngestSpanProcessor to existing OTel provider. " +
         "The provider does not support addSpanProcessor() (OTel SDK v1) " +
-        "or expose _activeSpanProcessor._spanProcessors (OTel SDK v2).",
+        "or expose _activeSpanProcessor._spanProcessors (OTel SDK v2). " +
+        "Docs: https://www.inngest.com/docs/examples/open-telemetry",
     );
   }
 

--- a/packages/inngest/src/experimental.ts
+++ b/packages/inngest/src/experimental.ts
@@ -1,9 +1,11 @@
-// AsyncLocalStorage
-
+// AI middleware bundle (scoring + metadata + extended traces)
+export type { AiMiddlewareOptions } from "./components/ai/middleware.ts";
+export { aiMiddleware } from "./components/ai/middleware.ts";
 export {
   createDefer,
   DeferredFunction,
 } from "./components/DeferredFunction.ts";
+// AsyncLocalStorage
 export type { AsyncContext } from "./components/execution/als.ts";
 export { getAsyncCtx } from "./components/execution/als.ts";
 // Extended Traces (OpenTelemetry)

--- a/packages/inngest/src/test/integration/ai/middleware.test.ts
+++ b/packages/inngest/src/test/integration/ai/middleware.test.ts
@@ -1,0 +1,119 @@
+import {
+  createState,
+  createTestApp,
+  getRunTraceMetadata,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { context, trace } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import { describe, expect, test } from "vitest";
+import { clientProcessorMap } from "../../../components/execution/otel/access.ts";
+import { aiMiddleware } from "../../../experimental.ts";
+import { Inngest } from "../../../index.ts";
+import { createServer } from "../../../node.ts";
+import {
+  expectNoSpanByName,
+  expectScoreValue,
+  findSpanByName,
+} from "../scoring/utils.ts";
+
+// The bundle's default traces behaviour is "extendProvider", which only works
+// if a global OTel provider exists before the middleware factory runs.
+trace.setGlobalTracerProvider(new BasicTracerProvider());
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+describe("aiMiddleware", () => {
+  test("score, metadata, and tracer all work through one run", async () => {
+    const state = createState({});
+
+    const client = new Inngest({
+      checkpointing: true,
+      id: randomSuffix(testFileName),
+      isDev: true,
+      middleware: aiMiddleware(),
+    });
+    expect(clientProcessorMap.get(client)).toBeDefined();
+
+    const eventName = randomSuffix("evt");
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 0,
+        triggers: { event: eventName },
+      },
+      async ({ runId, step, tracer }) => {
+        state.runId = runId;
+
+        await step.run("traced-step", () => {
+          tracer.startActiveSpan("bundle-span", (span) => {
+            span.end();
+          });
+        });
+
+        await step.metadata("set-status").run().update({ status: "done" });
+        await step.score("run-score", { name: "bundle_score", value: true });
+      },
+    );
+    await createTestApp({ client, functions: [fn], serve: createServer });
+
+    await client.send({ name: eventName, data: {} });
+    await state.waitForRunComplete();
+    const runTrace = await getRunTraceMetadata(await state.waitForRunId());
+
+    expectScoreValue(runTrace.metadata, "bundle_score", true);
+
+    findSpanByName(runTrace, "bundle-span");
+    findSpanByName(runTrace, "set-status");
+    expect(
+      runTrace.metadata.find((md) => md.kind === "userland.default")?.values,
+    ).toEqual(expect.objectContaining({ status: "done" }));
+  });
+
+  test('traces "off" sends no spans, but metadata and score still work', async () => {
+    const state = createState({});
+
+    const client = new Inngest({
+      checkpointing: true,
+      id: randomSuffix(testFileName),
+      isDev: true,
+      middleware: aiMiddleware({ traces: { behaviour: "off" } }),
+    });
+    expect(clientProcessorMap.get(client)).toBeUndefined();
+
+    const eventName = randomSuffix("evt");
+    const fn = client.createFunction(
+      {
+        id: "fn",
+        retries: 0,
+        triggers: { event: eventName },
+      },
+      async ({ runId, step, tracer }) => {
+        state.runId = runId;
+
+        await step.run("traced-step", () => {
+          tracer.startActiveSpan("bundle-span", (span) => {
+            span.end();
+          });
+        });
+
+        await step.metadata("set-status").run().update({ status: "done" });
+        await step.score("run-score", { name: "bundle_score", value: false });
+      },
+    );
+    await createTestApp({ client, functions: [fn], serve: createServer });
+
+    await client.send({ name: eventName, data: {} });
+    await state.waitForRunComplete();
+    const runTrace = await getRunTraceMetadata(await state.waitForRunId());
+
+    expectScoreValue(runTrace.metadata, "bundle_score", false);
+    expect(
+      runTrace.metadata.find((md) => md.kind === "userland.default")?.values,
+    ).toEqual(expect.objectContaining({ status: "done" }));
+    expectNoSpanByName(runTrace, "bundle-span");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds experimental `aiMiddleware()`, a single bundle enabling scoring (`step.score()`), metadata (`step.metadata()`), and extended traces (`ctx.tracer`) together. Returned as a tuple so it spreads into `middleware: [...]` and composes with user middleware. Pass `traces: { behaviour: "off" }` to leave the OpenTelemetry provider untouched.
- Fixes `extendedTracesMiddleware()` replacing the app's global OTel diagnostic logger even when it has no span processor of its own (`behaviour: "off"`, or `"extendProvider"` with no provider found).

Changesets included for both.

Stacked: the example app for this lands in a follow-up PR on top of this one.

Docs: inngest/website#1837.
