### PR TITLE
fix(otel): preserve third-party OTel async context in \step.run\ callbacks

### DIFF
--- a/.changeset/spotty-seas-argue.md
+++ b/.changeset/spotty-seas-argue.md
@@ -1,0 +1,5 @@
+---
+"inngest": patch
+---
+
+Preserve third-party OpenTelemetry async context (e.g. from Langfuse's `propagateAttributes`) inside `step.run()` callbacks.

--- a/packages/inngest/src/components/execution/otel/middleware.test.ts
+++ b/packages/inngest/src/components/execution/otel/middleware.test.ts
@@ -1,0 +1,53 @@
+import { InngestTestEngine } from "@inngest/test";
+import { context, createContextKey } from "@opentelemetry/api";
+import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Inngest } from "../../../index.ts";
+import { extendedTracesMiddleware } from "./middleware.ts";
+
+const REQUEST_CONTEXT_KEY = createContextKey("inngest:otel:test-request-ctx");
+
+describe("extendedTracesMiddleware", () => {
+  // Use the async-hooks context manager so that `context.with()` populates the
+  // active OTel context within the user's handler scope, mirroring how a
+  // real-world provider (e.g. Langfuse's `propagateAttributes`) works.
+  beforeEach(() => {
+    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+  });
+
+  afterEach(() => {
+    context.disable();
+  });
+
+  it("preserves third-party OTel context inside `step.run` callbacks", async () => {
+    const inngest = new Inngest({
+      id: "otel-context-middleware",
+      middleware: [extendedTracesMiddleware({ behaviour: "off" })],
+    });
+
+    const fn = inngest.createFunction(
+      { id: "otel-context-middleware-fn", triggers: [{ event: "test/event" }] },
+      async ({ step }) => {
+        // Simulate a third-party library (e.g. Langfuse's
+        // `propagateAttributes`) setting OTel context around a `step.run` call.
+        const ctx = context
+          .active()
+          .setValue(REQUEST_CONTEXT_KEY, "request-value-123");
+
+        return context.with(ctx, async () => {
+          return step.run("otel-context-step", () => {
+            return context.active().getValue(REQUEST_CONTEXT_KEY);
+          });
+        });
+      },
+    );
+
+    const t = new InngestTestEngine({ function: fn });
+    const { result, error } = await t.execute({
+      events: [{ name: "test/event", data: {} }],
+    });
+
+    expect(error).toBeUndefined();
+    expect(result).toBe("request-value-123");
+  });
+});

--- a/packages/inngest/src/components/execution/otel/middleware.ts
+++ b/packages/inngest/src/components/execution/otel/middleware.ts
@@ -1,4 +1,10 @@
-import { type DiagLogger, DiagLogLevel, diag, trace } from "@opentelemetry/api";
+import {
+  context,
+  type DiagLogger,
+  DiagLogLevel,
+  diag,
+  trace,
+} from "@opentelemetry/api";
 import Debug from "debug";
 import type { OTelSetup } from "../../../proto/src/components/sdkFeatureObservations/protobuf/feature_observations.ts";
 import { version } from "../../../version.ts";
@@ -221,11 +227,38 @@ export const extendedTracesMiddleware = ({
     override transformFunctionInput(
       arg: Middleware.TransformFunctionInputArgs,
     ) {
+      const step = arg.ctx.step;
+      const run = step.run;
+
+      // Preserve the OpenTelemetry async-context that is active when
+      // `step.run()` is called so that it is still active inside the step's
+      // callback when it executes. Steps run asynchronously via the execution
+      // engine, so by the time the callback runs the caller's `context.with()`
+      // scope (e.g. Langfuse's `propagateAttributes`) has already ended; this
+      // captures the context at declaration time and restores it on execution.
+      // See #1436
+      const stepWithPreservedContext = {
+        ...step,
+        run: ((
+          idOrOptions: Parameters<typeof run>[0],
+          fn: Parameters<typeof run>[1],
+          ...input: Parameters<typeof run>[2]
+        ) => {
+          const outerContext = context.active();
+
+          const preserveContext = (...args: Parameters<typeof fn>) =>
+            context.with(outerContext, () => fn(...args));
+
+          return run(idOrOptions, preserveContext as typeof fn, ...input);
+        }) as typeof run,
+      } as typeof step;
+
       return {
         ...arg,
         ctx: {
           ...arg.ctx,
           tracer: trace.getTracer("inngest", version),
+          step: stepWithPreservedContext,
         },
       };
     }


### PR DESCRIPTION
## Problem

Fixes #1436

Third-party OpenTelemetry providers (like Langfuse's \propagateAttributes\) set the active OTel [async context](https://opentelemetry.io/docs/specs/otel/context/) around a \step.run()\ call using \context.with(...)\. The context is lost inside the step callback: steps execute asynchronously through the execution engine, so by the time the callback runs, the caller's \context.with()\ scope has already ended.

This means any value a library places in the OTel context while calling \step.run()\ is invisible to the step's callback.

## Fix

In the \extendedTracesMiddleware\'s \	ransformFunctionInput\, wrap \ctx.step.run\ so that:

1. The active OTel context is captured when \step.run()\ is *called*.
2. It is restored with \context.with(outerContext, ...)\ around the step callback when the callback actually *executes*.

The wrapped step object is spread from the original, so all other step methods are untouched, and the \un\ signature is preserved via a cast to \	ypeof run\.

## Test

New regression test in \otel/middleware.test.ts\: an \AsyncHooksContextManager\ is installed, the function sets a value into the OTel context and calls \step.run()\ inside \context.with(...)\, and asserts the callback observes that value.

Verified locally:
- Fails before this change (\
ull\ instead of \equest-value-123\).
- Passes after.
- \itest run src/components/execution/otel/\ — 8 files / 127 tests pass.
- \	sc --noEmit --project tsconfig.types.json\ passes.
- \iome check\ passes.