### PR TITLE
fix(test): mock step.sendEvent in InngestTestEngine instead of calling the API

### DIFF
--- a/.changeset/fix-test-engine-sendevent-mock.md
+++ b/.changeset/fix-test-engine-sendevent-mock.md
@@ -1,0 +1,5 @@
+---
+"@inngest/test": patch
+---
+
+Mock `step.sendEvent` in `InngestTestEngine` (via the default `mockCtx`) so the call is recorded and resolves locally instead of proxying to the real Inngest client, which previously failed inside tests (e.g. with a 401 or a missing event key).

--- a/packages/test/src/sendEvent.test.ts
+++ b/packages/test/src/sendEvent.test.ts
@@ -1,0 +1,29 @@
+import { Inngest } from "inngest";
+import { describe, expect, it } from "vitest";
+import { InngestTestEngine } from "./index";
+
+describe("InngestTestEngine step.sendEvent", () => {
+  it("mocks step.sendEvent instead of calling the Inngest API", async () => {
+    const inngest = new Inngest({ id: "test-app" });
+
+    let called = false;
+    const fn = inngest.createFunction(
+      { id: "send-event-fn", triggers: [{ event: "test/event" }] },
+      async ({ step }) => {
+        await step.sendEvent("my-event", {
+          name: "my-event",
+          data: { hello: "world" },
+        });
+        called = true;
+        return "done";
+      },
+    );
+
+    const t = new InngestTestEngine({ function: fn });
+    const result = await t.execute({ events: [{ name: "test/event" }] });
+
+    expect(result.error).toBeUndefined();
+    expect(called).toBe(true);
+    expect(result.result).toBe("done");
+  });
+});

--- a/packages/test/src/util.ts
+++ b/packages/test/src/util.ts
@@ -1,6 +1,6 @@
 import { Context, EventPayload, internalEvents } from "inngest";
 import { ulid } from "ulid";
-import { mockAny } from "./spy.js";
+import { fn, mockAny } from "./spy.js";
 
 /**
  * The default context transformation function that mocks all step tools. Use
@@ -8,9 +8,17 @@ import { mockAny } from "./spy.js";
  * this functionality.
  */
 export const mockCtx = (ctx: Readonly<Context.Any>): Context.Any => {
+  const step = mockAny(ctx.step);
+
+  // `step.sendEvent` would otherwise proxy to the real Inngest client and make a
+  // network request, which fails inside tests (e.g. with a 401 or a missing
+  // event key). Mock it so the call is recorded and resolves locally instead
+  // of hitting the API.
+  (step as Record<string, unknown>).sendEvent = fn();
+
   return {
     ...ctx,
-    step: mockAny(ctx.step),
+    step,
   };
 };
 
@@ -40,7 +48,7 @@ export type DeepPartial<T> = {
  */
 export const isDeeplyEqual = <T extends object>(
   subset: DeepPartial<T>,
-  actual: T
+  actual: T,
 ): boolean => {
   return Object.keys(subset).every((key) => {
     const subsetValue = subset[key as keyof T];


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes inngest/inngest-js#1271. When a function calls `step.sendEvent`, `InngestTestEngine` did not mock it: the default `mockCtx` spy for `step.sendEvent` **called through** to the real Inngest client, so the test failed with a `401` / "missing event key" error instead of recording the call.

## Short description of the changes

- In `packages/test/src/util.ts`, `mockCtx` now overrides `step.sendEvent` with a spy that does **not** call through (it records the call and resolves locally), matching the existing behaviour of the other mocked step tools.
- This also benefits anyone using `mockCtx` directly.

## How to verify that this has the expected result

```bash
cd packages/test
pnpm exec vitest run src/sendEvent.test.ts
```

The new test builds a function that calls `step.sendEvent`, runs it through `InngestTestEngine`, and asserts the run completes without an error (`result.error` is `undefined`) and that `sendEvent` was called. All 20 tests in `packages/test` pass; `biome check` and `tsc --noEmit` are clean.

Assisted-by: opencode
