### PR TITLE
fix: send environment on signing-key API requests

### DIFF
--- a/.changeset/bright-branches-route.md
+++ b/.changeset/bright-branches-route.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Route signing-key API requests to the correct branch environment and include SDK identification headers.

--- a/packages/inngest/src/api/api.test.ts
+++ b/packages/inngest/src/api/api.test.ts
@@ -1,3 +1,4 @@
+import { version } from "../version.ts";
 import { InngestApi } from "./api.ts";
 
 describe("InngestApi environment headers", () => {
@@ -37,6 +38,9 @@ describe("InngestApi environment headers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     for (const requestHeaders of headers) {
       expect(requestHeaders.get("X-Inngest-Env")).toBe("preview");
+      expect(requestHeaders.get("X-Inngest-Sdk")).toBe(
+        `inngest-js:v${version}`,
+      );
     }
     expect(headers.map((value) => value.get("Content-Type"))).toEqual([
       "application/json",

--- a/packages/inngest/src/api/api.test.ts
+++ b/packages/inngest/src/api/api.test.ts
@@ -1,0 +1,47 @@
+import { InngestApi } from "./api.ts";
+
+describe("InngestApi environment headers", () => {
+  test("adds the environment without changing request content types", async () => {
+    const headers: Headers[] = [];
+    const fetchMock: typeof fetch = vi.fn(async (input, init) => {
+      headers.push(new Headers(init?.headers));
+      const url = input.toString();
+      if (url.endsWith("/v1/realtime/token")) {
+        return Response.json({ jwt: "token" });
+      }
+      return new Response(null, { status: 200 });
+    });
+    const api = new InngestApi({
+      baseUrl: () => "https://api.example.test",
+      signingKey: () => "signkey-test",
+      signingKeyFallback: () => undefined,
+      environment: () => "preview",
+      fetch: () => fetchMock,
+    });
+
+    await api.checkpointStepsAsync({
+      runId: "run-id",
+      fnId: "fn-id",
+      queueItemId: "queue-item-id",
+      generationId: undefined,
+      requestId: undefined,
+      requestStartedAt: undefined,
+      steps: [],
+    });
+    await api.getSubscriptionToken("channel", ["topic"]);
+    await api.checkpointStream({
+      runId: "run-id",
+      body: new ReadableStream(),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    for (const requestHeaders of headers) {
+      expect(requestHeaders.get("X-Inngest-Env")).toBe("preview");
+    }
+    expect(headers.map((value) => value.get("Content-Type"))).toEqual([
+      "application/json",
+      "application/json",
+      "application/octet-stream",
+    ]);
+  });
+});

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -1,6 +1,6 @@
 import type { fetch } from "cross-fetch";
 import { z } from "zod/v3";
-import type { ExecutionVersion } from "../helpers/consts.ts";
+import { type ExecutionVersion, headerKeys } from "../helpers/consts.ts";
 import { getErrorMessage } from "../helpers/errors.ts";
 import { type Marker, markerKey } from "../helpers/marker.ts";
 import { fetchWithAuthFallback } from "../helpers/net.ts";
@@ -64,6 +64,7 @@ export namespace InngestApi {
     baseUrl: () => string | undefined;
     signingKey: () => string | undefined;
     signingKeyFallback: () => string | undefined;
+    environment: () => string | null;
     fetch: () => FetchT;
   }
 
@@ -86,17 +87,20 @@ export class InngestApi {
   private readonly _signingKey: () => string | undefined;
   private readonly _signingKeyFallback: () => string | undefined;
   private readonly _apiBaseUrl: () => string | undefined;
+  private readonly _environment: () => string | null;
   private readonly _fetch: () => FetchT;
 
   constructor({
     baseUrl,
     signingKey,
     signingKeyFallback,
+    environment,
     fetch,
   }: InngestApi.Options) {
     this._apiBaseUrl = baseUrl;
     this._signingKey = signingKey;
     this._signingKeyFallback = signingKeyFallback;
+    this._environment = environment;
     this._fetch = fetch;
   }
 
@@ -110,6 +114,11 @@ export class InngestApi {
 
   private get signingKeyFallback(): string | undefined {
     return this._signingKeyFallback();
+  }
+
+  private get environmentHeaders(): Record<string, string> {
+    const environment = this._environment();
+    return environment ? { [headerKeys.Environment]: environment } : {};
   }
 
   private get hashedKey(): string {
@@ -145,6 +154,7 @@ export class InngestApi {
           ...options,
           headers: {
             "Content-Type": "application/json",
+            ...this.environmentHeaders,
             ...options?.headers,
           },
         },
@@ -277,6 +287,7 @@ export class InngestApi {
         body: JSON.stringify(body),
         headers: {
           "Content-Type": "application/json",
+          ...this.environmentHeaders,
           ...options?.headers,
         },
       },
@@ -368,6 +379,7 @@ export class InngestApi {
         body: JSON.stringify(body),
         headers: {
           "Content-Type": "application/json",
+          ...this.environmentHeaders,
         },
       },
     })
@@ -615,6 +627,7 @@ export class InngestApi {
         body: args.body,
         headers: {
           "Content-Type": "application/octet-stream",
+          ...this.environmentHeaders,
         },
         // Required for streaming request bodies
         // @ts-expect-error duplex not in RequestInit types yet

--- a/packages/inngest/src/api/api.ts
+++ b/packages/inngest/src/api/api.ts
@@ -14,6 +14,7 @@ import {
   type Result,
   type SendSignalResponse,
 } from "../types.ts";
+import { version } from "../version.ts";
 import {
   type BatchResponse,
   batchSchema,
@@ -116,9 +117,12 @@ export class InngestApi {
     return this._signingKeyFallback();
   }
 
-  private get environmentHeaders(): Record<string, string> {
+  private get apiHeaders(): Record<string, string> {
     const environment = this._environment();
-    return environment ? { [headerKeys.Environment]: environment } : {};
+    return {
+      [headerKeys.SdkVersion]: `inngest-js:v${version}`,
+      ...(environment ? { [headerKeys.Environment]: environment } : {}),
+    };
   }
 
   private get hashedKey(): string {
@@ -154,7 +158,7 @@ export class InngestApi {
           ...options,
           headers: {
             "Content-Type": "application/json",
-            ...this.environmentHeaders,
+            ...this.apiHeaders,
             ...options?.headers,
           },
         },
@@ -287,7 +291,7 @@ export class InngestApi {
         body: JSON.stringify(body),
         headers: {
           "Content-Type": "application/json",
-          ...this.environmentHeaders,
+          ...this.apiHeaders,
           ...options?.headers,
         },
       },
@@ -379,7 +383,7 @@ export class InngestApi {
         body: JSON.stringify(body),
         headers: {
           "Content-Type": "application/json",
-          ...this.environmentHeaders,
+          ...this.apiHeaders,
         },
       },
     })
@@ -627,7 +631,7 @@ export class InngestApi {
         body: args.body,
         headers: {
           "Content-Type": "application/octet-stream",
-          ...this.environmentHeaders,
+          ...this.apiHeaders,
         },
         // Required for streaming request bodies
         // @ts-expect-error duplex not in RequestInit types yet

--- a/packages/inngest/src/components/Inngest.ts
+++ b/packages/inngest/src/components/Inngest.ts
@@ -433,6 +433,7 @@ export class Inngest<const TClientOpts extends ClientOptions = ClientOptions>
       baseUrl: () => this.apiBaseUrl,
       signingKey: () => this.signingKey,
       signingKeyFallback: () => this.signingKeyFallback,
+      environment: () => this.env,
       fetch: () => this.fetch,
     });
 


### PR DESCRIPTION
## Summary

- send `X-Inngest-Env` on checkpoint, state hydration, metadata, and realtime API requests
- preserve request-specific headers such as streaming content types
- cover checkpoint and realtime transport behavior

Without this header, branch-environment calls authenticate against the branch parent. Checkpoints then fail to find child-environment runs and fall back to the normal SDK response path.

## Verification

- `pnpm run test src/api/api.test.ts --typecheck.enabled=false`