### PR TITLE
fix(middleware-sentry): defer sampling to the app instead of forcing sampled=1

### DIFF
--- a/.changeset/middleware-sentry-deferred-sampling.md
+++ b/.changeset/middleware-sentry-deferred-sampling.md
@@ -1,0 +1,5 @@
+---
+"@inngest/middleware-sentry": patch
+---
+
+Stop forcing the sampled flag in the synthesized `sentry-trace`, so the app's `tracesSampleRate` / `tracesSampler` is respected. Previously the middleware always propagated `sampled=1`, which made the SDK inherit a "parent sampled" decision and export 100% of run/step spans even with `tracesSampleRate: 0`. Trace continuity (the deterministic run-derived trace ID) is unchanged. Note: apps that relied on the forced sampling to see spans should now set `tracesSampleRate` (or `tracesSampler`) explicitly.

--- a/packages/middleware-sentry/src/middleware.ts
+++ b/packages/middleware-sentry/src/middleware.ts
@@ -121,7 +121,13 @@ export class SentryMiddleware extends Middleware.BaseMiddleware {
     }
 
     this.#traceId = ulidToTraceId(runId);
-    const sentryTrace = `${this.#traceId}-1000000000000000-1`;
+    // The synthesized sentry-trace omits the sampled flag (deferred
+    // sampling). Appending `-1` would make the SDK treat this middleware as
+    // an upstream service that already decided to sample, which overrides
+    // the app's `tracesSampleRate` (including an explicit 0). Omitting the
+    // flag keeps the deterministic run-derived trace ID for continuity while
+    // leaving the sampling decision to the app's `Sentry.init` config.
+    const sentryTrace = `${this.#traceId}-1000000000000000`;
 
     // startNewTrace breaks out of the auto-instrumented HTTP span so our
     // trace ID (derived from the run ID) takes effect. continueTrace then

--- a/packages/middleware-sentry/src/test/integration/helpers.ts
+++ b/packages/middleware-sentry/src/test/integration/helpers.ts
@@ -43,6 +43,15 @@ function parseEnvelope(body: string | Uint8Array): CapturedItem[] {
   return items;
 }
 
+export interface InitSentryCaptureOptions {
+  /**
+   * Passed through to the Sentry client. Defaults to 1.0 so span-related
+   * tests capture transactions; pass 0 to verify the middleware defers the
+   * sampling decision to the app's config.
+   */
+  tracesSampleRate?: number;
+}
+
 /**
  * Initializes Sentry via @sentry/core's low-level API.
  *
@@ -50,7 +59,10 @@ function parseEnvelope(body: string | Uint8Array): CapturedItem[] {
  * imports from @sentry/core. pnpm isolates them as separate module instances
  * so only @sentry/core's global state is visible to the middleware.
  */
-export function initSentryCapture(): Captured {
+export function initSentryCapture(
+  options: InitSentryCaptureOptions = {},
+): Captured {
+  const { tracesSampleRate = 1.0 } = options;
   const captured: Captured = { items: [] };
 
   const makeTransport = (opts: InternalBaseTransportOptions): Transport =>
@@ -61,7 +73,7 @@ export function initSentryCapture(): Captured {
 
   const client = new ServerRuntimeClient({
     dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
-    tracesSampleRate: 1.0,
+    tracesSampleRate,
     integrations: [],
     stackParser: () => [],
     transport: makeTransport,

--- a/packages/middleware-sentry/src/test/integration/sentry.test.ts
+++ b/packages/middleware-sentry/src/test/integration/sentry.test.ts
@@ -444,3 +444,39 @@ test("request span uses function name", async () => {
     expect(hasMatchingTransaction).toBe(true);
   });
 });
+
+test("tracesSampleRate: 0 exports no transactions but still captures errors", async () => {
+  const captured = initSentryCapture({ tracesSampleRate: 0 });
+
+  const state = createState({});
+
+  const eventName = randomSuffix("evt");
+  const client = new Inngest({
+    id: randomSuffix(testFileName),
+    isDev: true,
+    middleware: [SentryMiddleware],
+  });
+
+  const fn = client.createFunction(
+    { id: "fn", retries: 0, triggers: [{ event: eventName }] },
+    async ({ step, runId }) => {
+      state.runId = runId;
+      await step.run("step-a", () => 1);
+      throw new Error("boom");
+    },
+  );
+
+  await createTestApp({ client, functions: [fn], serve: createServer });
+  await client.send({ name: eventName });
+  await state.waitForRunFailed();
+
+  // Wait for a positive signal (the error envelope) before asserting the
+  // absence of transactions, so the flush has demonstrably happened.
+  await waitFor(() => {
+    const errors = capturedErrors(captured);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some((e) => errorHasException(e, "boom"))).toBe(true);
+  });
+
+  expect(capturedTransactions(captured)).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

Fixes #1718.

The `sentry-trace` header synthesized in `wrapRequest` hardcoded the sampled flag (`-1`), which makes the Sentry SDK inherit a "parent sampled" decision. Since the SDK's sampling precedence is `tracesSampler` > inherited `parentSampled` > `tracesSampleRate`, this overrode the app's `tracesSampleRate` — including an explicit `0` — and forced 100% span export for every run and step.

This PR omits the flag (deferred sampling), so the sampling decision falls through to the app's `Sentry.init` config. The deterministic run-derived trace ID — which is what groups a durable run's multiple requests into one Sentry trace — is unchanged, as are `startNewTrace` / `continueTrace`.

## Changes

- `middleware.ts`: build `sentry-trace` as `${traceId}-1000000000000000` (no sampled flag), with a comment explaining why the flag must stay off
- `helpers.ts`: parameterize `initSentryCapture({ tracesSampleRate })` (defaults to `1.0`, so existing tests are unchanged)
- `sentry.test.ts`: add an integration test asserting that with `tracesSampleRate: 0` a failing run exports **no transactions but still captures errors** (waits on the error envelope as a positive signal before asserting the absence of transactions)
- changeset (patch): notes that apps relying on the forced sampling should now set `tracesSampleRate` / `tracesSampler` explicitly

## Testing

- `pnpm --filter @inngest/middleware-sentry test:integration`: 26/26 pass including the new test; the existing span-shape tests (`step spans created with correct names`, `request span uses function name`) still pass, confirming spans remain fully available for apps that sample
- Additionally verified the packed build against our production stack (Bun, `@sentry/bun` 10.49.0), driving the real `wrapRequest`: `tracesSampleRate: 0` → root span not sampled; `tracesSampler: () => 0` → not sampled; `tracesSampleRate: 1` → sampled

@RealBhupesh you mentioned in #1718 you were happy to take this — apologies for the crossed wires. If you already have work in progress, feel free to close this PR in favor of yours; otherwise treat it as a starting point (it follows the plan you outlined, including the parameterized `initSentryCapture`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)