### PR TITLE
fix(execution): throw NonRetriableError when step.invoke target is cancelled

### DIFF
--- a/.changeset/soft-walls-wonder.md
+++ b/.changeset/soft-walls-wonder.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Reject step.invoke with NonRetriableError when invoked function is cancelled

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -136,6 +136,48 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
+function normalizeMemoizedOp<T extends MemoizedOp>(op: T): T {
+  if (typeof op.data === "object" && op.data !== null) {
+    const dataObj = op.data as Record<string, unknown>;
+    const isFinishedEvent = dataObj.name === "inngest/function.finished";
+    const eventData = isFinishedEvent
+      ? (dataObj.data as Record<string, unknown> | undefined)
+      : undefined;
+
+    const status =
+      eventData?._inngest &&
+      typeof eventData._inngest === "object" &&
+      eventData._inngest !== null
+        ? (eventData._inngest as Record<string, unknown>).status
+        : dataObj._inngest &&
+            typeof dataObj._inngest === "object" &&
+            dataObj._inngest !== null
+          ? (dataObj._inngest as Record<string, unknown>).status
+          : undefined;
+
+    if (status === "Cancelled") {
+      return {
+        ...op,
+        data: undefined,
+        error: {
+          name: "NonRetriableError",
+          message: "Invoked function was cancelled",
+        },
+      };
+    }
+
+    if (isFinishedEvent && eventData?.error) {
+      return {
+        ...op,
+        data: undefined,
+        error: eventData.error as Record<string, unknown>,
+      };
+    }
+  }
+
+  return op;
+}
+
 /**
  * Placeholder step ID used when completing a checkpointed run.
  */
@@ -2138,10 +2180,14 @@ class InngestExecutionEngine
       void checkpointResults.return();
     });
 
-    const stepsToFulfill = Object.keys(this.options.stepState).length;
+    const stepState: Record<string, MemoizedOp> = {};
+    for (const [id, op] of Object.entries(this.options.stepState)) {
+      stepState[id] = normalizeMemoizedOp(op);
+    }
+    const stepsToFulfill = Object.keys(stepState).length;
 
     const state: ExecutionState = {
-      stepState: this.options.stepState,
+      stepState,
       priorDefers: this.options.priorDefers ?? {},
       stepsToFulfill,
       steps: new Map(),
@@ -2254,7 +2300,10 @@ class InngestExecutionEngine
         stepData.type === "data" &&
         stepData.data !== existing.data
       ) {
-        this.state.stepState[hashedId] = { ...existing, data: stepData.data };
+        this.state.stepState[hashedId] = normalizeMemoizedOp({
+          ...existing,
+          data: stepData.data,
+        });
       }
     }
   }
@@ -3016,7 +3065,7 @@ class InngestExecutionEngine
     if (resume) {
       userlandStep.fulfilled = true;
       userlandStep.hasStepState = true;
-      this.state.stepState[resultOp.id] = userlandStep;
+      this.state.stepState[resultOp.id] = normalizeMemoizedOp(userlandStep);
 
       userlandStep.handle();
     }

--- a/packages/inngest/src/test/integration/stepInvokeCancel.test.ts
+++ b/packages/inngest/src/test/integration/stepInvokeCancel.test.ts
@@ -1,0 +1,161 @@
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { expect, test } from "vitest";
+import { z } from "zod";
+import { Inngest } from "../../index.ts";
+import { createServer } from "../../node.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+test("step.invoke throws NonRetriableError when invoked function is cancelled", async () => {
+  const state = createState({
+    caughtError: null as unknown,
+  });
+
+  const cancelEvent = randomSuffix("cancel");
+  const childTrigger = randomSuffix("child");
+  const parentTrigger = randomSuffix("parent");
+
+  const inngest = new Inngest({ id: randomSuffix(testFileName), isDev: true });
+
+  const child = inngest.createFunction(
+    {
+      id: "child",
+      cancelOn: [{ event: cancelEvent }],
+      triggers: [{ event: childTrigger, schema: z.object({}) }],
+    },
+    async ({ step }) => {
+      await step.sleep("sleep", 60_000);
+      return { text: "hello world" };
+    },
+  );
+
+  const parent = inngest.createFunction(
+    {
+      id: "parent",
+      triggers: [{ event: parentTrigger, schema: z.object({}) }],
+    },
+    async ({ step, runId }) => {
+      state.runId = runId;
+      try {
+        await Promise.all([
+          step.invoke("invoke child", { function: child, data: {} }),
+          step.sendEvent("cancel child", { name: cancelEvent, data: {} }),
+        ]);
+      } catch (err) {
+        state.caughtError = err;
+      }
+    },
+  );
+
+  await createTestApp({
+    client: inngest,
+    functions: [parent, child],
+    serve: createServer,
+  });
+
+  await inngest.send({ name: parentTrigger, data: {} });
+  await state.waitForRunComplete();
+
+  expect(state.caughtError).toBeDefined();
+  expect((state.caughtError as Error).name).toBe("NonRetriableError");
+  expect((state.caughtError as Error).message).toBe(
+    "Invoked function was cancelled",
+  );
+});
+
+test("step.invoke causes run to fail when cancelled and unhandled", async () => {
+  const state = createState({});
+
+  const cancelEvent = randomSuffix("cancel-unhandled");
+  const childTrigger = randomSuffix("child-unhandled");
+  const parentTrigger = randomSuffix("parent-unhandled");
+
+  const inngest = new Inngest({ id: randomSuffix(testFileName), isDev: true });
+
+  const child = inngest.createFunction(
+    {
+      id: "child-unhandled",
+      cancelOn: [{ event: cancelEvent }],
+      triggers: [{ event: childTrigger, schema: z.object({}) }],
+    },
+    async ({ step }) => {
+      await step.sleep("sleep", 60_000);
+      return { text: "hello world" };
+    },
+  );
+
+  const parent = inngest.createFunction(
+    {
+      id: "parent-unhandled",
+      triggers: [{ event: parentTrigger, schema: z.object({}) }],
+    },
+    async ({ step, runId }) => {
+      state.runId = runId;
+      await Promise.all([
+        step.invoke("invoke child", { function: child, data: {} }),
+        step.sendEvent("cancel child", { name: cancelEvent, data: {} }),
+      ]);
+    },
+  );
+
+  await createTestApp({
+    client: inngest,
+    functions: [parent, child],
+    serve: createServer,
+  });
+
+  await inngest.send({ name: parentTrigger, data: {} });
+  await state.waitForRunFailed();
+});
+
+test("step.invoke returns data when invoked function succeeds", async () => {
+  const state = createState({
+    result: null as unknown,
+  });
+
+  const childTrigger = randomSuffix("child-succ");
+  const parentTrigger = randomSuffix("parent-succ");
+
+  const inngest = new Inngest({ id: randomSuffix(testFileName), isDev: true });
+
+  const child = inngest.createFunction(
+    {
+      id: "child-succ",
+      triggers: [{ event: childTrigger, schema: z.object({}) }],
+    },
+    async () => {
+      return { text: "hello world" };
+    },
+  );
+
+  const parent = inngest.createFunction(
+    {
+      id: "parent-succ",
+      triggers: [{ event: parentTrigger, schema: z.object({}) }],
+    },
+    async ({ step, runId }) => {
+      state.runId = runId;
+      const result = await step.invoke("invoke child", {
+        function: child,
+        data: {},
+      });
+      state.result = result;
+    },
+  );
+
+  await createTestApp({
+    client: inngest,
+    functions: [parent, child],
+    serve: createServer,
+  });
+
+  await inngest.send({ name: parentTrigger, data: {} });
+  await state.waitForRunComplete();
+
+  expect(state.result).toEqual({ text: "hello world" });
+});


### PR DESCRIPTION
## Summary
When an invoked child function was cancelled in the Dev UI or via API, `step.invoke(...)` previously resolved with the internal `inngest/function.finished` event payload (with `data._inngest.status === "Cancelled"`) instead of rejecting. This broke TypeScript return type assumptions and caused runtime crashes when trying to parse or use the return value.

This PR normalizes memoized step states in `engine.ts` (`normalizeMemoizedOp`) so that cancelled invocations set `data: undefined` and `error: { name: "NonRetriableError", message: "Invoked function was cancelled" }`. This ensures:
1. `step.invoke(...)` rejects with a `StepError` (`NonRetriableError`).
2. Parent functions can catch and handle cancellations cleanly using `try { await step.invoke(...) } catch (err)`.
3. Uncaught cancellations immediately fail the parent run without wasteful retries.

## Checklist
- [ ] ~~Added a docs PR that references this PR~~ N/A Bug fix aligning with existing NonRetriableError step behavior
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
Fixes #1694 
