### PR TITLE
fix(serve): read and verify body for signed GET step-execution requests

### DIFF
--- a/.changeset/fix-self-hosted-get-signature.md
+++ b/.changeset/fix-self-hosted-get-signature.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Read and verify the request body for self-hosted step-execution requests sent as `GET` with a JSON body so signature validation succeeds and the step actually executes, instead of always signing an empty body and returning `401` (inngest/inngest-js#1543).

--- a/packages/inngest/src/components/InngestCommHandler.test.ts
+++ b/packages/inngest/src/components/InngestCommHandler.test.ts
@@ -957,3 +957,76 @@ describe("introspection", () => {
     expect(await res.json()).toEqual({ message: "Unauthorized" });
   });
 });
+
+describe("self-hosted step-execution over GET (inngest/inngest-js#1543)", () => {
+  const logger = new ConsoleLogger({ level: "silent" });
+
+  test("signed GET with a JSON body is validated and executed, not 401", async () => {
+    const signingKey = "signkey-test-deadbeefcafef00d";
+    const inngest = createClient({ id: "test", isDev: false, signingKey });
+
+    let executed = false;
+    const fn = inngest.createFunction(
+      { id: "test", triggers: [{ event: "demo/event.sent" }] },
+      () => {
+        executed = true;
+        return "ran";
+      },
+    );
+
+    const body = {
+      version: ExecutionVersion.V2,
+      ctx: {
+        fn_id: "test-test",
+        run_id: "run-123",
+        step_id: "step",
+        attempt: 0,
+        disable_immediate_execution: false,
+        use_api: false,
+        stack: { stack: [], current: 0 },
+      },
+      event: { name: "demo/event.sent", data: {} },
+      events: [{ name: "demo/event.sent", data: {} }],
+      steps: {},
+    };
+    const rawBody = JSON.stringify(body);
+    const commHandler = new InngestCommHandler({
+      client: inngest,
+      frameworkName: "test",
+      functions: [fn],
+      handler: (req: Request) => ({
+        body: () => rawBody,
+        headers: (key: string) => req.headers.get(key),
+        method: () => req.method,
+        url: () => new URL(req.url),
+        transformResponse: ({ body: resBody, headers, status }) =>
+          new Response(resBody, { status, headers }),
+      }),
+    });
+    const handler = commHandler["createHandler"]();
+
+    const ts = Math.round(Date.now() / 1000).toString();
+    const mac = await signDataWithKey(body, signingKey, ts, logger);
+
+    const req = new Request(
+      "https://localhost:3000/api/inngest?fnId=test-test&stepId=step",
+      {
+        method: "GET",
+        headers: {
+          host: "localhost:3000",
+          [headerKeys.Signature]: `t=${ts}&s=${mac}`,
+          [headerKeys.InngestRunId]: "run-123",
+          [headerKeys.InngestStepId]: "step",
+        },
+      },
+    );
+
+    const res = await handler(req);
+
+    // Before the fix the SDK signed an empty body for GET requests, so signature
+    // validation failed and the request returned 401. Now the body is read and
+    // verified for signed GETs, so the function should be executed.
+    expect(res.status).not.toBe(401);
+    expect(executed).toBe(true);
+  });
+});

--- a/packages/inngest/src/components/InngestCommHandler.ts
+++ b/packages/inngest/src/components/InngestCommHandler.ts
@@ -1163,6 +1163,12 @@ export class InngestCommHandler<
 
     const methodP = actions.method("starting to handle request");
 
+    // Detect whether this looks like an inbound Inngest request (a run ID and a
+    // signature header are both present). Self-hosted servers send step-execution
+    // requests as `GET` with a JSON body; knowing this lets us read and verify
+    // the body for those requests too (inngest/inngest-js#1543).
+    const isInngestRequest = await this.isInngestReq(actions);
+
     const [signature, method, body] = await Promise.all([
       actions
         .headers("checking signature for request", headerKeys.Signature)
@@ -1185,6 +1191,24 @@ export class InngestCommHandler<
             return JSON.parse(body);
           }
           return body;
+        }
+
+        // Self-hosted Inngest servers send signed step-execution requests as
+        // `GET` with a JSON body (inngest/inngest-js#1543). Read and verify the
+        // body for these requests so signature validation succeeds and the step
+        // is executed, instead of always signing an empty body and failing the
+        // check.
+        if (method === "GET" && isInngestRequest) {
+          const getBody = await actions.body(
+            `checking body for request signing as method is ${method}`,
+          );
+          if (!getBody) {
+            return "";
+          }
+          if (typeof getBody === "string") {
+            return JSON.parse(getBody);
+          }
+          return getBody;
         }
 
         return "";
@@ -1266,6 +1290,7 @@ export class InngestCommHandler<
           signatureValidation,
           body,
           method,
+          isInngestRequest,
           forceExecution: Boolean(forceExecution),
           fns,
           mwInstances,
@@ -1582,6 +1607,7 @@ export class InngestCommHandler<
     signatureValidation,
     body: rawBody,
     method,
+    isInngestRequest,
     forceExecution,
     fns,
     mwInstances,
@@ -1593,6 +1619,7 @@ export class InngestCommHandler<
     signatureValidation: ReturnType<InngestCommHandler["validateSignature"]>;
     body: unknown;
     method: string;
+    isInngestRequest: boolean;
     forceExecution: boolean;
     fns?: InngestFunction.Any[];
     mwInstances?: Middleware.BaseMiddleware[];
@@ -1640,7 +1667,11 @@ export class InngestCommHandler<
         }
       }
 
-      if (method === "POST" || forceExecution) {
+      if (
+        method === "POST" ||
+        forceExecution ||
+        (method === "GET" && isInngestRequest)
+      ) {
         if (!forceExecution && isMissingBody) {
           this.client[internalLoggerSymbol].error(
             "Missing body when executing, possibly due to missing request body middleware",


### PR DESCRIPTION
Fixes #1543

## What changed

`packages/inngest/src/components/InngestCommHandler.ts`
- `handleAsyncRequest` now computes `isInngestRequest` (run ID + signature header present) and reads/parses the request body for signed `GET` requests, not just `POST`/`PUT`. The signature is therefore validated against the real body instead of an empty string.
- `handleAction` now treats a signed `GET` (`method === "GET" && isInngestRequest`) as an execution request, so self-hosted step-execution calls actually run the function instead of being routed to introspection.

`packages/inngest/src/components/InngestCommHandler.test.ts`
- Added a regression test that sends a self-hosted-style signed `GET` with a JSON body and asserts the function executes (and is not rejected with `401`).

`.changeset/fix-self-hosted-get-signature.md`
- Patch changeset.

## Why

Self-hosted Inngest servers (e.g. `inngest/inngest:v1.22`) send step-execution requests as `GET` with a JSON body, signing `body + ts`. The SDK only read the body for `POST`/`PUT`, so for `GET` it validated an empty body and returned `401 Unauthorized`, deadlocking every step on self-hosted. The previous behaviour was worse-but-silent: SDK `<= 4.2.5` returned a `200` introspection body without ever running the step.

## How tested

- `pnpm exec vitest run src/components/InngestCommHandler.test.ts` — 67 passed (including the new regression test). The new test fails before the fix (returns `401` / function never executes) and passes after.
- `pnpm exec biome check` on the changed files — clean.
- Limitation: I could not run the repo-wide suite in this environment because the `@inngest/test` workspace package is not built locally; the comm-handler tests covering this change pass. PR CI will validate the full matrix.

## AI assistance

This change was authored with AI assistance (OpenCode agent). I reviewed the diff and the regression test and verified it locally; the fix and its reasoning are my own.
