### PR TITLE
Parse streamed SSE per the spec (CRLF + optional space)

### DIFF
--- a/.changeset/spec-compliant-iterSse.md
+++ b/.changeset/spec-compliant-iterSse.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Parse streamed SSE responses per the Server-Sent Events spec: handle CRLF line endings and an optional (or absent) space after a field's colon, so `\r\n`-delimited streams and `data:value`/`event:value` lines are no longer silently dropped.

--- a/packages/inngest/src/components/execution/streaming.test.ts
+++ b/packages/inngest/src/components/execution/streaming.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import { iterSse, type RawSseEvent } from "./streaming.ts";
+
+/**
+ * Build a `ReadableStream<Uint8Array>` from one or more string chunks, so a
+ * single logical SSE payload can be split across `reader.read()` boundaries.
+ */
+const streamOf = (...chunks: string[]): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+};
+
+const collect = async (
+  body: ReadableStream<Uint8Array>,
+): Promise<RawSseEvent[]> => {
+  const out: RawSseEvent[] = [];
+  for await (const event of iterSse(body)) {
+    out.push(event);
+  }
+  return out;
+};
+
+describe("iterSse", () => {
+  test("parses a canonical `\\n` + space payload", async () => {
+    const events = await collect(
+      streamOf('event: inngest.response\ndata: {"ok":1}\n\n'),
+    );
+    expect(events).toEqual([{ event: "inngest.response", data: '{"ok":1}' }]);
+  });
+
+  test("parses CRLF (`\\r\\n`) line endings", async () => {
+    const events = await collect(
+      streamOf('event: inngest.response\r\ndata: {"ok":1}\r\n\r\n'),
+    );
+    expect(events).toEqual([{ event: "inngest.response", data: '{"ok":1}' }]);
+  });
+
+  test("parses fields with no space after the colon", async () => {
+    const events = await collect(
+      streamOf('event:inngest.response\ndata:{"ok":1}\n\n'),
+    );
+    expect(events).toEqual([{ event: "inngest.response", data: '{"ok":1}' }]);
+  });
+
+  test("joins multiple data lines with a newline", async () => {
+    const events = await collect(
+      streamOf("event: inngest.stream\ndata: line one\ndata: line two\n\n"),
+    );
+    expect(events).toEqual([
+      { event: "inngest.stream", data: "line one\nline two" },
+    ]);
+  });
+
+  test("ignores comment lines and defaults the event to `message`", async () => {
+    const events = await collect(streamOf(": keep-alive\ndata: hello\n\n"));
+    expect(events).toEqual([{ event: "message", data: "hello" }]);
+  });
+
+  test("reassembles an event split across read boundaries", async () => {
+    const events = await collect(
+      streamOf("event: inngest.response\nda", 'ta: {"ok":1}\n\n'),
+    );
+    expect(events).toEqual([{ event: "inngest.response", data: '{"ok":1}' }]);
+  });
+});

--- a/packages/inngest/src/components/execution/streaming.ts
+++ b/packages/inngest/src/components/execution/streaming.ts
@@ -227,9 +227,10 @@ export async function* iterSse(
 
       buffer += decoder.decode(value, { stream: true });
 
-      // SSE events are delimited by a blank line (double newline) per the
-      // Server-Sent Events spec.
-      const parts = buffer.split("\n\n");
+      // SSE events are delimited by a blank line per the Server-Sent Events
+      // spec. Accept CRLF as well as LF so a server or proxy that uses `\r\n`
+      // line endings still splits into events instead of buffering forever.
+      const parts = buffer.split(/\r?\n\r?\n/);
       buffer = parts.pop() ?? "";
 
       for (const part of parts) {
@@ -238,11 +239,21 @@ export async function* iterSse(
         let event = "message";
         const dataLines: string[] = [];
 
-        for (const line of part.split("\n")) {
-          if (line.startsWith("event: ")) {
-            event = line.slice(7);
-          } else if (line.startsWith("data: ")) {
-            dataLines.push(line.slice(6));
+        for (const line of part.split(/\r?\n/)) {
+          // Each line is `field:value`. The space after the colon is optional
+          // (a single leading space is stripped), and a `:`-prefixed line is a
+          // comment. Matching a literal `"data: "` dropped a spec-valid
+          // `data:value` line and mis-read `event:value` as the default event.
+          if (line.startsWith(":")) continue;
+          const colon = line.indexOf(":");
+          const field = colon === -1 ? line : line.slice(0, colon);
+          let value = colon === -1 ? "" : line.slice(colon + 1);
+          if (value.startsWith(" ")) value = value.slice(1);
+
+          if (field === "event") {
+            event = value;
+          } else if (field === "data") {
+            dataLines.push(value);
           }
         }
 


### PR DESCRIPTION
### What

`iterSse` (the SSE parser behind experimental durable-endpoint streaming) split events on `"\n\n"` and matched the literal prefixes `"event: "` and `"data: "`. Both assume LF line endings and a space after the colon, so two spec-valid shapes were dropped silently:

- **CRLF streams.** With `\r\n` line endings, events are separated by `\r\n\r\n`, which does not contain `\n\n`. `buffer.split("\n\n")` never splits, so the buffer grows and no event is ever yielded.
- **No space after the colon.** The space after an SSE field's colon is optional. `data:{"x":1}` fails `startsWith("data: ")` and is ignored, and `event:foo` falls back to the default `message` event, so the event is mis-typed and then dropped by `parseSseEvent`.

For a durable-execution stream, a dropped event can mean a lost step result.

### Repro

```ts
// current behaviour
[...iterSse('event: x\r\ndata: {"ok":1}\r\n\r\n')]  // []  (event lost)
[...iterSse('event:x\ndata:{"ok":1}\n\n')]          // [{ event: "message", data: "" }]
```

### Fix

Split events on `/\r?\n\r?\n/`, and parse each line as `field` + `value` with a single optional leading space stripped (and skip `:`-prefixed comment lines), per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation). Canonical `\n` + space payloads (what the SDK's own `buildSseEvent` emits) parse identically.

### Tests

`iterSse` had no test coverage; this adds `streaming.test.ts` covering canonical LF, CRLF, no-space fields, multi-line `data`, comment lines, and an event split across read boundaries. All pass under `vitest`, and `biome check` is clean.
