### PR TITLE
fix(sandbox): export SandboxCommand type

### DIFF
--- a/.changeset/tidy-sandboxes-command.md
+++ b/.changeset/tidy-sandboxes-command.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Export `SandboxCommand` from `inngest/experimental`.

--- a/packages/inngest/src/experimental.test.ts
+++ b/packages/inngest/src/experimental.test.ts
@@ -1,0 +1,6 @@
+import { expectTypeOf, test } from "vitest";
+import type { SandboxCommand } from "./experimental.ts";
+
+test("exports the sandbox command type", () => {
+  expectTypeOf<SandboxCommand>().toEqualTypeOf<string | readonly string[]>();
+});

--- a/packages/inngest/src/experimental.ts
+++ b/packages/inngest/src/experimental.ts
@@ -20,6 +20,7 @@ export type {
   Sandbox,
   SandboxAction,
   SandboxClient,
+  SandboxCommand,
   SandboxCommandOptions,
   SandboxCommandOutputMetadata,
   SandboxCommandResult,


### PR DESCRIPTION
Exports SandboxCommand from inngest/experimental so users can type shared command helpers without reaching into SDK internals.

```ts
import type { SandboxCommand } from "inngest/experimental";
```

Includes a type test and patch changeset.