### PR TITLE
fix(otel): don't track non-recording spans in the metadata processor

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,7 @@
+---
+"inngest": patch
+---
+
+Stop `InngestMetadataSpanProcessor` retaining an execution engine per run when traces are sampled below 100%.
+
+Span processors only receive `onStart`/`onEnd` for recording spans, so tracking a non-recording span seeded an entry in `#spanSinks` that could never be removed, retaining the `AIMetadataSink` closure and the `InngestExecutionEngine` it captures for the lifetime of the process. `trackSpan` now skips non-recording spans.

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -1,5 +1,8 @@
 import { type Attributes, context, trace } from "@opentelemetry/api";
-import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import {
+  AlwaysOffSampler,
+  BasicTracerProvider,
+} from "@opentelemetry/sdk-trace-base";
 import type { AIMetadata } from "./aiExtractor.ts";
 import { InngestMetadataSpanProcessor } from "./metadataProcessor.ts";
 
@@ -256,5 +259,65 @@ describe("InngestMetadataSpanProcessor", () => {
     expect(processorsOf(provider).filter((p) => p === processor)).toHaveLength(
       1,
     );
+  });
+
+  /**
+   * Same wiring as {@link setup}, but with a sampler that records nothing —
+   * the shape of any host app tracing at less than 100%.
+   */
+  function setupUnsampled() {
+    const processor = new InngestMetadataSpanProcessor();
+    const provider = new BasicTracerProvider({
+      sampler: new AlwaysOffSampler(),
+    });
+    trace.setGlobalTracerProvider(provider);
+    processor.attach();
+    return { processor, tracer: provider.getTracer("test") };
+  }
+
+  test("tracks a declared root while it is open, and releases it on end", () => {
+    const { processor, tracer } = setup();
+    const { root } = declaredRoot(processor, tracer);
+
+    expect(processor.trackedSpanCount).toBe(1);
+
+    root.end();
+
+    expect(processor.trackedSpanCount).toBe(0);
+  });
+
+  test("does not track non-recording spans", () => {
+    const { processor, tracer } = setupUnsampled();
+
+    // Processors are never handed onStart/onEnd for non-recording spans, so a
+    // tracked entry here could never be removed: it would retain the sink, and
+    // through it the execution engine, for the lifetime of the process.
+    for (let i = 0; i < 100; i++) {
+      const root = tracer.startSpan("inngest.execution");
+      expect(root.isRecording()).toBe(false);
+      processor.declareStartingSpan({
+        span: root,
+        traceparent: TRACEPARENT,
+        onAIMetadata: () => {},
+      });
+      root.end();
+    }
+
+    expect(processor.trackedSpanCount).toBe(0);
+  });
+
+  test("does not accumulate entries across many completed runs", () => {
+    const { processor, tracer } = setup();
+
+    for (let i = 0; i < 100; i++) {
+      const { root } = declaredRoot(processor, tracer);
+      endChild(tracer, root, "llm", {
+        "gen_ai.request.model": "gpt-4.1-nano",
+        "gen_ai.usage.input_tokens": 1,
+      });
+      root.end();
+    }
+
+    expect(processor.trackedSpanCount).toBe(0);
   });
 });

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -133,11 +133,37 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    * are stamped on the span.
    */
   private trackSpan(span: Span, sink: AIMetadataSink): void {
+    // OTel only delivers `onStart`/`onEnd` to span processors for recording
+    // spans, so tracking a non-recording one can only ever leak: `onEnd` will
+    // never fire to remove the entry. The `#spanCleanup` registry cannot
+    // recover it either, because the entry keeps the sink alive, the sink keeps
+    // the engine alive, and the engine keeps the span reachable — so the span
+    // is never collected and the finalizer never runs.
+    if (!span.isRecording()) {
+      return processorDevDebug(
+        "span",
+        span.spanContext().spanId,
+        "is not recording, so skipping it",
+      );
+    }
+
     const { traceId, spanId } = span.spanContext();
     const key = spanSinkKey(traceId, spanId);
 
     this.#spanCleanup.register(span, key, span);
     this.#spanSinks.set(key, sink);
+  }
+
+  /**
+   * The number of spans currently tracked.
+   *
+   * Exposed only so tests can assert that entries do not accumulate;
+   * `#spanSinks` is a private field and cannot otherwise be observed.
+   *
+   * @internal
+   */
+  public get trackedSpanCount(): number {
+    return this.#spanSinks.size;
   }
 
   /**


### PR DESCRIPTION
Fixes #1702.

## Problem

`InngestMetadataSpanProcessor` seeds `#spanSinks` in `declareStartingSpan` with a callback that captures the `InngestExecutionEngine`, and only removes the entry when the span **ends**. OTel does not deliver `onStart`/`onEnd` to span processors for **non-recording** spans, so when the host application samples traces below 100% the entry is never removed — and because the processor is attached to the process-global tracer provider, **one execution engine is retained per run, for the lifetime of the process.**

The `#spanCleanup` `FinalizationRegistry` cannot recover it either. The retention is self-sustaining: the `#spanSinks` entry keeps the sink alive → the sink keeps the engine alive → the engine's pending execution keeps the span reachable. The span is therefore never collected, so the finalizer that would delete the entry never runs. The only thing that would free the span is deleting the entry, which is what the finalizer was supposed to do.

We hit this in production on 4.13.0 with `@sentry/remix` at `tracesSampleRate` ~0.01. The service OOM-crashed every couple of hours with `FATAL ERROR: Ineffective mark-compacts near heap limit`, growing ~9–10 MB/min. A heap snapshot from a live pod showed **6,560 `InngestExecutionEngine` instances alive** after 53 minutes, all held by:

```
global → Symbol(opentelemetry.js.api.1) → ProxyTracerProvider
      → BasicTracerProvider._registeredSpanProcessors[1]
      → InngestMetadataSpanProcessor → #spanSinks (Map)
      → closure onAIMetadata → this: InngestExecutionEngine
```

Each retained engine drags its whole graph with it — 85,243 `wrappedMatchOp`, 26,232 `AsyncGenerator`, 118,088 `Promise`, ~1M plain `Object`. Full analysis in #1702.

## Fix

`trackSpan` now skips non-recording spans.

Tracking them was never useful: the processor is never told when such a span starts or ends, so its sink could never fire and no AI metadata was ever collected for it. This only removes entries that could not have been acted on — for anyone sampling at 100%, behaviour is unchanged.

The guard lives in `trackSpan` rather than `declareStartingSpan` so it covers the `onStart` path too, though in practice OTel already filters that one.

## Tests

Three added to `metadataProcessor.test.ts`:

- **`does not track non-recording spans`** — the regression test. Uses `AlwaysOffSampler`, declares 100 roots, asserts nothing is retained. Without the fix this fails with `expected 100 to be +0`.
- **`tracks a declared root while it is open, and releases it on end`** — pins the normal lifecycle so the guard can't over-reach and break tracking for recording spans.
- **`does not accumulate entries across many completed runs`** — 100 full run cycles at 100% sampling leave the map empty.

Asserting this needs visibility into `#spanSinks`, which is a true private field, so I added a `trackedSpanCount` getter marked `@internal`. Happy to drop it for a different approach if you'd rather not widen the surface at all.

`pnpm test` on the file passes 14/14 and `biome check` is clean.

## Notes

- Present and unchanged in 4.13.0 through 4.18.0.
- Workaround for anyone affected before this lands: `new Inngest({ id, aiMetadata: false })`.
- Possibly compounding, but distinct: #1440 (`V1InngestExecution` not clearing `state.steps` / `this.execution`). That issue explains why each retained engine is so expensive; this one explains what roots them globally. Fixing #1440 alone would not release these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
