### PR TITLE
feat(sandbox): wait for running by default

### DIFF
--- a/.changeset/calm-sandboxes-wait.md
+++ b/.changeset/calm-sandboxes-wait.md
@@ -1,0 +1,5 @@
+---
+"inngest": minor
+---
+
+Wait for newly created sandboxes to reach RUNNING by default, with `runningTimeout: false` as an explicit opt-out.

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -13,6 +13,7 @@ import {
   createSandboxClient,
   createSandboxTools,
   parseSandboxOperation,
+  type SandboxCreateOptions,
   SandboxError,
   type SandboxOperationResultV1,
   type SandboxOperationV1,
@@ -287,6 +288,32 @@ describe("step.sandbox", () => {
     });
   });
 
+  test("serializes default and disabled Create waiting", async () => {
+    const operations: SandboxOperationV1[] = [];
+    const rawTool: SandboxRawTool = vi.fn(async (_id, operation) => {
+      operations.push(operation);
+      return resultForOperation(operation);
+    });
+    const tools = createSandboxTools(() => rawTool);
+
+    await tools.create("create-default", createOptions);
+    await tools.create("create-immediate", {
+      ...createOptions,
+      runningTimeout: false,
+    });
+
+    expect(operations).toMatchObject([
+      {
+        action: "create",
+        input: [{ ...createOptions, runningTimeoutMs: 120_000 }],
+      },
+      {
+        action: "create",
+        input: [{ ...createOptions, runningTimeoutMs: false }],
+      },
+    ]);
+  });
+
   test("validates Simcity limits without imposing identifier-style env keys", async () => {
     const rawTool = vi.fn<SandboxRawTool>(async (_id, operation) =>
       resultForOperation(operation),
@@ -325,6 +352,50 @@ describe("step.sandbox", () => {
         environment: { "": "invalid" },
       }),
     ).rejects.toBeInstanceOf(SandboxValidationError);
+    expect(rawTool).not.toHaveBeenCalled();
+  });
+
+  test("accepts false for direct and durable Create and rejects invalid values", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    const direct = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+    const rawTool = vi.fn<SandboxRawTool>();
+    const durable = createSandboxTools(() => rawTool);
+    const noWaitOptions: SandboxCreateOptions = {
+      ...createOptions,
+      runningTimeout: false,
+    };
+
+    const verifyCreateTypes = (): void => {
+      void direct.create(noWaitOptions);
+      void durable.create("create", noWaitOptions);
+      // @ts-expect-error runningTimeout only accepts a duration or false
+      void direct.create({ ...createOptions, runningTimeout: true });
+      void durable.create("create", {
+        ...createOptions,
+        // @ts-expect-error runningTimeout only accepts a duration or false
+        runningTimeout: true,
+      });
+    };
+    expect(verifyCreateTypes).toBeTypeOf("function");
+
+    await expect(
+      direct.create({ ...createOptions, runningTimeout: 0 }),
+    ).rejects.toBeInstanceOf(SandboxValidationError);
+    await expect(
+      durable.create("create-zero", { ...createOptions, runningTimeout: 0 }),
+    ).rejects.toBeInstanceOf(SandboxValidationError);
+    await expect(
+      direct.create({
+        ...createOptions,
+        runningTimeout: true,
+      } as unknown as SandboxCreateOptions),
+    ).rejects.toBeInstanceOf(SandboxValidationError);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(rawTool).not.toHaveBeenCalled();
   });
 
@@ -529,11 +600,21 @@ describe("step.sandbox", () => {
     });
   });
 
-  test("executes through REST in an ordinary run step and memoizes the result", async () => {
+  test("durable Create waits by default and replays without redispatching", async () => {
     const { kind: _kind, version: _version, ...sandboxResource } = sandboxRef;
-    const fetchMock: typeof fetch = vi.fn(async () =>
-      Response.json({ data: sandboxResource }, { status: 201 }),
-    );
+    const startingResource = {
+      ...sandboxResource,
+      status: "STARTING",
+      startedAt: undefined,
+    };
+    const methods: string[] = [];
+    const fetchMock: typeof fetch = vi.fn(async (_input, init) => {
+      const method = init?.method ?? "GET";
+      methods.push(method);
+      return method === "POST"
+        ? Response.json({ data: startingResource }, { status: 202 })
+        : Response.json({ data: sandboxResource });
+    });
     const client = new Inngest({
       id: testClientId,
       signingKey: "signkey-test",
@@ -560,13 +641,14 @@ describe("step.sandbox", () => {
         },
       },
     });
+    expect(methods).toEqual(["POST", "GET"]);
 
     const replay = await run();
     expect(replay.result).toMatchObject({
       type: "function-resolved",
       data: sandboxId,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test("keeps larger direct Exec results but tail-truncates them at the durable step boundary", async () => {
@@ -1300,35 +1382,44 @@ describe("inngest.sandboxes", () => {
     "TERMINATING",
     "TERMINATED",
     "FAILED",
-  ] as const)("accepts an existing %s sandbox from Create", async (status) => {
-    const { kind: _kind, version: _version, ...resource } = sandboxRef;
-    const fetchMock: typeof fetch = vi.fn(async () =>
-      Response.json(
-        {
-          data: {
-            ...resource,
-            status,
-            ...(status !== "RUNNING" && { startedAt: undefined }),
+  ] as const)(
+    "accepts an existing %s sandbox from Create when waiting is disabled",
+    async (status) => {
+      const { kind: _kind, version: _version, ...resource } = sandboxRef;
+      const requests: RequestInit[] = [];
+      const fetchMock: typeof fetch = vi.fn(async (_input, init) => {
+        requests.push(init ?? {});
+        return Response.json(
+          {
+            data: {
+              ...resource,
+              status,
+              ...(status !== "RUNNING" && { startedAt: undefined }),
+            },
           },
-        },
-        { status: 200 },
-      ),
-    );
-    const client = createSandboxClient({
-      baseUrl: () => "https://api.example.test",
-      apiKey: () => "signkey-test",
-      headers: () => ({ "X-Inngest-Env": "branch" }),
-      fetch: () => fetchMock,
-    });
+          { status: 200 },
+        );
+      });
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "signkey-test",
+        headers: () => ({ "X-Inngest-Env": "branch" }),
+        fetch: () => fetchMock,
+      });
 
-    const sandbox = await client.create(createOptions);
+      const sandbox = await client.create({
+        ...createOptions,
+        runningTimeout: false,
+      });
 
-    expect(sandbox.id).toBe(sandboxId);
-    expect(sandbox.status).toBe(status);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
+      expect(sandbox.id).toBe(sandboxId);
+      expect(sandbox.status).toBe(status);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(requests[0]?.body))).toEqual(createOptions);
+    },
+  );
 
-  test("makes readiness waiting opt-in on Create", async () => {
+  test("waits for a STARTING sandbox to reach RUNNING by default", async () => {
     const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
     const startingResource = {
       ...runningResource,
@@ -1351,24 +1442,56 @@ describe("inngest.sandboxes", () => {
       fetch: () => fetchMock,
     });
 
-    const immediate = await client.create(createOptions);
-    expect(immediate.status).toBe("STARTING");
-    expect(calls).toHaveLength(1);
-
-    const running = await client.create({
-      ...createOptions,
-      runningTimeout: "5s",
-    });
+    const running = await client.create(createOptions);
     expect(running.status).toBe("RUNNING");
-    expect(calls).toHaveLength(3);
-    expect(calls.map(({ init }) => init?.method)).toEqual([
-      "POST",
-      "POST",
-      "GET",
-    ]);
-    for (const call of calls.filter(({ init }) => init?.method === "POST")) {
-      expect(JSON.parse(String(call.init?.body))).toEqual(createOptions);
-    }
+    expect(calls).toHaveLength(2);
+    expect(calls.map(({ init }) => init?.method)).toEqual(["POST", "GET"]);
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual(createOptions);
+  });
+
+  test("does not poll when Create immediately returns RUNNING", async () => {
+    const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+    const fetchMock: typeof fetch = vi.fn(async () =>
+      Response.json({ data: runningResource }, { status: 201 }),
+    );
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+
+    await expect(client.create(createOptions)).resolves.toMatchObject({
+      id: sandboxId,
+      status: "RUNNING",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns STARTING immediately when runningTimeout is false", async () => {
+    const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+    const startingResource = {
+      ...runningResource,
+      status: "STARTING",
+      startedAt: undefined,
+    };
+    const requests: RequestInit[] = [];
+    const fetchMock: typeof fetch = vi.fn(async (_input, init) => {
+      requests.push(init ?? {});
+      return Response.json({ data: startingResource }, { status: 202 });
+    });
+    const client = createSandboxClient({
+      baseUrl: () => "https://api.example.test",
+      apiKey: () => "signkey-test",
+      headers: () => ({}),
+      fetch: () => fetchMock,
+    });
+
+    await expect(
+      client.create({ ...createOptions, runningTimeout: false }),
+    ).resolves.toMatchObject({ id: sandboxId, status: "STARTING" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(requests[0]?.body))).toEqual(createOptions);
   });
 
   test("waitUntilRunning reloads a STARTING sandbox", async () => {
@@ -1391,7 +1514,10 @@ describe("inngest.sandboxes", () => {
       },
     });
 
-    const starting = await client.create(createOptions);
+    const starting = await client.create({
+      ...createOptions,
+      runningTimeout: false,
+    });
     const running = await starting.waitUntilRunning({ timeout: "5s" });
 
     expect(starting.status).toBe("STARTING");
@@ -1426,9 +1552,7 @@ describe("inngest.sandboxes", () => {
       },
     });
 
-    await expect(
-      client.create({ ...createOptions, runningTimeout: "5s" }),
-    ).rejects.toMatchObject({
+    await expect(client.create(createOptions)).rejects.toMatchObject({
       name: "SandboxError",
       action: "create",
       code: "sandbox_start_failed",
@@ -1444,7 +1568,49 @@ describe("inngest.sandboxes", () => {
     expect(requestCount).toBe(2);
   });
 
-  test("reports readiness timeout without retrying Create", async () => {
+  test("defaults the readiness timeout to 120 seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
+      const startingResource = {
+        ...runningResource,
+        status: "STARTING",
+        startedAt: undefined,
+      };
+      const methods: string[] = [];
+      const fetchMock: typeof fetch = vi.fn(async (_input, init) => {
+        methods.push(init?.method ?? "GET");
+        return Response.json(
+          { data: startingResource },
+          { status: init?.method === "POST" ? 202 : 200 },
+        );
+      });
+      const client = createSandboxClient({
+        baseUrl: () => "https://api.example.test",
+        apiKey: () => "signkey-test",
+        headers: () => ({}),
+        fetch: () => fetchMock,
+      });
+
+      const result = client.create(createOptions);
+      const assertion = expect(result).rejects.toMatchObject({
+        name: "SandboxError",
+        action: "create",
+        code: "sandbox_start_timed_out",
+        sandboxId,
+        retryable: false,
+        details: [{ status: "STARTING", timeoutMs: 120_000 }],
+      });
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      await assertion;
+      expect(methods.filter((method) => method === "POST")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("honors an explicit readiness timeout without retrying Create", async () => {
     vi.useFakeTimers();
     try {
       const { kind: _kind, version: _version, ...runningResource } = sandboxRef;
@@ -1476,6 +1642,7 @@ describe("inngest.sandboxes", () => {
         code: "sandbox_start_timed_out",
         sandboxId,
         retryable: false,
+        details: [{ status: "STARTING", timeoutMs: 1_000 }],
       });
       await vi.advanceTimersByTimeAsync(1_000);
 

--- a/packages/inngest/src/components/sandbox/client.ts
+++ b/packages/inngest/src/components/sandbox/client.ts
@@ -964,7 +964,7 @@ export const createSandboxClient = (
           `Sandbox Create returned HTTP ${status} with status ${sandbox.status}`,
         );
       }
-      return runningTimeoutMs === undefined
+      return runningTimeoutMs === false
         ? createDirectSandboxFacade(sandbox, transport)
         : waitUntilSandboxRunning(
             sandbox,

--- a/packages/inngest/src/components/sandbox/protocol.ts
+++ b/packages/inngest/src/components/sandbox/protocol.ts
@@ -41,7 +41,9 @@ const createInputSchema = z
     vcpu: z.number().int().positive().max(0xffffffff),
     memoryMb: z.number().int().positive().max(0xffffffff),
     environment: z.record(z.string()).optional(),
-    runningTimeoutMs: z.number().int().positive().max(300_000).optional(),
+    runningTimeoutMs: z
+      .union([z.number().int().positive().max(300_000), z.literal(false)])
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/packages/inngest/src/components/sandbox/types.ts
+++ b/packages/inngest/src/components/sandbox/types.ts
@@ -56,12 +56,28 @@ export interface SandboxCreateOptions {
   environment?: Record<string, string>;
 
   /**
-   * Wait up to this duration for the sandbox to reach RUNNING.
+   * How long to wait for the sandbox to reach RUNNING after Create succeeds.
    *
-   * Omit this to return as soon as Create is accepted, with either STARTING or
-   * RUNNING status.
+   * Defaults to 120 seconds. Set this to `false` to return as soon as Create is
+   * accepted, with either STARTING or RUNNING status.
+   *
+   * @example
+   * ```ts
+   * const sandbox = await inngest.sandboxes.create({
+   *   ...options,
+   *   runningTimeout: "30s",
+   * });
+   * ```
+   *
+   * @example Return immediately without waiting
+   * ```ts
+   * const sandbox = await inngest.sandboxes.create({
+   *   ...options,
+   *   runningTimeout: false,
+   * });
+   * ```
    */
-  runningTimeout?: SandboxDuration;
+  runningTimeout?: SandboxDuration | false;
 }
 
 export interface SandboxWaitUntilRunningOptions {

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -5,7 +5,6 @@ import { isTemporalDuration } from "../../helpers/temporal.ts";
 import {
   type SandboxCommandOptions,
   type SandboxCreateOptions,
-  type SandboxDuration,
   type SandboxFileDownloadOptions,
   type SandboxFileUploadOptions,
   type SandboxListOptions,
@@ -387,8 +386,7 @@ export const normalizeSandboxCreateOptions = (
       runningTimeout === false
         ? false
         : normalizeDurationMs(
-            (runningTimeout ??
-              defaultSandboxRunningTimeoutMs) as SandboxDuration,
+            runningTimeout ?? defaultSandboxRunningTimeoutMs,
             maxSandboxRunningTimeoutMs,
             "runningTimeout",
           ),
@@ -405,7 +403,7 @@ export const normalizeSandboxWaitUntilRunningOptions = (
   );
   return {
     timeoutMs: normalizeDurationMs(
-      parsed.timeout as SandboxDuration,
+      parsed.timeout,
       maxSandboxRunningTimeoutMs,
       "timeout",
     ),
@@ -545,7 +543,7 @@ export const normalizeSandboxProcessWaitOptions = (
       parsed.timeout === undefined
         ? defaultSandboxProcessTimeoutMs
         : normalizeDurationMs(
-            parsed.timeout as SandboxDuration,
+            parsed.timeout,
             maxSandboxProcessTimeoutMs,
             "timeout",
           ),
@@ -573,7 +571,7 @@ export const normalizeSandboxProcessOutputOptions = (
 };
 
 export const normalizeDurationMs = (
-  duration: SandboxDuration,
+  duration: unknown,
   maximumMs: number,
   context: string,
 ): number => {

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -23,6 +23,7 @@ import {
 export const maxSandboxProcessTimeoutMs = 5 * 60 * 1_000;
 export const defaultSandboxProcessTimeoutMs = 30 * 1_000;
 export const maxSandboxRunningTimeoutMs = 5 * 60 * 1_000;
+export const defaultSandboxRunningTimeoutMs = 120 * 1_000;
 export const maxSandboxProcessTailBytes = 512 * 1_024;
 
 const maxProcessArgvCount = 128;
@@ -363,7 +364,7 @@ export const sandboxProcessRefFromResource = (
 export const normalizeSandboxCreateOptions = (
   options: SandboxCreateOptions,
 ): Omit<SandboxCreateOptions, "runningTimeout"> & {
-  runningTimeoutMs?: number;
+  runningTimeoutMs: number | false;
 } => {
   const parsed = parseWithSchema(
     z
@@ -382,13 +383,15 @@ export const normalizeSandboxCreateOptions = (
   const { runningTimeout, ...create } = parsed;
   return {
     ...create,
-    ...(runningTimeout !== undefined && {
-      runningTimeoutMs: normalizeDurationMs(
-        runningTimeout as SandboxDuration,
-        maxSandboxRunningTimeoutMs,
-        "runningTimeout",
-      ),
-    }),
+    runningTimeoutMs:
+      runningTimeout === false
+        ? false
+        : normalizeDurationMs(
+            (runningTimeout ??
+              defaultSandboxRunningTimeoutMs) as SandboxDuration,
+            maxSandboxRunningTimeoutMs,
+            "runningTimeout",
+          ),
   };
 };
 


### PR DESCRIPTION
- Make direct and durable sandbox Create wait for `RUNNING` for up to 120 seconds by default.
- Allow `runningTimeout: false` to preserve the immediate `STARTING | RUNNING` response behavior.
- Preserve explicit duration overrides and reuse the existing readiness polling path.

Most callers use a sandbox immediately after creating it. Waiting by default removes an extra readiness step from the common path while retaining an explicit non-blocking opt-out.

Addresses [SYS-1121](https://linear.app/inngest/issue/SYS-1121/dx-sdk-create-should-be-blocking-by-default-w-runningtimeout-having-a).