### PR TITLE
feat(sandbox): allow non-absolute commands

### DIFF
--- a/.changeset/calm-tools-exec.md
+++ b/.changeset/calm-tools-exec.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Allow sandbox commands to use executable names and relative paths.

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -314,11 +314,19 @@ describe("step.sandbox", () => {
       }),
     ).toThrow(SandboxValidationError);
 
+    for (const command of [["npm", "test"], ["./script"], ["bin/script"]]) {
+      await sandbox.commands.run("exec", { command });
+      expect(rawTool).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          input: [expect.objectContaining({ command })],
+        }),
+      );
+    }
+    rawTool.mockClear();
     await expect(
-      sandbox.commands.run("exec", {
-        command: ["npm", "test"],
-      }),
-    ).rejects.toThrow("absolute executable path");
+      sandbox.commands.run("exec", { command: [""] }),
+    ).rejects.toThrow("command[0] must not be empty");
     await expect(
       sandbox.processes.start("start", {
         command: ["/bin/true"],

--- a/packages/inngest/src/components/InngestSandbox.test.ts
+++ b/packages/inngest/src/components/InngestSandbox.test.ts
@@ -343,9 +343,6 @@ describe("step.sandbox", () => {
       }),
     ).toThrow(SandboxValidationError);
 
-    await expect(sandbox.commands.run("exec", ["npm", "test"])).rejects.toThrow(
-      "absolute executable path",
-    );
     await expect(sandbox.commands.run("exec", "npm test")).resolves.toEqual({
       stdout: "ok\n",
       stderr: "",
@@ -397,9 +394,22 @@ describe("step.sandbox", () => {
     await expect(sandbox.commands.run("nul", "printf \0")).rejects.toThrow(
       "must not contain NUL",
     );
+    for (const command of [["npm", "test"], ["./script"], ["bin/script"]]) {
+      await sandbox.commands.run("exec", command);
+      expect(rawTool).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          input: [expect.objectContaining({ command })],
+        }),
+      );
+    }
+    rawTool.mockClear();
     await expect(
       sandbox.commands.run("too-large", "x".repeat(32_760)),
     ).rejects.toThrow("must not exceed 32768 bytes");
+    await expect(sandbox.commands.run("exec", [""])).rejects.toThrow(
+      "command[0] must not be empty",
+    );
     await expect(
       sandbox.processes.start("start", {
         command: ["/bin/true"],

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -447,10 +447,8 @@ const normalizeProcessSpec = <
     "sandbox command options",
   ) as unknown as T;
 
-  if (!parsed.command[0]?.startsWith("/")) {
-    throw new SandboxValidationError(
-      "command must begin with an absolute executable path",
-    );
+  if (!parsed.command[0]) {
+    throw new SandboxValidationError("command[0] must not be empty");
   }
   let argvBytes = 0;
   parsed.command.forEach((argument, index) => {

--- a/packages/inngest/src/components/sandbox/validation.ts
+++ b/packages/inngest/src/components/sandbox/validation.ts
@@ -456,10 +456,8 @@ const normalizeProcessSpec = <
     "sandbox command options",
   ) as unknown as T;
 
-  if (Array.isArray(parsed.command) && !parsed.command[0]?.startsWith("/")) {
-    throw new SandboxValidationError(
-      "command must begin with an absolute executable path",
-    );
+  if (Array.isArray(parsed.command) && !parsed.command[0]) {
+    throw new SandboxValidationError("command[0] must not be empty");
   }
   const argv =
     typeof parsed.command === "string"


### PR DESCRIPTION
- allow sandbox commands to use bare executable names
- allow cwd-relative executable paths
- retain empty, NUL, Unicode, and size validation

This exposes the execvp-style semantics implemented by inngest/simcity#45 through the cloud API change in inngest/monorepo#8209.