### PR TITLE
fix: prevent ai metadata span retention

### DIFF
--- a/.changeset/calm-spans-rest.md
+++ b/.changeset/calm-spans-rest.md
@@ -2,4 +2,4 @@
 "inngest": patch
 ---
 
-Prevent AI metadata tracking from retaining executions when OpenTelemetry samples out their root spans.
+Prevent AI metadata tracking from retaining executions after an SDK request ends, including when OpenTelemetry samples out root spans.

--- a/.changeset/calm-spans-rest.md
+++ b/.changeset/calm-spans-rest.md
@@ -2,4 +2,4 @@
 "inngest": patch
 ---
 
-Prevent AI metadata tracking from retaining executions after an SDK request ends, including when OpenTelemetry samples out root spans.
+Prevent AI metadata tracking from retaining executions after an SDK request ends, including when OpenTelemetry excludes the root span from sampling.

--- a/.changeset/calm-spans-rest.md
+++ b/.changeset/calm-spans-rest.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Prevent AI metadata tracking from retaining executions when OpenTelemetry samples out their root spans.

--- a/packages/inngest/src/components/execution/engine.test.ts
+++ b/packages/inngest/src/components/execution/engine.test.ts
@@ -1,6 +1,7 @@
 import { fromPartial } from "@total-typescript/shoehorn";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { InngestApi } from "../../api/api.ts";
+import { stream } from "../../experimental/durable-endpoints/index.ts";
 import { createDefer } from "../../experimental.ts";
 import { ExecutionVersion } from "../../helpers/consts.ts";
 import { createClient } from "../../test/helpers.ts";
@@ -11,6 +12,7 @@ import type { GenericStepTools } from "../InngestStepTools.ts";
 import { NonRetriableError } from "../NonRetriableError.ts";
 import { _internals } from "./engine.ts";
 import type { ExecutionResults } from "./InngestExecution.ts";
+import { metadataSpanProcessor } from "./otel/metadataProcessor.ts";
 
 describe("Execution engine checkpoint retry behavior", () => {
   const mockEvent = { name: "test/event", data: { foo: "bar" } };
@@ -917,6 +919,41 @@ describe("Execution engine checkpoint retry behavior", () => {
         name: "NonRetriableError",
         message: "permanent",
       });
+    });
+
+    test("keeps AI metadata scope open after sync SSE early response until core loop completes", async () => {
+      const api = makeSseApi();
+      const endScopeSpy = vi.spyOn(metadataSpanProcessor, "endScope");
+      let finishStep!: () => void;
+      const stepCanFinish = new Promise<void>((resolve) => {
+        finishStep = resolve;
+      });
+
+      const setup = setupExecution({
+        mockApi: api,
+        handler: async ({ step }) => {
+          await step.run("streaming-step", async () => {
+            stream.push("partial");
+            await stepCanFinish;
+            return "step result";
+          });
+          return "done";
+        },
+        stepMode: StepMode.Sync,
+        extraPartialOptions: { acceptsSse: true },
+      });
+
+      const result = await setup.execution.start();
+
+      expect(result.type).toBe("function-resolved");
+      expect(endScopeSpy).not.toHaveBeenCalled();
+
+      finishStep();
+      await (
+        (result as ExecutionResults["function-resolved"]).data as Response
+      ).text();
+
+      expect(endScopeSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -323,7 +323,10 @@ class InngestExecutionEngine
                 | ReturnType<typeof metadataSpanProcessor.startScope>
                 | undefined;
               if (this.options.client.aiMetadataEnabled) {
-                aiMetadataScope = metadataSpanProcessor.startScope();
+                aiMetadataScope = metadataSpanProcessor.startScope({
+                  runId: this.options.runId,
+                  span,
+                });
               }
 
               this.rootSpanId = span.spanContext().spanId;

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -319,6 +319,13 @@ class InngestExecutionEngine
           },
           async () => {
             return tracer.startActiveSpan("inngest.execution", (span) => {
+              let aiMetadataScope:
+                | ReturnType<typeof metadataSpanProcessor.startScope>
+                | undefined;
+              if (this.options.client.aiMetadataEnabled) {
+                aiMetadataScope = metadataSpanProcessor.startScope();
+              }
+
               this.rootSpanId = span.spanContext().spanId;
               clientProcessorMap.get(this.options.client)?.declareStartingSpan({
                 span,
@@ -327,10 +334,11 @@ class InngestExecutionEngine
                 tracestate: this.options.headers[headerKeys.TraceState],
               });
 
-              if (this.options.client.aiMetadataEnabled) {
+              if (aiMetadataScope) {
                 // The metadata span processor is independent of the Extended
                 // Traces processor above.
                 metadataSpanProcessor.declareStartingSpan({
+                  scope: aiMetadataScope,
                   span,
                   traceparent: this.options.headers[headerKeys.TraceParent],
                   onAIMetadata: (aiMetadata) => {
@@ -358,6 +366,9 @@ class InngestExecutionEngine
                 })
                 .finally(() => {
                   span.end();
+                  if (aiMetadataScope) {
+                    metadataSpanProcessor.endScope(aiMetadataScope);
+                  }
                 });
             });
           },

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -362,17 +362,15 @@ class InngestExecutionEngine
                 });
               }
 
-              return this._start()
-                .then((result) => {
-                  this.devDebug("result:", result);
-                  return result;
-                })
-                .finally(() => {
-                  span.end();
-                  if (aiMetadataScope) {
-                    metadataSpanProcessor.endScope(aiMetadataScope);
-                  }
-                });
+              return this._start(() => {
+                span.end();
+                if (aiMetadataScope) {
+                  metadataSpanProcessor.endScope(aiMetadataScope);
+                }
+              }).then((result) => {
+                this.devDebug("result:", result);
+                return result;
+              });
             });
           },
         );
@@ -402,15 +400,21 @@ class InngestExecutionEngine
 
   /**
    * Starts execution of the user's function and the core loop.
+   *
+   * @param onCoreLoopSettled - Called after this invocation has finished
+   * running user code and processing checkpoints, even if this method returned
+   * earlier. The run may re-enter later in a new SDK request.
    */
-  private async _start(): Promise<ExecutionResult> {
+  private async _start(
+    onCoreLoopSettled?: () => void,
+  ): Promise<ExecutionResult> {
     // Set up a deferred promise that handleStreamActivated resolves to return
     // the SSE Response early while the core loop keeps running.
     if (this.options.stepMode === StepMode.Sync && this.options.acceptsSse) {
       this.earlyStreamResponse = createDeferredPromise<ExecutionResult>();
     }
 
-    const coreLoop = this.runCoreLoop();
+    const coreLoop = this.runCoreLoop().finally(onCoreLoopSettled);
 
     if (this.earlyStreamResponse) {
       // Suppress: if earlyStreamResponse wins the race and coreLoop later

--- a/packages/inngest/src/components/execution/otel/AGENTS.md
+++ b/packages/inngest/src/components/execution/otel/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent guidance
+
+When working on `metadataProcessor.ts` or `metadataProcessor.test.ts`, read `metadataProcessor.md` first. It explains the AI metadata processor's tracking model, scope cleanup, and cleanup paths.

--- a/packages/inngest/src/components/execution/otel/CLAUDE.md
+++ b/packages/inngest/src/components/execution/otel/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.md
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.md
@@ -1,0 +1,29 @@
+# AI metadata span processor
+
+`InngestMetadataSpanProcessor` is a read-only OpenTelemetry span processor used to extract AI usage metadata from spans created during an Inngest execution. It is independent from `InngestSpanProcessor`, which exports Extended Traces.
+
+## What it tracks
+
+The execution engine declares the root `inngest.execution` span when a run starts and gives the metadata processor a callback for receiving AI metadata found during that execution. Internally, this callback is called the AI metadata sink.
+
+The processor records which spans should use that callback. It starts with the root span, then marks child spans in `onStart()` when their parent is already tracked.
+
+When a tracked span ends, `onEnd()` extracts allowlisted AI metadata from the span's attributes and sends it to the callback. The engine owns aggregation and step attribution.
+
+## Scope cleanup
+
+Tracking is owned by an `AIMetadataScope`, not by the OpenTelemetry trace. The engine starts a scope when the SDK execution begins and ends it when the SDK request/message finishes responding.
+
+This scope exists because OpenTelemetry only gives processors per-span lifecycle callbacks. Ending a parent span does not imply that descendants have ended, and sampled-out/non-recording spans do not call processor lifecycle hooks at all. In other words, scopes allow us to cleanup "endless" spans (avoiding a memory leak).
+
+At scope end, the processor deletes any remaining tracked spans for that execution. This prevents the processor from retaining the AI metadata sink after the SDK can no longer attach late metadata to a step.
+
+## Cleanup paths
+
+Tracked span state is removed in three ways:
+
+- `onEnd()` removes the entry for a span that ended normally.
+- `endScope()` removes all entries still owned by a completed SDK execution.
+- `FinalizationRegistry` is a best-effort fallback if an unended span becomes unreachable before its scope ends.
+
+The `span.isRecording()` guard avoids tracking spans for which OpenTelemetry will not call processor lifecycle hooks.

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -56,9 +56,9 @@ describe("InngestMetadataSpanProcessor", () => {
     processor: InngestMetadataSpanProcessor,
     tracer: ReturnType<BasicTracerProvider["getTracer"]>,
   ) {
-    const scope = processor.startScope();
     const pushed: AIMetadata[] = [];
     const root = tracer.startSpan("inngest.execution");
+    const scope = processor.startScope({ runId: "test-run", span: root });
     processor.declareStartingSpan({
       scope,
       span: root,
@@ -189,7 +189,7 @@ describe("InngestMetadataSpanProcessor", () => {
     expect(root.isRecording()).toBe(false);
 
     const pushed: AIMetadata[] = [];
-    const scope = processor.startScope();
+    const scope = processor.startScope({ runId: "test-run", span: root });
     processor.declareStartingSpan({
       scope,
       span: root,

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -56,14 +56,16 @@ describe("InngestMetadataSpanProcessor", () => {
     processor: InngestMetadataSpanProcessor,
     tracer: ReturnType<BasicTracerProvider["getTracer"]>,
   ) {
+    const scope = processor.startScope();
     const pushed: AIMetadata[] = [];
     const root = tracer.startSpan("inngest.execution");
     processor.declareStartingSpan({
+      scope,
       span: root,
       traceparent: TRACEPARENT,
       onAIMetadata: (metadata) => pushed.push(metadata),
     });
-    return { root, pushed };
+    return { scope, root, pushed };
   }
 
   test("is read-only: leaves tracked span attributes exactly as set", () => {
@@ -187,7 +189,9 @@ describe("InngestMetadataSpanProcessor", () => {
     expect(root.isRecording()).toBe(false);
 
     const pushed: AIMetadata[] = [];
+    const scope = processor.startScope();
     processor.declareStartingSpan({
+      scope,
       span: root,
       traceparent: TRACEPARENT,
       onAIMetadata: (metadata) => pushed.push(metadata),
@@ -211,6 +215,33 @@ describe("InngestMetadataSpanProcessor", () => {
     processor.onStart(child, parentContext);
     child.end();
     processor.onEnd(child as unknown as ReadableSpan);
+
+    expect(pushed).toEqual([]);
+  });
+
+  test("cleans up endless tracked spans when the request ends", () => {
+    const { processor, tracer } = setup();
+    const { scope, root, pushed } = declaredRoot(processor, tracer);
+
+    const child = tracer.startSpan(
+      "never-ended",
+      {
+        attributes: {
+          "gen_ai.request.model": "gpt-4.1-nano",
+          "gen_ai.usage.input_tokens": 42,
+        },
+      },
+      trace.setSpan(context.active(), root),
+    );
+
+    processor.endScope(scope);
+
+    // If scope cleanup did not remove the still-open child, this grandchild
+    // would inherit the child's metadata callback and push when it ends.
+    endChild(tracer, child, "late-grandchild", {
+      "gen_ai.request.model": "gpt-4.1-mini",
+      "gen_ai.usage.input_tokens": 5,
+    });
 
     expect(pushed).toEqual([]);
   });

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.test.ts
@@ -1,5 +1,10 @@
 import { type Attributes, context, trace } from "@opentelemetry/api";
-import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  BasicTracerProvider,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
 import type { AIMetadata } from "./aiExtractor.ts";
 import { InngestMetadataSpanProcessor } from "./metadataProcessor.ts";
 
@@ -166,6 +171,46 @@ describe("InngestMetadataSpanProcessor", () => {
     const { root, pushed } = declaredRoot(processor, tracer);
 
     endChild(tracer, root, "plain");
+
+    expect(pushed).toEqual([]);
+  });
+
+  test("does not track spans that are not recording", () => {
+    const processor = new InngestMetadataSpanProcessor();
+    const provider = new BasicTracerProvider({
+      sampler: new AlwaysOffSampler(),
+    });
+    trace.setGlobalTracerProvider(provider);
+    processor.attach();
+
+    const root = provider.getTracer("test").startSpan("inngest.execution");
+    expect(root.isRecording()).toBe(false);
+
+    const pushed: AIMetadata[] = [];
+    processor.declareStartingSpan({
+      span: root,
+      traceparent: TRACEPARENT,
+      onAIMetadata: (metadata) => pushed.push(metadata),
+    });
+
+    // Use a recording child to probe whether the non-recording root left a
+    // sink behind. OTel will never make this callback for the root itself.
+    const childProvider = new BasicTracerProvider({
+      sampler: new AlwaysOnSampler(),
+    });
+    const parentContext = trace.setSpan(context.active(), root);
+    const child = childProvider.getTracer("test").startSpan(
+      "llm",
+      {
+        attributes: {
+          "gen_ai.request.model": "gpt-4.1-nano",
+        },
+      },
+      parentContext,
+    );
+    processor.onStart(child, parentContext);
+    child.end();
+    processor.onEnd(child as unknown as ReadableSpan);
 
     expect(pushed).toEqual([]);
   });

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -19,7 +19,18 @@ const processorDevDebug = Debug(`${debugPrefix}:InngestMetadataSpanProcessor`);
 export type AIMetadataSink = (metadata: AIMetadata) => void;
 
 /**
- * Builds the `#spanSinks` key for a span. Span IDs are only guaranteed unique
+ * A logical tracking scope. The engine owns this lifecycle and ends it when
+ * control flow interrupts and the SDK responds.
+ */
+export type AIMetadataScope = symbol;
+
+type TrackedSpan = {
+  sink: AIMetadataSink;
+  scope: AIMetadataScope;
+};
+
+/**
+ * Builds the `#spans` key for a span. Span IDs are only guaranteed unique
  * within a single trace, so spans are keyed by trace ID + span ID to avoid
  * cross-trace collisions.
  */
@@ -38,7 +49,7 @@ const spanSinkKey = (traceId: string, spanId: string): string =>
  */
 export class InngestMetadataSpanProcessor implements SpanProcessor {
   /**
-   * A map of tracked spans to their sink.
+   * A map of tracked spans to their sink and owning scope.
    *
    * We use traceId:spanID as the key, which uniquely identifies each span. See
    * {@link spanSinkKey}
@@ -54,16 +65,26 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    * All spans with the same root span that started the step will share the
    * same sink.
    */
-  #spanSinks = new Map<string, AIMetadataSink>();
+  #spans = new Map<string, TrackedSpan>();
 
   /**
-   * A registry used to clean up items from `#spanSinks` when spans fall out of
+   * The inverse index for `#spans`, used to clear all span entries owned by a
+   * scope when it completes.
+   */
+  #scopeSpanKeys = new Map<AIMetadataScope, Set<string>>();
+
+  /**
+   * A registry used to clean up items from `#spans` when spans fall out of
    * reference without ending. Avoids leaking entries (and the engine sink
    * closures they reference) for spans that are never ended and are GC'd.
    */
   #spanCleanup = new FinalizationRegistry<string>((key) => {
     if (key) {
-      this.#spanSinks.delete(key);
+      const tracked = this.#spans.get(key);
+      this.#spans.delete(key);
+      if (tracked) {
+        this.#scopeSpanKeys.get(tracked.scope)?.delete(key);
+      }
     }
   });
 
@@ -74,6 +95,32 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    * double-count tokens).
    */
   #attachSetup: OTelSetup | undefined;
+
+  /**
+   * Start a logical scope for AI metadata tracking.
+   */
+  public startScope(): AIMetadataScope {
+    const scope = Symbol("inngest.ai-metadata-scope");
+    this.#scopeSpanKeys.set(scope, new Set());
+    return scope;
+  }
+
+  /**
+   * End a logical tracking scope and drop any span sinks still associated with
+   * it.
+   */
+  public endScope(scope: AIMetadataScope): void {
+    const keys = this.#scopeSpanKeys.get(scope);
+    if (!keys) {
+      return;
+    }
+
+    for (const key of keys) {
+      this.#spans.delete(key);
+    }
+
+    this.#scopeSpanKeys.delete(scope);
+  }
 
   /**
    * Idempotently attach this processor to the global OTel provider that already
@@ -98,10 +145,12 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    * its descendants share the same AIMetadata sink.
    */
   public declareStartingSpan({
+    scope,
     span,
     traceparent,
     onAIMetadata,
   }: {
+    scope: AIMetadataScope;
     span: Span;
     traceparent: string | undefined;
     onAIMetadata: AIMetadataSink;
@@ -122,7 +171,7 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
       );
     }
 
-    this.trackSpan(span, onAIMetadata);
+    this.trackSpan(scope, span, onAIMetadata);
   }
 
   /**
@@ -132,7 +181,11 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    * Read-only: unlike the Extended Traces processor, no attributes
    * are stamped on the span.
    */
-  private trackSpan(span: Span, sink: AIMetadataSink): void {
+  private trackSpan(
+    scope: AIMetadataScope,
+    span: Span,
+    sink: AIMetadataSink,
+  ): void {
     // OTel does not call span processors when a span is not recording, so an
     // entry for it would never be cleared by onEnd.
     if (!span.isRecording()) {
@@ -143,7 +196,8 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
     const key = spanSinkKey(traceId, spanId);
 
     this.#spanCleanup.register(span, key, span);
-    this.#spanSinks.set(key, sink);
+    this.#spans.set(key, { sink, scope });
+    this.#scopeSpanKeys.get(scope)?.add(key);
   }
 
   /**
@@ -151,8 +205,14 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    */
   private cleanupSpan(span: ReadableSpan): void {
     const { traceId, spanId } = span.spanContext();
+    const key = spanSinkKey(traceId, spanId);
+    const tracked = this.#spans.get(key);
+
     this.#spanCleanup.unregister(span);
-    this.#spanSinks.delete(spanSinkKey(traceId, spanId));
+    this.#spans.delete(key);
+    if (tracked) {
+      this.#scopeSpanKeys.get(tracked.scope)?.delete(key);
+    }
   }
 
   /**
@@ -168,14 +228,13 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
 
     // A child span always shares its parent's trace ID, so the parent's key
     // can be built from the child's own span context.
-    const sink = this.#spanSinks.get(
-      spanSinkKey(span.spanContext().traceId, parentSpanId),
-    );
-    if (!sink) {
+    const parentKey = spanSinkKey(span.spanContext().traceId, parentSpanId);
+    const tracked = this.#spans.get(parentKey);
+    if (!tracked) {
       return;
     }
 
-    this.trackSpan(span, sink);
+    this.trackSpan(tracked.scope, span, tracked.sink);
   }
 
   /**
@@ -186,8 +245,8 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
     const { traceId, spanId } = span.spanContext();
 
     try {
-      const sink = this.#spanSinks.get(spanSinkKey(traceId, spanId));
-      if (!sink) {
+      const tracked = this.#spans.get(spanSinkKey(traceId, spanId));
+      if (!tracked) {
         return;
       }
 
@@ -196,7 +255,7 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
         return;
       }
 
-      sink(aiMetadata);
+      tracked.sink(aiMetadata);
     } finally {
       this.cleanupSpan(span);
     }

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -133,6 +133,12 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
    * are stamped on the span.
    */
   private trackSpan(span: Span, sink: AIMetadataSink): void {
+    // OTel does not call span processors when a span is not recording, so an
+    // entry for it would never be cleared by onEnd.
+    if (!span.isRecording()) {
+      return;
+    }
+
     const { traceId, spanId } = span.spanContext();
     const key = spanSinkKey(traceId, spanId);
 

--- a/packages/inngest/src/components/execution/otel/metadataProcessor.ts
+++ b/packages/inngest/src/components/execution/otel/metadataProcessor.ts
@@ -99,8 +99,17 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
   /**
    * Start a logical scope for AI metadata tracking.
    */
-  public startScope(): AIMetadataScope {
-    const scope = Symbol("inngest.ai-metadata-scope");
+  public startScope({
+    runId,
+    span,
+  }: {
+    runId: string;
+    span: Span;
+  }): AIMetadataScope {
+    const { traceId, spanId } = span.spanContext();
+    const scope = Symbol(
+      `inngest.ai-metadata-scope:${runId}:${traceId}:${spanId}`,
+    );
     this.#scopeSpanKeys.set(scope, new Set());
     return scope;
   }
@@ -192,12 +201,17 @@ export class InngestMetadataSpanProcessor implements SpanProcessor {
       return;
     }
 
+    const keys = this.#scopeSpanKeys.get(scope);
+    if (!keys) {
+      return;
+    }
+
     const { traceId, spanId } = span.spanContext();
     const key = spanSinkKey(traceId, spanId);
 
     this.#spanCleanup.register(span, key, span);
     this.#spans.set(key, { sink, scope });
-    this.#scopeSpanKeys.get(scope)?.add(key);
+    keys.add(key);
   }
 
   /**


### PR DESCRIPTION
## Summary

skip ai metadata tracking for spans that otel marks as non-recording. addresses: #1702