### PR TITLE
fix(sandbox): return command output as text

### DIFF
--- a/.changeset/calm-sandboxes-speak.md
+++ b/.changeset/calm-sandboxes-speak.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Return captured sandbox command stdout and stderr as UTF-8 strings.

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -1052,6 +1052,43 @@ describe("inngest.sandboxes", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test("normalizes omitted empty captured Exec streams", async () => {
+    const { kind: _kind, version: _version, ...resource } = sandboxRef;
+    let requestCount = 0;
+    const fetchMock: typeof fetch = vi.fn(async () => {
+      requestCount++;
+      if (requestCount === 1) {
+        return Response.json({ data: resource });
+      }
+      return Response.json({
+        data: {
+          encoding: "base64",
+          exitCode: 0,
+        },
+      });
+    });
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+
+    const sandbox = await client.get(sandboxId);
+    if (!sandbox) {
+      throw new Error("Expected sandbox");
+    }
+    await expect(
+      sandbox.commands.run({ command: ["/bin/true"] }),
+    ).resolves.toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      output: { truncated: false },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   test("validates Create environment before transport", async () => {
     const fetchMock: typeof fetch = vi.fn();
     const client = createSandboxClient({

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -12,6 +12,7 @@ import { Inngest } from "./Inngest.ts";
 import {
   createSandboxClient,
   createSandboxTools,
+  encodeBase64,
   parseSandboxOperation,
   SandboxError,
   type SandboxOperationResultV1,
@@ -212,8 +213,8 @@ describe("step.sandbox", () => {
     expect(listed.items[0]).toMatchObject(sandboxRef);
     expect(fetched?.id).toBe(sandboxId);
     expect(command).toEqual({
-      stdout: new Uint8Array([111, 107, 10]),
-      stderr: new Uint8Array(),
+      stdout: "ok\n",
+      stderr: "",
       exitCode: 0,
       output: { truncated: false },
     });
@@ -570,8 +571,12 @@ describe("step.sandbox", () => {
   });
 
   test("keeps larger direct Exec results but tail-truncates them at the durable step boundary", async () => {
-    const threeMiBBase64 = `AQID${"AAAA".repeat((1 << 20) - 1)}`;
-    const oneMiBBase64 = `${"AAAA".repeat(349_525)}AA==`;
+    const stdoutBytes = new Uint8Array(3 << 20);
+    stdoutBytes.set([1, 2, 3]);
+    stdoutBytes.set([0xe2, 0x82, 0xac], (2 << 20) - 1);
+    const stderrBytes = new Uint8Array(1 << 20);
+    const threeMiBBase64 = encodeBase64(stdoutBytes);
+    const oneMiBBase64 = encodeBase64(stderrBytes);
     const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
     const fetchMock: typeof fetch = vi.fn(async (input, init) => {
       const url = new URL(input instanceof Request ? input.url : input);
@@ -605,9 +610,9 @@ describe("step.sandbox", () => {
     const direct = await directSandbox.commands.run({
       command: ["/bin/true"],
     });
-    expect(direct.stdout).toHaveLength(3 << 20);
+    expect(direct.stdout.startsWith("\u0001\u0002\u0003")).toBe(true);
+    expect(direct.stdout).toContain("€");
     expect(direct.stderr).toHaveLength(1 << 20);
-    expect(direct.stdout.slice(0, 3)).toEqual(new Uint8Array([1, 2, 3]));
     expect(direct.output).toEqual({ truncated: false });
 
     const fn = client.createFunction(
@@ -621,9 +626,8 @@ describe("step.sandbox", () => {
           command: ["/bin/true"],
         });
         return {
-          stdoutBytes: result.stdout.byteLength,
-          stderrBytes: result.stderr.byteLength,
-          firstStdoutByte: result.stdout[0],
+          stdoutStartsWithReplacement: result.stdout.startsWith("\uFFFD"),
+          stderrLength: result.stderr.length,
           output: result.output,
         };
       },
@@ -696,9 +700,8 @@ describe("step.sandbox", () => {
     ).resolves.toMatchObject({
       type: "function-resolved",
       data: {
-        stdoutBytes: 1 << 20,
-        stderrBytes: 1 << 20,
-        firstStdoutByte: 0,
+        stdoutStartsWithReplacement: true,
+        stderrLength: 1 << 20,
         output: {
           truncated: true,
           strategy: "tail",
@@ -1004,6 +1007,50 @@ describe("inngest.sandboxes", () => {
       expect(fetchMock).not.toHaveBeenCalled();
     },
   );
+
+  test("decodes captured Exec output as non-fatal UTF-8", async () => {
+    const { kind: _kind, version: _version, ...resource } = sandboxRef;
+    const stdout = new Uint8Array([
+      ...new TextEncoder().encode("hello π 🚀"),
+      0xff,
+    ]);
+    const stderr = new Uint8Array([0xe2, 0x82]);
+    let requestCount = 0;
+    const fetchMock: typeof fetch = vi.fn(async () => {
+      requestCount++;
+      if (requestCount === 1) {
+        return Response.json({ data: resource });
+      }
+      return Response.json({
+        data: {
+          stdout: encodeBase64(stdout),
+          stderr: encodeBase64(stderr),
+          encoding: "base64",
+          exitCode: 0,
+        },
+      });
+    });
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+
+    const sandbox = await client.get(sandboxId);
+    if (!sandbox) {
+      throw new Error("Expected sandbox");
+    }
+    await expect(
+      sandbox.commands.run({ command: ["/bin/true"] }),
+    ).resolves.toEqual({
+      stdout: "hello π 🚀�",
+      stderr: "�",
+      exitCode: 0,
+      output: { truncated: false },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 
   test("validates Create environment before transport", async () => {
     const fetchMock: typeof fetch = vi.fn();
@@ -1723,8 +1770,8 @@ describe("inngest.sandboxes", () => {
     expect("toJSON" in started).toBe(false);
     expect("refresh" in sandbox).toBe(false);
     expect(command).toEqual({
-      stdout: new Uint8Array([0, 255]),
-      stderr: new TextEncoder().encode("err\n"),
+      stdout: "\u0000�",
+      stderr: "err\n",
       exitCode: 7,
       output: { truncated: false },
     });

--- a/packages/inngest/src/components/sandbox/client.ts
+++ b/packages/inngest/src/components/sandbox/client.ts
@@ -84,8 +84,8 @@ const sandboxPageSchema = z
 
 const wireCommandResultSchema = z
   .object({
-    stdout: z.string(),
-    stderr: z.string(),
+    stdout: z.string().optional(),
+    stderr: z.string().optional(),
     encoding: z.literal("base64"),
     exitCode: z.number().int().min(-0x80000000).max(0x7fffffff),
   })
@@ -700,8 +700,8 @@ const createDirectSandboxFacade = (
       "sandbox exec result",
     );
     return {
-      stdout: decodeBase64(result.stdout, "sandbox exec stdout"),
-      stderr: decodeBase64(result.stderr, "sandbox exec stderr"),
+      stdout: decodeBase64(result.stdout ?? "", "sandbox exec stdout"),
+      stderr: decodeBase64(result.stderr ?? "", "sandbox exec stderr"),
       exitCode: result.exitCode,
       output: { truncated: false },
     };

--- a/packages/inngest/src/components/sandbox/client.ts
+++ b/packages/inngest/src/components/sandbox/client.ts
@@ -4,6 +4,8 @@ import {
   type Sandbox,
   type SandboxAction,
   type SandboxClient,
+  type SandboxCommandOptions,
+  type SandboxCommandOutputMetadata,
   type SandboxDestroyResult,
   SandboxError,
   type SandboxErrorCode,
@@ -19,6 +21,7 @@ import {
   canonicalUuidSchema,
   decodeBase64,
   decodeOutputChunk,
+  decodeUtf8,
   normalizeFileDownloadOptions,
   normalizeFileUploadOptions,
   normalizeSandboxCommandOptions,
@@ -637,42 +640,83 @@ const createDirectProcessFacade = (
   return Object.freeze(facade);
 };
 
+interface SandboxCommandByteResult {
+  stdout: Uint8Array;
+  stderr: Uint8Array;
+  exitCode: number;
+  output: SandboxCommandOutputMetadata;
+}
+
+type DirectSandboxCommandRunner = (
+  options: SandboxCommandOptions,
+) => Promise<SandboxCommandByteResult>;
+
+const directSandboxCommandRunners = new WeakMap<
+  Sandbox,
+  DirectSandboxCommandRunner
+>();
+
+/** Internal byte-preserving command execution used by the durable adapter. */
+export const runSandboxCommandForOperation = (
+  sandbox: Sandbox,
+  options: SandboxCommandOptions,
+): Promise<SandboxCommandByteResult> => {
+  const run = directSandboxCommandRunners.get(sandbox);
+  if (!run) {
+    throw new SandboxValidationError(
+      "Sandbox commands can only run on an SDK sandbox resource",
+    );
+  }
+  return run(options);
+};
+
 const createDirectSandboxFacade = (
   rawRef: unknown,
   transport: SandboxRestTransport,
 ): Sandbox => {
   const ref = parseWithSchema(sandboxRefSchema, rawRef, "sandbox reference");
   const basePath = `/v2/sandboxes/${encodeURIComponent(ref.id)}`;
+  const runCommand = async (
+    options: SandboxCommandOptions,
+  ): Promise<SandboxCommandByteResult> => {
+    const normalized = normalizeSandboxCommandOptions(options);
+    const { timeout: _timeout, timeoutMs, ...spec } = normalized;
+    const { envelope } = await transport.json(
+      "exec",
+      "POST",
+      `${basePath}/exec`,
+      {
+        body: {
+          ...spec,
+          timeout: `${timeoutMs}ms`,
+        },
+        statuses: [200],
+        sandboxId: ref.id,
+      },
+    );
+    const result = parseWithSchema(
+      wireCommandResultSchema,
+      envelope?.data,
+      "sandbox exec result",
+    );
+    return {
+      stdout: decodeBase64(result.stdout, "sandbox exec stdout"),
+      stderr: decodeBase64(result.stderr, "sandbox exec stderr"),
+      exitCode: result.exitCode,
+      output: { truncated: false },
+    };
+  };
   const facade: Sandbox = {
     ...ref,
     resources: Object.freeze({ ...ref.resources }),
     commands: Object.freeze({
       run: async (options) => {
-        const normalized = normalizeSandboxCommandOptions(options);
-        const { timeout: _timeout, timeoutMs, ...spec } = normalized;
-        const { envelope } = await transport.json(
-          "exec",
-          "POST",
-          `${basePath}/exec`,
-          {
-            body: {
-              ...spec,
-              timeout: `${timeoutMs}ms`,
-            },
-            statuses: [200],
-            sandboxId: ref.id,
-          },
-        );
-        const result = parseWithSchema(
-          wireCommandResultSchema,
-          envelope?.data,
-          "sandbox exec result",
-        );
+        const result = await runCommand(options);
         return {
-          stdout: decodeBase64(result.stdout, "sandbox exec stdout"),
-          stderr: decodeBase64(result.stderr, "sandbox exec stderr"),
+          stdout: decodeUtf8(result.stdout),
+          stderr: decodeUtf8(result.stderr),
           exitCode: result.exitCode,
-          output: { truncated: false },
+          output: result.output,
         };
       },
     }),
@@ -861,6 +905,7 @@ const createDirectSandboxFacade = (
       };
     },
   };
+  directSandboxCommandRunners.set(facade, runCommand);
   return Object.freeze(facade);
 };
 

--- a/packages/inngest/src/components/sandbox/durable.ts
+++ b/packages/inngest/src/components/sandbox/durable.ts
@@ -1,5 +1,9 @@
 import type { StepOptionsOrId } from "../../types.ts";
-import { sandboxForOperation, sandboxProcessForOperation } from "./client.ts";
+import {
+  runSandboxCommandForOperation,
+  sandboxForOperation,
+  sandboxProcessForOperation,
+} from "./client.ts";
 import {
   findSandboxErrorOptions,
   findSandboxValidationError,
@@ -20,7 +24,7 @@ import {
   type Sandbox,
   type SandboxAction,
   type SandboxClient,
-  type SandboxCommandResult,
+  type SandboxCommandOutputMetadata,
   type SandboxDestroyResult,
   SandboxError,
   type SandboxOutputChunk,
@@ -34,6 +38,7 @@ import {
   canonicalUuidSchema,
   decodeBase64,
   decodeOutputChunk,
+  decodeUtf8,
   encodeBase64,
   normalizeSandboxCommandOptions,
   normalizeSandboxCreateOptions,
@@ -52,7 +57,11 @@ import {
 const fitDurableSandboxExecOutput = (
   stdout: Uint8Array,
   stderr: Uint8Array,
-): Pick<SandboxCommandResult, "stdout" | "stderr" | "output"> => {
+): {
+  stdout: Uint8Array;
+  stderr: Uint8Array;
+  output: SandboxCommandOutputMetadata;
+} => {
   const originalBytes = {
     stdout: stdout.byteLength,
     stderr: stderr.byteLength,
@@ -208,7 +217,7 @@ export const executeSandboxOperation = async (
     case "exec": {
       const { timeoutMs, ...options } = operation.input[0];
       const sandbox = sandboxForOperation(client, operation.target.sandbox);
-      const result = await sandbox.commands.run({
+      const result = await runSandboxCommandForOperation(sandbox, {
         ...options,
         timeout: timeoutMs,
       });
@@ -453,8 +462,12 @@ export const createDurableSandboxFacade = (
           operation,
         );
         return {
-          stdout: decodeBase64(result.result.stdout, "sandbox exec stdout"),
-          stderr: decodeBase64(result.result.stderr, "sandbox exec stderr"),
+          stdout: decodeUtf8(
+            decodeBase64(result.result.stdout, "sandbox exec stdout"),
+          ),
+          stderr: decodeUtf8(
+            decodeBase64(result.result.stderr, "sandbox exec stderr"),
+          ),
           exitCode: result.result.exitCode,
           output: result.result.output,
         };

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -115,8 +115,16 @@ export type SandboxCommandOutputMetadata =
     };
 
 export interface SandboxCommandResult {
-  stdout: Uint8Array;
-  stderr: Uint8Array;
+  /**
+   * Captured stdout decoded as UTF-8. Invalid or truncated byte sequences are
+   * represented by the Unicode replacement character.
+   */
+  stdout: string;
+  /**
+   * Captured stderr decoded as UTF-8. Invalid or truncated byte sequences are
+   * represented by the Unicode replacement character.
+   */
+  stderr: string;
   exitCode: number;
   output: SandboxCommandOutputMetadata;
 }

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -669,6 +669,9 @@ export const decodeBase64 = (value: string, context: string): Uint8Array => {
   }
 };
 
+export const decodeUtf8 = (value: Uint8Array): string =>
+  new TextDecoder("utf-8", { fatal: false }).decode(value);
+
 export const encodeBase64 = (value: Uint8Array): string => {
   let binary = "";
   const chunkSize = 0x8000;


### PR DESCRIPTION
Captured sandbox command output should just be easy to use

This makes stdout and stderr UTF-8 strings for both direct and middleware-backed Exec. The REST and durable wire formats stay byte-safe/base64, and durable truncation still happens on the original bytes before decoding. Invalid or boundary-truncated UTF-8 uses replacement characters instead of throwing

also treat omitted empty `stdout` and `stderr` REST fields as empty strings, matching protobuf JSON's default-value omission (my bad, bug introduced from me)