### PR TITLE
fix(streaming): lazily allocate the StreamTools TransformStream

### DIFF
--- a/.changeset/lazy-stream-allocation.md
+++ b/.changeset/lazy-stream-allocation.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Stop allocating a `TransformStream` for every execution. Streams are now created lazily, only when a run actually streams or a consumer reads the SSE response, which avoids per-execution Web Streams allocation and the Bun GC retention it amplified.

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -599,7 +599,7 @@ export class InngestApi {
    */
   async checkpointStream(args: {
     runId: string;
-    body: ReadableStream;
+    body: ReadableStream | Uint8Array<ArrayBuffer>;
   }): Promise<void> {
     const url = await this.getTargetUrl(
       `/v1/realtime/publish/tee?channel=${encodeURIComponent(args.runId)}`,

--- a/packages/inngest/src/components/StreamTools.test.ts
+++ b/packages/inngest/src/components/StreamTools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { Stream } from "./StreamTools.ts";
 
 async function drain(s: Stream): Promise<string> {
@@ -65,5 +65,18 @@ describe("Stream.commit / rollback", () => {
     expect(raw).toContain('"hashedStepId":"step-a"');
     expect(raw).toContain("event: inngest.rollback");
     expect(raw).toContain('"hashedStepId":"step-b"');
+  });
+});
+
+describe("Stream.push after close", () => {
+  test("does not activate the stream", () => {
+    const onActivated = vi.fn();
+    const s = new Stream({ onActivated });
+
+    s.end();
+    s.push("late");
+
+    expect(s.activated).toBe(false);
+    expect(onActivated).not.toHaveBeenCalled();
   });
 });

--- a/packages/inngest/src/components/StreamTools.ts
+++ b/packages/inngest/src/components/StreamTools.ts
@@ -177,7 +177,7 @@ export class Stream implements StreamTools {
   }
 
   private activate(): void {
-    if (!this._activated) {
+    if (!this._activated && !this._closed) {
       this._activated = true;
       this.onActivated?.();
     }

--- a/packages/inngest/src/components/StreamTools.ts
+++ b/packages/inngest/src/components/StreamTools.ts
@@ -55,12 +55,21 @@ export interface StreamTools {
  * @internal
  */
 export class Stream implements StreamTools {
-  private transform: TransformStream<Uint8Array, Uint8Array>;
-  private writer: WritableStreamDefaultWriter<Uint8Array>;
+  private transform?: TransformStream<Uint8Array, Uint8Array>;
+  private writer?: WritableStreamDefaultWriter<Uint8Array>;
   private encoder = new TextEncoder();
   private _activated = false;
   private _errored = false;
+  private _closed = false;
   private writeChain: Promise<void> = Promise.resolve();
+
+  /**
+   * SSE events enqueued before the underlying `TransformStream` exists. The
+   * transform is only allocated when `readable` is first accessed, so
+   * executions whose stream is never consumed never allocate one
+   * (https://github.com/inngest/inngest-js/issues/1624).
+   */
+  private buffered: string[] = [];
 
   /**
    * Optional callback invoked the first time `push` or `pipe` is called.
@@ -82,6 +91,33 @@ export class Stream implements StreamTools {
   }) {
     this.onActivated = opts?.onActivated;
     this.onWriteError = opts?.onWriteError;
+  }
+
+  /**
+   * Whether `push` or `pipe` has been called at least once.
+   */
+  get activated(): boolean {
+    return this._activated;
+  }
+
+  /**
+   * The readable side of the underlying transform stream. Consumers (i.e. the
+   * HTTP response) read SSE events from here. Accessing this allocates the
+   * transform stream, so only access it when the stream will actually be
+   * delivered to a consumer.
+   */
+  get readable(): ReadableStream<Uint8Array> {
+    return this.materialize().readable;
+  }
+
+  /**
+   * Allocate the underlying `TransformStream` and flush any buffered events
+   * (and pending close) through it.
+   */
+  private materialize(): TransformStream<Uint8Array, Uint8Array> {
+    if (this.transform) {
+      return this.transform;
+    }
 
     let readableStrategy: QueuingStrategy<Uint8Array> | undefined;
 
@@ -103,22 +139,33 @@ export class Stream implements StreamTools {
       undefined,
       readableStrategy,
     );
-    this.writer = this.transform.writable.getWriter();
+    const writer = this.transform.writable.getWriter();
+    this.writer = writer;
+
+    for (const sseEvent of this.buffered) {
+      this.chainWrite(writer, sseEvent);
+    }
+    this.buffered = [];
+
+    if (this._closed) {
+      this.chainClose(writer);
+    }
+
+    return this.transform;
   }
 
   /**
-   * Whether `push` or `pipe` has been called at least once.
+   * The full SSE payload, known synchronously once the stream has closed
+   * without `readable` ever being materialized. Returns `undefined` while the
+   * stream is still open or once a consumer holds the readable side — in
+   * those cases the payload must be read from `readable` instead.
    */
-  get activated(): boolean {
-    return this._activated;
-  }
+  undeliveredPayload(): string | undefined {
+    if (!this._closed || this.transform) {
+      return undefined;
+    }
 
-  /**
-   * The readable side of the underlying transform stream. Consumers (i.e. the
-   * HTTP response) read SSE events from here.
-   */
-  get readable(): ReadableStream<Uint8Array> {
-    return this.transform.readable;
+    return this.buffered.join("");
   }
 
   /**
@@ -137,24 +184,39 @@ export class Stream implements StreamTools {
   }
 
   /**
-   * Encode and write an SSE event string to the underlying writer.
-   */
-  private writeEncoded(sseEvent: string): Promise<void> {
-    return this.writer.write(this.encoder.encode(sseEvent));
-  }
-
-  /**
-   * Enqueue a pre-built SSE event string onto the write chain.
+   * Enqueue a pre-built SSE event string, buffering it until the transform
+   * stream is materialized.
    */
   private enqueue(sseEvent: string): void {
-    if (this._errored) return;
+    if (this._errored || this._closed) return;
 
+    const writer = this.writer;
+    if (!writer) {
+      this.buffered.push(sseEvent);
+      return;
+    }
+
+    this.chainWrite(writer, sseEvent);
+  }
+
+  private chainWrite(
+    writer: WritableStreamDefaultWriter<Uint8Array>,
+    sseEvent: string,
+  ): void {
     this.writeChain = this.writeChain
-      .then(() => this.writeEncoded(sseEvent))
+      .then(() => writer.write(this.encoder.encode(sseEvent)))
       .catch((err) => {
         // Writer errored (e.g. stream closed) — swallow so the chain
         // doesn't break and subsequent writes fail gracefully.
         this._errored = true;
+        this.onWriteError?.(err);
+      });
+  }
+
+  private chainClose(writer: WritableStreamDefaultWriter<Uint8Array>): void {
+    this.writeChain = this.writeChain
+      .then(() => writer.close())
+      .catch((err) => {
         this.onWriteError?.(err);
       });
   }
@@ -254,7 +316,7 @@ export class Stream implements StreamTools {
     const chunks: string[] = [];
 
     for await (const chunk of source) {
-      if (this._errored) break;
+      if (this._errored || this._closed) break;
 
       chunks.push(chunk);
 
@@ -299,19 +361,20 @@ export class Stream implements StreamTools {
   }
 
   /**
-   * Optionally write a final SSE event, then close the writer.
+   * Optionally write a final SSE event, then close the writer. Idempotent —
+   * only the first close takes effect, and later enqueues are dropped.
    */
   private closeWriter(finalEvent?: string): void {
-    this.writeChain = this.writeChain
-      .then(async () => {
-        if (finalEvent) {
-          await this.writeEncoded(finalEvent);
-        }
-        await this.writer.close();
-      })
-      .catch((err) => {
-        this.onWriteError?.(err);
-      });
+    if (this._closed) return;
+
+    if (finalEvent) {
+      this.enqueue(finalEvent);
+    }
+    this._closed = true;
+
+    if (this.writer) {
+      this.chainClose(this.writer);
+    }
   }
 
   /**

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -207,6 +207,12 @@ class InngestExecutionEngine
   private redirectSent = false;
 
   /**
+   * Whether the checkpoint stream POST has started. Prevents duplicate
+   * payload delivery to the tee channel.
+   */
+  private checkpointStreamPosted = false;
+
+  /**
    * Promise that resolves once the redirect event has been written (or the
    * attempt completes). Stored so that `checkpointAndSwitchToAsync` can
    * await it before closing the writer.
@@ -783,12 +789,29 @@ class InngestExecutionEngine
    * real-time, or after completion if stream.push() was never called.
    */
   private postCheckpointStream(): void {
+    // At most one POST per execution: the tee channel must not receive the
+    // payload twice (e.g. terminal POST followed by a late activation), and
+    // `streamTools.readable` can only be consumed once.
+    if (this.checkpointStreamPosted) return;
+    this.checkpointStreamPosted = true;
+
     try {
+      // If the stream closed before any consumer materialized its readable
+      // side, the full payload is already known — POST it as static bytes
+      // instead of allocating a stream.
+      const undeliveredPayload = this.streamTools.undeliveredPayload();
+      const body =
+        undeliveredPayload === undefined
+          ? this.buildMetadataPrefixedStream()
+          : new TextEncoder().encode(
+              buildSseMetadataEvent(this.fnArg.runId) + undeliveredPayload,
+            );
+
       // Fire and forget — completes when the stream closes.
       void this.options.client["inngestApi"]
         .checkpointStream({
           runId: this.fnArg.runId,
-          body: this.buildMetadataPrefixedStream(),
+          body,
         })
         .catch((err: unknown) => {
           this.devDebug("checkpoint stream POST error:", err);

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -790,8 +790,7 @@ class InngestExecutionEngine
    */
   private postCheckpointStream(): void {
     // At most one POST per execution: the tee channel must not receive the
-    // payload twice (e.g. terminal POST followed by a late activation), and
-    // `streamTools.readable` can only be consumed once.
+    // payload twice, and `streamTools.readable` can only be consumed once.
     if (this.checkpointStreamPosted) return;
     this.checkpointStreamPosted = true;
 

--- a/packages/inngest/src/components/execution/engine.ts
+++ b/packages/inngest/src/components/execution/engine.ts
@@ -207,12 +207,6 @@ class InngestExecutionEngine
   private redirectSent = false;
 
   /**
-   * Whether the checkpoint stream POST has started. Prevents duplicate
-   * payload delivery to the tee channel.
-   */
-  private checkpointStreamPosted = false;
-
-  /**
    * Promise that resolves once the redirect event has been written (or the
    * attempt completes). Stored so that `checkpointAndSwitchToAsync` can
    * await it before closing the writer.
@@ -789,11 +783,6 @@ class InngestExecutionEngine
    * real-time, or after completion if stream.push() was never called.
    */
   private postCheckpointStream(): void {
-    // At most one POST per execution: the tee channel must not receive the
-    // payload twice, and `streamTools.readable` can only be consumed once.
-    if (this.checkpointStreamPosted) return;
-    this.checkpointStreamPosted = true;
-
     try {
       // If the stream closed before any consumer materialized its readable
       // side, the full payload is already known — POST it as static bytes

--- a/packages/inngest/src/test/helpers.ts
+++ b/packages/inngest/src/test/helpers.ts
@@ -3,6 +3,7 @@ import fetch from "cross-fetch";
 import type { Request, Response } from "express";
 import nock from "nock";
 import httpMocks from "node-mocks-http";
+import { onTestFinished, vi } from "vitest";
 import { z } from "zod/v3";
 import {
   type IInngestExecution,
@@ -2286,3 +2287,44 @@ export const nodeVersion = process.version
   : undefined;
 
 export const silencedLogger = new ConsoleLogger({ level: "silent" });
+
+/**
+ * Track every `TransformStream` and `CountQueuingStrategy` construction in
+ * this process for the rest of the current test, restoring the globals on
+ * test finish. Returns a function yielding the captured construction stacks,
+ * each prefixed with the constructor name. Deliberately unfiltered: nothing
+ * else constructs these during our tests, and filtering by callsite would
+ * let a moved or renamed allocation escape detection.
+ */
+export function trackStreamAllocations(): () => string[] {
+  const OriginalTransformStream = globalThis.TransformStream;
+  const OriginalCountQueuingStrategy = globalThis.CountQueuingStrategy;
+  const stacks: string[] = [];
+
+  class TrackedTransformStream extends OriginalTransformStream {
+    constructor(
+      ...args: ConstructorParameters<typeof OriginalTransformStream>
+    ) {
+      super(...args);
+      stacks.push(`TransformStream ${new Error().stack ?? ""}`);
+    }
+  }
+
+  class TrackedCountQueuingStrategy extends OriginalCountQueuingStrategy {
+    constructor(
+      ...args: ConstructorParameters<typeof OriginalCountQueuingStrategy>
+    ) {
+      super(...args);
+      stacks.push(`CountQueuingStrategy ${new Error().stack ?? ""}`);
+    }
+  }
+
+  vi.stubGlobal("TransformStream", TrackedTransformStream);
+  vi.stubGlobal("CountQueuingStrategy", TrackedCountQueuingStrategy);
+  onTestFinished(() => {
+    globalThis.TransformStream = OriginalTransformStream;
+    globalThis.CountQueuingStrategy = OriginalCountQueuingStrategy;
+  });
+
+  return () => stacks;
+}

--- a/packages/inngest/src/test/integration/durableEndpoints/asyncNoStream.test.ts
+++ b/packages/inngest/src/test/integration/durableEndpoints/asyncNoStream.test.ts
@@ -8,6 +8,7 @@ import { createState, testNameFromFileUrl } from "@inngest/test-harness";
 import { expect, test } from "vitest";
 import { step } from "../../../index.ts";
 
+import { trackStreamAllocations } from "../../helpers.ts";
 import { setupEndpoint, urlWithTestName } from "./helpers.ts";
 
 const testFileName = testNameFromFileUrl(import.meta.url);
@@ -35,6 +36,35 @@ test("return Response object", async () => {
   expect(await res.json()).toBe('"hello world"');
 
   await state.waitForRunComplete();
+});
+
+test("does not allocate a stream across async-mode reentries", async () => {
+  const state = createState({});
+  const { port, waitForRunId } = await setupEndpoint(testFileName, async () => {
+    const a = await step.run("a", async () => "hello");
+    await step.sleep("go-async", "1s");
+    const b = await step.run("b", async () => "world");
+    return Response.json(`${a} ${b}`);
+  });
+
+  const getStreamAllocations = trackStreamAllocations();
+
+  let res = await fetch(urlWithTestName(`http://localhost:${port}`), {
+    redirect: "manual",
+  });
+  expect(res.status).toBe(302);
+  expect(res.headers.get("location")).toBeTruthy();
+  state.runId = await waitForRunId();
+
+  res = await fetch(res.headers.get("location")!);
+  expect(res.status).toBe(200);
+
+  // FIXME: The output is double-encoded. This is a Inngest server bug (not SDK)
+  expect(await res.json()).toBe('"hello world"');
+
+  await state.waitForRunComplete();
+
+  expect(getStreamAllocations()).toEqual([]);
 });
 
 test("return string", async () => {

--- a/packages/inngest/src/test/integration/durableEndpoints/syncNoStream.test.ts
+++ b/packages/inngest/src/test/integration/durableEndpoints/syncNoStream.test.ts
@@ -8,6 +8,7 @@ import { createState, testNameFromFileUrl } from "@inngest/test-harness";
 import { expect, test } from "vitest";
 import { step } from "../../../index.ts";
 
+import { trackStreamAllocations } from "../../helpers.ts";
 import { setupEndpoint, urlWithTestName } from "./helpers.ts";
 
 const testFileName = testNameFromFileUrl(import.meta.url);
@@ -25,6 +26,25 @@ test("return Response object", async () => {
 
   state.runId = await waitForRunId();
   await state.waitForRunComplete();
+});
+
+test("does not allocate a stream when the response does not stream", async () => {
+  const state = createState({});
+  const { port, waitForRunId } = await setupEndpoint(testFileName, async () => {
+    await step.run("a", async () => {});
+    return Response.json("All done");
+  });
+
+  const getStreamAllocations = trackStreamAllocations();
+
+  const res = await fetch(urlWithTestName(`http://localhost:${port}`));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toBe("All done");
+
+  state.runId = await waitForRunId();
+  await state.waitForRunComplete();
+
+  expect(getStreamAllocations()).toEqual([]);
 });
 
 test("return string", async () => {

--- a/packages/inngest/src/test/integration/durableEndpoints/syncStream.test.ts
+++ b/packages/inngest/src/test/integration/durableEndpoints/syncStream.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from "vitest";
 import { Stream } from "../../../components/StreamTools.ts";
 import { stream } from "../../../experimental/durable-endpoints/index.ts";
 import { NonRetriableError, step } from "../../../index.ts";
+import { trackStreamAllocations } from "../../helpers.ts";
 
 import {
   getStreamData,
@@ -101,6 +102,8 @@ test("no explicit streaming", async () => {
     return Response.json("done");
   });
 
+  const getStreamAllocations = trackStreamAllocations();
+
   const res = await fetch(urlWithTestName(`http://localhost:${port}`), {
     headers: { Accept: "text/event-stream" },
   });
@@ -138,6 +141,11 @@ test("no explicit streaming", async () => {
       }),
     },
   ]);
+
+  // The delivered SSE stream must be backed by exactly one allocation.
+  expect(
+    getStreamAllocations().filter((s) => s.startsWith("TransformStream")),
+  ).toHaveLength(1);
 
   await state.waitForRunComplete();
 });

--- a/packages/inngest/src/test/integration/streamAllocation.test.ts
+++ b/packages/inngest/src/test/integration/streamAllocation.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Non-streaming executions must not allocate the underlying Web Streams
+ * objects for `StreamTools`. Eager per-execution `TransformStream` allocation
+ * is a regression (https://github.com/inngest/inngest-js/issues/1624).
+ */
+
+import {
+  createState,
+  createTestApp,
+  randomSuffix,
+  testNameFromFileUrl,
+} from "@inngest/test-harness";
+import { expect, test } from "vitest";
+import { Inngest } from "../../index.ts";
+import { createServer } from "../../node.ts";
+import { trackStreamAllocations } from "../helpers.ts";
+
+const testFileName = testNameFromFileUrl(import.meta.url);
+
+test("a function run that never streams does not allocate a stream", async () => {
+  const state = createState({});
+
+  const eventName = randomSuffix("evt");
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+  });
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ runId, step }) => {
+      state.runId = runId;
+      await step.run("a", () => "result");
+      return "done";
+    },
+  );
+  await createTestApp({ client, functions: [fn], serve: createServer });
+
+  const getStreamAllocations = trackStreamAllocations();
+
+  await client.send({ name: eventName });
+  await state.waitForRunComplete();
+
+  expect(getStreamAllocations()).toEqual([]);
+});


### PR DESCRIPTION
## Summary
Every execution built a `Stream`, which allocated a `TransformStream` and writer up front even when the run never called `stream.push()`/`pipe()` and nothing read the SSE response. That made optional streaming a per-execution Web Streams allocation and amplified a Bun GC-root bug ([oven-sh/bun#29891](https://github.com/oven-sh/bun/issues/29891)).

`Stream` now buffers SSE events as strings and allocates the `TransformStream` on first access to `readable`, flushing the buffer and any pending close through it. If the run closes before anything reads `readable`, the engine POSTs the known payload to the checkpoint tee as bytes instead of a stream. Wire output is unchanged.

`postCheckpointStream` now runs once per execution. `push()` activates before the closed check, so a late push after the terminal close would otherwise POST the payload twice; before, it threw on the locked `readable` and was swallowed.

A `trackStreamAllocations` helper stubs `TransformStream`/`CountQueuingStrategy` and asserts zero allocations for non-streaming runs and exactly one for a delivered SSE response.

## Checklist
- [ ] ~~Added a [docs PR](https://github.com/inngest/website) that references this PR~~ N/A Internal allocation fix, no API change.
- [x] Added unit/integration tests
- [x] Added changesets if applicable

## Related
- [EXE-1998](https://linear.app/inngest/issue/EXE-1998)
- Fixes #1624
- Supersedes #1651
